### PR TITLE
[front] enh: inline tool references in the conversation input

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -8081,7 +8081,8 @@
                 ],
                 "properties": {
                   "content": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Message text. Inline <tool> references enable the referenced MCP server views."
                   },
                   "mentions": {
                     "type": "array",
@@ -8715,7 +8716,8 @@
                     "type": "object",
                     "properties": {
                       "content": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Message text. Inline <tool> references enable the referenced MCP server views."
                       },
                       "mentions": {
                         "type": "array",

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
@@ -1,5 +1,6 @@
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { serializeToolTag } from "@app/lib/tools/format";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
@@ -47,7 +48,11 @@ function getTools(workspace: { sId: string }, conversationId: string) {
 }
 
 describe("POST /api/w/:wId/assistant/conversations/:cId/messages", () => {
-  it("enables MCP server views when selectedMCPServerViewIds are provided", async () => {
+  it.each([
+    "legacy",
+    "inline",
+    "both",
+  ] as const)("enables MCP server views from %s references", async (source) => {
     const { workspace, conversation, auth, globalSpace, user } =
       await setupTest("admin");
 
@@ -67,12 +72,17 @@ describe("POST /api/w/:wId/assistant/conversations/:cId/messages", () => {
     expect((await toolsBefore.json()).tools).toEqual([]);
 
     const response = await postMessage(workspace, conversation.sId, {
-      content: "Message with conversation tools",
+      content:
+        source === "legacy"
+          ? "Message with conversation tools"
+          : `Use ${serializeToolTag({ id: mcpServerView.sId, name: "Tool", icon: null })}`,
       mentions: [{ configurationId: GLOBAL_AGENTS_SID.DUST }],
       context: {
         timezone: "Europe/Paris",
         profilePictureUrl: user.imageUrl ?? null,
-        selectedMCPServerViewIds: [mcpServerView.sId],
+        ...(source !== "inline"
+          ? { selectedMCPServerViewIds: [mcpServerView.sId] }
+          : {}),
       },
       skipToolsValidation: true,
     });

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -10,6 +10,7 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { extractUniqueSkillIds } from "@app/lib/skills/format";
+import { extractToolTags } from "@app/lib/tools/format";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { statsDMetrics } from "@app/lib/utils/statsd";
 import { InternalPostMessagesRequestBodySchema } from "@app/types/api/assistant";
@@ -125,6 +126,7 @@ const app = workspaceApp();
  *             properties:
  *               content:
  *                 type: string
+ *                 description: Message text. Inline <tool> references enable the referenced MCP server views.
  *               mentions:
  *                 type: array
  *                 items:
@@ -327,10 +329,16 @@ app.post(
       }
     }
 
-    if (context.selectedMCPServerViewIds?.length) {
+    const selectedMCPServerViewIds = [
+      ...new Set([
+        ...(context.selectedMCPServerViewIds ?? []),
+        ...extractToolTags(content).map((tool) => tool.id),
+      ]),
+    ];
+    if (selectedMCPServerViewIds.length > 0) {
       const mcpServerViews = await MCPServerViewResource.fetchByIds(
         auth,
-        context.selectedMCPServerViewIds,
+        selectedMCPServerViewIds,
         { isRestrictedToSkills: false }
       );
 

--- a/front-api/routes/w/[wId]/assistant/conversations/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/index.test.ts
@@ -16,17 +16,77 @@ vi.mock("@app/lib/api/assistant/conversation/content_fragment", () => ({
 }));
 
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { serializeToolTag } from "@app/lib/tools/format";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 
 describe("POST /api/w/:wId/assistant/conversations", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("enables inline tool references when creating a conversation", async () => {
+    const { workspace, auth, globalSpace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    const remoteServer = await RemoteMCPServerFactory.create(workspace);
+    const systemView =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        auth,
+        remoteServer.sId
+      );
+    if (!systemView) {
+      throw new Error("Missing system view");
+    }
+    const { view } = await MCPServerViewResource.create(auth, {
+      systemView,
+      space: globalSpace,
+    });
+    const content = `Use ${serializeToolTag({ id: view.sId, name: "Tool", icon: null })}`;
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/assistant/conversations`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          contentFragments: [],
+          title: "Inline tools",
+          visibility: "unlisted",
+          message: {
+            content,
+            mentions: [],
+            context: { timezone: "Europe/Paris", profilePictureUrl: null },
+          },
+        }),
+      }
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      body.conversation.sId
+    );
+    if (!conversation) {
+      throw new Error("Missing conversation");
+    }
+    const relationships = await ConversationResource.fetchMCPServerViews(
+      auth,
+      conversation.toJSON()
+    );
+    expect(relationships).toHaveLength(1);
+    expect(relationships[0]).toMatchObject({
+      mcpServerViewId: view.id,
+      enabled: true,
+    });
   });
 
   it("creates a conversation with content fragments when private conversation URLs are enabled", async () => {

--- a/front-api/routes/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/index.ts
@@ -17,6 +17,7 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { extractUniqueSkillIds } from "@app/lib/skills/format";
+import { extractToolTags } from "@app/lib/tools/format";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { InternalPostConversationsRequestBodySchema } from "@app/types/api/assistant";
 import type {
@@ -138,6 +139,7 @@ const app = workspaceApp();
  *                 properties:
  *                   content:
  *                     type: string
+ *                     description: Message text. Inline <tool> references enable the referenced MCP server views.
  *                   mentions:
  *                     type: array
  *                     items:
@@ -422,10 +424,16 @@ app.post(
     if (message) {
       // If tools are enabled, we need to add the MCP server views to the
       // conversation before posting the message.
-      if (message.context.selectedMCPServerViewIds) {
+      const selectedMCPServerViewIds = [
+        ...new Set([
+          ...(message.context.selectedMCPServerViewIds ?? []),
+          ...extractToolTags(message.content).map((tool) => tool.id),
+        ]),
+      ];
+      if (selectedMCPServerViewIds.length > 0) {
         const mcpServerViews = await MCPServerViewResource.fetchByIds(
           auth,
-          message.context.selectedMCPServerViewIds,
+          selectedMCPServerViewIds,
           { isRestrictedToSkills: false }
         );
 

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -165,7 +165,7 @@ export function CapabilitiesPickerItemsList({
 interface CapabilitiesPickerProps {
   owner: WorkspaceType;
   user: UserType | null;
-  selectedMCPServerViews: MCPServerViewLightType[];
+  selectedMCPServerViews: Pick<MCPServerViewLightType, "sId">[];
   onSelect: (serverView: MCPServerViewLightType) => void;
   onSkillSelect: (skill: SkillWithoutInstructionsAndToolsType) => void;
   onSetupServer: (server: MCPServerType) => void;

--- a/front/components/assistant/UserMessageMarkdown.integration.test.tsx
+++ b/front/components/assistant/UserMessageMarkdown.integration.test.tsx
@@ -104,6 +104,67 @@ const mockMessage = {
 } as any;
 
 describe("UserMessageMarkdown - Integration Tests", () => {
+  it("renders inline tool references with literal names", () => {
+    const { container } = render(
+      <UserMessageMarkdown
+        owner={mockOwner}
+        message={{
+          ...mockMessage,
+          content:
+            'Use <tool id="tool_123" name="GitHub [Issues] &amp; PRs" icon="GithubLogo" /> here.',
+        }}
+        isLastMessage={false}
+      />
+    );
+    expect(screen.getByText("GitHub [Issues] & PRs")).toBeDefined();
+    expect(container.textContent).toBe("Use GitHub [Issues] & PRs here.");
+  });
+
+  it("preserves text following a tool reference at the start of a message", () => {
+    const { container } = render(
+      <UserMessageMarkdown
+        owner={mockOwner}
+        message={{
+          ...mockMessage,
+          content: '<tool id="tool_123" name="GitHub" /> find the issue.',
+        }}
+        isLastMessage={false}
+      />
+    );
+    expect(container.textContent).toBe("GitHub find the issue.");
+  });
+
+  it("preserves Markdown after a tool reference on its own line", () => {
+    const { container } = render(
+      <UserMessageMarkdown
+        owner={mockOwner}
+        message={{
+          ...mockMessage,
+          content: '<tool id="tool_123" name="GitHub" />\nFind **the issue**.',
+        }}
+        isLastMessage={false}
+      />
+    );
+    expect(container.textContent).toContain("Find the issue.");
+    expect(container.querySelector("strong")?.textContent).toBe("the issue");
+  });
+
+  it("keeps tool tags in code examples as literal text", () => {
+    render(
+      <UserMessageMarkdown
+        owner={mockOwner}
+        message={{
+          ...mockMessage,
+          content: '`<tool id="tool_123" name="GitHub" />`',
+        }}
+        isLastMessage={false}
+      />
+    );
+    expect(
+      screen.getByText('<tool id="tool_123" name="GitHub" />').tagName
+    ).toBe("CODE");
+  });
+
   describe("Basic Markdown Rendering", () => {
     it("renders plain text", () => {
       const message = { ...mockMessage, content: "Hello world" };

--- a/front/components/assistant/UserMessageMarkdown.tsx
+++ b/front/components/assistant/UserMessageMarkdown.tsx
@@ -1,3 +1,4 @@
+import { ToolChip } from "@app/components/editor/extensions/skill_builder/ToolChip";
 import {
   CiteBlock,
   getCiteDirective,
@@ -23,6 +24,8 @@ import {
   getTaskDirectiveBlock,
   taskDirective,
 } from "@app/components/markdown/TaskDirectiveBlock";
+import { CapabilityDetailsSheets } from "@app/components/shared/CapabilityDetailsSheets";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import {
   agentMentionDirective,
   getAgentMentionPlugin,
@@ -30,10 +33,12 @@ import {
   userMentionDirective,
 } from "@app/lib/mentions/markdown/plugin";
 import { parseSkillTag, SKILL_TAG_REGEX } from "@app/lib/skills/format";
+import type { ToolDirectiveProps } from "@app/lib/tools/markdown";
+import { toolDirective } from "@app/lib/tools/markdown";
 import type { UserMessageType } from "@app/types/assistant/conversation";
 import type { WorkspaceType } from "@app/types/user";
 import { Markdown } from "@dust-tt/sparkle";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
 
@@ -48,6 +53,8 @@ export const UserMessageMarkdown = ({
   message,
   isLastMessage,
 }: UserMessageMarkdownProps) => {
+  const { user } = useAuth();
+  const [selectedToolId, setSelectedToolId] = useState<string | null>(null);
   const additionalMarkdownComponents: Components = useMemo(
     () => ({
       sup: CiteBlock,
@@ -62,6 +69,13 @@ export const UserMessageMarkdown = ({
           skillIcon={skillIcon ?? null}
           skillId={skillId}
           skillName={skillName}
+        />
+      ),
+      tool: ({ toolId, toolIcon, toolName }: ToolDirectiveProps) => (
+        <ToolChip
+          title={toolName}
+          toolIcon={toolIcon ?? null}
+          onClick={() => setSelectedToolId(toolId)}
         />
       ),
       project_task: getTaskDirectiveBlock(owner),
@@ -79,6 +93,7 @@ export const UserMessageMarkdown = ({
       pastedAttachmentDirective,
       filePreviewDirective,
       skillDirective,
+      toolDirective,
     ],
     []
   );
@@ -99,14 +114,27 @@ export const UserMessageMarkdown = ({
   );
 
   return (
-    <Markdown
-      content={displayContent}
-      isStreaming={false}
-      isLastMessage={isLastMessage}
-      additionalMarkdownComponents={additionalMarkdownComponents}
-      additionalMarkdownPlugins={additionalMarkdownPlugins}
-      compactSpacing
-      canCopyQuotes={false}
-    />
+    <>
+      <Markdown
+        content={displayContent}
+        isStreaming={false}
+        isLastMessage={isLastMessage}
+        additionalMarkdownComponents={additionalMarkdownComponents}
+        additionalMarkdownPlugins={additionalMarkdownPlugins}
+        compactSpacing
+        canCopyQuotes={false}
+      />
+      {selectedToolId && (
+        <CapabilityDetailsSheets
+          owner={owner}
+          user={user}
+          selectedSkillId={null}
+          selectedMCPServerView={null}
+          selectedMCPServerViewId={selectedToolId}
+          onCloseSkill={() => {}}
+          onCloseTool={() => setSelectedToolId(null)}
+        />
+      )}
+    </>
   );
 };

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -1139,7 +1139,7 @@ export const ConversationViewer = ({
       input: string,
       mentions: RichMention[],
       contentFragments: ContentFragmentsType,
-      _selectedMCPServerViewIds?: string[],
+      selectedMCPServerViewIds?: string[],
       selectedSpaceIds?: string[],
       modelSelection?: ModelSelectionType
     ): Promise<Result<undefined, DustError>> => {
@@ -1169,6 +1169,7 @@ export const ConversationViewer = ({
           clientSideMCPServerIds:
             clientSideMCPServerIds ??
             agentBuilderContext?.clientSideMCPServerIds,
+          selectedMCPServerViewIds,
           selectedSpaceIds,
           skipToolsValidation: agentBuilderContext?.skipToolsValidation,
           modelSelection,

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -14,12 +14,7 @@ import {
   INPUT_BAR_COMPACT_PILL_CLASSES,
 } from "@app/components/assistant/conversation/input_bar/inputBarCompactStyles";
 import { useConversationDrafts } from "@app/components/assistant/conversation/input_bar/useConversationDrafts";
-import {
-  useAddDeleteConversationTool,
-  useConversationTools,
-} from "@app/hooks/conversations";
 import { RUNNING_AGENT_SWITCH_BLOCK_MESSAGE } from "@app/lib/api/assistant/errors";
-import type { MCPServerViewLightType } from "@app/lib/api/mcp";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { DustError } from "@app/lib/error";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
@@ -28,6 +23,7 @@ import {
   useSelectableConversationSpaces,
 } from "@app/lib/swr/conversation_selected_spaces";
 import { useSpaces } from "@app/lib/swr/spaces";
+import { extractToolTags } from "@app/lib/tools/format";
 import { TRACKING_AREAS, trackEvent } from "@app/lib/tracking";
 import { classNames } from "@app/lib/utils";
 import {
@@ -258,32 +254,9 @@ export const InputBar = React.memo(function InputBar({
     !!conversation &&
     getConversationGeneratingMessages(conversation.sId).length > 0;
 
-  // Tools selection
-
-  const [selectedMCPServerViews, setSelectedMCPServerViews] = useState<
-    MCPServerViewLightType[]
-  >([]);
   const [selectedSpacesState, setSelectedSpacesState] =
     useState<SelectedSpacesState | null>(null);
 
-  const { conversationTools } = useConversationTools({
-    conversationId: conversation?.sId,
-    workspaceId: owner.sId,
-  });
-
-  // The truth is in the conversationTools, we need to update the selectedMCPServerViewIds when the conversationTools change.
-  useEffect(() => {
-    setSelectedMCPServerViews(conversationTools);
-  }, [conversationTools]);
-
-  const { addTool, deleteTool } = useAddDeleteConversationTool({
-    conversationId: conversation?.sId,
-    workspaceId: owner.sId,
-  });
-  const selectedMCPServerViewIds = useMemo(
-    () => new Set(selectedMCPServerViews.map((serverView) => serverView.sId)),
-    [selectedMCPServerViews]
-  );
   const spacesSelectionKey = conversation?.sId ?? `draft:${draftKey}`;
   const draftSelectedSpaceIds = useMemo(
     () => getDraft()?.selectedSpaceIds ?? [],
@@ -408,48 +381,6 @@ export const InputBar = React.memo(function InputBar({
     ? isConversationSelectableSpacesLoading
     : isWorkspaceSpacesLoading;
 
-  const handleMCPServerViewSelect = useCallback(
-    (serverView: MCPServerViewLightType) => {
-      if (selectedMCPServerViewIds.has(serverView.sId)) {
-        return;
-      }
-
-      setSelectedMCPServerViews((prev) =>
-        prev.some((sv) => sv.sId === serverView.sId)
-          ? prev
-          : [...prev, serverView]
-      );
-      void addTool(serverView.sId);
-    },
-    [addTool, selectedMCPServerViewIds]
-  );
-
-  const handleMCPServerViewDeselect = useCallback(
-    (serverView: MCPServerViewLightType) => {
-      if (!selectedMCPServerViewIds.has(serverView.sId)) {
-        return;
-      }
-
-      setSelectedMCPServerViews((prev) =>
-        prev.filter((sv) => sv.sId !== serverView.sId)
-      );
-      void deleteTool(serverView.sId);
-    },
-    [deleteTool, selectedMCPServerViewIds]
-  );
-
-  const clearSideChannelSelections = useCallback(async () => {
-    const serverViewIds = selectedMCPServerViews.map(
-      (serverView) => serverView.sId
-    );
-    setSelectedMCPServerViews([]);
-    setAttachedNodes([]);
-
-    await Promise.all(
-      serverViewIds.map((serverViewId) => deleteTool(serverViewId))
-    );
-  }, [deleteTool, selectedMCPServerViews]);
-
   const handleSelectedSpaceIdsChange = useCallback(
     async (spaceIds: string[]): Promise<string[] | null> => {
       if (!shouldShowSpacesAction) {
@@ -483,7 +414,7 @@ export const InputBar = React.memo(function InputBar({
         const persistedSpaceIds = response.selectedSpaces.map(
           (selectedSpace) => selectedSpace.sId
         );
-        await clearSideChannelSelections();
+        setAttachedNodes([]);
         setSelectedSpacesState({
           key: spacesSelectionKey,
           spaceIds: persistedSpaceIds,
@@ -492,7 +423,7 @@ export const InputBar = React.memo(function InputBar({
         return persistedSpaceIds;
       }
 
-      await clearSideChannelSelections();
+      setAttachedNodes([]);
       setSelectedSpacesState({
         key: spacesSelectionKey,
         spaceIds: nextSpaceIds,
@@ -501,7 +432,6 @@ export const InputBar = React.memo(function InputBar({
     },
     [
       addConversationSelectedSpaces,
-      clearSideChannelSelections,
       conversation?.sId,
       mutateSelectableSpaces,
       spacesSelectionKey,
@@ -536,6 +466,7 @@ export const InputBar = React.memo(function InputBar({
     onBeforeSubmit?.();
 
     const { mentions: rawMentions, markdown } = markdownAndMentions;
+    const tools = uniqBy(extractToolTags(markdown), "id");
     const shouldInjectSelectedAgent =
       selectedSingleAgent &&
       !rawMentions.some((m) => m.id === selectedSingleAgent.id);
@@ -556,7 +487,7 @@ export const InputBar = React.memo(function InputBar({
       extra: {
         conversation_id: conversation?.sId ?? "new",
         has_attachments: attachedNodes.length > 0 || uploadedFiles.length > 0,
-        has_tools: selectedMCPServerViews.length > 0,
+        has_tools: tools.length > 0,
         has_agents: mentionedAgents.length > 0,
         has_default_agent: mentionedAgents.some((a) => isGlobalAgentId(a.sId)),
         has_custom_agent: mentionedAgents.some((a) => !isGlobalAgentId(a.sId)),
@@ -564,8 +495,8 @@ export const InputBar = React.memo(function InputBar({
         agent_count: mentions.length,
         agent_ids: mentionedAgents.map((a) => a.sId).join(","),
         attachment_count: attachedNodes.length + uploadedFiles.length,
-        tool_count: selectedMCPServerViews.length,
-        tool_names: selectedMCPServerViews.map((t) => t.server.name).join(","),
+        tool_count: tools.length,
+        tool_names: tools.map((tool) => tool.name).join(","),
         message_length: markdown.length,
       },
     });
@@ -591,9 +522,8 @@ export const InputBar = React.memo(function InputBar({
             }),
             contentNodes: attachedNodes,
           },
-          // Only send the selectedMCPServerViewIds if we are creating a new conversation.
-          // Once the conversation is created, the selectedMCPServerViewIds will be updated in the conversationTools hook.
-          selectedMCPServerViews.map((sv) => sv.sId),
+          // Keep sending IDs during rollout so older servers also enable inline tools.
+          tools.map((tool) => tool.id),
           selectedSpaceIds,
           modelSelectionRef.current
         );
@@ -629,9 +559,7 @@ export const InputBar = React.memo(function InputBar({
             }),
             contentNodes: attachedNodes,
           },
-          // Existing conversation: MCP server views are synced via the
-          // conversationTools hook.
-          undefined,
+          tools.map((tool) => tool.id),
           selectedSpaceIds,
           modelSelectionRef.current
         );
@@ -660,13 +588,6 @@ export const InputBar = React.memo(function InputBar({
 
   const handleNodesAttachmentRemove = (node: DataSourceViewContentNode) => {
     setAttachedNodes((prev) => prev.filter((n) => !isEqualNode(n, node)));
-  };
-
-  const handleResetMCPServerViews = () => {
-    setSelectedMCPServerViews((prev) => {
-      prev.forEach((sv) => void deleteTool(sv.sId));
-      return [];
-    });
   };
 
   const handleShake = useCallback(() => {
@@ -780,16 +701,12 @@ export const InputBar = React.memo(function InputBar({
             }
             onNodeSelect={handleNodesAttachmentSelect}
             onNodeUnselect={handleNodesAttachmentRemove}
-            selectedMCPServerViews={selectedMCPServerViews}
             selectedSpaceIds={selectedSpaceIds}
             selectableSpaces={selectableSpaces}
             shouldShowSpacesAction={shouldShowSpacesAction}
             isSelectableSpacesLoading={isSelectableSpacesLoading}
             onSelectedSpaceIdsChange={handleSelectedSpaceIdsChange}
-            onMCPServerViewSelect={handleMCPServerViewSelect}
             modelSelectionRef={modelSelectionRef}
-            onMCPServerViewDeselect={handleMCPServerViewDeselect}
-            onResetMCPServerViews={handleResetMCPServerViews}
             isAgentBuilder={isAgentBuilder}
             attachedNodes={attachedNodes}
             saveDraft={saveDraft}

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -79,7 +79,7 @@ interface InputBarButtonsProps {
   onSkillSelect: (skill: SkillWithoutInstructionsAndToolsType) => void;
   owner: WorkspaceType;
   selectedAgent: RichAgentMention | null;
-  selectedMCPServerViews: MCPServerViewLightType[];
+  selectedMCPServerViews: Pick<MCPServerViewLightType, "sId">[];
   selectedSpaceIds: string[];
   onSelectedSpaceIdsChange: (spaceIds: string[]) => void;
   spaces?: SelectableConversationSpaceType[];

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -39,7 +39,6 @@ import useCustomEditor, {
 import useHandleMentions from "@app/components/editor/input_bar/useHandleMentions";
 import useUrlHandler from "@app/components/editor/input_bar/useUrlHandler";
 import type { Selection } from "@app/components/model_picker/modelPickerUtils";
-import { getIcon } from "@app/components/resources/resources_icons";
 import { CapabilityDetailsSheets } from "@app/components/shared/CapabilityDetailsSheets";
 import {
   useCompactConversation,
@@ -57,6 +56,7 @@ import { useClientType } from "@app/lib/context/clientType";
 import { getSpaceIcon } from "@app/lib/spaces";
 import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
 import { useIsMobile, useIsWidthConstrained } from "@app/lib/swr/useIsMobile";
+import { extractToolTags } from "@app/lib/tools/format";
 import { classNames } from "@app/lib/utils";
 import { isVoiceTranscriptionAllowed } from "@app/lib/workspace_policies";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
@@ -105,7 +105,8 @@ import {
 } from "@dust-tt/sparkle";
 import type { Editor } from "@tiptap/react";
 import { EditorContent } from "@tiptap/react";
-import React, {
+import type React from "react";
+import {
   useCallback,
   useContext,
   useEffect,
@@ -232,12 +233,9 @@ export interface InputBarContainerProps {
   onVoiceActiveChange?: (active: boolean) => void;
   isSubmitting: boolean;
   onEnterKeyDown: CustomEditorProps["onEnterKeyDown"];
-  onMCPServerViewDeselect: (serverView: MCPServerViewLightType) => void;
-  onMCPServerViewSelect: (serverView: MCPServerViewLightType) => void;
   modelSelectionRef?: React.MutableRefObject<ModelSelectionType | undefined>;
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
-  onResetMCPServerViews: () => void;
   owner: WorkspaceType;
   saveDraft: (
     markdown: string,
@@ -246,7 +244,6 @@ export interface InputBarContainerProps {
   ) => void;
   pendingInputText: PendingInputText | null;
   selectedAgent: RichAgentMention | null;
-  selectedMCPServerViews: MCPServerViewLightType[];
   selectedSpaceIds?: string[];
   selectableSpaces?: SelectableConversationSpaceType[];
   shouldShowSpacesAction?: boolean;
@@ -294,12 +291,8 @@ const InputBarContainer = ({
   onNodeSelect,
   onNodeUnselect,
   attachedNodes,
-  onMCPServerViewSelect,
   modelSelectionRef,
-  onMCPServerViewDeselect,
-  selectedMCPServerViews,
   selectedSpaceIds = EMPTY_SPACE_IDS,
-  onResetMCPServerViews,
   onSelectedSpaceIdsChange = acceptSelectedSpaceIds,
   selectableSpaces = EMPTY_SELECTABLE_SPACES,
   shouldShowSpacesAction = false,
@@ -397,6 +390,9 @@ const InputBarContainer = ({
   // Tracks internalIds of nodes that have a dataSourceLink chip in the editor,
   // so we only sync removal for nodes that were created via URL paste.
   const dataSourceLinkNodeIdsRef = useRef<Set<string>>(new Set());
+  const [selectedMCPServerViews, setSelectedMCPServerViews] = useState<
+    Pick<MCPServerViewLightType, "sId">[]
+  >([]);
   const selectedMCPServerViewIds = useMemo(
     () => new Set(selectedMCPServerViews.map((serverView) => serverView.sId)),
     [selectedMCPServerViews]
@@ -443,6 +439,9 @@ const InputBarContainer = ({
       modelSelectionRef.current = selection.toSend;
     }
   };
+  const [selectedToolIdForDetails, setSelectedToolIdForDetails] = useState<
+    string | null
+  >(null);
   const [selectedSkillIdForDetails, setSelectedSkillIdForDetails] = useState<
     string | null
   >(null);
@@ -666,6 +665,18 @@ const InputBarContainer = ({
     }
   };
 
+  const handleToolSelect = (serverView: MCPServerViewLightType) => {
+    editorRef.current
+      ?.chain()
+      .focus()
+      .insertToolNode({
+        mcpServerViewId: serverView.sId,
+        toolName: getMcpServerViewDisplayName(serverView),
+        toolIcon: serverView.server.icon,
+      })
+      .run();
+  };
+
   const handleSkillSelect = ({
     sId: skillId,
     name: skillName,
@@ -730,7 +741,7 @@ const InputBarContainer = ({
         handleSkillSelect(item.data.skill);
         break;
       case SELECT_TOOL_SLASH_COMMAND_ACTION:
-        onMCPServerViewSelect(item.data.tool.view);
+        handleToolSelect(item.data.tool.view);
         break;
       default:
         assertNeverAndIgnore(item);
@@ -787,6 +798,7 @@ const InputBarContainer = ({
       onSelectRef,
       onDetailsRef,
       onSkillDetails: setSelectedSkillIdForDetails,
+      onToolDetails: setSelectedToolIdForDetails,
       selectedMCPServerViewIdsRef,
       slashCommandsRef,
       includeAttachKnowledgeRef,
@@ -1061,7 +1073,6 @@ const InputBarContainer = ({
     prevUserMentionedRef.current = userMentioned;
     if (startsWithUserMention && !wasUserMentioned) {
       setSelectedSingleAgent(null);
-      onResetMCPServerViews();
     }
   };
 
@@ -1083,6 +1094,9 @@ const InputBarContainer = ({
         selectedSpaceIdsRef.current
       );
     }
+    setSelectedMCPServerViews(
+      extractToolTags(markdown).map((tool) => ({ sId: tool.id }))
+    );
     const userMentioned = editorMentions.some((m) => m.type === "user");
 
     // Check if the very first content node in the editor is a user mention.
@@ -1607,8 +1621,12 @@ const InputBarContainer = ({
         user={user}
         selectedSkillId={selectedSkillIdForDetails}
         selectedMCPServerView={selectedServerViewForDetails}
+        selectedMCPServerViewId={selectedToolIdForDetails}
         onCloseSkill={() => setSelectedSkillIdForDetails(null)}
-        onCloseTool={() => setSelectedServerViewForDetails(null)}
+        onCloseTool={() => {
+          setSelectedServerViewForDetails(null);
+          setSelectedToolIdForDetails(null);
+        }}
       />
 
       {isCompact && (
@@ -1711,30 +1729,6 @@ const InputBarContainer = ({
             }}
           >
             <div className="mb-1 flex flex-wrap items-center px-3">
-              {selectedMCPServerViews.map((msv) => (
-                <React.Fragment key={msv.sId}>
-                  {/* Two Chips: one for larger screens (desktop), one for smaller screens (mobile). */}
-                  <Chip
-                    size="xs"
-                    label={getMcpServerViewDisplayName(msv)}
-                    icon={getIcon(msv.server.icon)}
-                    className="m-0.5 hidden bg-background text-foreground xs:flex"
-                    onClick={() => setSelectedServerViewForDetails(msv)}
-                    onRemove={() => {
-                      onMCPServerViewDeselect(msv);
-                    }}
-                  />
-                  <Chip
-                    size="xs"
-                    icon={getIcon(msv.server.icon)}
-                    className="m-0.5 flex bg-background text-foreground xs:hidden"
-                    onClick={() => setSelectedServerViewForDetails(msv)}
-                    onRemove={() => {
-                      onMCPServerViewDeselect(msv);
-                    }}
-                  />
-                </React.Fragment>
-              ))}
               {selectedSpaces.map((selectedSpace) => (
                 <Chip
                   key={selectedSpace.sId}
@@ -1782,7 +1776,7 @@ const InputBarContainer = ({
                       isInputDisabled={disableInput}
                       lastRequestedModel={lastRequestedModel}
                       onAgentRemove={handleAgentRemove}
-                      onMCPServerViewSelect={onMCPServerViewSelect}
+                      onMCPServerViewSelect={handleToolSelect}
                       modelSelectionRef={modelSelectionRef}
                       modelSelectionCommitRef={modelSelectionCommitRef}
                       onNodeSelect={onNodeSelect}

--- a/front/components/assistant/conversation/input_bar/InputBarPlusMenu.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarPlusMenu.tsx
@@ -47,7 +47,7 @@ interface InputBarPlusMenuProps {
   disabled: boolean;
   hideCapabilities: boolean;
   hideAttachments: boolean;
-  selectedMCPServerViews: MCPServerViewLightType[];
+  selectedMCPServerViews: Pick<MCPServerViewLightType, "sId">[];
   onMCPServerViewSelect: (serverView: MCPServerViewLightType) => void;
   onSkillSelect: (skill: SkillWithoutInstructionsAndToolsType) => void;
   onSetupServer: (server: MCPServerType) => void;

--- a/front/components/editor/extensions/input_bar/ToolNode.tsx
+++ b/front/components/editor/extensions/input_bar/ToolNode.tsx
@@ -1,0 +1,41 @@
+import { ToolChip } from "@app/components/editor/extensions/skill_builder/ToolChip";
+import { ToolNode as ToolNodeBase } from "@app/components/editor/extensions/skill_builder/ToolNode";
+import { serializeToolTag } from "@app/lib/tools/format";
+import type { NodeViewProps } from "@tiptap/react";
+import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
+
+interface ToolNodeOptions {
+  onToolDetails?: (mcpServerViewId: string) => void;
+}
+
+export const ToolNode = ToolNodeBase.extend<ToolNodeOptions>({
+  addOptions() {
+    return { ...this.parent?.(), onToolDetails: undefined };
+  },
+
+  renderText({ node }) {
+    return serializeToolTag({
+      id: node.attrs.mcpServerViewId,
+      name: node.attrs.toolName,
+      icon: node.attrs.toolIcon,
+    });
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer((props: NodeViewProps) => (
+      <NodeViewWrapper className="inline-flex align-middle">
+        <ToolChip
+          title={props.node.attrs.toolName}
+          toolIcon={props.node.attrs.toolIcon}
+          onClick={
+            this.options.onToolDetails
+              ? () =>
+                  this.options.onToolDetails?.(props.node.attrs.mcpServerViewId)
+              : undefined
+          }
+          onRemove={props.editor.isEditable ? props.deleteNode : undefined}
+        />
+      </NodeViewWrapper>
+    ));
+  },
+});

--- a/front/components/editor/input_bar/cleanupPastedHTML.ts
+++ b/front/components/editor/input_bar/cleanupPastedHTML.ts
@@ -31,11 +31,13 @@ const SANITIZE_CONFIG: Config = {
     "h4",
     "h5",
     "h6",
+    "tool",
   ],
 
   // IMPORTANT: don't set ALLOWED_ATTR here.
   // Let DOMPurify use its safe defaults and explicitly allow data-* below.
   ALLOW_DATA_ATTR: true,
+  ADD_ATTR: ["icon"],
 
   // Strip dangerous containers entirely
   FORBID_TAGS: [
@@ -61,7 +63,7 @@ const SANITIZE_CONFIG: Config = {
   ],
 
   // Remove styling/identifiers
-  FORBID_ATTR: ["style", "class", "id"],
+  FORBID_ATTR: ["style", "class"],
 
   // Keep text if unexpected wrappers appear
   KEEP_CONTENT: true,
@@ -125,6 +127,11 @@ function addHookOnce() {
     const element = node;
     const style = element.getAttribute("style");
     const tagName = element.tagName.toLowerCase();
+
+    // Tool IDs are reference metadata; strip ordinary HTML identifiers.
+    if (tagName !== "tool") {
+      element.removeAttribute("id");
+    }
 
     // Convert <br class="Apple-interchange-newline"> to empty text node (Apple paste metadata)
     // We replace it with a <span> but DOMPurify will handle the output formatting

--- a/front/components/editor/input_bar/cleanupPastedHTML.ts
+++ b/front/components/editor/input_bar/cleanupPastedHTML.ts
@@ -31,13 +31,11 @@ const SANITIZE_CONFIG: Config = {
     "h4",
     "h5",
     "h6",
-    "tool",
   ],
 
   // IMPORTANT: don't set ALLOWED_ATTR here.
   // Let DOMPurify use its safe defaults and explicitly allow data-* below.
   ALLOW_DATA_ATTR: true,
-  ADD_ATTR: ["icon"],
 
   // Strip dangerous containers entirely
   FORBID_TAGS: [
@@ -63,7 +61,7 @@ const SANITIZE_CONFIG: Config = {
   ],
 
   // Remove styling/identifiers
-  FORBID_ATTR: ["style", "class"],
+  FORBID_ATTR: ["style", "class", "id"],
 
   // Keep text if unexpected wrappers appear
   KEEP_CONTENT: true,
@@ -127,11 +125,6 @@ function addHookOnce() {
     const element = node;
     const style = element.getAttribute("style");
     const tagName = element.tagName.toLowerCase();
-
-    // Tool IDs are reference metadata; strip ordinary HTML identifiers.
-    if (tagName !== "tool") {
-      element.removeAttribute("id");
-    }
 
     // Convert <br class="Apple-interchange-newline"> to empty text node (Apple paste metadata)
     // We replace it with a <span> but DOMPurify will handle the output formatting

--- a/front/components/editor/input_bar/useCustomEditor.test.ts
+++ b/front/components/editor/input_bar/useCustomEditor.test.ts
@@ -2,11 +2,13 @@ import {
   InputBarSlashSuggestionExtension,
   inputBarSlashSuggestionPluginKey,
 } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension";
+import { cleanupPastedHTML } from "@app/components/editor/input_bar/cleanupPastedHTML";
 import useCustomEditor, {
   buildEditorExtensions,
 } from "@app/components/editor/input_bar/useCustomEditor";
 import type { WorkspaceType } from "@app/types/user";
 import { act, renderHook } from "@testing-library/react";
+import { closeHistory } from "@tiptap/pm/history";
 import { Editor } from "@tiptap/react";
 import { StarterKit } from "@tiptap/starter-kit";
 import {
@@ -192,6 +194,39 @@ describe("buildEditorExtensions", () => {
     expect(editor.getMarkdown()).toContain(
       '<skill id="skill_123" name="commit" icon="book_open" />'
     );
+  });
+
+  it("round-trips inline tools through drafts and sanitized HTML paste", () => {
+    const content =
+      'Use <tool id="tool_123" name="GitHub &amp; Issues" icon="GithubLogo" /> to find the issue.';
+    editor.commands.setContent(content, { contentType: "markdown" });
+    expect(editor.getMarkdown()).toBe(content);
+    expect(editor.getJSON().content?.[0].content?.[1]).toMatchObject({
+      type: "toolNode",
+      attrs: { mcpServerViewId: "tool_123", toolName: "GitHub & Issues" },
+    });
+
+    const pastedHtml = cleanupPastedHTML(editor.getHTML());
+    editor.commands.setContent(pastedHtml);
+    expect(editor.getMarkdown()).toBe(content);
+  });
+
+  it("inserts and removes an inline tool at the cursor", () => {
+    editor.commands.setContent("Find the issue.", { contentType: "markdown" });
+    editor.commands.setTextSelection(6);
+    editor.commands.insertToolNode({
+      mcpServerViewId: "tool_123",
+      toolName: "GitHub",
+      toolIcon: "GithubLogo",
+    });
+    expect(editor.getMarkdown()).toBe(
+      'Find <tool id="tool_123" name="GitHub" icon="GithubLogo" /> the issue.'
+    );
+    editor.view.dispatch(closeHistory(editor.state.tr));
+    editor.commands.deleteRange({ from: 6, to: 8 });
+    expect(editor.getMarkdown()).toBe("Find the issue.");
+    editor.commands.undo();
+    expect(editor.getMarkdown()).toContain('<tool id="tool_123"');
   });
 
   it("should handle bullet list with `*`", () => {

--- a/front/components/editor/input_bar/useCustomEditor.test.ts
+++ b/front/components/editor/input_bar/useCustomEditor.test.ts
@@ -2,7 +2,6 @@ import {
   InputBarSlashSuggestionExtension,
   inputBarSlashSuggestionPluginKey,
 } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension";
-import { cleanupPastedHTML } from "@app/components/editor/input_bar/cleanupPastedHTML";
 import useCustomEditor, {
   buildEditorExtensions,
 } from "@app/components/editor/input_bar/useCustomEditor";
@@ -196,7 +195,7 @@ describe("buildEditorExtensions", () => {
     );
   });
 
-  it("round-trips inline tools through drafts and sanitized HTML paste", () => {
+  it("round-trips inline tools through drafts", () => {
     const content =
       'Use <tool id="tool_123" name="GitHub &amp; Issues" icon="GithubLogo" /> to find the issue.';
     editor.commands.setContent(content, { contentType: "markdown" });
@@ -205,10 +204,6 @@ describe("buildEditorExtensions", () => {
       type: "toolNode",
       attrs: { mcpServerViewId: "tool_123", toolName: "GitHub & Issues" },
     });
-
-    const pastedHtml = cleanupPastedHTML(editor.getHTML());
-    editor.commands.setContent(pastedHtml);
-    expect(editor.getMarkdown()).toBe(content);
   });
 
   it("inserts and removes an inline tool at the cursor", () => {

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -10,6 +10,7 @@ import type { InputBarSlashCommand } from "@app/components/editor/extensions/inp
 import { KeyboardShortcutsExtension } from "@app/components/editor/extensions/input_bar/KeyboardShortcutsExtension";
 import { PastedAttachmentExtension } from "@app/components/editor/extensions/input_bar/PastedAttachmentExtension";
 import { SkillNode } from "@app/components/editor/extensions/input_bar/SkillNode";
+import { ToolNode } from "@app/components/editor/extensions/input_bar/ToolNode";
 import { URLDetectionExtension } from "@app/components/editor/extensions/input_bar/URLDetectionExtension";
 import { URLStorageExtension } from "@app/components/editor/extensions/input_bar/URLStorageExtension";
 import { MentionExtension } from "@app/components/editor/extensions/MentionExtension";
@@ -338,6 +339,7 @@ export interface CustomEditorProps {
     onSelectRef: React.RefObject<((item: SlashCommand) => void) | undefined>;
     onDetailsRef?: React.RefObject<((item: SlashCommand) => void) | undefined>;
     onSkillDetails?: (skillId: string) => void;
+    onToolDetails?: (mcpServerViewId: string) => void;
     selectedMCPServerViewIdsRef: React.RefObject<Set<string>>;
     slashCommandsRef: React.RefObject<InputBarSlashCommand[]>;
     includeAttachKnowledgeRef: React.RefObject<boolean>;
@@ -476,6 +478,9 @@ export const buildEditorExtensions = ({
     SkillNode.configure({
       onSkillDetails: slashSuggestion?.onSkillDetails,
     }),
+    ToolNode.configure({
+      onToolDetails: slashSuggestion?.onToolDetails,
+    }),
     VoicePartialNode,
     createEmojiExtension({ onActiveChange: notifySuggestionActiveChange }),
     Placeholder.configure({
@@ -504,6 +509,8 @@ export const buildEditorExtensions = ({
         enabledRef: slashSuggestion.enabledRef,
         onSelectRef: slashSuggestion.onSelectRef,
         onDetailsRef: slashSuggestion.onDetailsRef,
+        selectedMCPServerViewIdsRef:
+          slashSuggestion.selectedMCPServerViewIdsRef,
         onModelSelectRef: slashSuggestion.onModelSelectRef,
         onNodeSelectRef: slashSuggestion.onNodeSelectRef,
         onActiveChangeRef: onSuggestionActiveChangeRef,

--- a/front/components/shared/CapabilityDetailsSheets.tsx
+++ b/front/components/shared/CapabilityDetailsSheets.tsx
@@ -1,8 +1,12 @@
 import { MCPServerDetails } from "@app/components/actions/mcp/MCPServerDetails";
 import { SkillDetailsSheet } from "@app/components/skills/SkillDetailsSheet";
 import type { MCPServerViewLightType } from "@app/lib/api/mcp";
-import { useMCPServer } from "@app/lib/swr/mcp_servers";
+import {
+  useJITMCPServerViewsFromSpaces,
+  useMCPServer,
+} from "@app/lib/swr/mcp_servers";
 import { useSkill } from "@app/lib/swr/skill_configurations";
+import { useSpaces } from "@app/lib/swr/spaces";
 import type { UserType, WorkspaceType } from "@app/types/user";
 
 interface CapabilityDetailsSheetsProps {
@@ -10,6 +14,7 @@ interface CapabilityDetailsSheetsProps {
   user: UserType | null;
   selectedSkillId: string | null;
   selectedMCPServerView: MCPServerViewLightType | null;
+  selectedMCPServerViewId?: string | null;
   onCloseSkill: () => void;
   onCloseTool: () => void;
   replaceOnSkillEdit?: boolean;
@@ -20,6 +25,7 @@ export function CapabilityDetailsSheets({
   user,
   selectedSkillId,
   selectedMCPServerView,
+  selectedMCPServerViewId,
   onCloseSkill,
   onCloseTool,
   replaceOnSkillEdit,
@@ -31,18 +37,30 @@ export function CapabilityDetailsSheets({
     disabled: !selectedSkillId,
   });
 
+  // Inline references retain the view ID, so resolve the light view only on open.
+  const { spaces } = useSpaces({
+    workspaceId: owner.sId,
+    kinds: ["global"],
+    disabled: !selectedMCPServerViewId,
+  });
+  const { serverViews } = useJITMCPServerViewsFromSpaces(owner, spaces, {
+    disabled: !selectedMCPServerViewId,
+  });
+  const selectedView =
+    selectedMCPServerView ??
+    serverViews.find((view) => view.sId === selectedMCPServerViewId) ??
+    null;
+
   // List surfaces hold light views (no tools, no authorization); resolve the full view on
   // open from the server endpoint (SWR-deduped with MCPServerDetails' own fetch).
   const { server: mcpServerWithViews } = useMCPServer({
     owner,
-    serverId: selectedMCPServerView?.server.sId ?? "",
-    disabled: !selectedMCPServerView,
+    serverId: selectedView?.server.sId ?? "",
+    disabled: !selectedView,
   });
   const fullMCPServerView =
-    (selectedMCPServerView &&
-      mcpServerWithViews?.views.find(
-        (v) => v.sId === selectedMCPServerView.sId
-      )) ??
+    (selectedView &&
+      mcpServerWithViews?.views.find((v) => v.sId === selectedView.sId)) ??
     null;
 
   return (
@@ -60,7 +78,7 @@ export function CapabilityDetailsSheets({
       <MCPServerDetails
         owner={owner}
         mcpServerView={fullMCPServerView}
-        isOpen={selectedMCPServerView !== null}
+        isOpen={!!selectedView || !!selectedMCPServerViewId}
         onClose={onCloseTool}
         readOnly
       />

--- a/front/hooks/useSubmitMessage.ts
+++ b/front/hooks/useSubmitMessage.ts
@@ -36,6 +36,7 @@ export function useSubmitMessage({
       mentions: MentionType[];
       contentFragments: ContentFragmentsType;
       clientSideMCPServerIds?: string[];
+      selectedMCPServerViewIds?: string[];
       selectedSpaceIds?: string[];
       origin?: ClientMessageOrigin;
       skipToolsValidation?: boolean;
@@ -54,6 +55,7 @@ export function useSubmitMessage({
         mentions,
         contentFragments,
         clientSideMCPServerIds,
+        selectedMCPServerViewIds,
         selectedSpaceIds,
         origin: messageOrigin,
         skipToolsValidation,
@@ -130,6 +132,7 @@ export function useSubmitMessage({
                 Intl.DateTimeFormat().resolvedOptions().timeZone || "Etc/UTC",
               profilePictureUrl: user.image,
               clientSideMCPServerIds,
+              selectedMCPServerViewIds,
               selectedSpaceIds,
               origin,
             },

--- a/front/lib/tools/markdown.ts
+++ b/front/lib/tools/markdown.ts
@@ -1,0 +1,53 @@
+import { parseToolTag, TOOL_TAG_REGEX } from "@app/lib/tools/format";
+import { escapeXml } from "@app/types/shared/utils/string_utils";
+import { visit } from "unist-util-visit";
+
+export interface ToolDirectiveProps {
+  toolId: string;
+  toolIcon: string | null;
+  toolName: string;
+}
+
+export function toolDirective(this: {
+  parse: (content: string) => { type: string; children?: unknown };
+}) {
+  const processor = this;
+  return (tree: any) => {
+    visit(tree, ["html", "textDirective"], (node, index, parent) => {
+      if (node.type === "html" && parseToolTag(node.value)) {
+        // A tag on its own line can start an HTML block that also contains the
+        // following message text. Reparse it as Markdown so that text is retained.
+        const markdown = node.value.replace(TOOL_TAG_REGEX, (tag: string) => {
+          const tool = parseToolTag(tag);
+          if (!tool) {
+            return tag;
+          }
+          return `:tool[]{id="${escapeXml(tool.id)}" name="${escapeXml(tool.name)}" icon="${escapeXml(tool.icon ?? "")}"}`;
+        });
+        const parsed = processor.parse(markdown);
+        if (!Array.isArray(parsed.children)) {
+          return;
+        }
+        const firstNode = parsed.children[0];
+        const nodes =
+          parent.type === "paragraph" && firstNode?.type === "paragraph"
+            ? firstNode.children
+            : parsed.children;
+        // Remark transforms replace nodes in their parent in place.
+        parent.children.splice(index, 1, ...nodes);
+        return index;
+      }
+
+      if (node.type === "textDirective" && node.name === "tool") {
+        node.data = {
+          hName: "tool",
+          hProperties: {
+            toolId: node.attributes.id,
+            toolIcon: node.attributes.icon,
+            toolName: node.attributes.name,
+          },
+        };
+      }
+    });
+  };
+}


### PR DESCRIPTION
## Description

Tool selections now appear as inline chips at the cursor in the conversation input, using Skill Builder's `<tool>` format. References survive drafts, message editing and copy/paste, and render as clickable chips in sent messages.

Like skills, tools are enabled when the message is submitted. Existing conversation tools stay enabled, and the server accepts both inline tags and legacy `selectedMCPServerViewIds`, deduplicating them. The client continues sending IDs during rollout so older servers also enable the referenced tools. No data migration is needed.

## Tests

- Added coverage for editor round-trips, sanitized paste, insertion/removal and multiline message rendering.
- Covered conversation creation and legacy, inline and mixed tool submissions.
- Storybook checks blocked by a setup-file import failure; the product input bar has no registered stories.

## Risk

- Medium. Changes conversation tool selection and activation timing.

## Deploy Plan

- Deploy front.
