### PR TITLE
Fix: tsgo

### DIFF
--- a/front/lib/api/url_safety.ts
+++ b/front/lib/api/url_safety.ts
@@ -70,7 +70,7 @@ export async function validateExternalUrl(url: string): Promise<string | null> {
     if (family !== 4 && family !== 6) {
       return "URL resolves to an unsupported address family.";
     }
-    if (isPrivateIp(address, family)) {
+    if (_isPrivateIp(address, family)) {
       return "URL resolves to a private or reserved IP address.";
     }
   }


### PR DESCRIPTION
## Description

`validateExternalUrl` now calls the `_isPrivateIp` helper when checking DNS results. This restores `tsgo` compatibility without changing SSRF protection for private and reserved IPv4/IPv6 addresses.

## Tests

Validated the fix with `tsgo`. No runtime behavior changes.

## Risk

Low risk. The change only renames an internal helper reference and is safe to roll back.

## Deploy Plan

Deploy `front`. No migrations or infrastructure changes.