### PR TITLE
admin governance: merge a space's manual members and its groups

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -10394,8 +10394,7 @@
                 "required": [
                   "isRestricted",
                   "name",
-                  "spaceKind",
-                  "managementMode"
+                  "spaceKind"
                 ],
                 "properties": {
                   "isRestricted": {
@@ -10411,26 +10410,27 @@
                       "project"
                     ]
                   },
-                  "managementMode": {
-                    "type": "string",
-                    "enum": [
-                      "manual",
-                      "group"
-                    ]
-                  },
                   "memberIds": {
                     "type": "array",
                     "items": {
                       "type": "string"
                     },
-                    "description": "Required when managementMode is manual"
+                    "description": "The space's manual member list. Omitted or empty means the space starts with no manual member."
                   },
                   "groupIds": {
                     "type": "array",
                     "items": {
                       "type": "string"
                     },
-                    "description": "Required when managementMode is group"
+                    "description": "The groups given access to the space. Omitted or empty means no group has access to it."
+                  },
+                  "managementMode": {
+                    "type": "string",
+                    "enum": [
+                      "manual",
+                      "group"
+                    ],
+                    "description": "Deprecated and ignored. A space's members are its manual member list plus the members of the groups given access to it."
                   }
                 }
               }
@@ -12294,7 +12294,8 @@
             "enum": [
               "manual",
               "group"
-            ]
+            ],
+            "description": "Deprecated. Derived from whether any group has access to the space; a space's members are its manual member list plus the members of those groups."
           },
           "createdAt": {
             "type": "integer"

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -1096,6 +1096,7 @@
  *         managementMode:
  *           type: string
  *           enum: [manual, group]
+ *           description: Deprecated. Derived from whether any group has access to the space; a space's members are its manual member list plus the members of those groups.
  *         createdAt:
  *           type: integer
  *         updatedAt:

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
@@ -55,17 +55,6 @@ app.delete(
       });
     }
 
-    if (space.managementMode === "group") {
-      return apiError(ctx, {
-        status_code: 404,
-        api_error: {
-          type: "space_not_found",
-          message:
-            "Space is managed by provisioned group access, members can't be edited by API.",
-        },
-      });
-    }
-
     const updateRes = await space.removeMembers(auth, {
       userIds: [userId],
     });

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/index.ts
@@ -72,17 +72,6 @@ const withEditableSpace = createMiddleware<
     });
   }
 
-  if (space.managementMode === "group") {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "space_not_found",
-        message:
-          "Space is managed by provisioned group access, members can't be edited by API.",
-      },
-    });
-  }
-
   ctx.set("space", space);
   await next();
 });
