### PR TITLE
[front] feat: empty stacked seat credits on credit.segment.start

### DIFF
--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -17,6 +17,7 @@ import {
 import { fetchPerApiKeyAwuUsage } from "@app/lib/metronome/per_api_key_usage";
 import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import type { CachedContract } from "@app/lib/metronome/plan_type";
+import { getActiveContract } from "@app/lib/metronome/plan_type";
 import { getWorkspacePoolAwuBalance } from "@app/lib/metronome/pool_balance";
 import { fetchProgrammaticAwuSpend } from "@app/lib/metronome/programmatic_awu_usage";
 import {
@@ -24,6 +25,7 @@ import {
   setProgrammaticCreditStateReconciled,
 } from "@app/lib/metronome/programmatic_credit_state_machine";
 import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
+import { correctStackedSeatCreditsFromBalances } from "@app/lib/metronome/stacked_seat_credits";
 import {
   clearWorkspaceProgrammaticWarningReached,
   setUserNearLimit,
@@ -685,6 +687,110 @@ export async function reconcileWorkspaceUserCreditStates({
       );
     }
     await heartbeat();
+  }
+}
+
+/**
+ * Detect and empty "stacked" per-seat AWU credits for a workspace: a seat that
+ * still holds a live balance on a per-seat recurring credit belonging to a
+ * different seat type than its current tier (e.g. a max seat carrying the pro
+ * credit after an upgrade stranded the origin grant). Consumption charged to the
+ * stray is carried onto the home credit so the seat nets the correct balance.
+ *
+ * Triggered from the debounced `credit.segment.start` reconcile: each seat credit
+ * is materialized one period ahead, so a mid-period seat change leaves a stray on
+ * the NEXT segment that only becomes a live balance when that segment starts —
+ * exactly when this runs. The N concurrent segment-start events collapse to one
+ * execution (see `launchReconcileWorkspaceUserCreditStatesWorkflow`), so we read
+ * balances once here. Never throws — logs and returns on failure.
+ */
+export async function reconcileStackedSeatCreditsForWorkspace({
+  workspace,
+  metronomeCustomerId,
+  metronomeContractId,
+  planCode,
+}: {
+  workspace: LightWorkspaceType;
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+  planCode: string;
+}): Promise<void> {
+  if (!isCreditPricedPlanPrefix(planCode)) {
+    return;
+  }
+  const workspaceId = workspace.sId;
+
+  const contract = await getActiveContract(workspaceId);
+  if (!contract) {
+    logger.warn(
+      { workspaceId },
+      "[StackedSeatCredits] no active contract — skipping stray-credit reconcile"
+    );
+    return;
+  }
+
+  let memberships: MembershipResource[];
+  try {
+    const result = await MembershipResource.getActiveMemberships({ workspace });
+    memberships = result.memberships;
+  } catch (err) {
+    logger.error(
+      { workspaceId, err: normalizeError(err) },
+      "[StackedSeatCredits] failed to load memberships"
+    );
+    return;
+  }
+
+  // Current tier per seat, restricted to seats that carry an individual seat
+  // balance (pro/max and their _yearly variants) — the only ones that can stack.
+  const currentSeatTypeBySeatId = new Map<string, MembershipSeatType>();
+  for (const membership of memberships) {
+    const sId = membership.user?.sId;
+    if (sId && hasMetronomeSeatBalance(membership.seatType)) {
+      currentSeatTypeBySeatId.set(sId, membership.seatType);
+    }
+  }
+  if (currentSeatTypeBySeatId.size === 0) {
+    return;
+  }
+
+  const balancesResult = await listMetronomeSeatBalances({
+    metronomeCustomerId,
+    metronomeContractId,
+    seatIds: [...currentSeatTypeBySeatId.keys()],
+  });
+  if (balancesResult.isErr()) {
+    logger.error(
+      { workspaceId, err: balancesResult.error },
+      "[StackedSeatCredits] failed to read seat balances"
+    );
+    return;
+  }
+
+  const result = await correctStackedSeatCreditsFromBalances({
+    workspaceId,
+    metronomeCustomerId,
+    metronomeContractId,
+    contract,
+    seatBalances: balancesResult.value,
+    currentSeatTypeBySeatId,
+    execute: true,
+    logger,
+  });
+  if (result.isErr()) {
+    logger.error(
+      { workspaceId, err: normalizeError(result.error) },
+      "[StackedSeatCredits] failed to reconcile stacked seat credits"
+    );
+    return;
+  }
+  const { appliedAdjustmentCount, totalEmptiedAwu, totalCarriedAwu } =
+    result.value;
+  if (appliedAdjustmentCount > 0) {
+    logger.info(
+      { workspaceId, appliedAdjustmentCount, totalEmptiedAwu, totalCarriedAwu },
+      "[StackedSeatCredits] corrected stacked seat credits"
+    );
   }
 }
 

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -754,15 +754,30 @@ export async function reconcileStackedSeatCreditsForWorkspace({
     return;
   }
 
-  const balancesResult = await listMetronomeSeatBalances({
-    metronomeCustomerId,
-    metronomeContractId,
-    seatIds: [...currentSeatTypeBySeatId.keys()],
-  });
+  const seatIds = [...currentSeatTypeBySeatId.keys()];
+  const [balancesResult, usageResult] = await Promise.all([
+    listMetronomeSeatBalances({
+      metronomeCustomerId,
+      metronomeContractId,
+      seatIds,
+    }),
+    fetchPerUserAwuUsage({
+      workspaceId,
+      metronomeCustomerId,
+      userIds: seatIds,
+    }),
+  ]);
   if (balancesResult.isErr()) {
     logger.error(
       { workspaceId, err: balancesResult.error },
       "[StackedSeatCredits] failed to read seat balances"
+    );
+    return;
+  }
+  if (usageResult.isErr()) {
+    logger.error(
+      { workspaceId, err: usageResult.error },
+      "[StackedSeatCredits] failed to read per-user usage"
     );
     return;
   }
@@ -774,6 +789,7 @@ export async function reconcileStackedSeatCreditsForWorkspace({
     contract,
     seatBalances: balancesResult.value,
     currentSeatTypeBySeatId,
+    usageBySeatId: usageResult.value,
     execute: true,
     logger,
   });

--- a/front/temporal/metronome_events_queue/activities.ts
+++ b/front/temporal/metronome_events_queue/activities.ts
@@ -1,7 +1,10 @@
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import { updateMembershipSeatAndTrack } from "@app/lib/api/membership";
 import { processMetronomeWebhook } from "@app/lib/api/metronome/process_webhook";
-import { reconcileWorkspaceUserCreditStates } from "@app/lib/api/metronome/reconcile_credit_state";
+import {
+  reconcileStackedSeatCreditsForWorkspace,
+  reconcileWorkspaceUserCreditStates,
+} from "@app/lib/api/metronome/reconcile_credit_state";
 import { setUserSpendLimit } from "@app/lib/api/users/spend_limit";
 import { Authenticator } from "@app/lib/auth";
 import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
@@ -247,8 +250,19 @@ export async function reconcileWorkspaceUserCreditStatesActivity({
   if (!subscription?.metronomeContractId) {
     return;
   }
+  const lightWorkspace = renderLightWorkspaceType({ workspace });
   await reconcileWorkspaceUserCreditStates({
-    workspace: renderLightWorkspaceType({ workspace }),
+    workspace: lightWorkspace,
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    metronomeContractId: subscription.metronomeContractId,
+    planCode: subscription.getPlan().code,
+  });
+
+  // Empty any per-seat credit stranded by a mid-period seat change once its
+  // segment starts (the event that debounced us here). Reuses the same debounced,
+  // workspace-scoped execution so it runs once per period boundary, not per event.
+  await reconcileStackedSeatCreditsForWorkspace({
+    workspace: lightWorkspace,
     metronomeCustomerId: workspace.metronomeCustomerId,
     metronomeContractId: subscription.metronomeContractId,
     planCode: subscription.getPlan().code,


### PR DESCRIPTION
## Description

Wires the shared stacked-seat-credit core (added in the parent PR #31709) into the debounced credit-state reconcile so **new** stacked per-seat AWU credits are cleaned automatically, at the source, instead of needing the backfill script.

Why `credit.segment.start`: a per-seat recurring credit is materialized one period ahead, so a mid-period seat change strands a stray grant on the **next** segment that only becomes a live balance when that segment starts. The 4 concurrent segment-start events per contract (2 pro + 2 max) already collapse to one workspace-scoped execution via `WorkflowIdConflictPolicy.USE_EXISTING`, so the new `reconcileStackedSeatCreditsForWorkspace`:

- reads seat balances **once** (with the per-seat `credits[]` breakdown),
- maps each materialized credit id → seat type,
- empties any credit whose type ≠ the seat's current tier and carries its consumption onto the home credit,
- busts the per-user balance caches.

It runs right after the existing per-user reconcile in `reconcileWorkspaceUserCreditStatesActivity`. Idempotent and self-healing: each stray is cleaned when its segment becomes current; a re-run reads strays at 0 and emits nothing.

## Tests

- `npx tsgo --noEmit` clean; `biome check` clean.
- Detection/correction core validated on real workspaces via the backfill script (same code path): exact stray-emptying + consumption carry (e.g. a seat that spent 69 AWU against its stray nets `8000 − 69 = 7931`, not a full 8000).
- Manual verification of the debounce on a seat-type change pending in a test workspace.

## Risk

Low. Additive: a new lib function called after the existing reconcile on an already-debounced, low-frequency path (period boundaries / seat changes). Apply is two-phase (empty strays, then carry only for seats whose strays emptied), so a partial Metronome failure can never double-debit a user — worst case is the pre-existing small over-credit. Manual ledger entries don't fire Metronome webhooks, so there is no reconcile feedback loop.

## Deploy Plan

Ship after #31709 (depends on the `lib/metronome/stacked_seat_credits` core). No migration. Backfill existing strays with the script; this PR prevents new ones going forward.