### PR TITLE
[Admin Governance] Fix editor backfill connection pool starvation

### DIFF
--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -6,11 +6,14 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { getNamespace } from "@app/tests/utils/test_cls";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { grantKey } from "@app/types/group_permissions";
 import { isString } from "@app/types/shared/utils/general";
+import assert from "assert";
 import type { QueryOptions } from "sequelize";
+import { Transaction } from "sequelize";
 import type { AbstractQuery } from "sequelize/types/dialects/abstract/query";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -695,6 +698,58 @@ describe("GroupPermissionResource", () => {
           ],
         })
       ).rejects.toThrow(/regular_auto/);
+    });
+  });
+
+  describe("grantToUsers / revokeFromUsers", () => {
+    it("uses the explicit transaction for every membership read and write", async () => {
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "user" });
+      const namespace = getNamespace("test-namespace");
+      assert(namespace);
+      const transaction = namespace.get("transaction");
+      assert(transaction instanceof Transaction);
+      const AGENT_ID = 7;
+      const spec = {
+        grantType: "editor" as const,
+        resourceType: "agent" as const,
+        resourceId: AGENT_ID,
+        transaction,
+      };
+
+      // Production has no CLS transaction. Reads outside the explicit transaction cannot see
+      // these uncommitted fixtures, exposing missing propagation without exhausting the pool.
+      namespace.set("transaction", null);
+      try {
+        const grantResult = await GroupPermissionResource.grantToUsers(auth, {
+          ...spec,
+          users: [user.toJSON()],
+        });
+        expect(grantResult.isOk()).toBe(true);
+
+        const group =
+          await GroupPermissionResource.findRegularAutoGroupForGrant(
+            auth,
+            spec
+          );
+        assert(group);
+        const members = await group.getActiveMembers(auth, { transaction });
+        expect(members.map((member) => member.id)).toEqual([user.id]);
+
+        const revokeResult = await GroupPermissionResource.revokeFromUsers(
+          auth,
+          {
+            ...spec,
+            users: [user.toJSON()],
+          }
+        );
+        expect(revokeResult.isOk()).toBe(true);
+        expect(
+          await GroupPermissionResource.findRegularAutoGroupForGrant(auth, spec)
+        ).toBeNull();
+      } finally {
+        namespace.set("transaction", transaction);
+      }
     });
   });
 

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1553,7 +1553,8 @@ export class GroupResource extends BaseResource<GroupModel> {
     }
 
     const users = await UserResource.fetchByModelIds(
-      memberships.map((m) => m.userId)
+      memberships.map((m) => m.userId),
+      { transaction }
     );
 
     const { memberships: workspaceMemberships } =
@@ -1671,7 +1672,9 @@ export class GroupResource extends BaseResource<GroupModel> {
     }
 
     const userIds = users.map((u) => u.sId);
-    const userResources = await UserResource.fetchByIds(userIds);
+    const userResources = await UserResource.fetchByIds(userIds, {
+      transaction,
+    });
 
     if (userResources.length !== userIds.length) {
       return new Err(
@@ -1686,6 +1689,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       await MembershipResource.getActiveMemberships({
         users: userResources,
         workspace: owner,
+        transaction,
       });
 
     if (
@@ -1814,7 +1818,9 @@ export class GroupResource extends BaseResource<GroupModel> {
     }
 
     const userIds = users.map((u) => u.sId);
-    const userResources = await UserResource.fetchByIds(userIds);
+    const userResources = await UserResource.fetchByIds(userIds, {
+      transaction,
+    });
     if (userResources.length !== userIds.length) {
       return new Err(
         new DustError(

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -151,11 +151,15 @@ export class UserResource extends BaseResource<UserModel> {
     return userResource;
   }
 
-  static async fetchByIds(userIds: string[]): Promise<UserResource[]> {
+  static async fetchByIds(
+    userIds: string[],
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<UserResource[]> {
     const users = await UserModel.findAll({
       where: {
         sId: userIds,
       },
+      transaction,
     });
 
     return users.map((user) => new UserResource(UserModel, user.get()));

--- a/front/migrations/20260903_backfill_agent_editor_grants.ts
+++ b/front/migrations/20260903_backfill_agent_editor_grants.ts
@@ -16,7 +16,7 @@ import assert from "assert";
 import { col, fn, Op } from "sequelize";
 
 const AGENT_CONCURRENCY = 8;
-const WORKSPACE_CONCURRENCY = 4;
+const WORKSPACE_CONCURRENCY = 2;
 
 const AgentConfigModel: ModelStaticWorkspaceAware<AgentConfigurationModel> =
   AgentConfigurationModel;


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/31825.

The all-workspace editor-grant backfill can time out acquiring a database connection. Transactions hold one connection, but some group-member reads omit the transaction and request another. Concurrent agents can therefore exhaust the 10-connection pool while waiting for additional connections.

Pass the transaction through these reads and reduce concurrency from 4 workspaces × 8 agents to **2 × 8**, preserving throughput within large workspaces without increasing the pool or its timeout.

## Risks

Blast radius: group membership reads/additions/removals inside transactions and the editor-grant backfill.
Risk: low — existing queries now use their caller's transaction; membership semantics are unchanged.

## Deploy Plan

- Deploy the updated front code before rerunning the backfill.
- Rerun `migrations/20260903_backfill_agent_editor_grants.ts --execute`; already matching agents need no writes.

## Tests

- [x] Regression test with automatic transaction propagation disabled: grant, read members, revoke, and remove the empty group. Confirmed it fails before the fix and passes after.
- [x] Backfill, group-permission, group, and user resource suites: 119 tests pass.
