### PR TITLE
feat: add seat_type to es consumption index

### DIFF
--- a/front/lib/analytics/agent_message_consumption/load.ts
+++ b/front/lib/analytics/agent_message_consumption/load.ts
@@ -14,6 +14,7 @@ import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { RunUsageWithRunKeyType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -153,16 +154,26 @@ async function loadAnalyticsUser({
     "Triggering user is missing while loading consumption analytics"
   );
 
-  const groups = await GroupResource.listUserGroupsInWorkspace({
-    auth,
-    user,
-    groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
-    at: completedAt,
-  });
+  const workspace = auth.getNonNullableWorkspace();
+
+  const [groups, seatType] = await Promise.all([
+    GroupResource.listUserGroupsInWorkspace({
+      auth,
+      user,
+      groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
+      at: completedAt,
+    }),
+    MembershipResource.getActiveSeatTypeForUserModelId({
+      workspace,
+      userModelId: user.id,
+      at: completedAt,
+    }),
+  ]);
 
   return {
     id: user.sId,
     group_ids: groups.map((group) => group.sId).sort(),
+    seat_type: seatType,
   };
 }
 

--- a/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
+++ b/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
@@ -87,6 +87,9 @@
         },
         "group_ids": {
           "type": "keyword"
+        },
+        "seat_type": {
+          "type": "keyword"
         }
       }
     },

--- a/front/lib/analytics/migrations/20260905_add_seat_type_to_agent_message_consumption_analytics_1.http
+++ b/front/lib/analytics/migrations/20260905_add_seat_type_to_agent_message_consumption_analytics_1.http
@@ -1,0 +1,12 @@
+PUT /front.agent_message_consumption_analytics_1/_mapping
+{
+  "properties": {
+    "user": {
+      "properties": {
+        "seat_type": {
+          "type": "keyword"
+        }
+      }
+    }
+  }
+}

--- a/front/scripts/seed/factories/seedConsumptionAnalytics.ts
+++ b/front/scripts/seed/factories/seedConsumptionAnalytics.ts
@@ -188,6 +188,7 @@ async function loadConsumptionPools(
     users: catalog.user.map((entry) => ({
       id: entry.value,
       group_ids: [...(groupIdsByUserId.get(entry.value) ?? [])].sort(),
+      seat_type: "pro",
     })),
     models: removeNulls(
       catalog.model.map((entry) => getModelConfigByModelId(entry.value) ?? null)

--- a/front/temporal/analytics_queue/activities/consumption_export.test.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.test.ts
@@ -86,7 +86,7 @@ const LLM_DOC: AgentMessageConsumptionAnalyticsLlmData = {
   step_index: 0,
   trigger_id: null,
   usage_type: "user",
-  user: { id: "user1", group_ids: ["group1"] },
+  user: { id: "user1", group_ids: ["group1"], seat_type: "pro" },
   consumption_type: "llm",
   gross_credit_micro: {
     system: 100_000,

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -136,6 +136,7 @@ export interface AgentMessageConsumptionAnalyticsUser {
   id: string;
   // Group sIds the user belonged to when the message completed.
   group_ids: string[];
+  seat_type: string | null;
 }
 
 export interface AgentMessageConsumptionAnalyticsTool {


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/10309

Add `seat_type` to `front.agent_message_consumption_analytics` so we can figure out what kind of seat the user had at the time the message was sent.
Useful to track free usage and be iso with `front.agent_message_analytics`.

## Tests

```
POST /front.agent_message_consumption_analytics/_search
{
  "query": {
    "exists": { "field": "user.seat_type"}
  },
  "_source": ["user.seat_type"]
}
```

## Risk

Low.

## Deploy Plan

Apply ES migration first then deploy front