### PR TITLE
fix(onboarding): make Pro checkout page responsive on mobile

### DIFF
--- a/front/components/pages/onboarding/CheckoutPage.tsx
+++ b/front/components/pages/onboarding/CheckoutPage.tsx
@@ -467,9 +467,9 @@ export function CheckoutPage() {
   }
 
   return (
-    <main className="flex h-screen overflow-hidden">
+    <main className="flex min-h-screen flex-col md:h-screen md:flex-row md:overflow-hidden">
       {/* Left pane: order summary + coupon */}
-      <div className="flex w-1/2 flex-col gap-14 overflow-y-auto bg-muted-background p-24">
+      <div className="flex w-full flex-col gap-14 overflow-y-auto bg-muted-background p-6 md:w-1/2 md:p-24">
         <div>
           <Icon visual={DustLogoSquare} size="lg" />
         </div>
@@ -649,15 +649,15 @@ export function CheckoutPage() {
           card_capture (with Stripe iframe): uniform p-24 with no centering so the iframe fills from the top.
           All other phases (spinners): centered. */}
       <div
-        className={`flex w-1/2 flex-col overflow-y-auto bg-white ${
+        className={`flex w-full flex-col overflow-y-auto bg-white md:w-1/2 ${
           phase === "card_capture" && clientSecret
-            ? "p-24"
+            ? "p-6 md:p-24"
             : phase === "payment_review" ||
                 phase === "error" ||
                 phase === "confirming" ||
                 phase === "waiting_for_payment"
-              ? "px-24 pb-24 pt-[296px]"
-              : "items-center justify-center p-24"
+              ? "p-6 md:px-24 md:pb-24 md:pt-[296px]"
+              : "items-center justify-center p-6 md:p-24"
         }`}
       >
         <RightPane

--- a/front/components/pages/onboarding/CheckoutPage.tsx
+++ b/front/components/pages/onboarding/CheckoutPage.tsx
@@ -1,4 +1,5 @@
 import { PaymentMethodRow } from "@app/components/checkout/PaymentMethodRow";
+import { useDocumentScrollMode } from "@app/hooks/useDocumentScrollMode";
 import config from "@app/lib/api/config";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import {
@@ -12,6 +13,7 @@ import {
   useUserBillingCurrency,
 } from "@app/lib/client/subscription";
 import { useAppRouter, useSearchParam } from "@app/lib/platform";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import {
   useAuthContext,
   useCheckBusinessActivation,
@@ -99,6 +101,11 @@ export function CheckoutPage() {
   const { mutateAuthContext } = useAuthContext({ workspaceId: owner.sId });
   const shouldRedirectAwayFromCheckout =
     useRedirectAwayFromCheckoutIfAlreadyPaid();
+
+  // On mobile the two panes stack vertically; enable document scroll so the
+  // whole page (not just each pane) can scroll to reach the payment fields.
+  const isMobile = useIsMobile();
+  useDocumentScrollMode(isMobile);
 
   // Determine if CP checkout is enabled.
   const isMetronomeCheckout = useIsMetronomeCheckout();
@@ -467,7 +474,7 @@ export function CheckoutPage() {
   }
 
   return (
-    <main className="flex min-h-screen flex-col md:h-screen md:flex-row md:overflow-hidden">
+    <main className="flex min-h-screen flex-col md:flex-row md:overflow-hidden">
       {/* Left pane: order summary + coupon */}
       <div className="flex w-full flex-col gap-14 overflow-y-auto bg-muted-background p-6 md:w-1/2 md:p-24">
         <div>


### PR DESCRIPTION
## Description

Fixes the Pro subscription checkout page not rendering correctly on Safari mobile (dust-tt/tasks#10312).

The page in `front/components/pages/onboarding/CheckoutPage.tsx` used a fixed two-pane layout with **no responsive breakpoints**: the root `<main>` was `flex h-screen overflow-hidden` and both panes were locked to `w-1/2` with `p-24` (6rem) padding. On a narrow Safari-mobile portrait viewport each pane was squeezed to 50% width while still carrying that padding, so the Stripe payment iframe overflowed — and because the container was `overflow-hidden`, there was no way to swipe/scroll to reach the payment fields. Landscape "worked" only because the wider viewport left room for the 50% panes.

Changes (desktop `md:` ≥768px stays pixel-identical):
- **Layout**: `<main>` stacks vertically on mobile (`flex min-h-screen flex-col md:flex-row md:overflow-hidden`); both panes are `w-full md:w-1/2` with `p-6 md:p-24`. The desktop-only `pt-[296px]` alignment offset is gated behind `md:`.
- **Mobile scroll**: enable the app's existing `useDocumentScrollMode(isMobile)` mechanism (already used by `AppContentLayout`) so the stacked panes participate in one natural document scroll instead of two cramped per-pane scroll areas. This is what makes `min-h-screen` meaningful — it frees the `html/body/#root` height chain (`height:auto; min-height:100dvh`) so `main` grows with content.
- Dropped the redundant `md:h-screen`: the unlayered global `main { height:100% }` rule (`front/styles/global.css`) wins over the layered Tailwind utility regardless, and already equals the viewport via the `h-full` chain.

## Tests

Type-check (`tsgo --noEmit`) and biome format pass. Verified the DOM chain from `#root` down to this page's `<main>` is context-providers/`<Outlet>` only (no intermediate fixed-height wrapper), so `document-scroll-mode` propagates correctly. Not visually verified on a physical Safari-mobile device — worth a quick manual check on a phone. No automated tests exist for this page and none added (layout-only change).

## Risk

Low. Layout-only change scoped to one component. Desktop rendering is unchanged (all original classes preserved behind `md:`, and `document-scroll-mode` is mobile-only via `useIsMobile`). Trivially rollback-able.

## Deploy Plan

Standard front-spa deploy, no migrations or coordination required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)