### PR TITLE
admin governance: space settings send members and groups together

### DIFF
--- a/front/components/assistant/conversation/CreatePodModal.tsx
+++ b/front/components/assistant/conversation/CreatePodModal.tsx
@@ -94,7 +94,6 @@ export function CreatePodModal({
       {
         name: trimmedName,
         isRestricted: !isPodOpen,
-        managementMode: "manual",
         memberIds: [],
         spaceKind: "project",
       },

--- a/front/components/assistant/conversation/space/ManageUsersPanel.tsx
+++ b/front/components/assistant/conversation/space/ManageUsersPanel.tsx
@@ -115,7 +115,6 @@ export function ManageUsersPanel(props: ManageUsersPanelProps) {
           isRestricted: props.space.isRestricted,
           memberIds,
           editorIds,
-          managementMode: "manual",
           name: props.space.name,
         },
         {

--- a/front/components/pages/spaces/SpacePage.tsx
+++ b/front/components/pages/spaces/SpacePage.tsx
@@ -14,8 +14,7 @@ export function SpacePage() {
   const router = useAppRouter();
   const spaceId = useRequiredPathParam("spaceId");
   const owner = useWorkspace();
-  const { subscription, isAdmin } = useAuth();
-  const plan = subscription.plan;
+  const { isAdmin } = useAuth();
 
   const {
     spaceInfo: space,
@@ -83,7 +82,6 @@ export function SpacePage() {
           onClose={() => setShowSpaceEditionModal(false)}
           space={space}
           isAdmin={isAdmin}
-          plan={plan}
         />
       </Page.Vertical>
     </SpaceSearchInput>

--- a/front/components/pod/settings/PodMembersTable.tsx
+++ b/front/components/pod/settings/PodMembersTable.tsx
@@ -84,7 +84,6 @@ export function PodMembersTable({
             .filter((member) => !member.isEditor)
             .map((member) => member.sId),
           editorIds: updatedMembers.filter((m) => m.isEditor).map((m) => m.sId),
-          managementMode: "manual",
           name: pod.name,
         },
         {
@@ -138,7 +137,6 @@ export function PodMembersTable({
           editorIds: updatedMembers
             .filter((member) => member.isEditor)
             .map((member) => member.sId),
-          managementMode: "manual",
           name: pod.name,
         },
         {

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -375,7 +375,6 @@ export function PodSettingsTab({
         isRestricted,
         memberIds: podMembers.filter((m) => !m.isEditor).map((m) => m.sId),
         editorIds: podMembers.filter((m) => m.isEditor).map((m) => m.sId),
-        managementMode: "manual",
         name: newPodName,
       },
       {
@@ -469,7 +468,6 @@ export function PodSettingsTab({
         isRestricted: !newIsOpen,
         memberIds: podMembers.filter((m) => !m.isEditor).map((m) => m.sId),
         editorIds: podMembers.filter((m) => m.isEditor).map((m) => m.sId),
-        managementMode: "manual",
         name: pod.name,
       },
       {

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -3,7 +3,6 @@ import { ConfirmDeleteSpaceDialog } from "@app/components/spaces/ConfirmDeleteSp
 import { RestrictedAccessBody } from "@app/components/spaces/RestrictedAccessBody";
 import { RestrictedAccessHeader } from "@app/components/spaces/RestrictedAccessHeader";
 import { useAuth } from "@app/lib/auth/AuthContext";
-import { isSCIMEnabled } from "@app/lib/plans/scim";
 import { useAppRouter } from "@app/lib/platform";
 import { useGroups } from "@app/lib/swr/groups";
 import {
@@ -15,10 +14,10 @@ import {
 import type { SpaceCategoryInfo } from "@app/types/api/spaces";
 import type { GroupType } from "@app/types/groups";
 import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
-import type { PlanType } from "@app/types/plan";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
+  ContentMessage,
   Input,
   Page,
   Separator,
@@ -33,8 +32,6 @@ import {
 import * as React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-type MembersManagementType = "manual" | "group";
-
 interface CreateOrEditSpaceModalProps {
   defaultRestricted?: boolean;
   isAdmin: boolean;
@@ -43,7 +40,6 @@ interface CreateOrEditSpaceModalProps {
   onCreated?: (space: SpaceType) => void;
   owner: LightWorkspaceType;
   space?: SpaceType;
-  plan: PlanType;
 }
 
 export function CreateOrEditSpaceModal({
@@ -54,7 +50,6 @@ export function CreateOrEditSpaceModal({
   onCreated,
   owner,
   space,
-  plan,
 }: CreateOrEditSpaceModalProps) {
   const confirm = React.useContext(ConfirmContext);
   const [spaceName, setSpaceName] = useState<string>(space?.name ?? "");
@@ -68,18 +63,9 @@ export function CreateOrEditSpaceModal({
   const [isSaving, setIsSaving] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isRestricted, setIsRestricted] = useState(false);
-  const [managementType, setManagementType] =
-    useState<MembersManagementType>("manual");
   const [isDirty, setIsDirty] = useState(false);
 
-  const scimEnabled = isSCIMEnabled(plan);
   const { user } = useAuth();
-
-  useEffect(() => {
-    if (!scimEnabled) {
-      setManagementType("manual");
-    }
-  }, [scimEnabled]);
 
   const doCreate = useCreateSpace({ owner });
   const doUpdate = useUpdateSpace({ owner });
@@ -87,37 +73,35 @@ export function CreateOrEditSpaceModal({
 
   const router = useAppRouter();
 
-  const { spaceInfo, mutateSpaceInfo, isSpaceInfoLoading } = useSpaceInfo({
-    workspaceId: owner.sId,
-    spaceId: space?.sId ?? null,
-    includeAllMembers: true, // Include members whose membership is not active yet.
-  });
+  const { spaceInfo, mutateSpaceInfo, isSpaceInfoLoading, isSpaceInfoError } =
+    useSpaceInfo({
+      workspaceId: owner.sId,
+      spaceId: space?.sId ?? null,
+      includeAllMembers: true, // Include members whose membership is not active yet.
+    });
 
-  const { groups } = useGroups({
+  const { groups, isGroupsLoading, isGroupsError } = useGroups({
     owner,
     kinds: MANAGEABLE_GROUP_KINDS,
-    disabled: !scimEnabled,
   });
+
+  // A save carries the space's whole membership, both lists at once, so the sheet must not open
+  // on half of it: `useSpaceInfo` seeds the selected members and groups, and `useGroups` names the
+  // groups that can be picked. Either one still loading and a save would write an empty list.
+  const isAccessLoading = (!!space && isSpaceInfoLoading) || isGroupsLoading;
+
+  // Either one failing blocks the save outright, for the same reason: the sheet cannot send a
+  // membership it does not know.
+  const isAccessUnavailable = (!!space && !!isSpaceInfoError) || isGroupsError;
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   useEffect(() => {
     if (isOpen) {
       const spaceMembers = spaceInfo?.members ?? null;
 
-      // Initialize management type from space data (if editing) or default to manual for new spaces
-      if (spaceInfo?.managementMode !== undefined) {
-        setManagementType(spaceInfo.managementMode);
-      } else {
-        setManagementType("manual");
-      }
-
-      // Initialize selected groups based on space's groupIds (only if workos feature is enabled)
-      if (
-        scimEnabled &&
-        spaceInfo?.groupIds &&
-        spaceInfo.groupIds.length > 0 &&
-        groups
-      ) {
+      // Initialize the selected groups from the space's grants, once the workspace's groups have
+      // loaded (`groups` also holds what a group is called, and which of them are selectable).
+      if (!isAccessLoading && spaceInfo?.groupIds?.length) {
         const spaceGroups = groups.filter((group) =>
           spaceInfo.groupIds.includes(group.sId)
         );
@@ -147,9 +131,9 @@ export function CreateOrEditSpaceModal({
     }
   }, [
     defaultRestricted,
+    isAccessLoading,
     groups,
     isOpen,
-    scimEnabled,
     setSpaceName,
     spaceInfo,
     user,
@@ -166,7 +150,6 @@ export function CreateOrEditSpaceModal({
       setIsRestricted(false);
       setSelectedMemberIds(new Set());
       setSelectedGroups([]);
-      setManagementType("manual");
       setIsDeleting(false);
       setIsSaving(false);
       setIsDirty(false);
@@ -197,47 +180,28 @@ export function CreateOrEditSpaceModal({
 
     setIsSaving(true);
 
+    // Both lists are always sent: a space's members are the manual list plus the members of the
+    // groups given access to it, and the request describes the whole membership.
+    const groupIds = selectedGroups.map((group) => group.sId);
+
     if (space) {
-      if (scimEnabled && managementType === "group") {
-        await doUpdate(space, {
-          isRestricted,
-          groupIds: selectedGroups.map((group) => group.sId),
-          editorGroupIds: [],
-          managementMode: "group",
-          name: trimmedName,
-        });
-      } else {
-        await doUpdate(space, {
-          isRestricted,
-          memberIds: Array.from(selectedMemberIds),
-          editorIds: [],
-          managementMode: "manual",
-          name: trimmedName,
-        });
-      }
+      await doUpdate(space, {
+        isRestricted,
+        memberIds: Array.from(selectedMemberIds),
+        groupIds,
+        name: trimmedName,
+      });
 
       // FIXME: we should update the page space's name as well.
       await mutateSpaceInfo();
     } else if (!space) {
-      let createdSpace;
-
-      if (scimEnabled && managementType === "group") {
-        createdSpace = await doCreate({
-          name: trimmedName,
-          isRestricted,
-          groupIds: selectedGroups.map((group) => group.sId),
-          managementMode: "group",
-          spaceKind: "regular",
-        });
-      } else {
-        createdSpace = await doCreate({
-          name: trimmedName,
-          isRestricted,
-          memberIds: Array.from(selectedMemberIds),
-          managementMode: "manual",
-          spaceKind: "regular",
-        });
-      }
+      const createdSpace = await doCreate({
+        name: trimmedName,
+        isRestricted,
+        memberIds: Array.from(selectedMemberIds),
+        groupIds,
+        spaceKind: "regular",
+      });
 
       setIsSaving(false);
       if (createdSpace && onCreated) {
@@ -258,9 +222,7 @@ export function CreateOrEditSpaceModal({
     spaceInfo,
     selectedMemberIds,
     spaceName,
-    managementType,
     selectedGroups,
-    scimEnabled,
   ]);
 
   const onDelete = useCallback(async () => {
@@ -279,21 +241,16 @@ export function CreateOrEditSpaceModal({
     }
   }, [doDelete, handleClose, owner.sId, router, space]);
 
-  const handleManagementTypeChange = useCallback(
-    (managementType: MembersManagementType) => {
-      setManagementType(managementType);
-      setIsDirty(true);
-    },
-    []
-  );
-
   const disabled = useMemo(() => {
     const hasName = spaceName.trim().length > 0;
 
+    // A restricted space needs someone in it: a member, or a group that has members.
     const canSave =
-      !isRestricted ||
-      (managementType === "manual" && selectedMemberIds.size > 0) ||
-      (managementType === "group" && selectedGroups.length > 0);
+      !isRestricted || selectedMemberIds.size > 0 || selectedGroups.length > 0;
+
+    if (isAccessLoading || isAccessUnavailable) {
+      return true;
+    }
 
     if (!spaceInfo) {
       return !canSave || !hasName;
@@ -302,21 +259,14 @@ export function CreateOrEditSpaceModal({
     return !isDirty || !canSave || !hasName;
   }, [
     isRestricted,
-    managementType,
     selectedMemberIds.size,
     selectedGroups.length,
     spaceInfo,
     isDirty,
     spaceName,
+    isAccessLoading,
+    isAccessUnavailable,
   ]);
-  const isManual = !scimEnabled || managementType === "manual";
-
-  // When editing an existing space, hold the access section back until its members have loaded: the
-  // toggle's state and the member table's contents both come from `spaceInfo`, and the table seeds
-  // its display cache once, at mount. Rendering it early shows an empty member list.
-  // `isSpaceInfoLoading` stays true when there is no space (the hook is disabled), hence the guard.
-  const isLoadingSpaceInfo = !!space && isSpaceInfoLoading;
-
   const handleNameChange = useCallback((value: string) => {
     setSpaceName(value);
     setIsDirty(true);
@@ -344,10 +294,17 @@ export function CreateOrEditSpaceModal({
               isDeleting={isDeleting}
             />
 
-            {isLoadingSpaceInfo ? (
+            {isAccessLoading ? (
               <div className="flex justify-center p-8">
                 <Spinner />
               </div>
+            ) : isAccessUnavailable ? (
+              <ContentMessage
+                variant="warning"
+                title="Access settings unavailable"
+              >
+                Failed to load group members, please reload the page.
+              </ContentMessage>
             ) : (
               <>
                 <RestrictedAccessHeader
@@ -394,13 +351,9 @@ export function CreateOrEditSpaceModal({
                 {/* Shown in both states: an open space still has members, and they are the ones
                     who can write to it. The toggle only controls who can read. */}
                 <RestrictedAccessBody
-                  isManual={isManual}
-                  scimEnabled={scimEnabled}
-                  managementType={managementType}
                   owner={owner}
                   selectedMemberIds={selectedMemberIds}
                   selectedGroups={selectedGroups}
-                  onManagementTypeChange={handleManagementTypeChange}
                   onMemberIdsUpdated={(memberIds) => {
                     setSelectedMemberIds(memberIds);
                     setIsDirty(true);

--- a/front/components/spaces/RestrictedAccessBody.tsx
+++ b/front/components/spaces/RestrictedAccessBody.tsx
@@ -1,162 +1,54 @@
-import { ConfirmContext } from "@app/components/Confirm";
 import { GroupSelectionTable } from "@app/components/groups/GroupSelectionTable";
 import type { SearchMemberType } from "@app/components/members/MemberSelectionTable";
 import { MemberSelectionTable } from "@app/components/members/MemberSelectionTable";
 import type { GroupType } from "@app/types/groups";
 import type { LightWorkspaceType } from "@app/types/user";
-import {
-  Button,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@dust-tt/sparkle";
-import { useContext, useMemo } from "react";
-
-type MembersManagementType = "manual" | "group";
-
-function isMembersManagementType(
-  value: string
-): value is MembersManagementType {
-  return value === "manual" || value === "group";
-}
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@dust-tt/sparkle";
+import { useState } from "react";
 
 interface RestrictedAccessBodyProps {
-  isManual: boolean;
-  scimEnabled: boolean;
-  managementType: MembersManagementType;
   owner: LightWorkspaceType;
   selectedMemberIds: Set<string>;
   selectedGroups: GroupType[];
-  onManagementTypeChange: (managementType: MembersManagementType) => void;
   onMemberIdsUpdated: (memberIds: Set<string>) => void;
   onGroupsUpdated: (groups: GroupType[]) => void;
   initialMembers?: SearchMemberType[];
 }
 
 export function RestrictedAccessBody({
-  isManual,
-  scimEnabled,
-  managementType,
   owner,
   selectedMemberIds,
   selectedGroups,
-  onManagementTypeChange,
   onMemberIdsUpdated,
   onGroupsUpdated,
   initialMembers,
 }: RestrictedAccessBodyProps) {
-  const confirm = useContext(ConfirmContext);
+  const [activeTab, setActiveTab] = useState("members");
 
-  const selectedGroupIds = useMemo(
-    () => new Set(selectedGroups.map((g) => g.sId)),
-    [selectedGroups]
-  );
-
-  const handleMemberSelectionChange = (ids: Set<string>) => {
-    onMemberIdsUpdated(ids);
-  };
-
-  const handleGroupSelectionChange = (
-    _ids: Set<string>,
-    groups: GroupType[]
-  ) => {
-    onGroupsUpdated(groups);
-  };
-
-  const handleManagementTypeChange = async (newManagementType: string) => {
-    if (!isMembersManagementType(newManagementType) || !scimEnabled) {
-      return;
-    }
-
-    if (
-      managementType === "manual" &&
-      newManagementType === "group" &&
-      selectedMemberIds.size > 0
-    ) {
-      const confirmed = await confirm({
-        title: "Switch to groups",
-        message:
-          "This switches from manual member to group-based access. " +
-          "Your current member list will be removed; you'll need to re-add " +
-          "members to switch back.",
-        validateLabel: "Confirm",
-        validateVariant: "primary",
-      });
-
-      if (confirmed) {
-        onManagementTypeChange("group");
-      }
-    } else if (
-      managementType === "group" &&
-      newManagementType === "manual" &&
-      selectedGroups.length > 0
-    ) {
-      const confirmed = await confirm({
-        title: "Switch to members",
-        message:
-          "This switches from group-based access to manual member management. " +
-          "Your current group selection will be removed; you'll need to re-select groups to switch back.",
-        validateLabel: "Confirm",
-        validateVariant: "primary",
-      });
-
-      if (confirmed) {
-        onManagementTypeChange("manual");
-      }
-    } else {
-      onManagementTypeChange(newManagementType);
-    }
-  };
-
+  // Members and groups are not exclusive: the space's members are the ones picked here plus the
+  // members of the groups picked in the other tab. The tabs only decide which one is on screen —
+  // saving always sends both.
   return (
-    <>
-      {scimEnabled && (
-        <div className="flex flex-row items-center justify-between">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                isSelect
-                label={
-                  managementType === "manual" ? "Manual access" : "Group access"
-                }
-              />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              <DropdownMenuItem
-                label="Manual access"
-                onClick={() => {
-                  void handleManagementTypeChange("manual");
-                }}
-              />
-              <DropdownMenuItem
-                label="Group access"
-                onClick={() => {
-                  void handleManagementTypeChange("group");
-                }}
-              />
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      )}
-
-      {isManual && (
+    <Tabs value={activeTab} onValueChange={setActiveTab}>
+      <TabsList>
+        <TabsTrigger value="members" label="Members" />
+        <TabsTrigger value="groups" label="Groups" />
+      </TabsList>
+      <TabsContent value="members">
         <MemberSelectionTable
           owner={owner}
           selectedMemberIds={selectedMemberIds}
-          onSelectionChange={handleMemberSelectionChange}
+          onSelectionChange={onMemberIdsUpdated}
           initialMembers={initialMembers}
         />
-      )}
-
-      {!isManual && (
+      </TabsContent>
+      <TabsContent value="groups">
         <GroupSelectionTable
           owner={owner}
-          selectedGroupIds={selectedGroupIds}
-          onSelectionChange={handleGroupSelectionChange}
+          selectedGroupIds={new Set(selectedGroups.map((g) => g.sId))}
+          onSelectionChange={(_ids, groups) => onGroupsUpdated(groups)}
         />
-      )}
-    </>
+      </TabsContent>
+    </Tabs>
   );
 }

--- a/front/components/spaces/SpaceLayout.tsx
+++ b/front/components/spaces/SpaceLayout.tsx
@@ -123,7 +123,6 @@ export function SpaceLayout({ children }: SpaceLayoutProps) {
             void router.push(`/w/${owner.sId}/spaces/${space.sId}`);
           }}
           defaultRestricted={spaceCreationModalState.defaultRestricted}
-          plan={plan}
         />
       )}
       {isAdmin && isLimitReached && (

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -556,70 +556,31 @@ export function useCreateSpace({ owner }: { owner: LightWorkspaceType }) {
     params: PostSpaceRequestBodyType,
     notification?: { title: string; description: string }
   ) => {
-    const { name, managementMode, isRestricted, spaceKind } = params;
+    const { name, memberIds, groupIds, isRestricted, spaceKind } = params;
 
     if (!name) {
       return null;
     }
 
-    const url = `/api/w/${owner.sId}/spaces`;
-    let res;
-    let body: PostSpaceRequestBodyType;
-
-    if (managementMode === "manual") {
-      const { memberIds } = params;
-
-      // Must have memberIds for manual management mode, except for projects
-      // where the backend handles adding the creator to the editor group
-      if (
-        spaceKind !== "project" &&
-        isRestricted &&
-        (!memberIds || memberIds.length < 1)
-      ) {
-        return null;
-      }
-
-      body = {
-        name,
-        memberIds,
-        managementMode,
-        isRestricted,
-        spaceKind,
-      };
-
-      res = await clientFetch(url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(body),
-      });
-    } else if (managementMode === "group") {
-      const { groupIds } = params;
-
-      // Must have groupIds for group management mode
-      if (isRestricted && (!groupIds || groupIds.length < 1)) {
-        return null;
-      }
-
-      body = {
-        name,
-        groupIds,
-        managementMode,
-        isRestricted,
-        spaceKind,
-      };
-
-      res = await clientFetch(url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(body),
-      });
-    } else {
+    // A restricted space needs someone in it — a member or a group. Projects are the exception:
+    // the backend adds the creator to the editor group.
+    if (
+      spaceKind !== "project" &&
+      isRestricted &&
+      !memberIds?.length &&
+      !groupIds?.length
+    ) {
       return null;
     }
+
+    const url = `/api/w/${owner.sId}/spaces`;
+    const res = await clientFetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(params satisfies PostSpaceRequestBodyType),
+    });
 
     if (!res.ok) {
       const errorData = await getErrorFromResponse(res);
@@ -666,7 +627,7 @@ export function useUpdateSpace({ owner }: { owner: LightWorkspaceType }) {
     params: PatchSpaceMembersRequestBodyType,
     notification?: { title: string; description: string }
   ) => {
-    const { name: newName, managementMode, isRestricted } = params;
+    const { name: newName, isRestricted } = params;
 
     const updatePromises: Promise<Response>[] = [];
 
@@ -688,43 +649,22 @@ export function useUpdateSpace({ owner }: { owner: LightWorkspaceType }) {
 
     const spaceMembersUrl = `/api/w/${owner.sId}/spaces/${space.sId}/members`;
 
-    if (managementMode === "manual") {
-      updatePromises.push(
-        clientFetch(spaceMembersUrl, {
-          method: "PATCH",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            name: newName,
-            isRestricted,
-            managementMode,
-            memberIds: params.memberIds,
-            editorIds: params.editorIds,
-          } satisfies PatchSpaceMembersRequestBodyType),
-        })
-      );
-    } else if (managementMode === "group") {
-      updatePromises.push(
-        clientFetch(spaceMembersUrl, {
-          method: "PATCH",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            name: newName,
-            isRestricted,
-            managementMode,
-            groupIds: params.groupIds,
-            editorGroupIds: params.editorGroupIds,
-          } satisfies PatchSpaceMembersRequestBodyType),
-        })
-      );
-    }
-
-    if (updatePromises.length === 0) {
-      return null;
-    }
+    // The request describes the space's whole membership: a dimension the caller leaves out is
+    // emptied server-side, not kept. The Pod tabs carry members and editors only, which says a
+    // Pod has no groups — true while Pods are managed manually.
+    updatePromises.push(
+      clientFetch(spaceMembersUrl, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          ...params,
+          name: newName,
+          isRestricted,
+        } satisfies PatchSpaceMembersRequestBodyType),
+      })
+    );
 
     const results = await Promise.all(updatePromises);
 


### PR DESCRIPTION
## Description

Third of 4 PRs merging the two ways a space gets its members. Stacked on #31929.

Before, the space settings sheet had a dropdown picking *Manual access* or *Group access*, showed one table or the other, and each save replaced the other side — with a confirm dialog warning you that it would.
Now that the two are merged server-side, the sheet shows both: a **Members** tab and a **Groups** tab, and saving sends both lists.

<img width="1150" height="1288" alt="image" src="https://github.com/user-attachments/assets/85143031-157e-45a0-8971-2b8a7e288989" />

<img width="1142" height="1284" alt="image" src="https://github.com/user-attachments/assets/2093ef1f-3a4d-4a3c-a38e-14cdfed3365c" />


The design is a first pass — two tabs standing in for the two menus that were there. It will be
replaced when the real design lands.

## Tests

manually tested

## Risk

Low. UI only, easy to revert.

## Deploy Plan

- Deploy front