@@ -102,7 +91,9 @@ app.get(
   async (ctx): HandlerResult<GetSpaceMembersResponseBody> => {
     const auth = ctx.get("auth");
     const space = ctx.get("space");
-    const groups = await space.fetchGroupResources(auth);
+    // The groups that make up the space's membership: an open space attaches the workspace global
+    // group as a reader, and its members are not members of the space.
+    const groups = await space.fetchMembershipGroups(auth);
 
     const currentMembers = uniqBy(
       (

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/join.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/join.ts
@@ -39,17 +39,6 @@ app.post(
       });
     }
 
-    if (space.managementMode !== "manual") {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "invalid_request_error",
-          message:
-            "You cannot join this Pod, its members are not managed manually.",
-        },
-      });
-    }
-
     if (space.isMember(auth)) {
       return apiError(ctx, {
         status_code: 400,

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/members.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/members.test.ts
@@ -2,6 +2,7 @@ import { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { setupAgentOwner } from "@app/tests/utils/AgentOwnerFactory";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { honoApp } from "@front-api/app";
@@ -161,7 +162,6 @@ describe("PATCH /api/w/:wId/spaces/:spaceId/members", () => {
     const response = await patchMembers(workspace, project.sId, {
       name: project.name,
       isRestricted: false,
-      managementMode: "manual",
       memberIds: [],
       editorIds: [user.sId],
     });
@@ -176,6 +176,141 @@ describe("PATCH /api/w/:wId/spaces/:spaceId/members", () => {
     });
   });
 
+  it("sets the members and the groups from one request", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await SpaceFactory.defaults(auth);
+    const space = await SpaceFactory.regular(workspace);
+
+    const provisionedGroup = await GroupFactory.provisioned(
+      workspace,
+      "Provisioned"
+    );
+    const response = await patchMembers(workspace, space.sId, {
+      name: space.name,
+      isRestricted: true,
+      memberIds: [user.sId],
+      groupIds: [provisionedGroup.sId],
+    });
+    expect(response.status).toBe(200);
+
+    const refreshedSpace = await SpaceResource.fetchById(auth, space.sId);
+    const attached = await refreshedSpace!.fetchAttachedManageableGroups(auth);
+    expect(attached.memberGroups.map((g) => g.sId)).toEqual([
+      provisionedGroup.sId,
+    ]);
+
+    const memberGroup = await refreshedSpace!.fetchManualMemberGroup(auth);
+    const members = await memberGroup.getActiveMembers(auth);
+    expect(members.map((m) => m.sId)).toEqual([user.sId]);
+  });
+
+  it("clears the groups when the request only carries members", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await SpaceFactory.defaults(auth);
+    const space = await SpaceFactory.regular(workspace);
+
+    const provisionedGroup = await GroupFactory.provisioned(
+      workspace,
+      "Provisioned"
+    );
+    const withGroup = await patchMembers(workspace, space.sId, {
+      name: space.name,
+      isRestricted: true,
+      groupIds: [provisionedGroup.sId],
+    });
+    expect(withGroup.status).toBe(200);
+
+    // The request carries the space's whole membership, so leaving the groups out drops them —
+    // what a client switching the space back to manual access means.
+    const response = await patchMembers(workspace, space.sId, {
+      name: space.name,
+      isRestricted: true,
+      memberIds: [user.sId],
+    });
+    expect(response.status).toBe(200);
+
+    const refreshedSpace = await SpaceResource.fetchById(auth, space.sId);
+    const attached = await refreshedSpace!.fetchAttachedManageableGroups(auth);
+    expect(attached.memberGroups).toEqual([]);
+  });
+
+  it("clears the members when the request only carries groups", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await SpaceFactory.defaults(auth);
+    const space = await SpaceFactory.regular(workspace);
+
+    const withMember = await patchMembers(workspace, space.sId, {
+      name: space.name,
+      isRestricted: true,
+      memberIds: [user.sId],
+    });
+    expect(withMember.status).toBe(200);
+
+    // The mirror of the case above: leaving the members out drops them, which is what a client
+    // switching the space to group access means.
+    const provisionedGroup = await GroupFactory.provisioned(
+      workspace,
+      "Provisioned"
+    );
+    const response = await patchMembers(workspace, space.sId, {
+      name: space.name,
+      isRestricted: true,
+      groupIds: [provisionedGroup.sId],
+    });
+    expect(response.status).toBe(200);
+
+    const refreshedSpace = await SpaceResource.fetchById(auth, space.sId);
+    const memberGroup = await refreshedSpace!.fetchManualMemberGroup(auth);
+    expect(await memberGroup.getActiveMembers(auth)).toEqual([]);
+
+    const attached = await refreshedSpace!.fetchAttachedManageableGroups(auth);
+    expect(attached.memberGroups.map((g) => g.sId)).toEqual([
+      provisionedGroup.sId,
+    ]);
+  });
+
+  it("adds a member to a group-backed space", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await SpaceFactory.defaults(auth);
+    const space = await SpaceFactory.regular(workspace);
+
+    const provisionedGroup = await GroupFactory.provisioned(
+      workspace,
+      "Provisioned"
+    );
+    const withGroup = await patchMembers(workspace, space.sId, {
+      name: space.name,
+      isRestricted: true,
+      groupIds: [provisionedGroup.sId],
+    });
+    expect(withGroup.status).toBe(200);
+
+    // A space's manual member list and its groups live side by side, so POST still adds one.
+    const response = await postMembers(workspace, space.sId, {
+      memberIds: [user.sId],
+    });
+    expect(response.status).toBe(200);
+
+    const refreshedSpace = await SpaceResource.fetchById(auth, space.sId);
+    const memberGroup = await refreshedSpace!.fetchManualMemberGroup(auth);
+    const members = await memberGroup.getActiveMembers(auth);
+    expect(members.map((m) => m.sId)).toEqual([user.sId]);
+
+    // And the group is still attached.
+    const attached = await refreshedSpace!.fetchAttachedManageableGroups(auth);
+    expect(attached.memberGroups.map((g) => g.sId)).toEqual([
+      provisionedGroup.sId,
+    ]);
+  });
+
   it("allows making a restricted project open when open projects are allowed", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
       role: "admin",
@@ -186,7 +321,6 @@ describe("PATCH /api/w/:wId/spaces/:spaceId/members", () => {
     const response = await patchMembers(workspace, project.sId, {
       name: project.name,
       isRestricted: false,
-      managementMode: "manual",
       memberIds: [],
       editorIds: [user.sId],
     });

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/members.ts
@@ -224,7 +224,7 @@ app.patch(
 
     // Track current members before update to identify newly added ones.
     let currentMemberIds: Set<string> | undefined;
-    if (space.isProject() && body.managementMode === "manual") {
+    if (space.isProject() && body.memberIds) {
       const memberGroup = await space.fetchManualMemberGroup(auth);
       const currentMembers = await memberGroup.getActiveMembers(auth);
       currentMemberIds = new Set(currentMembers.map((m) => m.sId));
@@ -235,26 +235,19 @@ app.patch(
       return membersMutationError(ctx, updateRes.error.code);
     }
 
+    // Only the dimensions the request carried are reported: the others were left untouched.
     emitSpacePermissionsUpdatedAuditLogs(auth, space, {
-      management_mode: body.managementMode,
       is_restricted: String(body.isRestricted),
-      ...(body.managementMode === "manual"
-        ? {
-            member_ids: body.memberIds.join(","),
-            editor_ids: body.editorIds.join(","),
-          }
-        : {
-            group_ids: body.groupIds.join(","),
-            editor_group_ids: body.editorGroupIds.join(","),
-          }),
+      ...(body.memberIds ? { member_ids: body.memberIds.join(",") } : {}),
+      ...(body.editorIds ? { editor_ids: body.editorIds.join(",") } : {}),
+      ...(body.groupIds ? { group_ids: body.groupIds.join(",") } : {}),
+      ...(body.editorGroupIds
+        ? { editor_group_ids: body.editorGroupIds.join(",") }
+        : {}),
     });
 
     // Trigger notifications for newly added members (projects only).
-    if (
-      space.isProject() &&
-      body.managementMode === "manual" &&
-      currentMemberIds
-    ) {
+    if (space.isProject() && body.memberIds && currentMemberIds) {
       const newlyAddedUserIds = body.memberIds.filter(
         (id) => !currentMemberIds.has(id)
       );
@@ -286,17 +279,6 @@ app.post(
       return guardError;
     }
 
-    if (space.managementMode !== "manual") {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message:
-            "The members of this space are managed by groups. Add users to one of its groups instead.",
-        },
-      });
-    }
-
     const { memberIds } = ctx.req.valid("json");
 
     const addRes = await space.addMembers(auth, { userIds: memberIds });
@@ -305,7 +287,6 @@ app.post(
     }
 
     emitSpacePermissionsUpdatedAuditLogs(auth, space, {
-      management_mode: "manual",
       is_restricted: String(await space.isRestricted(auth)),
       member_ids: addRes.value.map((user) => user.sId).join(","),
     });

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -1,5 +1,6 @@
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { ProjectFileFactory } from "@app/tests/utils/ProjectFileFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
@@ -106,6 +107,38 @@ describe("PATCH /api/w/:wId/spaces/:spaceId/project_metadata", () => {
     });
 
     expect(response.status).toBe(403);
+  });
+
+  it("refuses admin-controlled mode while a group is attached to the Pod", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await FeatureFlagFactory.basic(auth, "admin_controlled_pods");
+    await SpaceFactory.defaults(auth);
+    const project = await SpaceFactory.project(workspace, user.id);
+    const group = await GroupFactory.provisioned(workspace, "Pod Editors");
+
+    const attachRes = await project.updatePermissions(auth, {
+      name: project.name,
+      isRestricted: true,
+      editorIds: [user.sId],
+      editorGroupIds: [group.sId],
+    });
+    expect(attachRes.isOk()).toBe(true);
+
+    // A group attached as an editor would keep administrating a Pod that is supposed to be
+    // administrated by workspace admins only.
+    const response = await patchMetadata(workspace, project.sId, {
+      isAdminControlled: true,
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "Admin-controlled mode requires manual membership management.",
+      },
+    });
   });
 
   it("archives a project", async () => {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -99,7 +99,11 @@ app.patch(
         });
       }
 
-      if (space.managementMode !== "manual") {
+      // Admin-controlled means workspace admins are the only administrators. A group attached to
+      // the Pod as an editor would keep administrating it, so the mode is refused while one is.
+      // Pods are manually managed in the product today; this covers one configured through the
+      // API.
+      if (await space.hasAttachedGroups(auth)) {
         return apiError(ctx, {
           status_code: 400,
           api_error: {

--- a/front-api/routes/w/[wId]/spaces/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/index.test.ts
@@ -107,7 +107,6 @@ describe("POST /api/w/:wId/spaces", () => {
       name: "Open project should fail",
       isRestricted: false,
       spaceKind: "project",
-      managementMode: "manual",
       memberIds: [],
     });
 
@@ -145,7 +144,6 @@ describe("POST /api/w/:wId/spaces", () => {
       name: "Open project is allowed",
       isRestricted: false,
       spaceKind: "project",
-      managementMode: "manual",
       memberIds: [],
     });
 
@@ -175,7 +173,6 @@ describe("POST /api/w/:wId/spaces", () => {
       name: "[Dust FS] Test project",
       isRestricted: true,
       spaceKind: "project",
-      managementMode: "manual",
       memberIds: [],
     });
 

--- a/front-api/routes/w/[wId]/spaces/index.ts
+++ b/front-api/routes/w/[wId]/spaces/index.ts
@@ -119,7 +119,6 @@ const GetSpacesQuerySchema = z.object({
  *               - isRestricted
  *               - name
  *               - spaceKind
- *               - managementMode
  *             properties:
  *               isRestricted:
  *                 type: boolean
@@ -128,19 +127,20 @@ const GetSpacesQuerySchema = z.object({
  *               spaceKind:
  *                 type: string
  *                 enum: [regular, project]
- *               managementMode:
- *                 type: string
- *                 enum: [manual, group]
  *               memberIds:
  *                 type: array
  *                 items:
  *                   type: string
- *                 description: Required when managementMode is manual
+ *                 description: The space's manual member list. Omitted or empty means the space starts with no manual member.
  *               groupIds:
  *                 type: array
  *                 items:
  *                   type: string
- *                 description: Required when managementMode is group
+ *                 description: The groups given access to the space. Omitted or empty means no group has access to it.
+ *               managementMode:
+ *                 type: string
+ *                 enum: [manual, group]
+ *                 description: Deprecated and ignored. A space's members are its manual member list plus the members of the groups given access to it.
  *     responses:
  *       201:
  *         description: Successfully created space

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -318,7 +318,6 @@ export function createProjectManagerTools(
             const updatePermissionsRes = await pod.updatePermissions(auth, {
               name: pod.name,
               isRestricted: newIsRestricted,
-              managementMode: "manual",
               memberIds,
               editorIds,
             });
@@ -973,8 +972,6 @@ export function createProjectManagerTools(
           name: params.title,
           isRestricted: params.access !== "open",
           spaceKind: "project",
-          managementMode: "manual",
-          memberIds: [],
         });
 
         if (createSpaceRes.isErr()) {

--- a/front/lib/api/assistant/conversation/permissions.test.ts
+++ b/front/lib/api/assistant/conversation/permissions.test.ts
@@ -222,8 +222,6 @@ describe("canAgentBeUsedInProjectConversation", () => {
         name: `open solo ${faker.string.alphanumeric(10)}`,
         isRestricted: false,
         spaceKind: "project",
-        managementMode: "manual",
-        memberIds: [],
       });
       if (openProjectRes.isErr()) {
         throw new Error(openProjectRes.error.message);
@@ -399,7 +397,7 @@ describe("canAgentBeUsedInProjectConversation", () => {
     ).resolves.toBe(true);
   });
 
-  it("rejects the agent when a project member reaches the restricted space only through a provisioned group on a manually-managed space", async () => {
+  it("allows the agent when a project member reaches the restricted space through a provisioned group", async () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
@@ -411,9 +409,9 @@ describe("canAgentBeUsedInProjectConversation", () => {
 
     await addUserToSpaceRegularGroup(internalAdminAuth, projectSpace, userJson);
 
-    // The user's only link to the restricted space is a provisioned group. Provisioned groups
-    // carry no grants on manually-managed spaces (see spaceGroupRoles), so the user is not a
-    // member of the space.
+    // The user's only link to the restricted space is a provisioned group. A space's manual
+    // member list and the groups attached to it are merged, so the group makes the user a member
+    // of the space.
     const provisionedGroup = await GroupFactory.provisioned(
       workspace,
       faker.string.alphanumeric(8)
@@ -440,7 +438,7 @@ describe("canAgentBeUsedInProjectConversation", () => {
         ]),
         conversation: conversationJson,
       })
-    ).resolves.toBe(false);
+    ).resolves.toBe(true);
   });
 
   it("allows the agent when all project members belong to required restricted spaces mixed with open spaces", async () => {

--- a/front/lib/api/file_system/dust_file_system.test.ts
+++ b/front/lib/api/file_system/dust_file_system.test.ts
@@ -929,7 +929,6 @@ describe("DustFileSystem.forAgentLoop", () => {
         name: `open pod ${Date.now()}`,
         isRestricted: false,
         spaceKind: "project",
-        managementMode: "manual",
         memberIds: [],
       });
       assert(

--- a/front/lib/api/poke/plugins/spaces/activation_management.ts
+++ b/front/lib/api/poke/plugins/spaces/activation_management.ts
@@ -232,8 +232,6 @@ async function provisionTrainingPod(
     name: podName,
     isRestricted: true,
     spaceKind: "project",
-    managementMode: "manual",
-    memberIds: [],
   });
   if (createResult.isErr()) {
     return new Err(new Error(createResult.error.message));

--- a/front/lib/api/poke/plugins/spaces/update_pod_members.ts
+++ b/front/lib/api/poke/plugins/spaces/update_pod_members.ts
@@ -2,7 +2,6 @@ import { createPlugin } from "@app/lib/api/poke/types";
 import { getMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import type { GroupResource } from "@app/lib/resources/group_resource";
-import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -86,28 +85,6 @@ async function syncGroupMembers(
   return new Ok({ added: usersToAdd, removed: usersToRemove, userMap });
 }
 
-async function getManualMemberGroup(
-  auth: Authenticator,
-  space: SpaceResource
-): Promise<GroupResource | null> {
-  // The manual member group only exists for manually-managed pods.
-  if (space.managementMode !== "manual") {
-    return null;
-  }
-  return space.fetchManualMemberGroup(auth);
-}
-
-async function getManualEditorGroup(
-  auth: Authenticator,
-  space: SpaceResource
-): Promise<GroupResource | null> {
-  // The manual editor group only exists for manually-managed pods.
-  if (space.managementMode !== "manual") {
-    return null;
-  }
-  return space.fetchManualEditorGroup(auth);
-}
-
 export const updatePodMembersPlugin = createPlugin({
   manifest: {
     id: "update-pod-members",
@@ -145,8 +122,10 @@ export const updatePodMembersPlugin = createPlugin({
       activeOnly: true,
     });
 
-    const memberGroup = await getManualMemberGroup(auth, resource);
-    const editorGroup = await getManualEditorGroup(auth, resource);
+    const memberGroup = resource.isProject()
+      ? await resource.fetchManualMemberGroup(auth)
+      : null;
+    const editorGroup = await resource.fetchManualEditorGroup(auth);
 
     const currentMembers = memberGroup
       ? await memberGroup.getActiveMembers(auth)
@@ -180,20 +159,11 @@ export const updatePodMembersPlugin = createPlugin({
       return new Err(new Error("This plugin only applies to pods"));
     }
 
-    if (resource.managementMode !== "manual") {
-      return new Err(
-        new Error(
-          "This plugin only applies to pods with manual member management"
-        )
-      );
-    }
+    // A Pod always has its own member group, alongside any group attached to it. This plugin
+    // edits the manual list only; group-backed access is managed through the groups themselves.
+    const memberGroup = await resource.fetchManualMemberGroup(auth);
 
-    const memberGroup = await getManualMemberGroup(auth, resource);
-    if (!memberGroup) {
-      return new Err(new Error("Pod does not have a member group"));
-    }
-
-    const editorGroup = await getManualEditorGroup(auth, resource);
+    const editorGroup = await resource.fetchManualEditorGroup(auth);
     if (!editorGroup) {
       return new Err(new Error("Pod does not have an editor group"));
     }
@@ -290,6 +260,6 @@ export const updatePodMembersPlugin = createPlugin({
     if (!resource) {
       return false;
     }
-    return resource.isProject() && resource.managementMode === "manual";
+    return resource.isProject();
   },
 });

--- a/front/lib/api/poke/plugins/workspaces/create_space.ts
+++ b/front/lib/api/poke/plugins/workspaces/create_space.ts
@@ -39,9 +39,7 @@ export const createSpacePlugin = createPlugin({
       auth,
       {
         name: formattedName,
-        memberIds: [],
         isRestricted,
-        managementMode: "manual",
         spaceKind: "regular",
       },
       {

--- a/front/lib/api/projects/list.test.ts
+++ b/front/lib/api/projects/list.test.ts
@@ -62,7 +62,6 @@ describe("listPodsForScope", () => {
       name: "Open Alpha Pod",
       isRestricted: false,
       spaceKind: "project",
-      managementMode: "manual",
       memberIds: [],
     });
     expect(openPodRes.isOk()).toBe(true);
@@ -101,7 +100,6 @@ describe("listPodsForScope", () => {
       name: "Alpha Launch",
       isRestricted: false,
       spaceKind: "project",
-      managementMode: "manual",
       memberIds: [],
     });
     expect(alphaPodRes.isOk()).toBe(true);
@@ -110,7 +108,6 @@ describe("listPodsForScope", () => {
       name: "Beta Rollout",
       isRestricted: false,
       spaceKind: "project",
-      managementMode: "manual",
       memberIds: [],
     });
     expect(betaPodRes.isOk()).toBe(true);
@@ -143,7 +140,6 @@ describe("listPodsForScope", () => {
       name: "Café Launch",
       isRestricted: false,
       spaceKind: "project",
-      managementMode: "manual",
       memberIds: [],
     });
     expect(cafePodRes.isOk()).toBe(true);

--- a/front/lib/api/search.ts
+++ b/front/lib/api/search.ts
@@ -39,7 +39,11 @@ type SearchError = {
   error: APIError;
 };
 
-function getSpaceAccessPriority(space: SpaceResource, isOpen: boolean) {
+function getSpaceAccessPriority(
+  space: SpaceResource,
+  isOpen: boolean,
+  hasAttachedGroups: boolean
+) {
   // Global spaces have highest priority.
   if (space.isGlobal()) {
     return 3;
@@ -50,19 +54,20 @@ function getSpaceAccessPriority(space: SpaceResource, isOpen: boolean) {
     return 2;
   }
 
-  // For restricted spaces: provisioned groups get higher priority than manual membership. A space
-  // in group management mode is backed by provisioned (IdP-owned) groups.
-  if (space.managementMode === "group") {
+  // For restricted spaces: access through a directory group (provisioned or manual) gets higher
+  // priority than a hand-picked member list.
+  if (hasAttachedGroups) {
     return 1;
   }
 
-  // Restricted spaces with manual membership have the lowest priority.
+  // Restricted spaces with manual membership only have the lowest priority.
   return 0;
 }
 
 function selectHighestPriorityDataSourceView(
   views: DataSourceViewResource[],
-  openSpaceIds: Set<ModelId>
+  openSpaceIds: Set<ModelId>,
+  spaceIdsWithAttachedGroups: Set<ModelId>
 ): DataSourceViewResource {
   if (views.length <= 1) {
     return views[0];
@@ -72,7 +77,8 @@ function selectHighestPriorityDataSourceView(
     view,
     priority: getSpaceAccessPriority(
       view.space,
-      openSpaceIds.has(view.space.id)
+      openSpaceIds.has(view.space.id),
+      spaceIdsWithAttachedGroups.has(view.space.id)
     ),
     spaceName: view.space.name,
   }));
@@ -145,6 +151,11 @@ export async function handleSearch(
     auth,
     spacesToSearch
   );
+  const spaceIdsWithAttachedGroups =
+    await SpaceResource.listSpaceModelIdsWithAttachedGroups(
+      auth,
+      spacesToSearch
+    );
 
   const allDatasourceViews = await DataSourceViewResource.listBySpaces(
     auth,
@@ -252,7 +263,13 @@ export async function handleSearch(
       }
 
       const selectedViews = prioritizeSpaceAccess
-        ? [selectHighestPriorityDataSourceView(matchingViews, openSpaceIds)]
+        ? [
+            selectHighestPriorityDataSourceView(
+              matchingViews,
+              openSpaceIds,
+              spaceIdsWithAttachedGroups
+            ),
+          ]
         : matchingViews;
 
       return {

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -523,7 +523,8 @@ describe("createSpaceAndGroup", () => {
       if (result.isOk()) {
         const space = result.value;
         expect(space.name).toBe("Test Empty Group Space");
-        expect(space.managementMode).toBe("group");
+        // `managementMode` is derived from the groups actually attached.
+        expect(space.managementMode).toBe("manual");
       }
     });
   });

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -45,7 +45,7 @@ import {
 } from "@app/types/groups";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { SpaceMembershipUpdate } from "@app/types/space";
 import assert from "assert";
 import uniq from "lodash/uniq";
 import uniqBy from "lodash/uniqBy";
@@ -606,10 +606,7 @@ export async function createSpaceAndGroup(
     name: string;
     isRestricted: boolean;
     spaceKind: "regular" | "project";
-  } & (
-    | { memberIds: string[]; managementMode: "manual" }
-    | { groupIds: string[]; managementMode: "group" }
-  ),
+  } & Pick<SpaceMembershipUpdate, "memberIds" | "groupIds" | "managementMode">,
   {
     ignoreWorkspaceLimit = false,
   }: {
@@ -640,8 +637,11 @@ export async function createSpaceAndGroup(
   }
   const owner = auth.getNonNullableWorkspace();
   const plan = auth.getNonNullablePlan();
-  const { name: rawName, isRestricted, spaceKind, managementMode } = params;
+  const { name: rawName, isRestricted, spaceKind } = params;
   const name = rawName.trim();
+  // A new space starts empty, so a client that still sends `managementMode` gets what it expects
+  // without the field being read: the dimension its mode does not cover is simply not seeded.
+  const { memberIds = [], groupIds = [] } = params;
 
   if (
     spaceKind === "project" &&
@@ -738,7 +738,9 @@ export async function createSpaceAndGroup(
       {
         name,
         kind: spaceKind,
-        managementMode,
+        // `managementMode` no longer drives anything: it is kept up to date only so that clients
+        // that still read it see something coherent, and goes away with the field.
+        managementMode: groupIds.length > 0 ? "group" : "manual",
         workspaceId: owner.id,
       },
       { members: [membersGroup], editors: editorGroups },
@@ -757,96 +759,74 @@ export async function createSpaceAndGroup(
       memberGroups.push(globalGroup);
     }
 
-    // Handle member-based space creation
-    switch (managementMode) {
-      case "manual":
-        if (spaceKind === "project") {
-          assert(
-            params.memberIds.length === 0,
-            "Cannot add members to Pods on creation."
-          );
-          break;
-        }
-
-        // Seeding a regular space's members requires administering it. The member
-        // group is a regular_auto group whose permissions are not checked directly,
-        // so gate on the space instead.
-        if (!auth.can("admin", space)) {
-          return new Err(
-            new DustError(
-              "unauthorized",
-              "Only admins can change group members"
-            )
-          );
-        }
-
-        // Add members to the member group in regular spaces
-        const users = (await UserResource.fetchByIds(params.memberIds)).map(
-          (user) => user.toJSON()
+    // Seed the space's manual members, and attach the selected groups. Both are optional and
+    // independent: a space can be created with a member list, with groups, or with both.
+    if (memberIds.length > 0 || groupIds.length > 0) {
+      // Seeding a space's members or attaching groups requires administering it. The member group
+      // is a regular_auto group whose permissions are not checked directly, so gate on the space.
+      if (!auth.can("admin", space)) {
+        return new Err(
+          new DustError("unauthorized", "Only admins can change group members")
         );
-        const groupsResult = await membersGroup.dangerouslyAddMembers(auth, {
-          users,
-          transaction: t,
-        });
-        if (groupsResult.isErr()) {
-          logger.error(
-            {
-              error: groupsResult.error,
-            },
-            "Failed to add members to the member group"
-          );
-          return new Err(
-            new DustError("internal_error", "The space cannot be created.")
-          );
-        }
-        break;
+      }
+    }
 
-      // Handle group-based space creation
-      case "group":
-        // For group-based spaces, we need to associate the selected groups with the space
-        if (params.groupIds.length > 0) {
-          // Associating groups requires administering the space.
-          if (!auth.can("admin", space)) {
-            return new Err(
-              new DustError(
-                "unauthorized",
-                "Only admins can change group members"
-              )
-            );
-          }
-          const selectedGroupsResult = await GroupResource.fetchByIds(
-            auth,
-            params.groupIds
-          );
-          if (selectedGroupsResult.isErr()) {
-            logger.error(
-              {
-                error: selectedGroupsResult.error,
-              },
-              "The space cannot be created - failed to fetch groups"
-            );
-            return new Err(
-              new DustError("internal_error", "The space cannot be created.")
-            );
-          }
+    if (memberIds.length > 0) {
+      assert(
+        spaceKind !== "project",
+        "Cannot add members to Pods on creation."
+      );
 
-          const selectedGroups = selectedGroupsResult.value;
-          // `fetchByIds` only checks that the caller can read the groups, not what they are. Keep
-          // internal groups (global, system, another space's regular_auto, agent/skill editors) out
-          // of a space's group-managed access.
-          if (selectedGroups.some((g) => !isManageableGroupKind(g.kind))) {
-            return new Err(
-              new DustError(
-                "invalid_request_error",
-                "Only provisioned and manual groups can be given access to a space."
-              )
-            );
-          }
-          memberGroups.push(...selectedGroups);
-        }
-        break;
-      default:
-        assertNever(managementMode);
+      const users = (await UserResource.fetchByIds(memberIds)).map((user) =>
+        user.toJSON()
+      );
+      const groupsResult = await membersGroup.dangerouslyAddMembers(auth, {
+        users,
+        transaction: t,
+      });
+      if (groupsResult.isErr()) {
+        logger.error(
+          {
+            error: groupsResult.error,
+          },
+          "Failed to add members to the member group"
+        );
+        return new Err(
+          new DustError("internal_error", "The space cannot be created.")
+        );
+      }
+    }
+
+    if (groupIds.length > 0) {
+      const selectedGroupsResult = await GroupResource.fetchByIds(
+        auth,
+        groupIds
+      );
+      if (selectedGroupsResult.isErr()) {
+        logger.error(
+          {
+            error: selectedGroupsResult.error,
+          },
+          "The space cannot be created - failed to fetch groups"
+        );
+        return new Err(
+          new DustError("internal_error", "The space cannot be created.")
+        );
+      }
+
+      const selectedGroups = selectedGroupsResult.value;
+      // `fetchByIds` only checks that the caller can read the groups, not what they are. Keep
+      // internal groups (global, system, another space's regular_auto, agent/skill editors) out
+      // of a space's group-managed access.
+      if (selectedGroups.some((g) => !isManageableGroupKind(g.kind))) {
+        return new Err(
+          new DustError(
+            "invalid_request_error",
+            "Only provisioned and manual groups can be given access to a space."
+          )
+        );
+      }
+      memberGroups.push(...selectedGroups);
     }
 
     // Create empty project metadata for project spaces

--- a/front/lib/api/spaces/members.ts
+++ b/front/lib/api/spaces/members.ts
@@ -1,23 +1,18 @@
 import { z } from "zod";
 
-export const PatchSpaceMembersRequestBodySchema = z.intersection(
-  z.object({
-    isRestricted: z.boolean(),
-    name: z.string(),
-  }),
-  z.discriminatedUnion("managementMode", [
-    z.object({
-      memberIds: z.array(z.string()),
-      managementMode: z.literal("manual"),
-      editorIds: z.array(z.string()),
-    }),
-    z.object({
-      groupIds: z.array(z.string()),
-      managementMode: z.literal("group"),
-      editorGroupIds: z.array(z.string()),
-    }),
-  ])
-);
+// The space's whole desired membership. Every dimension is optional, and one the request leaves
+// out is emptied, not kept: omitting `groupIds` says no group has access, the same as sending an
+// empty array. `managementMode` is legacy and ignored — a client that sends it also omits the
+// dimension its mode does not cover, and so gets the clearing it expects.
+export const PatchSpaceMembersRequestBodySchema = z.object({
+  isRestricted: z.boolean(),
+  name: z.string(),
+  memberIds: z.array(z.string()).optional(),
+  editorIds: z.array(z.string()).optional(),
+  groupIds: z.array(z.string()).optional(),
+  editorGroupIds: z.array(z.string()).optional(),
+  managementMode: z.enum(["manual", "group"]).optional(),
+});
 
 export type PatchSpaceMembersRequestBodyType = z.infer<
   typeof PatchSpaceMembersRequestBodySchema

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -495,6 +495,152 @@ describe("SpaceResource", () => {
       });
     });
 
+    describe("merged membership", () => {
+      it("keeps both the manual members and the attached groups", async () => {
+        const provisionedGroup = await GroupResource.makeNew({
+          name: "Provisioned Group",
+          workspaceId: workspace.id,
+          kind: "provisioned",
+        });
+
+        const result = await regularSpace.updatePermissions(adminAuth, {
+          name: "Test Space",
+          isRestricted: true,
+          memberIds: [user1.sId],
+          groupIds: [provisionedGroup.sId],
+        });
+        expect(result.isOk()).toBe(true);
+
+        // The manual member keeps their membership, and the group is granted alongside it.
+        const members = await regularGroup.getActiveMembers(adminAuth);
+        expect(members.map((m) => m.sId)).toEqual([user1.sId]);
+        expect(
+          await spaceGrantsForGroups([regularGroup, provisionedGroup])
+        ).toEqual(
+          [
+            { groupId: regularGroup.id, grantType: "member" },
+            { groupId: provisionedGroup.id, grantType: "member" },
+          ].sort((a, b) => a.groupId - b.groupId)
+        );
+      });
+
+      it("clears the groups when the update only carries members", async () => {
+        const provisionedGroup = await GroupResource.makeNew({
+          name: "Provisioned Group",
+          workspaceId: workspace.id,
+          kind: "provisioned",
+        });
+
+        const withGroup = await regularSpace.updatePermissions(adminAuth, {
+          name: "Test Space",
+          isRestricted: true,
+          groupIds: [provisionedGroup.sId],
+        });
+        expect(withGroup.isOk()).toBe(true);
+
+        // The request carries the whole membership: a dimension it leaves out is emptied, which
+        // is what an old client switching the space to manual access means.
+        const space = await SpaceResource.fetchById(
+          adminAuth,
+          regularSpace.sId
+        );
+        const membersOnly = await space!.updatePermissions(adminAuth, {
+          name: "Test Space",
+          isRestricted: true,
+          memberIds: [user1.sId],
+        });
+        expect(membersOnly.isOk()).toBe(true);
+
+        expect(
+          await spaceGrantsForGroups([regularGroup, provisionedGroup])
+        ).toEqual([{ groupId: regularGroup.id, grantType: "member" }]);
+      });
+
+      it("clears the members when the update only carries groups", async () => {
+        await regularGroup.dangerouslyAddMembers(adminAuth, {
+          users: [user1.toJSON()],
+        });
+
+        const provisionedGroup = await GroupResource.makeNew({
+          name: "Provisioned Group",
+          workspaceId: workspace.id,
+          kind: "provisioned",
+        });
+
+        const result = await regularSpace.updatePermissions(adminAuth, {
+          name: "Test Space",
+          isRestricted: true,
+          groupIds: [provisionedGroup.sId],
+        });
+        expect(result.isOk()).toBe(true);
+
+        expect(await regularGroup.getActiveMembers(adminAuth)).toEqual([]);
+      });
+
+      it("ignores a legacy managementMode", async () => {
+        await regularGroup.dangerouslyAddMembers(adminAuth, {
+          users: [user1.toJSON()],
+        });
+
+        const provisionedGroup = await GroupResource.makeNew({
+          name: "Provisioned Group",
+          workspaceId: workspace.id,
+          kind: "provisioned",
+        });
+
+        // An old client sends the mode alongside the one dimension it knows about. The mode is
+        // not read: emptying what the request omits gives it the behaviour it expects anyway.
+        const result = await regularSpace.updatePermissions(adminAuth, {
+          name: "Test Space",
+          isRestricted: true,
+          managementMode: "group",
+          groupIds: [provisionedGroup.sId],
+          editorGroupIds: [],
+        });
+        expect(result.isOk()).toBe(true);
+
+        expect(await regularGroup.getActiveMembers(adminAuth)).toEqual([]);
+        expect(
+          await spaceGrantsForGroups([regularGroup, provisionedGroup])
+        ).toEqual(
+          [
+            { groupId: regularGroup.id, grantType: "member" },
+            { groupId: provisionedGroup.id, grantType: "member" },
+          ].sort((a, b) => a.groupId - b.groupId)
+        );
+      });
+
+      it("adds a member one at a time even once a group is attached", async () => {
+        const provisionedGroup = await GroupResource.makeNew({
+          name: "Provisioned Group",
+          workspaceId: workspace.id,
+          kind: "provisioned",
+        });
+
+        const withGroup = await regularSpace.updatePermissions(adminAuth, {
+          name: "Test Space",
+          isRestricted: true,
+          groupIds: [provisionedGroup.sId],
+        });
+        expect(withGroup.isOk()).toBe(true);
+
+        // A regular space's settings show its member list and its groups side by side, so adding
+        // one member is made with the whole picture in view.
+        const space = await SpaceResource.fetchById(
+          adminAuth,
+          regularSpace.sId
+        );
+        expect(await space!.canAddMember(adminAuth, user1.sId)).toBe(true);
+        const addRes = await space!.addMembers(adminAuth, {
+          userIds: [user1.sId],
+        });
+        expect(addRes.isOk()).toBe(true);
+
+        const members = await regularGroup.getActiveMembers(adminAuth);
+        expect(members.map((m) => m.sId)).toEqual([user1.sId]);
+      });
+    });
+
     describe("group management mode", () => {
       it("should successfully update space with group mode and set groups", async () => {
         const provisionedGroup1 = await GroupResource.makeNew({
@@ -955,13 +1101,19 @@ describe("SpaceResource", () => {
     });
 
     describe("management mode persistence", () => {
-      it("should persist managementMode when updating permissions", async () => {
+      // `managementMode` no longer drives anything; it is derived from whether the space has
+      // groups attached, for the clients that still read it.
+      it("should derive managementMode from the attached groups", async () => {
+        const provisionedGroup = await GroupResource.makeNew({
+          name: "Provisioned Group",
+          workspaceId: workspace.id,
+          kind: "provisioned",
+        });
+
         const groupResult = await regularSpace.updatePermissions(adminAuth, {
           name: "Test Space",
           isRestricted: true,
-          managementMode: "group",
-          groupIds: [],
-          editorGroupIds: [],
+          groupIds: [provisionedGroup.sId],
         });
         expect(groupResult.isOk()).toBe(true);
 
@@ -974,9 +1126,8 @@ describe("SpaceResource", () => {
         const manualResult = await updatedSpace!.updatePermissions(adminAuth, {
           name: "Test Space",
           isRestricted: true,
-          managementMode: "manual",
           memberIds: [user1.sId],
-          editorIds: [],
+          groupIds: [],
         });
         expect(manualResult.isOk()).toBe(true);
 
@@ -2720,45 +2871,41 @@ describe("SpaceResource group_permissions enforcement", () => {
     expect(refreshedMemberAuth.can("write", withoutGroup!)).toBe(false);
   });
 
-  it("stops a group-mode group from granting once the space switches to manual", async () => {
+  it("stops an attached group granting once an update drops it", async () => {
     const manualGroup = await GroupFactory.regularManual(workspace, "Squad");
     await GroupFactory.withMembers(adminAuth, manualGroup, [memberUser]);
 
     const space = await SpaceFactory.regular(workspace);
-    const groupModeRes = await space.updatePermissions(adminAuth, {
+    const withGroupRes = await space.updatePermissions(adminAuth, {
       name: space.name,
       isRestricted: true,
-      managementMode: "group",
       groupIds: [manualGroup.sId],
-      editorGroupIds: [],
     });
-    expect(groupModeRes.isOk()).toBe(true);
+    expect(withGroupRes.isOk()).toBe(true);
 
-    const inGroupMode = await SpaceResource.fetchById(adminAuth, space.sId);
+    const withGroup = await SpaceResource.fetchById(adminAuth, space.sId);
     const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
       memberUser.sId,
       workspace.sId
     );
-    expect(memberAuth.can("read", inGroupMode!)).toBe(true);
+    expect(memberAuth.can("read", withGroup!)).toBe(true);
 
-    // Switching back to manual leaves the group_vaults row in place, so only the kind filter in
-    // `spaceGroupRoles` stops it granting in a mode that never selected it.
-    const manualModeRes = await space.updatePermissions(adminAuth, {
+    // An update carries the space's whole membership, so one that lists no group drops this
+    // one's grant and the access it conferred.
+    const membersOnlyRes = await space.updatePermissions(adminAuth, {
       name: space.name,
       isRestricted: true,
-      managementMode: "manual",
       memberIds: [],
-      editorIds: [],
     });
-    expect(manualModeRes.isOk()).toBe(true);
+    expect(membersOnlyRes.isOk()).toBe(true);
 
     const refreshedMemberAuth = await Authenticator.fromUserIdAndWorkspaceId(
       memberUser.sId,
       workspace.sId
     );
-    const inManualMode = await SpaceResource.fetchById(adminAuth, space.sId);
-    expect(refreshedMemberAuth.can("read", inManualMode!)).toBe(false);
-    expect(refreshedMemberAuth.can("write", inManualMode!)).toBe(false);
+    const withoutGroup = await SpaceResource.fetchById(adminAuth, space.sId);
+    expect(refreshedMemberAuth.can("read", withoutGroup!)).toBe(false);
+    expect(refreshedMemberAuth.can("write", withoutGroup!)).toBe(false);
   });
 
   it("rejects internal groups in group management mode", async () => {

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -8,6 +8,7 @@ import type { ConcreteGrantType } from "@app/lib/resources/group_permission_regi
 import { grantTypesForVerb } from "@app/lib/resources/group_permission_registry";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupPermissionModel } from "@app/lib/resources/storage/models/group_permissions";
@@ -37,6 +38,7 @@ import type { GroupType } from "@app/types/groups";
 import {
   GLOBAL_SPACE_NAME,
   isManageableGroupKind,
+  MANAGEABLE_GROUP_KINDS,
   PROJECT_EDITOR_GROUP_PREFIX,
   PROJECT_GROUP_PREFIX,
   SPACE_GROUP_PREFIX,
@@ -50,7 +52,12 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
-import type { EnrichedSpaceType, SpaceKind, SpaceType } from "@app/types/space";
+import type {
+  EnrichedSpaceType,
+  SpaceKind,
+  SpaceMembershipUpdate,
+  SpaceType,
+} from "@app/types/space";
 import assert from "assert";
 import type {
   Attributes,
@@ -999,79 +1006,76 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   // Permissions.
 
+  // Serializes membership updates on this space. `updatePermissions` reads back the dimensions a
+  // request leaves out and then rewrites the space's whole grant set, so two overlapping partial
+  // updates would otherwise lose one another's changes — one of them re-granting a group the other
+  // just removed. Mirrors the grant-tuple lock in `GroupPermissionResource`.
+  private async getMembershipLock(transaction: Transaction): Promise<void> {
+    const key = `space_membership:${this.workspaceId}:${this.id}`;
+    // biome-ignore lint/plugin/noRawSql: advisory lock requires raw SQL
+    await frontSequelize.query("SELECT pg_advisory_xact_lock(hashtext(:key))", {
+      replacements: { key },
+      transaction,
+    });
+  }
+
   // Resolves and validates everything in an `updatePermissions` request that can reject it, before
   // it mutates anything. `updatePermissions` runs in a transaction that only rolls back on a throw
   // — an `Err` return commits — so a request that fails validation halfway through would leave the
-  // space's mode switched and its manual memberships ended.
+  // space's membership half-written.
   //
-  // Returns the groups the request selected (empty in manual mode).
+  // Returns the groups the request selected, member and editor groups apart.
   private async resolveAndValidatePermissionsUpdateGroups(
     auth: Authenticator,
-    params:
-      | { memberIds: string[]; managementMode: "manual"; editorIds: string[] }
-      | {
-          groupIds: string[];
-          managementMode: "group";
-          editorGroupIds: string[];
-        }
+    params: SpaceMembershipUpdate
   ): Promise<
     Result<
-      {
-        selectedGroups: GroupResource[];
-        selectedEditorGroups: GroupResource[];
-      },
+      { memberGroups: GroupResource[]; editorGroups: GroupResource[] },
       DustError<
         "unauthorized" | "group_not_found" | "invalid_group_kind" | "invalid_id"
       >
     >
   > {
-    if (params.managementMode === "manual") {
-      // Admin-controlled Pods have an empty editor group; workspace admins administrate via role.
-      if (
-        this.isProject() &&
-        params.editorIds.length > 0 &&
-        (await this.fetchIsAdminControlled())
-      ) {
-        return new Err(
-          new DustError(
-            "unauthorized",
-            "Editors cannot be set while this Pod is admin-controlled."
-          )
-        );
-      }
-
-      return new Ok({ selectedGroups: [], selectedEditorGroups: [] });
-    }
-
-    const selectedGroupsRes = await GroupResource.fetchByIds(
-      auth,
-      params.groupIds
-    );
-    if (selectedGroupsRes.isErr()) {
-      return selectedGroupsRes;
-    }
-    const selectedGroups = selectedGroupsRes.value;
-
-    let selectedEditorGroups: GroupResource[] = [];
-    if (this.isProject()) {
-      const selectedEditorGroupsRes = await GroupResource.fetchByIds(
-        auth,
-        params.editorGroupIds
+    // Admin-controlled Pods have an empty editor group; workspace admins administrate via role.
+    if (
+      this.isProject() &&
+      (params.editorIds?.length || params.editorGroupIds?.length) &&
+      (await this.fetchIsAdminControlled())
+    ) {
+      return new Err(
+        new DustError(
+          "unauthorized",
+          "Editors cannot be set while this Pod is admin-controlled."
+        )
       );
-      if (selectedEditorGroupsRes.isErr()) {
-        return selectedEditorGroupsRes;
-      }
-      selectedEditorGroups = selectedEditorGroupsRes.value;
     }
+
+    const memberGroupsRes = await GroupResource.fetchByIds(
+      auth,
+      params.groupIds ?? []
+    );
+    if (memberGroupsRes.isErr()) {
+      return memberGroupsRes;
+    }
+
+    // Only projects have editor groups; a regular space's `editorGroupIds` are ignored.
+    const editorGroupsRes = this.isProject()
+      ? await GroupResource.fetchByIds(auth, params.editorGroupIds ?? [])
+      : new Ok([]);
+    if (editorGroupsRes.isErr()) {
+      return editorGroupsRes;
+    }
+
+    const memberGroups = memberGroupsRes.value;
+    const editorGroups = editorGroupsRes.value;
 
     // `fetchByIds` only checks that the caller can read the groups, not what they are. Without
     // this, any readable group could be attached: the global group (which would silently make the
     // space open), another space's regular_auto group (two of those on one space breaks
     // `fetchManualMemberGroup`), or an agent/skill editors group.
-    const unsupportedGroups = [
-      ...selectedGroups,
-      ...selectedEditorGroups,
-    ].filter((group) => !isManageableGroupKind(group.kind));
+    const unsupportedGroups = [...memberGroups, ...editorGroups].filter(
+      (group) => !isManageableGroupKind(group.kind)
+    );
     if (unsupportedGroups.length > 0) {
       return new Err(
         new DustError(
@@ -1081,22 +1085,27 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       );
     }
 
-    return new Ok({ selectedGroups, selectedEditorGroups });
+    return new Ok({ memberGroups, editorGroups });
   }
 
+  /**
+   * Overwrites the space's membership with the request's: its manual member list, its editors
+   * (projects only), and the groups given member and editor access to it. The request carries the
+   * whole desired state — a dimension it leaves out is emptied, not kept — so a client that only
+   * knows about members clears the groups, and the other way around, which is what switching a
+   * space from one to the other has always done.
+   *
+   * The two used to be exclusive, selected by `managementMode`: a space's members were either its
+   * manual list or the members of its groups. They are now merged, and a space's members are its
+   * manual list plus the members of every group attached to it. `managementMode` is still accepted
+   * (and ignored) so that clients sending it are not broken.
+   */
   async updatePermissions(
     auth: Authenticator,
     params: {
       name: string;
       isRestricted: boolean;
-    } & (
-      | { memberIds: string[]; managementMode: "manual"; editorIds: string[] }
-      | {
-          groupIds: string[];
-          managementMode: "group";
-          editorGroupIds: string[];
-        }
-    )
+    } & SpaceMembershipUpdate
   ): Promise<
     Result<
       undefined,
@@ -1131,7 +1140,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       );
     }
 
-    const { isRestricted } = params;
+    // The request is the space's whole desired membership: a dimension it leaves out is emptied.
+    const { isRestricted, memberIds = [], editorIds = [] } = params;
 
     const groupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
     if (groupRes.isErr()) {
@@ -1141,143 +1151,111 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     const globalGroup = groupRes.value;
 
     const result = await withTransaction(async (t) => {
-      // Update managementMode if provided
-      const { managementMode } = params;
+      // Held for the whole update: the membership mutations and the grant rewrite below must not
+      // interleave with another update's.
+      await this.getMembershipLock(t);
 
       // Everything that can reject the request is resolved before anything is mutated: an `Err`
       // returned from this callback does not roll back the transaction (`withTransaction` only
       // rolls back on a throw), so validating later would leave a rejected request having already
-      // switched the mode and ended the space's manual memberships.
+      // rewritten part of the space's membership.
       const requestedGroupsRes =
         await this.resolveAndValidatePermissionsUpdateGroups(auth, params);
       if (requestedGroupsRes.isErr()) {
         return requestedGroupsRes;
       }
-      const { selectedGroups, selectedEditorGroups } = requestedGroupsRes.value;
+      const { memberGroups, editorGroups } = requestedGroupsRes.value;
+
+      const isAdminControlled = await this.fetchIsAdminControlled();
 
       // The space is open (unrestricted) exactly when the workspace global group is one of its
-      // groups. There is no separate group_vaults add/remove: the global group is simply included in
-      // `members` iff the space is (becoming) open.
+      // groups: it is simply included in `members` iff the space is (becoming) open.
       const willBeOpen = !isRestricted;
 
-      const previousManagementMode = this.managementMode;
-      await this.update({ managementMode }, t);
-
-      // Handle member status updates based on management mode changes
-      if (previousManagementMode !== managementMode) {
-        if (managementMode === "group") {
-          // When switching to group mode, end the memberships of the space's own groups
-          await this.endManualGroupMembers(auth, t);
-        } else if (
-          managementMode === "manual" &&
-          previousManagementMode === "group"
-        ) {
-          // When switching from group to manual mode, restore the memberships left suspended by
-          // the previous behaviour (a no-op once the backfill has run).
-          await this.restoreManualGroupMembers(auth, t);
-        }
+      // The space's own groups always hold its manual members, alongside the attached groups.
+      const memberGroup = await this.fetchManualMemberGroup(auth, t);
+      const members: GroupResource[] = [memberGroup, ...memberGroups];
+      if (willBeOpen) {
+        members.push(globalGroup);
       }
 
-      // The desired member/editor group sets for this space, written once into group_permissions at
-      // the end of the transaction (or on an early membership-mutation error, so the grants still
-      // reflect the group associations).
-      const members: GroupResource[] = [];
       const editors: GroupResource[] = [];
+      if (this.isProject()) {
+        let manualEditorGroup = await this.fetchManualEditorGroup(auth, t);
+        if (!manualEditorGroup) {
+          manualEditorGroup = await GroupResource.makeNew(
+            {
+              name: `${PROJECT_EDITOR_GROUP_PREFIX} ${this.name}`,
+              kind: "regular_auto",
+              workspaceId: this.workspaceId,
+            },
+            { transaction: t }
+          );
+        }
+        editors.push(manualEditorGroup, ...editorGroups);
+      }
+
+      // Written once, after the membership mutations below — or on one of their errors, so the
+      // grants still reflect the space's group set.
       const syncGroupPermissions = async () =>
         this.writeGroupPermissions(auth, { members, editors, transaction: t });
 
-      if (managementMode === "manual") {
-        const memberIds = params.memberIds;
-        const editorIds = params.editorIds;
+      const manualEditorGroup = this.isProject() ? editors[0] : null;
 
-        assert(
-          memberIds.every((id) => !editorIds.includes(id)),
-          "A user cannot be both a member and an editor of the same space."
-        );
+      assert(
+        memberIds.every((id) => !editorIds.includes(id)),
+        "A user cannot be both a member and an editor of the same space."
+      );
 
-        // Admin-controlled Pods have an empty editor group; workspace admins administrate via
-        // role. `resolveAndValidatePermissionsUpdate` already rejected any attempt to set editors.
-        const isAdminControlled = await this.fetchIsAdminControlled();
+      const users = await UserResource.fetchByIds(memberIds);
+      const setMembersRes = await memberGroup.dangerouslySetMembers(auth, {
+        users: users.map((u) => u.toJSON()),
+        transaction: t,
+      });
+      if (setMembersRes.isErr()) {
+        await syncGroupPermissions();
+        return setMembersRes;
+      }
 
-        // Handle member-based management
-        const users = await UserResource.fetchByIds(memberIds);
-
-        const memberGroup = await this.fetchManualMemberGroup(auth, t);
-        members.push(memberGroup);
-        if (willBeOpen) {
-          members.push(globalGroup);
-        }
-
-        // Handle editor group - create if needed and update members
-        if (this.isProject()) {
-          let editorGroup = await this.fetchManualEditorGroup(auth, t);
-          if (!editorGroup) {
-            // Create a new editor group (no group_vaults row; the grant is written below).
-            editorGroup = await GroupResource.makeNew(
-              {
-                name: `${PROJECT_EDITOR_GROUP_PREFIX} ${this.name}`,
-                kind: "regular_auto",
-                workspaceId: this.workspaceId,
-              },
-              { transaction: t }
-            );
-          }
-          editors.push(editorGroup);
-        }
-
-        const setMembersRes = await memberGroup.dangerouslySetMembers(auth, {
-          users: users.map((u) => u.toJSON()),
-          transaction: t,
-        });
-        if (setMembersRes.isErr()) {
-          await syncGroupPermissions();
-          return setMembersRes;
-        }
-
-        if (this.isProject()) {
-          const [editorGroup] = editors;
-          const editorUsers = await UserResource.fetchByIds(editorIds);
-          assert(
-            editorUsers.length > 0 || isAdminControlled,
-            "Pods must have at least one editor."
-          );
-          const setEditorsRes = await editorGroup.dangerouslySetMembers(auth, {
+      if (manualEditorGroup) {
+        const editorUsers = await UserResource.fetchByIds(editorIds);
+        const setEditorsRes = await manualEditorGroup.dangerouslySetMembers(
+          auth,
+          {
             users: editorUsers.map((u) => u.toJSON()),
             transaction: t,
-          });
-          if (setEditorsRes.isErr()) {
-            await syncGroupPermissions();
-            return setEditorsRes;
           }
-        }
-      } else if (managementMode === "group") {
-        // The space's regular_auto member group (and, for projects, its regular_auto editor group)
-        // are kept alongside the selected provisioned groups — group mode adds provisioned grants on
-        // top of the manual groups rather than replacing them. Deselecting a group removes its
-        // access for free: writeGroupPermissions rewrites the space's whole grant set from the
-        // members/editors accumulated here.
-        const memberGroup = await this.fetchManualMemberGroup(auth, t);
-        members.push(memberGroup);
-        if (willBeOpen) {
-          members.push(globalGroup);
-        }
-
-        // Add the selected groups, resolved and kind-checked before any mutation.
-        members.push(...selectedGroups);
-
-        if (this.isProject()) {
-          const manualEditorGroup = await this.fetchManualEditorGroup(auth, t);
-          if (manualEditorGroup) {
-            editors.push(manualEditorGroup);
-          }
-
-          assert(
-            selectedEditorGroups.length > 0,
-            "Pods must have at least one editor group."
-          );
-          editors.push(...selectedEditorGroups);
+        );
+        if (setEditorsRes.isErr()) {
+          await syncGroupPermissions();
+          return setEditorsRes;
         }
       }
+
+      // A Pod is administrated by its editors, so it must keep at least one — held by its own
+      // editor group or by an attached group. Admin-controlled Pods are the exception: workspace
+      // admins administrate them by role and the editor group is empty by design.
+      if (manualEditorGroup && !isAdminControlled) {
+        const manualEditors = await manualEditorGroup.getActiveMembers(auth, {
+          transaction: t,
+        });
+        assert(
+          manualEditors.length > 0 || editorGroups.length > 0,
+          "Pods must have at least one editor."
+        );
+      }
+
+      // `managementMode` no longer drives anything: it is kept up to date only so that clients
+      // that still read it see something coherent, and goes away with the field.
+      await this.update(
+        {
+          managementMode:
+            memberGroups.length > 0 || editorGroups.length > 0
+              ? "group"
+              : "manual",
+        },
+        t
+      );
 
       // Write the updated group associations into group_permissions
       await syncGroupPermissions();
@@ -1319,10 +1297,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     >
   > {
     assert(this.isProject(), "Only projects support admin-controlled mode.");
-    assert(
-      this.managementMode === "manual",
-      "Admin-controlled mode requires manual membership management."
-    );
 
     if (!auth.isAdmin()) {
       return new Err(
@@ -1334,6 +1308,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     }
 
     return withTransaction(async (t: Transaction) => {
+      // Serialized against `updatePermissions`, which reads and rewrites the same groups.
+      await this.getMembershipLock(t);
+
       const editorGroup = await this.fetchManualEditorGroup(auth, t);
       const memberGroup = await this.fetchManualMemberGroup(auth, t);
       assert(editorGroup, "A project must have a manual editor group.");
@@ -1473,10 +1450,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       this.isRegular() || this.isProject(),
       "Only regular spaces and projects can have manual members."
     );
-    assert(
-      this.managementMode === "manual",
-      "Can only add members in manual management mode."
-    );
 
     const users = await UserResource.fetchByIds(userIds);
     const foundIds = new Set(users.map((user) => user.sId));
@@ -1556,10 +1529,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     }
 
     assert(this.isProject(), "Only projects can have editors.");
-    assert(
-      this.managementMode === "manual",
-      "Can only add editors in manual management mode."
-    );
 
     const users = await UserResource.fetchByIds(userIds);
     const foundIds = new Set(users.map((user) => user.sId));
@@ -1650,10 +1619,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     }
 
     assert(this.isProject(), "Only projects can have editors.");
-    assert(
-      this.managementMode === "manual",
-      "Can only remove editors in manual management mode."
-    );
 
     const users = await UserResource.fetchByIds(userIds);
     if (users.length === 0) {
@@ -1670,6 +1635,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return new Ok([]);
     }
 
+    // A Pod must keep at least one editor. Only the manual list is counted: this path is refused
+    // outright when a group is attached (see the guard above).
     if (activeEditors.length - usersToRemove.length < 1) {
       return new Err(
         new DustError(
@@ -1925,6 +1892,46 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       await this.fetchGrantReferences(transaction)
     ).filter((group) => !group.isReader());
     return this.fetchGroupResources(auth, { groupReferences, transaction });
+  }
+
+  // The manageable (provisioned / regular_manual) groups attached to this space, split by what
+  // their grant confers. These are the groups an admin selects; the space's own regular_auto
+  // groups and the workspace global group are excluded — they are not selectable.
+  async fetchAttachedManageableGroups(
+    auth: Authenticator,
+    transaction?: Transaction
+  ): Promise<{ memberGroups: GroupResource[]; editorGroups: GroupResource[] }> {
+    const references = await this.fetchGrantReferences(transaction);
+    const groups = await this.fetchGroupResources(auth, {
+      groupReferences: references,
+      transaction,
+    });
+
+    const memberGroups: GroupResource[] = [];
+    const editorGroups: GroupResource[] = [];
+
+    // `fetchGroupResources` preserves the order of the references it is given.
+    references.forEach((reference, index) => {
+      const group = groups[index];
+      if (!isManageableGroupKind(group.kind)) {
+        return;
+      }
+      if (reference.grantType === SPACE_EDITOR_GRANT_TYPE) {
+        editorGroups.push(group);
+      } else {
+        memberGroups.push(group);
+      }
+    });
+
+    return { memberGroups, editorGroups };
+  }
+
+  // Whether any group is attached to this space, i.e. part of its access comes from a group's
+  // membership rather than from the space's own member list.
+  async hasAttachedGroups(auth: Authenticator): Promise<boolean> {
+    const { memberGroups, editorGroups } =
+      await this.fetchAttachedManageableGroups(auth);
+    return memberGroups.length > 0 || editorGroups.length > 0;
   }
 
   // The space's manual member group: the regular_auto group holding this space's membership. A
@@ -2185,14 +2192,10 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       }));
     }
 
-    // A manually-managed space draws its access from its own auto-created groups, plus the
-    // workspace global group when it is open. The groups a user can pick in group mode —
-    // provisioned and manual alike — keep their `group_vaults` rows when the space switches back to
-    // manual, so they are filtered out here rather than granting in a mode that never selected them.
-    const groups =
-      this.managementMode === "manual"
-        ? associatedGroups.filter((group) => !isManageableGroupKind(group.kind))
-        : associatedGroups;
+    // A regular space or Pod draws its access from its own auto-created groups, the groups
+    // attached to it, and the workspace global group when it is open. The caller passes the group
+    // set it just computed, so every group in it is granted.
+    const groups = associatedGroups;
 
     // A space is open when the workspace global group is one of its groups.
     const isOpen = associatedGroups.some((group) => group.isGlobal());
@@ -2314,11 +2317,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return false;
     }
 
-    // Can only add members in manual management mode.
-    if (this.managementMode !== "manual") {
-      return false;
-    }
-
     // Assert the space still has exactly one manual member group (invariant preserved from the
     // former GroupSpaceMemberResource path).
     await this.fetchManualMemberGroup(auth);
@@ -2408,6 +2406,48 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     }
 
     return openSpaceModelIds;
+  }
+
+  // The model ids of the `spaces` that have at least one manageable (provisioned / regular_manual)
+  // group attached — spaces whose membership is (partly) backed by a directory group rather than
+  // by a hand-picked member list. Two queries for the whole batch.
+  static async listSpaceModelIdsWithAttachedGroups(
+    auth: Authenticator,
+    spaces: SpaceResource[]
+  ): Promise<Set<ModelId>> {
+    const spaceModelIds = new Set<ModelId>();
+    if (spaces.length === 0) {
+      return spaceModelIds;
+    }
+
+    const grants = await GroupPermissionModel.findAll({
+      attributes: ["resourceId", "groupId"],
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        resourceType: "space",
+        resourceId: spaces.map((space) => space.id),
+      },
+    });
+    if (grants.length === 0) {
+      return spaceModelIds;
+    }
+
+    const manageableGroups = await GroupResource.dangerouslyFetchByModelIds(
+      auth,
+      [...new Set(grants.map((grant) => grant.groupId))],
+      { groupKinds: [...MANAGEABLE_GROUP_KINDS] }
+    );
+    const manageableGroupModelIds = new Set(
+      manageableGroups.map((group) => group.id)
+    );
+
+    for (const grant of grants) {
+      if (manageableGroupModelIds.has(grant.groupId)) {
+        spaceModelIds.add(grant.resourceId);
+      }
+    }
+
+    return spaceModelIds;
   }
 
   isDeletable() {

--- a/front/scripts/ensure_pod_sandbox.ts
+++ b/front/scripts/ensure_pod_sandbox.ts
@@ -78,8 +78,6 @@ makeScript(
         name,
         isRestricted: true,
         spaceKind: "project",
-        managementMode: "manual",
-        memberIds: [],
       });
       if (createResult.isErr()) {
         logger.error({ err: createResult.error }, "Pod creation failed");

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -643,7 +643,7 @@ async function autoCreateSpaceForProvisionedGroup(
     return;
   }
 
-  // Create restricted space with group-based management
+  // Create a restricted space whose access comes from the provisioned group.
   const spaceName = group.name;
 
   const spaceResult = await createSpaceAndGroup(
@@ -652,7 +652,6 @@ async function autoCreateSpaceForProvisionedGroup(
       name: spaceName,
       groupIds: [group.sId],
       isRestricted: true,
-      managementMode: "group",
       spaceKind: "regular",
     },
     { ignoreWorkspaceLimit: false }

--- a/front/types/api/spaces.ts
+++ b/front/types/api/spaces.ts
@@ -53,23 +53,17 @@ export type PatchPodMetadataBodyType = z.infer<
   typeof PatchPodMetadataBodySchema
 >;
 
-export const PostSpaceRequestBodySchema = z.intersection(
-  z.object({
-    isRestricted: z.boolean(),
-    name: z.string(),
-    spaceKind: z.enum(["regular", "project"]),
-  }),
-  z.discriminatedUnion("managementMode", [
-    z.object({
-      memberIds: z.array(z.string()),
-      managementMode: z.literal("manual"),
-    }),
-    z.object({
-      groupIds: z.array(z.string()),
-      managementMode: z.literal("group"),
-    }),
-  ])
-);
+// A new space's members: its manual member list, the groups given access to it, or both. A
+// dimension the request leaves out is simply not seeded, and `managementMode` is ignored (see
+// `PatchSpaceMembersRequestBodySchema` for the same shape on update).
+export const PostSpaceRequestBodySchema = z.object({
+  isRestricted: z.boolean(),
+  name: z.string(),
+  spaceKind: z.enum(["regular", "project"]),
+  memberIds: z.array(z.string()).optional(),
+  groupIds: z.array(z.string()).optional(),
+  managementMode: z.enum(["manual", "group"]).optional(),
+});
 
 export type PostSpaceRequestBodyType = z.infer<
   typeof PostSpaceRequestBodySchema

--- a/front/types/space.ts
+++ b/front/types/space.ts
@@ -16,6 +16,26 @@ export type SpaceKind = (typeof SPACE_KINDS)[number];
 
 type UniqueSpaceKind = (typeof UNIQUE_SPACE_KINDS)[number];
 /**
+ * A space's whole desired membership. Every dimension is optional, and one the request leaves out
+ * is emptied rather than kept: the request describes the end state, not a patch.
+ *
+ * - `memberIds` / `editorIds`: the space's manual member and editor lists (editors are Pod-only).
+ * - `groupIds` / `editorGroupIds`: the groups given member and editor access to the space.
+ *
+ * `managementMode` is legacy and ignored. The two used to be exclusive — a space was managed
+ * either by a manual member list or by groups — and clients that still send the field get the
+ * behaviour they expect for free: the dimension their mode does not cover is one they do not
+ * send, and so is emptied. Dropped once no client sends it.
+ */
+export type SpaceMembershipUpdate = {
+  memberIds?: string[];
+  editorIds?: string[];
+  groupIds?: string[];
+  editorGroupIds?: string[];
+  managementMode?: "manual" | "group";
+};
+
+/**
  * @swaggerschema PrivateSpace (swagger_private_schemas.ts)
  */
 export type SpaceType = {


### PR DESCRIPTION
## Description

Second of 4 PRs merging the two ways a space gets its members. Stacked on #31899.

A space's members were either a manual list or the members of the groups attached to it, never both: `vaults.managementMode` picked one, and the other was dropped. They are now merged: a space's members are its manual list **plus** every member of every group attached to it.

`updatePermissions` takes each dimension on its own (`memberIds`, `editorIds`, `groupIds`, `editorGroupIds`): the ones a request carries are overwritten, the ones it leaves out keep their current value. So the UI can keep sending only members, or only groups.

Nothing switches modes any more. 

UI still switch between both mode, when saved it overrides everything

## Tests

 - added new unit tests to cover this

## Risk

Large blast radius: it rewrites the space permission path, which is what every space read is checked against.

## Deploy Plan

- Deploy front

Requires #31899 and its backfill to have run first: this PR removes the guards that kept a suspended member list from coming back.
