### PR TITLE
[front] fix: restore OAuth detection for remote MCP servers

### DIFF
--- a/front/lib/actions/mcp_oauth_provider.ts
+++ b/front/lib/actions/mcp_oauth_provider.ts
@@ -22,8 +22,15 @@ export class MCPOAuthProvider implements OAuthClientProvider {
   constructor(tokens?: OAuthTokens) {
     this.token = tokens;
   }
-  get redirectUrl(): undefined {
-    return undefined;
+  get redirectUrl(): string {
+    // Must return a concrete redirect URI. The MCP SDK (>=1.29) treats a falsy
+    // `redirectUrl` as a non-interactive (client_credentials) flow and calls
+    // `fetchToken()` with no authorization code and no `prepareTokenRequest`,
+    // throwing "Either provider.prepareTokenRequest() or authorizationCode is
+    // required" on any OAuth-gated server. Returning the URI keeps the
+    // interactive authorization-code path, where `saveCodeVerifier()` throws to
+    // cleanly signal that OAuth is required.
+    return finalizeUriForProvider("mcp");
   }
 
   get clientMetadata(): OAuthClientMetadata {


### PR DESCRIPTION
## Description

A customer could not connect the Tolgee remote MCP server; it errored with:

```
Error establishing connection to remote MCP server via URL
Error: Either provider.prepareTokenRequest() or authorizationCode is required
  at fetchToken (@modelcontextprotocol/sdk/.../client/auth.ts)
  at authInternal (.../auth.ts)
  at StreamableHTTPClientTransport.send (.../streamableHttp.ts)
```

Root cause: `MCPOAuthProvider.redirectUrl` returned `undefined` (introduced in #26469). The MCP SDK (>=1.29) computes `nonInteractiveFlow = !provider.redirectUrl`, so a falsy `redirectUrl` makes the SDK treat the connection as a non-interactive (client_credentials/jwt-bearer) flow. When the anonymous connection probe hits a `401` from an OAuth-gated remote MCP server, the SDK then calls `fetchToken()` with no authorization code and no `prepareTokenRequest`, throwing the error above. This broke OAuth *detection* for remote MCP servers generally; Tolgee just surfaced it as the terminal error.

Fix: return the concrete redirect URI (`finalizeUriForProvider("mcp")`, the same value already used in `clientMetadata.redirect_uris`). The SDK then stays on the interactive authorization-code path and reaches `saveCodeVerifier()`, which throws `MCPOAuthProviderError` to cleanly signal "OAuth required" — letting `discover_oauth_metadata` fall through to Dust's own OAuth discovery.

Relates to https://github.com/dust-tt/tasks/issues/10267

## Tests

- `npx tsgo --noEmit` passes.
- Manual verification of the SDK control flow against `@modelcontextprotocol/sdk@1.29.0` `auth.js`: with a concrete `redirectUrl`, `nonInteractiveFlow` is `false`, `fetchToken()` is skipped, and the probe throws at `saveCodeVerifier()` (the existing tripwire) instead of the cryptic `fetchToken` error.
- Needs a manual smoke test before deploy against (a) a working DCR OAuth server (Supabase/Intercom/Miro) to confirm the happy path is unchanged, and (b) an OAuth-gated server without DCR (Tolgee) to confirm the error is now the clean "no dynamic client registration" message.

## Risk

Low, and easy to roll back (single-line behavioral change on the probe OAuth provider). It touches OAuth for all remote MCP servers, so the main risk is regressing the happy path for DCR-based OAuth servers — mitigated by the smoke test above. The returned URI already matches `clientMetadata.redirect_uris[0]`, so it is consistent with what the SDK already advertises during registration.

## Deploy Plan

Standard `front` deploy. No migration, no config, no coordination required.