### PR TITLE
[front] plan mode: confirm before archiving a plan

### DIFF
--- a/front/components/assistant/conversation/plan_mode/ConversationPlanModePanel.tsx
+++ b/front/components/assistant/conversation/plan_mode/ConversationPlanModePanel.tsx
@@ -38,7 +38,7 @@ export function ConversationPlanModePanel({
       message:
         "This plan will be moved to the conversation's archived files. You can still open it later, and the agent can create a new plan if needed.",
       validateLabel: "Archive plan",
-      validateVariant: "warning",
+      validateVariant: "primary",
     });
     if (confirmed) {
       await closePlan();

--- a/front/components/assistant/conversation/plan_mode/ConversationPlanModePanel.tsx
+++ b/front/components/assistant/conversation/plan_mode/ConversationPlanModePanel.tsx
@@ -36,7 +36,7 @@ export function ConversationPlanModePanel({
     const confirmed = await confirm({
       title: "Archive this plan?",
       message:
-        "This plan will be moved to the conversation's archived files. You can still open it later, and the agent can create a new plan if needed.",
+        "The plan will no longer appear in the plan panel, but you can still open it from the conversation's Files panel. The agent can create a new plan.",
       validateLabel: "Archive plan",
       validateVariant: "primary",
     });

--- a/front/components/assistant/conversation/plan_mode/ConversationPlanModePanel.tsx
+++ b/front/components/assistant/conversation/plan_mode/ConversationPlanModePanel.tsx
@@ -36,7 +36,7 @@ export function ConversationPlanModePanel({
     const confirmed = await confirm({
       title: "Archive this plan?",
       message:
-        "The plan will no longer appear in the plan panel, but you can still open it from the conversation's Files panel. The agent can create a new plan.",
+        "This will hide the current plan from the side panel, but keep it in the conversation's files. The agent can create a new one.",
       validateLabel: "Archive plan",
       validateVariant: "primary",
     });

--- a/front/components/assistant/conversation/plan_mode/ConversationPlanModePanel.tsx
+++ b/front/components/assistant/conversation/plan_mode/ConversationPlanModePanel.tsx
@@ -1,5 +1,6 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { extractPlanTitle } from "@app/components/assistant/conversation/plan_mode/utils";
+import { ConfirmContext } from "@app/components/Confirm";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import {
   useClosePlan,
@@ -7,7 +8,8 @@ import {
 } from "@app/hooks/conversations/usePlanFile";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Button, Markdown, Spinner, Trash04, XClose } from "@dust-tt/sparkle";
+import { Archive, Button, Markdown, Spinner, XClose } from "@dust-tt/sparkle";
+import { useContext } from "react";
 
 interface ConversationPlanModePanelProps {
   conversation: ConversationWithoutContentType;
@@ -27,6 +29,21 @@ export function ConversationPlanModePanel({
     workspaceId: owner.sId,
     conversationId: conversation.sId,
   });
+  const confirm = useContext(ConfirmContext);
+
+  // Sits next to the panel close button, so ask before archiving.
+  const archivePlan = async () => {
+    const confirmed = await confirm({
+      title: "Archive plan?",
+      message:
+        "The plan is removed from this conversation. The agent can create a new one if needed.",
+      validateLabel: "Archive",
+      validateVariant: "warning",
+    });
+    if (confirmed) {
+      await closePlan();
+    }
+  };
 
   const title = extractPlanTitle(content);
 
@@ -44,10 +61,10 @@ export function ConversationPlanModePanel({
               <Button
                 variant="ghost"
                 size="sm"
-                icon={Trash04}
-                tooltip="Close plan"
+                icon={Archive}
+                tooltip="Archive plan"
                 isLoading={isClosing}
-                onClick={() => void closePlan()}
+                onClick={() => void archivePlan()}
               />
             )}
             <Button

--- a/front/components/assistant/conversation/plan_mode/ConversationPlanModePanel.tsx
+++ b/front/components/assistant/conversation/plan_mode/ConversationPlanModePanel.tsx
@@ -34,10 +34,10 @@ export function ConversationPlanModePanel({
   // Sits next to the panel close button, so ask before archiving.
   const archivePlan = async () => {
     const confirmed = await confirm({
-      title: "Archive plan?",
+      title: "Archive this plan?",
       message:
-        "The plan is removed from this conversation. The agent can create a new one if needed.",
-      validateLabel: "Archive",
+        "This plan will be moved to the conversation's archived files. You can still open it later, and the agent can create a new plan if needed.",
+      validateLabel: "Archive plan",
       validateVariant: "warning",
     });
     if (confirmed) {

--- a/front/hooks/conversations/usePlanFile.ts
+++ b/front/hooks/conversations/usePlanFile.ts
@@ -67,7 +67,7 @@ export function useClosePlan({
         const errorData = await getErrorFromResponse(res);
         sendNotification({
           type: "error",
-          title: "Failed to close plan",
+          title: "Failed to archive plan",
           description: errorData.message,
         });
         return false;


### PR DESCRIPTION
The plan panel header has a trash icon labeled "Close plan" right next to the X that closes the panel. Easy to mix up, and archiving can't be undone from the UI.

The action is now "Archive plan" with the archive icon (that's what the endpoint does, it moves `plan.md` to `archived_plans/`), and it asks for confirmation first, using the shared `ConfirmContext` dialog like file deletion does. The dialog says the file stays available in the conversation's archived files (wording from uxWriter). The error toast says "archive" too.

Follow-up to #31895.

