### PR TITLE
feat: add micro_usd to es consumption index

### DIFF
--- a/front/lib/analytics/agent_message_consumption/llm_documents.ts
+++ b/front/lib/analytics/agent_message_consumption/llm_documents.ts
@@ -175,6 +175,7 @@ function buildLlmConsumptionDocument({
     // The agent message stores only aggregate model latency, which cannot be split across runs.
     // TODO(2026-08-07 flav): Persist execution duration on each run and index it here.
     execution_time_ms: null,
+    micro_usd: usage.costMicroUsd,
     model: modelForUsage(input.model, usage),
     status: input.messageStatus,
     tool: null,

--- a/front/lib/analytics/agent_message_consumption/store.test.ts
+++ b/front/lib/analytics/agent_message_consumption/store.test.ts
@@ -43,6 +43,7 @@ function makeDocument(): AgentMessageConsumptionAnalyticsData {
     conversation_id: "conversation_1",
     credit_micro: 1_000_000,
     execution_time_ms: null,
+    micro_usd: 500_000,
     parent_message_id: null,
     gross_credit_micro: {
       system: 0,

--- a/front/lib/analytics/agent_message_consumption/tool_documents.ts
+++ b/front/lib/analytics/agent_message_consumption/tool_documents.ts
@@ -129,6 +129,7 @@ function buildToolConsumptionDocument({
     ...summarizeToolConsumptionItem({ allocation, item }),
     consumption_type: "tool",
     execution_time_ms: serializedAction.executionDurationMs,
+    micro_usd: null,
     model: modelForUsage(input.model, usage),
     status: serializedAction.status,
     tool: {

--- a/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
+++ b/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
@@ -171,6 +171,9 @@
     "credit_micro": {
       "type": "long"
     },
+    "micro_usd": {
+      "type": "long"
+    },
     "usage_type": {
       "type": "keyword"
     },

--- a/front/lib/analytics/migrations/20260907_add_micro_usd_to_agent_message_consumption_analytics_1.http
+++ b/front/lib/analytics/migrations/20260907_add_micro_usd_to_agent_message_consumption_analytics_1.http
@@ -1,0 +1,8 @@
+PUT /front.agent_message_consumption_analytics_1/_mapping
+{
+  "properties": {
+    "micro_usd": {
+      "type": "long"
+    }
+  }
+}

--- a/front/lib/api/analytics/consumption/export_lines.ts
+++ b/front/lib/api/analytics/consumption/export_lines.ts
@@ -56,6 +56,7 @@ type ConsumptionLineExportRow = {
   creditsReasoning: number;
   creditsDirect: number;
   totalCredits: number;
+  costMicroUsd: number;
   usageType: string;
   status: string;
   stepIndex: number;
@@ -100,6 +101,7 @@ const CONSUMPTION_LINE_EXPORT_HEADERS: (keyof ConsumptionLineExportRow)[] = [
   "creditsReasoning",
   "creditsDirect",
   "totalCredits",
+  "costMicroUsd",
   "usageType",
   "status",
   "stepIndex",
@@ -253,6 +255,7 @@ async function buildConsumptionLineExportRows(
         microCreditsToCredits(gross.direct ?? 0)
       ),
       totalCredits: roundToTwoDecimals(microCreditsToCredits(doc.credit_micro)),
+      costMicroUsd: doc.micro_usd ?? 0,
       usageType: doc.usage_type,
       status: doc.status,
       stepIndex: doc.step_index,

--- a/front/scripts/seed/factories/seedConsumptionAnalytics.ts
+++ b/front/scripts/seed/factories/seedConsumptionAnalytics.ts
@@ -377,6 +377,7 @@ function makeLlmDocument(
     }),
     consumption_type: "llm",
     credit_micro: creditMicro,
+    micro_usd: creditMicro,
     gross_credit_micro: {
       system: systemCreditMicro,
       input:
@@ -427,6 +428,7 @@ function makeToolDocument(
     }),
     consumption_type: "tool",
     credit_micro: creditMicro,
+    micro_usd: null,
     gross_credit_micro: {
       system: 0,
       input: null,

--- a/front/temporal/analytics_queue/activities/consumption_export.test.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.test.ts
@@ -71,6 +71,7 @@ const LLM_DOC: AgentMessageConsumptionAnalyticsLlmData = {
   conversation_id: "conv1",
   credit_micro: 1_000_000,
   execution_time_ms: null,
+  micro_usd: 500_000,
   message_version: "1",
   model: {
     provider_id: "anthropic",
@@ -110,6 +111,7 @@ const TOOL_DOC: AgentMessageConsumptionAnalyticsToolData = {
   ...LLM_DOC,
   consumption_key: "action:1",
   consumption_type: "tool",
+  micro_usd: null,
   model: null,
   gross_credit_micro: {
     system: 0,

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -253,6 +253,8 @@ interface AgentMessageConsumptionAnalyticsBaseData
   // billed cost.
   credit_micro: number;
   execution_time_ms: number | null;
+  // Provider cost in micro-USD for this LLM call. Only set when consumption_type is "llm".
+  micro_usd: number | null;
   message_version: string;
   parent_message_id: string | null;
   model: AgentMessageAnalyticsModel | null;


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/10310

Add `micro_usd` field to `front.agent_message_consumption_analytics`. Index the per-run cost, similar to how we have `tokens. cost_micro_usd` in index `front.agent_message_analytics` that represents the per-message dollar cost.

The sum of `micro_usd` for a given `message_id` equals `tokens. cost_micro_usd`.

## Tests

Tested locally comparing a message with several llm and tool call

```
POST /front.agent_message_analytics/_search
{
  "query": {
      "bool": {
        "filter": [
          { "term": { "message_id":"jvU13pThFE" } }
        ]
      }
    },
  "_source": ["tokens.cost_micro_usd"]
}
 "hits": {
    "total": {
      "value": 1,
      "relation": "eq"
    },
    "max_score": 0,
    "hits": [
      {
        "_index": "front.agent_message_analytics_2",
        "_id": "AYjP6ks68g_jvU13pThFE_0",
        "_score": 0,
        "_source": {
          "tokens": {
            "cost_micro_usd": 1943
          }
        }
      }
    ]
  }
```

```
POST /front.agent_message_consumption_analytics/_search
{
  "query": {
      "bool": {
        "filter": [
          { "term": { "agent_message_id":"jvU13pThFE" } },
          { "term": { "consumption_type": "llm" } }
        ]
      }
    },
    "aggs": {
      "cost": {
        "sum": {
          "field": "micro_usd"
        }
        
      }
    }, 
  "_source": ["micro_usd"]
}
"hits": {
    "total": {
      "value": 4,
      "relation": "eq"
    },
    "max_score": 0,
    "hits": [
      {
        "_index": "front.agent_message_consumption_analytics_1",
        "_id": "AYjP6ks68g_jvU13pThFE_run-usage:491",
        "_score": 0,
        "_source": {
          "micro_usd": 446
        }
      },
      {
        "_index": "front.agent_message_consumption_analytics_1",
        "_id": "AYjP6ks68g_jvU13pThFE_run-usage:492",
        "_score": 0,
        "_source": {
          "micro_usd": 492
        }
      },
      {
        "_index": "front.agent_message_consumption_analytics_1",
        "_id": "AYjP6ks68g_jvU13pThFE_run-usage:493",
        "_score": 0,
        "_source": {
          "micro_usd": 406
        }
      },
      {
        "_index": "front.agent_message_consumption_analytics_1",
        "_id": "AYjP6ks68g_jvU13pThFE_run-usage:494",
        "_score": 0,
        "_source": {
          "micro_usd": 599
        }
      }
    ]
  },
  "aggregations": {
    "cost": {
      "value": 1943
    }
  }
```

## Risk

Low

## Deploy Plan

apply ES migration first then deploy front