### PR TITLE
[Admin Governance] Backfill missing agent editor groups

### DIFF
--- a/front/migrations/20260907_backfill_editor_groups.test.ts
+++ b/front/migrations/20260907_backfill_editor_groups.test.ts
@@ -1,0 +1,93 @@
+import { archiveAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import logger from "@app/logger/logger";
+import { backfillEditorGroups } from "@app/migrations/20260907_backfill_editor_groups";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import assert from "assert";
+import { describe, expect, it } from "vitest";
+
+describe("backfillEditorGroups", () => {
+  it("creates a missing group with the author, skips drafts, and can be rerun", async () => {
+    const {
+      authenticator: auth,
+      workspace,
+      user,
+    } = await createResourceTest({ role: "admin" });
+    const draft = await AgentConfigurationFactory.createTestAgent(auth);
+    const agent = await AgentConfigurationFactory.updateTestAgent(
+      auth,
+      draft.sId
+    );
+    const group = await GroupResource.fetchByAgentConfiguration({
+      auth,
+      agentConfiguration: agent,
+    });
+    assert(group);
+    expect((await group.delete(auth)).isOk()).toBe(true);
+    await AgentConfigurationModel.update(
+      { status: "draft" },
+      { where: { workspaceId: workspace.id, id: draft.id } }
+    );
+
+    await backfillEditorGroups(auth, agent.sId, false, logger);
+    expect(
+      (await GroupResource.findEditorGroupForAgent(auth, agent)).isErr()
+    ).toBe(true);
+
+    await backfillEditorGroups(auth, agent.sId, true, logger);
+    const created = await GroupResource.fetchByAgentConfiguration({
+      auth,
+      agentConfiguration: agent,
+    });
+    assert(created);
+    expect((await created.getActiveMembers(auth)).map(({ id }) => id)).toEqual([
+      user.id,
+    ]);
+    expect(
+      (await GroupResource.findEditorGroupForAgent(auth, draft)).isErr()
+    ).toBe(true);
+
+    await backfillEditorGroups(auth, agent.sId, true, logger);
+    const reused = await GroupResource.fetchByAgentConfiguration({
+      auth,
+      agentConfiguration: agent,
+    });
+    expect(reused?.id).toBe(created.id);
+  });
+
+  it("reuses an earlier version's group for an archived agent", async () => {
+    const {
+      authenticator: auth,
+      workspace,
+      user,
+    } = await createResourceTest({ role: "admin" });
+    const first = await AgentConfigurationFactory.createTestAgent(auth);
+    const latest = await AgentConfigurationFactory.updateTestAgent(
+      auth,
+      first.sId
+    );
+    const group = await GroupResource.fetchByAgentConfiguration({
+      auth,
+      agentConfiguration: first,
+    });
+    assert(group);
+    await archiveAgentConfiguration(auth, latest.sId);
+    // Reproduce the missing association without deleting the shared editor group.
+    await GroupAgentModel.destroy({
+      where: { workspaceId: workspace.id, agentConfigurationId: latest.id },
+    });
+
+    await backfillEditorGroups(auth, latest.sId, true, logger);
+    const repaired = await GroupResource.fetchByAgentConfiguration({
+      auth,
+      agentConfiguration: latest,
+    });
+    expect(repaired?.id).toBe(group.id);
+    expect((await group.getActiveMembers(auth)).map(({ id }) => id)).toEqual([
+      user.id,
+    ]);
+  });
+});

--- a/front/migrations/20260907_backfill_editor_groups.ts
+++ b/front/migrations/20260907_backfill_editor_groups.ts
@@ -1,0 +1,119 @@
+import { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { AGENT_GROUP_PREFIX } from "@app/types/groups";
+import assert from "assert";
+import type { Transaction } from "sequelize";
+import { Op } from "sequelize";
+
+async function createEditorGroup(
+  auth: Authenticator,
+  latest: AgentConfigurationModel,
+  transaction: Transaction
+) {
+  const workspace = auth.getNonNullableWorkspace();
+  const authors = await UserResource.fetchByModelIds([latest.authorId], {
+    transaction,
+  });
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    workspace,
+    users: authors,
+    transaction,
+  });
+  return GroupResource.makeNew(
+    {
+      workspaceId: workspace.id,
+      name: `${AGENT_GROUP_PREFIX} ${latest.name} (${latest.sId})`,
+      kind: "agent_editors",
+    },
+    {
+      memberIds: memberships.map(({ userId }) => userId),
+      transaction,
+    }
+  );
+}
+
+export async function backfillEditorGroups(
+  auth: Authenticator,
+  agentId: string,
+  execute: boolean,
+  logger: Logger
+) {
+  const workspaceId = auth.getNonNullableWorkspace().id;
+  await withTransaction(async (transaction) => {
+    // The sId index limits this repair to one agent's versions.
+    const configs = await AgentConfigurationModel.findAll({
+      attributes: ["id", "sId", "workspaceId", "name", "authorId"],
+      where: { workspaceId, sId: agentId, status: { [Op.ne]: "draft" } },
+      order: [["version", "DESC"]],
+      transaction,
+      lock: execute,
+    });
+    assert(configs.length > 0, "No non-draft configurations found for agent.");
+    const links = await GroupAgentModel.findAll({
+      attributes: ["groupId", "agentConfigurationId"],
+      where: { workspaceId, agentConfigurationId: configs.map(({ id }) => id) },
+      transaction,
+    });
+    const groupIds = [...new Set(links.map(({ groupId }) => groupId))];
+    assert(groupIds.length <= 1, "Agent has multiple editor groups.");
+    const groups = await GroupResource.dangerouslyFetchByModelIds(
+      auth,
+      groupIds,
+      {
+        groupKinds: ["agent_editors"],
+        transaction,
+      }
+    );
+    assert(
+      groups.length === groupIds.length,
+      "Invalid editor group association."
+    );
+    const linkedIds = new Set(
+      links.map(({ agentConfigurationId }) => agentConfigurationId)
+    );
+    const missing = configs.filter(({ id }) => !linkedIds.has(id));
+    logger.info(
+      {
+        agentId,
+        workspaceId,
+        execute,
+        createGroup: groups.length === 0,
+        missingVersions: missing.length,
+      },
+      "Agent editor group backfill"
+    );
+    if (!execute || missing.length === 0) {
+      return;
+    }
+    const group =
+      groups[0] ?? (await createEditorGroup(auth, configs[0], transaction));
+    await GroupAgentModel.bulkCreate(
+      missing.map(({ id }) => ({
+        workspaceId,
+        agentConfigurationId: id,
+        groupId: group.id,
+      })),
+      { transaction }
+    );
+  });
+}
+
+if (require.main === module) {
+  makeScript(
+    {
+      wId: { type: "string", required: true },
+      agentId: { type: "string", required: true },
+    },
+    async ({ wId, agentId, execute }, logger) => {
+      const auth = await Authenticator.internalAdminForWorkspace(wId);
+      await backfillEditorGroups(auth, agentId, execute, logger);
+    }
+  );
+}


### PR DESCRIPTION
## Description

Some non-draft agent versions have no editor-group association, causing the exactly-one-group check to fail. Add a backfill scoped to one workspace and agent: reuse the group from another version, or create one with the latest author if they still belong to the workspace, then link all missing non-draft versions.

The script defaults to dry run, preserves existing group members, and applies each repair in one transaction. Rerunning it makes no further changes.

## Risks

Blast radius: Editor groups and associations for the explicitly selected agent.
Risk: low.

## Deploy Plan

- From `front`, run `npx tsx migrations/20260907_backfill_editor_groups.ts --wId <workspace-id> --agentId <agent-id>` for each affected agent and inspect the dry-run output.
- Repeat with `--execute` to apply the repair.

## Tests

- [x] `npm run test --workspace=front -- migrations/20260907_backfill_editor_groups.test.ts` — 2 database tests covering creation, dry run, draft exclusion, reruns, and reuse of an archived agent's existing group.
