### PR TITLE
Invitations now uses cell.

### DIFF
--- a/front/components/pages/onboarding/InviteChoosePage.tsx
+++ b/front/components/pages/onboarding/InviteChoosePage.tsx
@@ -89,10 +89,7 @@ export function InviteChoosePage() {
                       onClick={() =>
                         handleInvitationSelection(
                           invitation.token,
-                          // TODO(single-tenant): fix so that invations are using cell, not region.
-                          // Fallback to first cell with a matching region.
-                          cells.find((c) => c.region === invitation.region)
-                            ?.name
+                          invitation.cell
                         )
                       }
                     />

--- a/front/lib/api/cells/lookup.ts
+++ b/front/lib/api/cells/lookup.ts
@@ -242,7 +242,7 @@ export async function fetchInvitationsInOtherCells(
       invitations.push(
         ...data.pendingInvitations.map((inv) => ({
           ...inv,
-          region: cell.region,
+          cell: cell.name,
         }))
       );
     }

--- a/front/types/membership_invitation.ts
+++ b/front/types/membership_invitation.ts
@@ -1,5 +1,4 @@
-import type { RegionType } from "@app/types/region";
-
+import type { CellType } from "./cell";
 import type { MembershipSeatType } from "./memberships";
 import type { ModelId } from "./shared/model_id";
 import type { ActiveRoleType } from "./user";
@@ -27,7 +26,7 @@ export interface PendingInvitationOption {
   initialRole: ActiveRoleType;
   createdAt: number;
   isExpired: boolean;
-  region?: RegionType;
+  cell?: CellType;
 }
 
 // Types for the invite form in Poke.


### PR DESCRIPTION
## Description

`PendingInvitationOption` now carries the target `cell` instead of a `region`. Cross-cell invitation lookup preserves `cell.name`, and onboarding passes that exact cell to `handleInvitationSelection`, removing the region-based fallback.

## Tests

Not run; frontend-only type and routing update.

## Risk

Low. The change routes invitations to the cell returned by the lookup instead of inferring it from the region. Rollback is a single frontend revert.

## Deploy Plan

Deploy `front`.