### PR TITLE
[front] fix: keep SWR mutation keys when disabled

### DIFF
--- a/front/lib/swr/data_source_view_tables.ts
+++ b/front/lib/swr/data_source_view_tables.ts
@@ -92,11 +92,9 @@ export function useDataSourceViewTables({
   const tablesFetcher: Fetcher<
     ListTablesResponseBody | SearchTablesResponseBody
   > = fetcher;
-  const { data, error, mutate } = useSWRWithDefaults(
-    isDisabled ? null : url,
-    tablesFetcher,
-    { disabled: isDisabled }
-  );
+  const { data, error, mutate } = useSWRWithDefaults(url, tablesFetcher, {
+    disabled: isDisabled,
+  });
 
   return {
     tables: data?.tables ?? emptyArray(),

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -433,14 +433,15 @@ export function useFileProcessedContent({
     disabled?: boolean;
   };
 }) {
-  const isDisabled = config?.disabled ?? !fileId;
+  const isDisabled = !fileId || config?.disabled === true;
+  const swrKey = fileId ? getFileProcessedUrl(owner, fileId) : null;
 
   const {
     data: response,
     error,
     mutate,
   } = useSWRWithDefaults(
-    isDisabled ? null : getFileProcessedUrl(owner, fileId),
+    swrKey,
     // Stream fetcher -> don't try to parse the stream.
     // Wait for initial response to trigger swr error handling.
     async (...args) => {
@@ -457,7 +458,7 @@ export function useFileProcessedContent({
 
       return response;
     },
-    config
+    { ...config, disabled: isDisabled }
   );
 
   return {
@@ -534,22 +535,21 @@ export function useFileMetadata({
   const fileMetadataFetcher: Fetcher<FileTypeWithMetadata> = fetcher;
 
   // Include cacheKey in the SWR key if provided to force cache invalidation.
-  const swrKey =
-    !disabled && fileId
-      ? cacheKey
-        ? `/api/w/${owner.sId}/files/${fileId}/metadata?v=${cacheKey}`
-        : `/api/w/${owner.sId}/files/${fileId}/metadata`
-      : null;
+  const swrKey = fileId
+    ? cacheKey
+      ? `/api/w/${owner.sId}/files/${fileId}/metadata?v=${cacheKey}`
+      : `/api/w/${owner.sId}/files/${fileId}/metadata`
+    : null;
 
   const { data, error, mutateRegardlessOfQueryParams } = useSWRWithDefaults(
     swrKey,
     fileMetadataFetcher,
-    { disabled: swrKey === null }
+    { disabled: disabled || swrKey === null }
   );
 
   return {
     fileMetadata: data,
-    isFileMetadataLoading: swrKey !== null && !error && !data,
+    isFileMetadataLoading: !disabled && swrKey !== null && !error && !data,
     isFileMetadataError: error,
     mutateFileMetadata: mutateRegardlessOfQueryParams,
   };

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -87,19 +87,16 @@ export function usePodContextAttachments({
   const podContextFetcher: Fetcher<GetProjectContextResponseBody> = fetcher;
 
   const key = useMemo(() => {
-    if (disabled) {
-      return null;
-    }
     const params = new URLSearchParams();
     if (query && query.trim().length > 0) {
       params.set("query", query);
     }
     const qs = params.toString();
     return `/api/w/${owner.sId}/spaces/${podId}/project_context${qs ? `?${qs}` : ""}`;
-  }, [disabled, owner.sId, podId, query]);
+  }, [owner.sId, podId, query]);
 
   const { data, error, mutate, mutateRegardlessOfQueryParams } =
-    useSWRWithDefaults(key, podContextFetcher);
+    useSWRWithDefaults(key, podContextFetcher, { disabled });
 
   const refreshPodContextAttachments = useCallback(async () => {
     // Do not pass `undefined` as data — it clears the cache and causes UI flicker.
@@ -497,17 +494,13 @@ export function usePodTasks({
   const { fetcher } = useFetcher();
   const tasksFetcher: Fetcher<GetPodTasksResponseBody> = fetcher;
   const tasksUrl = useMemo(
-    () =>
-      disabled
-        ? null
-        : buildPodTasksListSwrKey(owner.sId, podId, taskOwnerFilter),
-    [disabled, owner.sId, podId, taskOwnerFilter]
+    () => buildPodTasksListSwrKey(owner.sId, podId, taskOwnerFilter),
+    [owner.sId, podId, taskOwnerFilter]
   );
 
-  const { data, error, mutate } = useSWRWithDefaults(
-    disabled ? null : tasksUrl,
-    tasksFetcher
-  );
+  const { data, error, mutate } = useSWRWithDefaults(tasksUrl, tasksFetcher, {
+    disabled,
+  });
 
   const stableTaskOrderByAssigneeKeyRef = useRef<Map<string, string[]>>(
     new Map()
@@ -855,21 +848,23 @@ export function useWorkspacePodTask({
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
-  const url =
-    !disabled && taskId
-      ? `/api/w/${workspaceId}/project_tasks/${encodeURIComponent(taskId)}`
-      : null;
+  const url = taskId
+    ? `/api/w/${workspaceId}/project_tasks/${encodeURIComponent(taskId)}`
+    : null;
   const podTaskFetcher: Fetcher<GetWorkspacePodTaskResponseBody> = fetcher;
 
   const { data, error, isLoading, mutate } = useSWRWithDefaults(
     url,
-    podTaskFetcher
+    podTaskFetcher,
+    {
+      disabled: disabled || !taskId,
+    }
   );
 
   return {
     task: data?.task ?? null,
     pod: data?.space ?? null,
-    isWorkspacePodTaskLoading: !error && isLoading && !!url,
+    isWorkspacePodTaskLoading: !disabled && !error && isLoading && !!taskId,
     isWorkspacePodTaskError: !!error,
     mutateWorkspacePodTask: mutate,
   };

--- a/front/lib/swr/swr.test.ts
+++ b/front/lib/swr/swr.test.ts
@@ -1,0 +1,74 @@
+import { useSWRWithDefaults } from "@app/lib/swr/swr";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  cache: new Map(),
+  globalMutate: vi.fn(),
+  localMutate: vi.fn(),
+  useSWR: vi.fn(),
+}));
+
+vi.mock("swr", () => ({
+  default: mocks.useSWR,
+  useSWRConfig: () => ({
+    cache: mocks.cache,
+    mutate: mocks.globalMutate,
+  }),
+}));
+
+describe("useSWRWithDefaults", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.cache.clear();
+    mocks.globalMutate.mockResolvedValue(undefined);
+    mocks.localMutate.mockResolvedValue(undefined);
+    mocks.useSWR.mockReturnValue({ mutate: mocks.localMutate });
+  });
+
+  it("uses the concrete key to mutate when disabled", async () => {
+    const key = "/api/w/w_test/resources?view=list";
+
+    const { result } = renderHook(() =>
+      useSWRWithDefaults(key, null, { disabled: true })
+    );
+
+    await act(async () => {
+      await result.current.mutate();
+    });
+
+    expect(mocks.useSWR).toHaveBeenCalledWith(
+      null,
+      null,
+      expect.objectContaining({ disabled: true })
+    );
+    expect(mocks.globalMutate).toHaveBeenCalledWith(key);
+    expect(mocks.localMutate).not.toHaveBeenCalled();
+  });
+
+  it("uses the concrete key to mutate matching cache entries when disabled", async () => {
+    const key = "/api/w/w_test/resources?view=list";
+    const relatedKey = "/api/w/w_test/resources?view=manage";
+    mocks.cache.set(key, {});
+    mocks.cache.set(relatedKey, {});
+    mocks.cache.set("/api/w/w_test/other", {});
+
+    const { result } = renderHook(() =>
+      useSWRWithDefaults(key, null, { disabled: true })
+    );
+
+    await act(async () => {
+      await result.current.mutateRegardlessOfQueryParams();
+    });
+
+    expect(mocks.useSWR).toHaveBeenCalledWith(
+      null,
+      null,
+      expect.objectContaining({ disabled: true })
+    );
+    expect(mocks.globalMutate).toHaveBeenCalledWith(relatedKey);
+    expect(mocks.globalMutate).toHaveBeenCalledWith(key);
+    expect(mocks.globalMutate).not.toHaveBeenCalledWith("/api/w/w_test/other");
+    expect(mocks.localMutate).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/swr/workspace_branding.ts
+++ b/front/lib/swr/workspace_branding.ts
@@ -32,7 +32,7 @@ export function useWorkspaceBranding({
   const brandingFetcher: Fetcher<GetWorkspaceBrandingResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
-    disabled ? null : `/api/w/${owner.sId}/branding`,
+    `/api/w/${owner.sId}/branding`,
     brandingFetcher,
     { disabled }
   );

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -670,13 +670,12 @@ export function useCheckoutStatus({
   const { fetcher } = useFetcher();
   const checkoutFetcher: Fetcher<GetCheckoutStatusResponseBody> = fetcher;
 
-  const url = disabled
-    ? null
-    : planCode
-      ? `/api/w/${workspaceId}/subscriptions/checkout-status?session_id=${sessionId}&plan_code=${planCode}`
-      : `/api/w/${workspaceId}/subscriptions/checkout-status?session_id=${sessionId}`;
+  const url = planCode
+    ? `/api/w/${workspaceId}/subscriptions/checkout-status?session_id=${sessionId}&plan_code=${planCode}`
+    : `/api/w/${workspaceId}/subscriptions/checkout-status?session_id=${sessionId}`;
 
   const { data, error, mutate } = useSWRWithDefaults(url, checkoutFetcher, {
+    disabled,
     refreshInterval: pollIntervalMs,
   });
 

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -158,10 +158,9 @@ export function usePokeAwuPoolSummary({
   const fetcherFn: Fetcher<AwuPoolSummaryResponseBody> = fetcher;
 
   const { data, error, isValidating, mutate } = useSWRWithDefaults(
-    disabled
-      ? null
-      : `/api/poke/workspaces/${owner.sId}/credits/awu-pool-summary`,
-    fetcherFn
+    `/api/poke/workspaces/${owner.sId}/credits/awu-pool-summary`,
+    fetcherFn,
+    { disabled }
   );
 
   return {
@@ -181,10 +180,9 @@ export function usePokeAwuPoolCurrentCycle({
   const fetcherFn: Fetcher<AwuPoolCurrentCycleResponseBody> = fetcher;
 
   const { data, error, isValidating, mutate } = useSWRWithDefaults(
-    disabled
-      ? null
-      : `/api/poke/workspaces/${owner.sId}/credits/awu-pool-current-cycle`,
-    fetcherFn
+    `/api/poke/workspaces/${owner.sId}/credits/awu-pool-current-cycle`,
+    fetcherFn,
+    { disabled }
   );
 
   return {
@@ -204,10 +202,9 @@ export function usePokeAwuPoolCycleHistory({
   const fetcherFn: Fetcher<AwuPoolCycleHistoryResponseBody> = fetcher;
 
   const { data, error, isValidating, mutate } = useSWRWithDefaults(
-    disabled
-      ? null
-      : `/api/poke/workspaces/${owner.sId}/credits/awu-pool-cycle-history`,
-    fetcherFn
+    `/api/poke/workspaces/${owner.sId}/credits/awu-pool-cycle-history`,
+    fetcherFn,
+    { disabled }
   );
 
   return {
@@ -228,8 +225,9 @@ export function usePokeTopUpsHistory({
   const fetcherFn: Fetcher<GetAwuTopUpsHistoryResponseBody> = fetcher;
 
   const { data, error, isValidating, mutate } = useSWRWithDefaults(
-    disabled ? null : `/api/poke/workspaces/${owner.sId}/credits/top-ups`,
-    fetcherFn
+    `/api/poke/workspaces/${owner.sId}/credits/top-ups`,
+    fetcherFn,
+    { disabled }
   );
 
   return {
@@ -298,11 +296,9 @@ export function usePokeMembersUsage({
   }
 
   const { data, error, isValidating, mutate } = useSWRWithDefaults(
-    disabled
-      ? null
-      : `/api/poke/workspaces/${owner.sId}/credits/members-usage?${params.toString()}`,
+    `/api/poke/workspaces/${owner.sId}/credits/members-usage?${params.toString()}`,
     fetcherFn,
-    { revalidateOnFocus: false, keepPreviousData: true }
+    { disabled, revalidateOnFocus: false, keepPreviousData: true }
   );
 
   return {
@@ -324,11 +320,9 @@ export function usePokeApiKeysUsage({
   const fetcherFn: Fetcher<GetApiKeysUsageResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
-    disabled
-      ? null
-      : `/api/poke/workspaces/${owner.sId}/credits/api-keys-usage`,
+    `/api/poke/workspaces/${owner.sId}/credits/api-keys-usage`,
     fetcherFn,
-    { revalidateOnFocus: false }
+    { disabled, revalidateOnFocus: false }
   );
 
   return {

--- a/front/poke/swr/frame_details.ts
+++ b/front/poke/swr/frame_details.ts
@@ -16,8 +16,9 @@ export function usePokeFileDetails({
   const fileFetcher: Fetcher<GetPokeFileResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
-    sId && !disabled ? `/api/poke/workspaces/${owner.sId}/files/${sId}` : null,
-    fileFetcher
+    sId ? `/api/poke/workspaces/${owner.sId}/files/${sId}` : null,
+    fileFetcher,
+    { disabled: disabled || !sId }
   );
 
   return {


### PR DESCRIPTION
## Description

We have a few `mutate` that actually do nothing. In some SWR hooks we sometimes pass `null` as a key to `useSWRWithDefaults` when disabled, in this case our implementation of `useSWRWithDefaults` makes it impossible to identify the cache entry and the mutate becomes a no-op.

This PR fixes that by aligning on always passing the key + disabled as a config. This allows `mutate` and `mutateRegardlessOfQueryParams` to target mounted cache entries without starting requests.

We currently sometimes do it and sometimes not, my guess is that we sometimes do this because agents are not always aware of the fact that we override a bunch of things in `useSWRWithDefaults` and rely on the more classic SWR patterns.

## Tests

- Added tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
