### PR TITLE
[front] fix: preserve pasted tool and skill references

### DIFF
--- a/front/components/editor/input_bar/cleanupPastedHTML.test.ts
+++ b/front/components/editor/input_bar/cleanupPastedHTML.test.ts
@@ -19,6 +19,22 @@ describe("cleanupPastedHTML", () => {
       expect(result).toContain("https://example.com");
       expect(result).toContain("Link");
     });
+
+    test.each([
+      "tool",
+      "skill",
+    ])("preserves %s reference metadata while removing unsafe attributes", (tag) => {
+      const html = `<p id="paragraph">Use <${tag} id="ref_123" name="Research &amp; analysis" icon="ActionBrainIcon" class="chip" style="color: red" onclick="alert(1)"></${tag}> here.</p>`;
+      expect(cleanupPastedHTML(html)).toBe(
+        `<p>Use <${tag} id="ref_123" name="Research &amp; analysis" icon="ActionBrainIcon"></${tag}> here.</p>`
+      );
+    });
+
+    test("preserves unavailable skill references", () => {
+      const html =
+        '<p><unavailable_skill id="skill_123"></unavailable_skill></p>';
+      expect(cleanupPastedHTML(html)).toBe(html);
+    });
   });
 
   describe("forbidden tags removal", () => {

--- a/front/components/editor/input_bar/cleanupPastedHTML.ts
+++ b/front/components/editor/input_bar/cleanupPastedHTML.ts
@@ -31,11 +31,15 @@ const SANITIZE_CONFIG: Config = {
     "h4",
     "h5",
     "h6",
+    "tool",
+    "skill",
+    "unavailable_skill",
   ],
 
   // IMPORTANT: don't set ALLOWED_ATTR here.
   // Let DOMPurify use its safe defaults and explicitly allow data-* below.
   ALLOW_DATA_ATTR: true,
+  ADD_ATTR: ["icon"],
 
   // Strip dangerous containers entirely
   FORBID_TAGS: [
@@ -61,7 +65,7 @@ const SANITIZE_CONFIG: Config = {
   ],
 
   // Remove styling/identifiers
-  FORBID_ATTR: ["style", "class", "id"],
+  FORBID_ATTR: ["style", "class"],
 
   // Keep text if unexpected wrappers appear
   KEEP_CONTENT: true,
@@ -125,6 +129,15 @@ function addHookOnce() {
     const element = node;
     const style = element.getAttribute("style");
     const tagName = element.tagName.toLowerCase();
+
+    // Tool and skill IDs are reference metadata; strip ordinary HTML identifiers.
+    if (
+      tagName !== "tool" &&
+      tagName !== "skill" &&
+      tagName !== "unavailable_skill"
+    ) {
+      element.removeAttribute("id");
+    }
 
     // Convert <br class="Apple-interchange-newline"> to empty text node (Apple paste metadata)
     // We replace it with a <span> but DOMPurify will handle the output formatting


### PR DESCRIPTION
## Description

Copying and pasting tool or skill references currently loses their tags and metadata. Preserve tool, skill, and unavailable-skill tags during HTML cleanup, including their reference IDs and icons, while still stripping ordinary HTML IDs, styling, and unsafe attributes.

Split out of #31936 so the paste fix can ship independently.

## Tests

- Added coverage for tool and skill metadata, unavailable skills, and unsafe attribute removal.

## Risk

- Low. Limited to pasted HTML cleanup.

## Deploy Plan

- Deploy front.
