### PR TITLE
[sparkle] Typography improvement

### DIFF
--- a/front/styles/global.css
+++ b/front/styles/global.css
@@ -21,9 +21,8 @@
 
   html {
     touch-action: manipulation;
-    font-feature-settings:
-      "rlig" 1,
-      "calt" 0;
+    /* Geist ships contextual alternates; keep them off. `rlig` is on by default. */
+    font-variant-ligatures: no-contextual;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;

--- a/marketing/styles/global.css
+++ b/marketing/styles/global.css
@@ -20,9 +20,8 @@
 
   html {
     touch-action: manipulation;
-    font-feature-settings:
-      "rlig" 1,
-      "calt" 0;
+    /* Geist ships contextual alternates; keep them off. `rlig` is on by default. */
+    font-variant-ligatures: no-contextual;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -139,9 +139,9 @@ const buttonVariants = cva(
         ),
       },
       size: {
-        xs: "h-6 gap-1.5 px-2 text-sm font-medium leading-4 tracking-[-0.28px] rounded-[9px]",
-        sm: "h-8 gap-1.5 px-3 text-sm font-medium tracking-[-0.28px] rounded-xl",
-        md: "h-10 gap-1.5 px-4 text-base font-medium tracking-[-0.32px] rounded-[15px]",
+        xs: "h-6 gap-1.5 px-2 text-sm font-medium leading-4 rounded-[9px]",
+        sm: "h-8 gap-1.5 px-3 text-sm font-medium rounded-xl",
+        md: "h-10 gap-1.5 px-4 text-base font-medium rounded-[15px]",
       },
       isIconOnly: {
         true: "",

--- a/sparkle/src/components/Input.tsx
+++ b/sparkle/src/components/Input.tsx
@@ -40,8 +40,9 @@ const fieldVariants = cva(
     variants: {
       size: {
         xs: "h-6 rounded-lg text-xs",
-        sm: "h-8 rounded-xl text-sm tracking-[-0.28px]",
-        md: "h-10 rounded-[15px] text-sm tracking-[-0.28px]",
+        // 16px on small viewports so Mobile Safari does not zoom on focus.
+        sm: "h-8 rounded-xl text-base md:text-sm",
+        md: "h-10 rounded-[15px] text-base md:text-sm",
       },
       state: {
         default: cn(
@@ -76,8 +77,8 @@ const innerInputVariants = cva(
     variants: {
       size: {
         xs: "px-2 text-xs",
-        sm: "px-3 text-sm",
-        md: "px-3 text-sm",
+        sm: "px-3 text-base md:text-sm",
+        md: "px-3 text-base md:text-sm",
       },
     },
     defaultVariants: {
@@ -90,8 +91,8 @@ const labelVariants = cva("pb-0.5 font-medium text-foreground", {
   variants: {
     size: {
       xs: "text-xs",
-      sm: "text-sm tracking-[-0.28px]",
-      md: "text-sm tracking-[-0.28px]",
+      sm: "text-sm",
+      md: "text-sm",
     },
   },
   defaultVariants: {

--- a/sparkle/src/components/OptionCard.tsx
+++ b/sparkle/src/components/OptionCard.tsx
@@ -152,7 +152,7 @@ export function OptionCard(props: OptionCardProps) {
           />
         ) : (
           <>
-            <span className="text-sm font-medium tracking-[-0.28px] text-foreground">
+            <span className="text-sm font-medium text-foreground">
               {props.label}
             </span>
             {props.description && (

--- a/sparkle/src/components/TextArea.tsx
+++ b/sparkle/src/components/TextArea.tsx
@@ -22,7 +22,8 @@ export interface TextareaProps
 
 const textAreaVariants = cva(
   cn(
-    "flex w-full px-3 py-2 text-sm",
+    // 16px on small viewports so Mobile Safari does not zoom on focus.
+    "flex w-full px-3 py-2 text-base md:text-sm",
     "text-foreground",
     "bg-muted-background",
     "placeholder:text-muted-foreground",
@@ -139,7 +140,7 @@ const ReadOnlyTextArea = ({
       isDisplay
       minRows={minRows}
       className={cn(
-        "copy-sm h-full min-h-60 w-full min-w-0 rounded-xl",
+        "text-base font-normal md:text-sm h-full min-h-60 w-full min-w-0 rounded-xl",
         "resize-none border-border bg-muted-background"
       )}
       defaultValue={content ?? ""}

--- a/sparkle/src/components/markdown/ParagraphBlock.tsx
+++ b/sparkle/src/components/markdown/ParagraphBlock.tsx
@@ -14,7 +14,11 @@ export const paragraphBlockVariants = cva(
     variants: {
       compactSpacing: {
         true: ["py-0"],
-        false: ["py-1 @md:pt-2 @md:pb-[10px] @md:leading-relaxed"],
+        // The conversation column is capped at 65ch (~690px in Geist), so a
+        // 48rem (@md) container is never reached inside a message; @sm (40rem)
+        // is the "comfortable column" step. Below it (side panels, phones) stay
+        // compact.
+        false: ["py-1 @sm:pt-2 @sm:pb-[10px] @sm:leading-relaxed"],
       },
     },
   }

--- a/sparkle/src/stories/Typography.stories.tsx
+++ b/sparkle/src/stories/Typography.stories.tsx
@@ -224,9 +224,9 @@ export const FontWeights: Story = {
       title="Font Weights"
       description={
         <p className="text-sm text-primary-600">
-          Geist follows the standard weight scale — medium is 500 and semibold
-          600. The semantic utilities already pick the right weight; these are
-          for manual composition.
+          Geist is tuned slightly lighter than the usual scale — medium is 450
+          and semibold 550. The semantic utilities already pick the right
+          weight; these are for manual composition.
         </p>
       }
     >
@@ -242,13 +242,13 @@ export const FontWeights: Story = {
             name: "font-medium",
             className: "text-xl font-medium",
             sample: "Aa",
-            description: "500 — labels and buttons (what label-* uses).",
+            description: "450 — labels and buttons (what label-* uses).",
           },
           {
             name: "font-semibold",
             className: "text-xl font-semibold",
             sample: "Aa",
-            description: "600 — headings (what heading-* uses).",
+            description: "550 — headings (what heading-* uses).",
           },
           {
             name: "font-bold",
@@ -297,7 +297,7 @@ export const Headings: Story = {
       title="Headings"
       description={
         <p className="text-sm text-primary-600">
-          Semibold (600) headings across the scale — size, line-height, and
+          Semibold (550) headings across the scale — size, line-height, and
           letter-spacing are packaged together. Sizes above 3xl are for
           marketing surfaces.
         </p>
@@ -393,7 +393,7 @@ export const Labels: Story = {
       title="Labels"
       description={
         <p className="text-sm text-primary-600">
-          Medium-weight (500) styles for interactive and compact UI text.
+          Medium-weight (450) styles for interactive and compact UI text.
         </p>
       }
     >

--- a/sparkle/src/stories/Typography.stories.tsx
+++ b/sparkle/src/stories/Typography.stories.tsx
@@ -224,9 +224,9 @@ export const FontWeights: Story = {
       title="Font Weights"
       description={
         <p className="text-sm text-primary-600">
-          Geist is tuned slightly lighter than the usual scale — medium is 450
-          and semibold 550. The semantic utilities already pick the right
-          weight; these are for manual composition.
+          Geist follows the standard weight scale — medium is 500 and semibold
+          600. The semantic utilities already pick the right weight; these are
+          for manual composition.
         </p>
       }
     >
@@ -242,13 +242,13 @@ export const FontWeights: Story = {
             name: "font-medium",
             className: "text-xl font-medium",
             sample: "Aa",
-            description: "450 — labels and buttons (what label-* uses).",
+            description: "500 — labels and buttons (what label-* uses).",
           },
           {
             name: "font-semibold",
             className: "text-xl font-semibold",
             sample: "Aa",
-            description: "550 — headings (what heading-* uses).",
+            description: "600 — headings (what heading-* uses).",
           },
           {
             name: "font-bold",
@@ -297,7 +297,7 @@ export const Headings: Story = {
       title="Headings"
       description={
         <p className="text-sm text-primary-600">
-          Semibold (550) headings across the scale — size, line-height, and
+          Semibold (600) headings across the scale — size, line-height, and
           letter-spacing are packaged together. Sizes above 3xl are for
           marketing surfaces.
         </p>
@@ -393,7 +393,7 @@ export const Labels: Story = {
       title="Labels"
       description={
         <p className="text-sm text-primary-600">
-          Medium-weight (450) styles for interactive and compact UI text.
+          Medium-weight (500) styles for interactive and compact UI text.
         </p>
       }
     >

--- a/sparkle/src/styles/tailwind.css
+++ b/sparkle/src/styles/tailwind.css
@@ -69,9 +69,8 @@
 
   html {
     touch-action: manipulation;
-    font-feature-settings:
-      "rlig" 1,
-      "calt" 0;
+    /* Geist ships contextual alternates; keep them off. `rlig` is on by default. */
+    font-variant-ligatures: no-contextual;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;

--- a/sparkle/src/styles/theme.css
+++ b/sparkle/src/styles/theme.css
@@ -38,50 +38,61 @@
   --font-sans: Geist, sans-serif;
   --font-mono: "Geist Mono", monospace;
 
-  /* Font weight overrides (shared by sparkle/front/marketing). */
-  --font-weight-medium: 450;
-  --font-weight-semibold: 550;
+  /* Font weight overrides (shared by sparkle/front/marketing).
+     Geist readability-first spec (2026-09-07 test): 500 for labels/buttons,
+     600 for headings and strong. Previously 450 / 550. */
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
 
-  /* Font sizes — px scale with line-height + letter-spacing. */
+  /* Font sizes — px scale with line-height + letter-spacing.
+     Geist readability-first spec (2026-09-07 test), 16px root, mobile-first.
+     Desktop (>= 48rem) overrides for 2xl and 4xl live in the @media block
+     after this @theme. Role mapping, spec -> token:
+       ui-micro 12/16            -> xs      ui-compact & label 14/20 -> sm
+       ui-body 16/24             -> base    article-h4 18/26 -0.005em -> lg
+       ui-section-title 20/28    -> xl      ui-page-title 24/32 (28/36 desktop) -> 2xl
+       article-h1 & marketing-section 32/40 -> 3xl
+       marketing-hero 40/44 (section 40/48 desktop) -> 4xl
+       5xl..9xl follow the hero/display ramp (leading 1.05-1.15, tracking -0.035/-0.04em). */
   --text-xs: 12px;
   --text-xs--line-height: 16px;
-  --text-xs--letter-spacing: normal;
+  --text-xs--letter-spacing: 0;
   --text-sm: 14px;
   --text-sm--line-height: 20px;
-  --text-sm--letter-spacing: -0.28px;
+  --text-sm--letter-spacing: 0;
   --text-base: 16px;
   --text-base--line-height: 24px;
-  --text-base--letter-spacing: -0.32px;
+  --text-base--letter-spacing: 0;
   --text-lg: 18px;
   --text-lg--line-height: 26px;
-  --text-lg--letter-spacing: -0.36px;
+  --text-lg--letter-spacing: -0.09px;
   --text-xl: 20px;
   --text-xl--line-height: 28px;
-  --text-xl--letter-spacing: -0.4px;
+  --text-xl--letter-spacing: -0.3px;
   --text-2xl: 24px;
-  --text-2xl--line-height: 30px;
-  --text-2xl--letter-spacing: -0.96px;
+  --text-2xl--line-height: 32px;
+  --text-2xl--letter-spacing: -0.36px;
   --text-3xl: 32px;
-  --text-3xl--line-height: 36px;
-  --text-3xl--letter-spacing: -1.28px;
+  --text-3xl--line-height: 40px;
+  --text-3xl--letter-spacing: -0.64px;
   --text-4xl: 40px;
-  --text-4xl--line-height: 42px;
-  --text-4xl--letter-spacing: -2.4px;
+  --text-4xl--line-height: 44px;
+  --text-4xl--letter-spacing: -1.2px;
   --text-5xl: 48px;
-  --text-5xl--line-height: 52px;
-  --text-5xl--letter-spacing: -2.88px;
+  --text-5xl--line-height: 56px;
+  --text-5xl--letter-spacing: -1.68px;
   --text-6xl: 56px;
-  --text-6xl--line-height: 60px;
-  --text-6xl--letter-spacing: -3.36px;
+  --text-6xl--line-height: 62px;
+  --text-6xl--letter-spacing: -2.24px;
   --text-7xl: 64px;
   --text-7xl--line-height: 68px;
-  --text-7xl--letter-spacing: -3.84px;
+  --text-7xl--letter-spacing: -2.56px;
   --text-8xl: 72px;
   --text-8xl--line-height: 76px;
-  --text-8xl--letter-spacing: -4.32px;
+  --text-8xl--letter-spacing: -2.88px;
   --text-9xl: 80px;
   --text-9xl--line-height: 84px;
-  --text-9xl--letter-spacing: -4.8px;
+  --text-9xl--letter-spacing: -3.2px;
 
   /* Spacing additions. Numeric keys (100/125/150) feed the width, height,
      min and max size utilities — they were the preset's sizeScale. */
@@ -143,6 +154,21 @@
   --animate-move-square: move-square 3s ease-out infinite;
   --animate-breathing: breathing 3s infinite ease-in-out;
   --animate-breathing-scale: breathing-scale 3s infinite ease-in-out;
+}
+
+/*
+ * Geist readability-first spec: desktop steps (>= 48rem). The spec sizes the
+ * UI page title 24px on mobile and 28px on desktop, and relaxes the 40px step
+ * from hero leading (1.1) to section leading (1.2). `@theme` above is not
+ * inline, so the utilities read these custom properties at runtime.
+ */
+@media (min-width: 48rem) {
+  :root {
+    --text-2xl: 28px;
+    --text-2xl--line-height: 36px;
+    --text-2xl--letter-spacing: -0.56px;
+    --text-4xl--line-height: 48px;
+  }
 }
 
 /*
@@ -558,19 +584,19 @@
 @utility label-xs {
   font-size: var(--text-xs);
   line-height: var(--text-xs--line-height);
-  letter-spacing: var(--text-xs--letter-spacing);
+  letter-spacing: 0;
   font-weight: 500;
 }
 @utility label-sm {
   font-size: var(--text-sm);
   line-height: var(--text-sm--line-height);
-  letter-spacing: var(--text-sm--letter-spacing);
+  letter-spacing: 0;
   font-weight: 500;
 }
 @utility label-base {
   font-size: var(--text-base);
   line-height: var(--text-base--line-height);
-  letter-spacing: var(--text-base--letter-spacing);
+  letter-spacing: 0;
   font-weight: 500;
 }
 
@@ -578,79 +604,80 @@
   font-size: var(--text-xs);
   line-height: var(--text-xs--line-height);
   letter-spacing: var(--text-xs--letter-spacing);
-  font-weight: 550;
+  font-weight: 600;
 }
 @utility heading-sm {
   font-size: var(--text-sm);
   line-height: var(--text-sm--line-height);
   letter-spacing: var(--text-sm--letter-spacing);
-  font-weight: 550;
+  font-weight: 600;
 }
 @utility heading-base {
   font-size: var(--text-base);
   line-height: var(--text-base--line-height);
-  letter-spacing: var(--text-base--letter-spacing);
-  font-weight: 550;
+  /* Spec ui-card-title: -0.01em; the base token itself stays at 0 for body. */
+  letter-spacing: -0.16px;
+  font-weight: 600;
 }
 @utility heading-lg {
   font-size: var(--text-lg);
   line-height: var(--text-lg--line-height);
   letter-spacing: var(--text-lg--letter-spacing);
-  font-weight: 550;
+  font-weight: 600;
 }
 @utility heading-xl {
   font-size: var(--text-xl);
   line-height: var(--text-xl--line-height);
   letter-spacing: var(--text-xl--letter-spacing);
-  font-weight: 550;
+  font-weight: 600;
 }
 @utility heading-2xl {
   font-size: var(--text-2xl);
   line-height: var(--text-2xl--line-height);
   letter-spacing: var(--text-2xl--letter-spacing);
-  font-weight: 550;
+  font-weight: 600;
 }
 @utility heading-3xl {
   font-size: var(--text-3xl);
   line-height: var(--text-3xl--line-height);
   letter-spacing: var(--text-3xl--letter-spacing);
-  font-weight: 550;
+  font-weight: 600;
 }
 @utility heading-4xl {
   font-size: var(--text-4xl);
   line-height: var(--text-4xl--line-height);
   letter-spacing: var(--text-4xl--letter-spacing);
-  font-weight: 450;
+  font-weight: 600;
 }
 @utility heading-5xl {
   font-size: var(--text-5xl);
   line-height: var(--text-5xl--line-height);
   letter-spacing: var(--text-5xl--letter-spacing);
-  font-weight: 450;
+  font-weight: 600;
 }
 @utility heading-6xl {
   font-size: var(--text-6xl);
   line-height: var(--text-6xl--line-height);
   letter-spacing: var(--text-6xl--letter-spacing);
-  font-weight: 450;
+  font-weight: 600;
 }
 @utility heading-7xl {
   font-size: var(--text-7xl);
   line-height: var(--text-7xl--line-height);
   letter-spacing: var(--text-7xl--letter-spacing);
-  font-weight: 450;
+  font-weight: 600;
 }
 @utility heading-8xl {
   font-size: var(--text-8xl);
   line-height: var(--text-8xl--line-height);
   letter-spacing: var(--text-8xl--letter-spacing);
-  font-weight: 450;
+  font-weight: 600;
 }
 @utility heading-9xl {
   font-size: var(--text-9xl);
   line-height: var(--text-9xl--line-height);
   letter-spacing: var(--text-9xl--letter-spacing);
-  font-weight: 450;
+  font-weight: 600;
 }
 
 @utility heading-mono-lg {
@@ -727,36 +754,36 @@
 @utility copy-xs {
   font-size: var(--text-xs);
   line-height: var(--text-xs--line-height);
-  letter-spacing: var(--text-xs--letter-spacing);
+  letter-spacing: 0;
   font-weight: 400;
 }
 @utility copy-sm {
   font-size: var(--text-sm);
   line-height: var(--text-sm--line-height);
-  letter-spacing: var(--text-sm--letter-spacing);
+  letter-spacing: 0;
   font-weight: 400;
 }
 @utility copy-base {
   font-size: var(--text-base);
-  line-height: var(--text-base--line-height);
-  letter-spacing: var(--text-base--letter-spacing);
+  line-height: 26px;
+  letter-spacing: 0;
   font-weight: 400;
 }
 @utility copy-lg {
   font-size: var(--text-lg);
-  line-height: var(--text-lg--line-height);
-  letter-spacing: var(--text-lg--letter-spacing);
+  line-height: 28px;
+  letter-spacing: 0;
   font-weight: 400;
 }
 @utility copy-xl {
   font-size: var(--text-xl);
-  line-height: var(--text-xl--line-height);
-  letter-spacing: var(--text-xl--letter-spacing);
+  line-height: 30px;
+  letter-spacing: 0;
   font-weight: 400;
 }
 @utility copy-2xl {
   font-size: var(--text-2xl);
-  line-height: var(--text-2xl--line-height);
-  letter-spacing: var(--text-2xl--letter-spacing);
+  line-height: 34px;
+  letter-spacing: 0;
   font-weight: 400;
 }

--- a/sparkle/src/styles/theme.css
+++ b/sparkle/src/styles/theme.css
@@ -42,55 +42,56 @@
   --font-weight-medium: 450;
   --font-weight-semibold: 550;
 
-  /* Font sizes — px scale with line-height + letter-spacing.
+  /* Font sizes — px sizes with unitless line-height and em letter-spacing,
+     so leading and tracking follow any size change (zoom, overrides).
      Geist readability-first spec (2026-09-07 test), 16px root, mobile-first.
      Desktop (>= 48rem) overrides for 2xl and 4xl live in the @media block
      after this @theme. Role mapping, spec -> token:
-       ui-micro 12/16            -> xs      ui-compact & label 14/20 -> sm
-       ui-body 16/24             -> base    article-h4 18/26 -0.005em -> lg
-       ui-section-title 20/28    -> xl      ui-page-title 24/32 (28/36 desktop) -> 2xl
-       article-h1 & marketing-section 32/40 -> 3xl
-       marketing-hero 40/44 (section 40/48 desktop) -> 4xl
-       5xl..9xl follow the hero/display ramp (leading 1.05-1.15, tracking -0.035/-0.04em). */
+       ui-micro 12            -> xs      ui-compact & label 14     -> sm
+       ui-body 16             -> base    article-h4 18 -0.005em    -> lg
+       ui-section-title 20    -> xl      ui-page-title 24 (28 desktop) -> 2xl
+       article-h1 & marketing-section 32 -> 3xl
+       marketing-hero 40 (section leading on desktop) -> 4xl
+       5xl..9xl follow the hero/display ramp (leading 1.05-1.17, tracking -0.035/-0.04em). */
   --text-xs: 12px;
-  --text-xs--line-height: 16px;
+  --text-xs--line-height: 1.333333;
   --text-xs--letter-spacing: 0;
   --text-sm: 14px;
-  --text-sm--line-height: 20px;
+  --text-sm--line-height: 1.428571;
   --text-sm--letter-spacing: 0;
   --text-base: 16px;
-  --text-base--line-height: 24px;
+  --text-base--line-height: 1.5;
   --text-base--letter-spacing: 0;
   --text-lg: 18px;
-  --text-lg--line-height: 26px;
-  --text-lg--letter-spacing: -0.09px;
+  --text-lg--line-height: 1.444444;
+  --text-lg--letter-spacing: -0.005em;
   --text-xl: 20px;
-  --text-xl--line-height: 28px;
-  --text-xl--letter-spacing: -0.3px;
+  --text-xl--line-height: 1.4;
+  --text-xl--letter-spacing: -0.015em;
   --text-2xl: 24px;
-  --text-2xl--line-height: 32px;
-  --text-2xl--letter-spacing: -0.36px;
+  --text-2xl--line-height: 1.333333;
+  --text-2xl--letter-spacing: -0.015em;
   --text-3xl: 32px;
-  --text-3xl--line-height: 40px;
-  --text-3xl--letter-spacing: -0.64px;
+  --text-3xl--line-height: 1.25;
+  --text-3xl--letter-spacing: -0.02em;
   --text-4xl: 40px;
-  --text-4xl--line-height: 44px;
-  --text-4xl--letter-spacing: -1.2px;
+  --text-4xl--line-height: 1.1;
+  --text-4xl--letter-spacing: -0.03em;
   --text-5xl: 48px;
-  --text-5xl--line-height: 56px;
-  --text-5xl--letter-spacing: -1.68px;
+  --text-5xl--line-height: 1.166667;
+  --text-5xl--letter-spacing: -0.035em;
   --text-6xl: 56px;
-  --text-6xl--line-height: 62px;
-  --text-6xl--letter-spacing: -2.24px;
+  --text-6xl--line-height: 1.1;
+  --text-6xl--letter-spacing: -0.04em;
   --text-7xl: 64px;
-  --text-7xl--line-height: 68px;
-  --text-7xl--letter-spacing: -2.56px;
+  --text-7xl--line-height: 1.0625;
+  --text-7xl--letter-spacing: -0.04em;
   --text-8xl: 72px;
-  --text-8xl--line-height: 76px;
-  --text-8xl--letter-spacing: -2.88px;
+  --text-8xl--line-height: 1.055556;
+  --text-8xl--letter-spacing: -0.04em;
   --text-9xl: 80px;
-  --text-9xl--line-height: 84px;
-  --text-9xl--letter-spacing: -3.2px;
+  --text-9xl--line-height: 1.05;
+  --text-9xl--letter-spacing: -0.04em;
 
   /* Spacing additions. Numeric keys (100/125/150) feed the width, height,
      min and max size utilities — they were the preset's sizeScale. */
@@ -166,9 +167,9 @@
 @media (min-width: 48rem) {
   :root {
     --text-2xl: 28px;
-    --text-2xl--line-height: 36px;
-    --text-2xl--letter-spacing: -0.56px;
-    --text-4xl--line-height: 48px;
+    --text-2xl--line-height: 1.285714;
+    --text-2xl--letter-spacing: -0.02em;
+    --text-4xl--line-height: 1.2;
   }
 }
 
@@ -617,7 +618,7 @@
   font-size: var(--text-base);
   line-height: var(--text-base--line-height);
   /* Spec ui-card-title: -0.01em; the base token itself stays at 0 for body. */
-  letter-spacing: -0.16px;
+  letter-spacing: -0.01em;
   font-weight: 550;
 }
 @utility heading-lg {
@@ -766,25 +767,25 @@
 }
 @utility copy-base {
   font-size: var(--text-base);
-  line-height: 26px;
+  line-height: 1.625;
   letter-spacing: 0;
   font-weight: 400;
 }
 @utility copy-lg {
   font-size: var(--text-lg);
-  line-height: 28px;
+  line-height: 1.555556;
   letter-spacing: 0;
   font-weight: 400;
 }
 @utility copy-xl {
   font-size: var(--text-xl);
-  line-height: 30px;
+  line-height: 1.5;
   letter-spacing: 0;
   font-weight: 400;
 }
 @utility copy-2xl {
   font-size: var(--text-2xl);
-  line-height: 34px;
+  line-height: 1.416667;
   letter-spacing: 0;
   font-weight: 400;
 }

--- a/sparkle/src/styles/theme.css
+++ b/sparkle/src/styles/theme.css
@@ -99,8 +99,11 @@
   --spacing-125: 500px;
   --spacing-150: 600px;
 
-  /* Named max-width (max-w-conversation). v4 maps `max-w-*` onto `--container-*`. */
-  --container-conversation: 48rem;
+  /* Named max-width (max-w-conversation). v4 maps `max-w-*` onto `--container-*`.
+     Geist readability-first spec (2026-09-07 test): 65ch reading measure
+     (was 48rem). `ch` resolves against the container's font-size, so this is
+     about 620px at the 16px base. */
+  --container-conversation: 65ch;
 
   /* Transition timing functions (was theme.extend.transitionTimingFunction). */
   --ease-out-quad: cubic-bezier(0.25, 0.46, 0.45, 0.94);

--- a/sparkle/src/styles/theme.css
+++ b/sparkle/src/styles/theme.css
@@ -52,7 +52,9 @@
        ui-section-title 20    -> xl      ui-page-title 24 (28 desktop) -> 2xl
        article-h1 & marketing-section 32 -> 3xl
        marketing-hero 40 (section leading on desktop) -> 4xl
-       5xl..9xl follow the hero/display ramp (leading 1.05-1.17, tracking -0.035/-0.04em). */
+       5xl..9xl follow the hero/display ramp (leading 1.05-1.17).
+     Tracking bands: 16-20px -0.005..-0.015em, 24-32px -0.015..-0.02em,
+     40-72px -0.025..-0.04em, interpolated linearly per step. */
   --text-xs: 12px;
   --text-xs--line-height: 1.333333;
   --text-xs--letter-spacing: 0;
@@ -64,7 +66,7 @@
   --text-base--letter-spacing: 0;
   --text-lg: 18px;
   --text-lg--line-height: 1.444444;
-  --text-lg--letter-spacing: -0.005em;
+  --text-lg--letter-spacing: -0.01em;
   --text-xl: 20px;
   --text-xl--line-height: 1.4;
   --text-xl--letter-spacing: -0.015em;
@@ -76,16 +78,16 @@
   --text-3xl--letter-spacing: -0.02em;
   --text-4xl: 40px;
   --text-4xl--line-height: 1.1;
-  --text-4xl--letter-spacing: -0.03em;
+  --text-4xl--letter-spacing: -0.025em;
   --text-5xl: 48px;
   --text-5xl--line-height: 1.166667;
-  --text-5xl--letter-spacing: -0.035em;
+  --text-5xl--letter-spacing: -0.029em;
   --text-6xl: 56px;
   --text-6xl--line-height: 1.1;
-  --text-6xl--letter-spacing: -0.04em;
+  --text-6xl--letter-spacing: -0.0325em;
   --text-7xl: 64px;
   --text-7xl--line-height: 1.0625;
-  --text-7xl--letter-spacing: -0.04em;
+  --text-7xl--letter-spacing: -0.036em;
   --text-8xl: 72px;
   --text-8xl--line-height: 1.055556;
   --text-8xl--letter-spacing: -0.04em;
@@ -168,7 +170,7 @@
   :root {
     --text-2xl: 28px;
     --text-2xl--line-height: 1.285714;
-    --text-2xl--letter-spacing: -0.02em;
+    --text-2xl--letter-spacing: -0.0175em;
     --text-4xl--line-height: 1.2;
   }
 }
@@ -617,8 +619,8 @@
 @utility heading-base {
   font-size: var(--text-base);
   line-height: var(--text-base--line-height);
-  /* Spec ui-card-title: -0.01em; the base token itself stays at 0 for body. */
-  letter-spacing: -0.01em;
+  /* Small-heading tracking at 16px: -0.005em; the base token stays at 0 for body. */
+  letter-spacing: -0.005em;
   font-weight: 550;
 }
 @utility heading-lg {

--- a/sparkle/src/styles/theme.css
+++ b/sparkle/src/styles/theme.css
@@ -38,11 +38,9 @@
   --font-sans: Geist, sans-serif;
   --font-mono: "Geist Mono", monospace;
 
-  /* Font weight overrides (shared by sparkle/front/marketing).
-     Geist readability-first spec (2026-09-07 test): 500 for labels/buttons,
-     600 for headings and strong. Previously 450 / 550. */
-  --font-weight-medium: 500;
-  --font-weight-semibold: 600;
+  /* Font weight overrides (shared by sparkle/front/marketing). */
+  --font-weight-medium: 450;
+  --font-weight-semibold: 550;
 
   /* Font sizes — px scale with line-height + letter-spacing.
      Geist readability-first spec (2026-09-07 test), 16px root, mobile-first.
@@ -604,80 +602,80 @@
   font-size: var(--text-xs);
   line-height: var(--text-xs--line-height);
   letter-spacing: var(--text-xs--letter-spacing);
-  font-weight: 600;
+  font-weight: 550;
 }
 @utility heading-sm {
   font-size: var(--text-sm);
   line-height: var(--text-sm--line-height);
   letter-spacing: var(--text-sm--letter-spacing);
-  font-weight: 600;
+  font-weight: 550;
 }
 @utility heading-base {
   font-size: var(--text-base);
   line-height: var(--text-base--line-height);
   /* Spec ui-card-title: -0.01em; the base token itself stays at 0 for body. */
   letter-spacing: -0.16px;
-  font-weight: 600;
+  font-weight: 550;
 }
 @utility heading-lg {
   font-size: var(--text-lg);
   line-height: var(--text-lg--line-height);
   letter-spacing: var(--text-lg--letter-spacing);
-  font-weight: 600;
+  font-weight: 550;
 }
 @utility heading-xl {
   font-size: var(--text-xl);
   line-height: var(--text-xl--line-height);
   letter-spacing: var(--text-xl--letter-spacing);
-  font-weight: 600;
+  font-weight: 550;
 }
 @utility heading-2xl {
   font-size: var(--text-2xl);
   line-height: var(--text-2xl--line-height);
   letter-spacing: var(--text-2xl--letter-spacing);
-  font-weight: 600;
+  font-weight: 550;
 }
 @utility heading-3xl {
   font-size: var(--text-3xl);
   line-height: var(--text-3xl--line-height);
   letter-spacing: var(--text-3xl--letter-spacing);
-  font-weight: 600;
+  font-weight: 550;
 }
 @utility heading-4xl {
   font-size: var(--text-4xl);
   line-height: var(--text-4xl--line-height);
   letter-spacing: var(--text-4xl--letter-spacing);
-  font-weight: 600;
+  font-weight: 450;
 }
 @utility heading-5xl {
   font-size: var(--text-5xl);
   line-height: var(--text-5xl--line-height);
   letter-spacing: var(--text-5xl--letter-spacing);
-  font-weight: 600;
+  font-weight: 450;
 }
 @utility heading-6xl {
   font-size: var(--text-6xl);
   line-height: var(--text-6xl--line-height);
   letter-spacing: var(--text-6xl--letter-spacing);
-  font-weight: 600;
+  font-weight: 450;
 }
 @utility heading-7xl {
   font-size: var(--text-7xl);
   line-height: var(--text-7xl--line-height);
   letter-spacing: var(--text-7xl--letter-spacing);
-  font-weight: 600;
+  font-weight: 450;
 }
 @utility heading-8xl {
   font-size: var(--text-8xl);
   line-height: var(--text-8xl--line-height);
   letter-spacing: var(--text-8xl--letter-spacing);
-  font-weight: 600;
+  font-weight: 450;
 }
 @utility heading-9xl {
   font-size: var(--text-9xl);
   line-height: var(--text-9xl--line-height);
   letter-spacing: var(--text-9xl--letter-spacing);
-  font-weight: 600;
+  font-weight: 450;
 }
 
 @utility heading-mono-lg {

--- a/sparkle/src/styles/tokens.css
+++ b/sparkle/src/styles/tokens.css
@@ -275,7 +275,8 @@
   --color-faint: var(--color-stone-400);
 
   /* Text */
-  --color-foreground: var(--color-stone-950);
+  /* stone-900 (17.9:1 on white) softens the black; stone-950 was 19.8:1. */
+  --color-foreground: var(--color-stone-900);
   --color-muted-foreground: var(--color-stone-600);
   --color-foreground-warning: var(--color-rose-500);
 


### PR DESCRIPTION
## Description

Experimental typography pass applying Geist's readability-first recommendations to Sparkle's shared tokens. The changes are metrics-only (no color changes beyond a foreground softening from `stone-950` to `stone-900`):

- **`theme.css` type scale**: `--text-*` line-heights switched from fixed px to unitless ratios and letter-spacing from fixed px to `em` (so both scale correctly with zoom/overrides). Tracking below 18px is now 0; large display steps drop from ~−6% to ~−3.5/−4%.
- **Font weights**: `font-medium` bumped from 450 → 500, `font-semibold` from 550 → 600; `heading-*` utilities hardcoded to 600, `label-*` and `copy-*` to zero tracking.
- **Responsive overrides**: a `@media (min-width: 48rem)` block bumps `2xl` (page title) from 24px to 28px and relaxes `4xl` leading on desktop.
- **Max-width**: `--container-conversation` changed from `48rem` to `65ch` (Geist's reading-measure recommendation).
- **`font-feature-settings`** replaced with the higher-level `font-variant-ligatures: no-contextual` in `front`, `marketing`, and `sparkle` global CSS.
- **Components**: hardcoded `tracking-[-0.28px]` / `tracking-[-0.32px]` removed from `Button`, `Input`, `OptionCard`; `Input` and `TextArea` bumped to `text-base` on mobile (prevents Mobile Safari auto-zoom on focus); `ParagraphBlock` container query threshold corrected from `@md` to `@sm`.

## Tests

Visual/manual: load Storybook (`sparkle`) and compare Typography stories before and after. No automated tests — this is an intentional experimental pass to validate the spec against real UI.

## Risk

Medium. `theme.css` is shared by `sparkle`, `front`, and `marketing`, so every surface using `heading-*`, `label-*`, `copy-*`, or raw `text-*` utilities will visually change. Weights will appear slightly bolder and leading/tracking will differ across all sizes.

## Deploy Plan

Deploy sparkle / front / marketing.