### PR TITLE
refact: consumption analytics: propagate and log error

### DIFF
--- a/front/lib/analytics/agent_message_consumption/documents.test.ts
+++ b/front/lib/analytics/agent_message_consumption/documents.test.ts
@@ -211,7 +211,16 @@ async function buildDocuments(
   const input = await loadAgentMessageConsumptionAnalyticsInput(context.auth, {
     agentMessageId: context.agentMessage.sId,
   });
-  return input ? buildAgentMessageConsumptionAnalyticsDocuments(input) : null;
+  if (!input) {
+    return null;
+  }
+  const result = buildAgentMessageConsumptionAnalyticsDocuments(input);
+  if (result.isErr()) {
+    throw new Error(
+      `Consumption documents were not built: ${result.error.code}`
+    );
+  }
+  return result.value;
 }
 
 describe("buildAgentMessageConsumptionAnalyticsDocuments", () => {

--- a/front/lib/analytics/agent_message_consumption/documents.ts
+++ b/front/lib/analytics/agent_message_consumption/documents.ts
@@ -1,10 +1,28 @@
 import { buildLlmConsumptionDocuments } from "@app/lib/analytics/agent_message_consumption/llm_documents";
 import type { AgentMessageConsumptionAnalyticsInput } from "@app/lib/analytics/agent_message_consumption/load";
 import { buildToolConsumptionDocuments } from "@app/lib/analytics/agent_message_consumption/tool_documents";
+import type { AllocationSkipReason } from "@app/lib/api/assistant/agent_message_consumption_attribution/allocation";
 import { buildLatestMessageConsumptionAllocation } from "@app/lib/api/assistant/agent_message_consumption_attribution/allocation";
 import { roundCreditsToMicroCredits } from "@app/lib/credits/units";
-import logger from "@app/logger/logger";
 import type { AgentMessageConsumptionAnalyticsData } from "@app/types/assistant/analytics";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export type ConsumptionDocumentsSkipReason =
+  | AllocationSkipReason
+  | {
+      code: "credit_mismatch";
+      context: {
+        attributionVersion: number;
+        indexedCreditMicro: number;
+        billedCreditMicro: number;
+        documentCount: number;
+      };
+    }
+  | {
+      code: "empty_documents";
+      context: Record<string, never>;
+    };
 
 /**
  * Projects one complete message attribution into the document grain of the consumption index:
@@ -23,8 +41,11 @@ import type { AgentMessageConsumptionAnalyticsData } from "@app/types/assistant/
  */
 export function buildAgentMessageConsumptionAnalyticsDocuments(
   input: AgentMessageConsumptionAnalyticsInput
-): AgentMessageConsumptionAnalyticsData[] | null {
-  const allocation = buildLatestMessageConsumptionAllocation({
+): Result<
+  AgentMessageConsumptionAnalyticsData[],
+  ConsumptionDocumentsSkipReason
+> {
+  const allocationResult = buildLatestMessageConsumptionAllocation({
     actions: input.actions,
     billedCredits: input.billedCredits,
     dustRunIds: input.dustRunIds,
@@ -32,9 +53,10 @@ export function buildAgentMessageConsumptionAnalyticsDocuments(
     runs: input.runs,
     usages: input.usages,
   });
-  if (!allocation) {
-    return null;
+  if (allocationResult.isErr()) {
+    return allocationResult;
   }
+  const allocation = allocationResult.value;
 
   const documents = [
     ...buildLlmConsumptionDocuments(input, allocation),
@@ -48,23 +70,18 @@ export function buildAgentMessageConsumptionAnalyticsDocuments(
 
   // This is the final safety check before indexing: every per-usage/action document must reconcile
   // exactly to the authoritative message charge.
-  // TODO(2026-08-07 OBSERVABILITY): Replace with an assert once done implementing.
   const billedCreditMicro = roundCreditsToMicroCredits(input.billedCredits);
   if (indexedCreditMicro !== billedCreditMicro) {
-    logger.warn(
-      {
-        workspaceId: input.workspaceId,
-        agentMessageId: input.agentMessageId,
+    return new Err({
+      code: "credit_mismatch",
+      context: {
         attributionVersion: allocation.attributionVersion,
         indexedCreditMicro,
         billedCreditMicro,
         documentCount: documents.length,
       },
-      "[ConsumptionAnalytics] Indexed credits do not match billed credits"
-    );
-
-    return null;
+    });
   }
 
-  return documents;
+  return new Ok(documents);
 }

--- a/front/lib/analytics/agent_message_consumption/index.ts
+++ b/front/lib/analytics/agent_message_consumption/index.ts
@@ -1,3 +1,4 @@
+import type { ConsumptionDocumentsSkipReason } from "@app/lib/analytics/agent_message_consumption/documents";
 import { buildAgentMessageConsumptionAnalyticsDocuments } from "@app/lib/analytics/agent_message_consumption/documents";
 import { loadAgentMessageConsumptionAnalyticsInput } from "@app/lib/analytics/agent_message_consumption/load";
 import { upsertAgentMessageConsumptionAnalyticsDocuments } from "@app/lib/analytics/agent_message_consumption/store";
@@ -5,8 +6,7 @@ import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { Result } from "@app/types/shared/result";
-import { Ok } from "@app/types/shared/result";
-import assert from "assert";
+import { Err, Ok } from "@app/types/shared/result";
 
 /**
  * Loads, projects, and indexes the complete consumption analytics snapshot for one agent message.
@@ -22,7 +22,7 @@ export async function indexAgentMessageConsumptionAnalytics(
     agentMessageId: string;
     preloadedActions?: AgentMCPActionResource[];
   }
-): Promise<Result<void, ElasticsearchError>> {
+): Promise<Result<void, ElasticsearchError | ConsumptionDocumentsSkipReason>> {
   const input = await loadAgentMessageConsumptionAnalyticsInput(auth, {
     agentMessageId,
     preloadedActions,
@@ -31,11 +31,13 @@ export async function indexAgentMessageConsumptionAnalytics(
     return new Ok(undefined);
   }
 
-  const documents = buildAgentMessageConsumptionAnalyticsDocuments(input);
-  assert(
-    documents && documents.length > 0,
-    "Consumption attribution is incomplete for analytics"
-  );
+  const documentsResult = buildAgentMessageConsumptionAnalyticsDocuments(input);
+  if (documentsResult.isErr()) {
+    return documentsResult;
+  }
+  if (documentsResult.value.length === 0) {
+    return new Err({ code: "empty_documents", context: {} });
+  }
 
-  return upsertAgentMessageConsumptionAnalyticsDocuments(documents);
+  return upsertAgentMessageConsumptionAnalyticsDocuments(documentsResult.value);
 }

--- a/front/lib/analytics/agent_message_consumption/llm_documents.test.ts
+++ b/front/lib/analytics/agent_message_consumption/llm_documents.test.ts
@@ -111,7 +111,7 @@ describe("buildLlmConsumptionDocuments", () => {
     if (!input) {
       throw new Error("Consumption analytics input was not loaded");
     }
-    const allocation = buildLatestMessageConsumptionAllocation({
+    const allocationResult = buildLatestMessageConsumptionAllocation({
       actions: input.actions,
       billedCredits: input.billedCredits,
       dustRunIds: input.dustRunIds,
@@ -119,9 +119,12 @@ describe("buildLlmConsumptionDocuments", () => {
       runs: input.runs,
       usages: input.usages,
     });
-    if (!allocation) {
-      throw new Error("Consumption allocation was not built");
+    if (allocationResult.isErr()) {
+      throw new Error(
+        `Consumption allocation was not built: ${allocationResult.error.code}`
+      );
     }
+    const allocation = allocationResult.value;
 
     expect(buildLlmConsumptionDocuments(input, allocation)).toEqual([
       expect.objectContaining({

--- a/front/lib/api/assistant/agent_message_consumption_attribution/allocation.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/allocation.ts
@@ -7,6 +7,8 @@ import type {
   RunUsageWithRunKeyType,
 } from "@app/lib/resources/run_resource";
 import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 
 const FIRST_ATTRIBUTION_VERSION_WITH_TOOL_ROWS = 2;
 
@@ -21,6 +23,16 @@ export type MessageConsumptionAllocation<
   items: AgentMessageConsumptionItemResource[];
   messageUsages: TUsage[];
   reconciledCreditAmounts: ReconciledCreditAmounts;
+};
+
+export type AllocationSkipReason = {
+  code:
+    | "no_billed_credits"
+    | "no_items_or_dust_run_ids"
+    | "no_message_usages"
+    | "incomplete_attribution"
+    | "reconciliation_failed";
+  context: Record<string, number | boolean>;
 };
 
 /**
@@ -208,9 +220,16 @@ function buildMessageConsumptionAllocationForVersion<
   items: AgentMessageConsumptionItemResource[];
   runs: RunResource[];
   usages: TUsage[];
-}): MessageConsumptionAllocation<TUsage> | null {
+}): Result<MessageConsumptionAllocation<TUsage>, AllocationSkipReason> {
   if (items.length === 0 || dustRunIds.length === 0) {
-    return null;
+    return new Err({
+      code: "no_items_or_dust_run_ids",
+      context: {
+        attributionVersion,
+        dustRunIdCount: dustRunIds.length,
+        itemCount: items.length,
+      },
+    });
   }
 
   const dustRunIdSet = new Set(dustRunIds);
@@ -221,7 +240,16 @@ function buildMessageConsumptionAllocationForVersion<
     messageRunModelIds.has(usage.runModelId)
   );
   if (messageUsages.length === 0) {
-    return null;
+    return new Err({
+      code: "no_message_usages",
+      context: {
+        attributionVersion,
+        dustRunIdCount: dustRunIds.length,
+        runCount: runs.length,
+        matchedRunCount: messageRunModelIds.size,
+        totalUsageCount: usages.length,
+      },
+    });
   }
 
   const dustRunIdByRunModelId = new Map(
@@ -234,16 +262,27 @@ function buildMessageConsumptionAllocationForVersion<
     })
   );
 
-  if (
-    !hasCompleteModelAttribution(items, messageUsages) ||
-    (attributionVersion >= FIRST_ATTRIBUTION_VERSION_WITH_TOOL_ROWS &&
-      !hasCompleteToolAttribution({
-        actions,
-        items,
-        dustRunIdsWithUsage,
-      }))
-  ) {
-    return null;
+  const completeModel = hasCompleteModelAttribution(items, messageUsages);
+  const completeTool =
+    attributionVersion < FIRST_ATTRIBUTION_VERSION_WITH_TOOL_ROWS ||
+    hasCompleteToolAttribution({
+      actions,
+      items,
+      dustRunIdsWithUsage,
+    });
+
+  if (!completeModel || !completeTool) {
+    return new Err({
+      code: "incomplete_attribution",
+      context: {
+        attributionVersion,
+        completeModel,
+        completeTool,
+        itemCount: items.length,
+        messageUsageCount: messageUsages.length,
+        actionCount: actions.length,
+      },
+    });
   }
 
   const reconciledCreditAmounts = reconcileInputCredits({
@@ -251,15 +290,32 @@ function buildMessageConsumptionAllocationForVersion<
     billedCredits,
   });
   if (!reconciledCreditAmounts) {
-    return null;
+    const billedCreditAmountMicro = roundCreditsToMicroCredits(billedCredits);
+    const nonInputCreditAmountMicro = items.reduce(
+      (total, item) =>
+        item.itemType === "input"
+          ? total
+          : total + item.grossAttributedCreditAmountMicro,
+      0
+    );
+    return new Err({
+      code: "reconciliation_failed",
+      context: {
+        attributionVersion,
+        billedCreditAmountMicro,
+        nonInputCreditAmountMicro,
+        inputItemCount: items.filter((item) => item.itemType === "input")
+          .length,
+      },
+    });
   }
 
-  return {
+  return new Ok({
     attributionVersion,
     items,
     messageUsages,
     reconciledCreditAmounts,
-  };
+  });
 }
 
 /** Selects and allocates the newest self-consistent attribution stored for a message. */
@@ -279,9 +335,9 @@ export function buildLatestMessageConsumptionAllocation<
   items: AgentMessageConsumptionItemResource[];
   runs: RunResource[];
   usages: TUsage[];
-}): MessageConsumptionAllocation<TUsage> | null {
+}): Result<MessageConsumptionAllocation<TUsage>, AllocationSkipReason> {
   if (billedCredits === null) {
-    return null;
+    return new Err({ code: "no_billed_credits", context: {} });
   }
 
   const itemsByAttributionVersion = new Map<
@@ -298,8 +354,9 @@ export function buildLatestMessageConsumptionAllocation<
   const attributionVersions = [...itemsByAttributionVersion.keys()].sort(
     (left, right) => right - left
   );
+  let lastSkipReason: AllocationSkipReason | undefined;
   for (const attributionVersion of attributionVersions) {
-    const allocation = buildMessageConsumptionAllocationForVersion({
+    const result = buildMessageConsumptionAllocationForVersion({
       actions,
       attributionVersion,
       billedCredits,
@@ -308,10 +365,16 @@ export function buildLatestMessageConsumptionAllocation<
       runs,
       usages,
     });
-    if (allocation) {
-      return allocation;
+    if (result.isOk()) {
+      return result;
     }
+    lastSkipReason = result.error;
   }
 
-  return null;
+  return new Err(
+    lastSkipReason ?? {
+      code: "no_items_or_dust_run_ids",
+      context: { itemCount: 0, dustRunIdCount: dustRunIds.length },
+    }
+  );
 }

--- a/front/lib/api/assistant/agent_message_consumption_attribution/message_details.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/message_details.ts
@@ -261,7 +261,7 @@ export function buildLatestAvailableMessageConsumptionDetails({
   toolsAttributedToAgentWork?: ToolsAttributedToAgentWork;
   usages: RunUsageWithRunKeyType[];
 }): MessageConsumptionDetails | null {
-  const allocation = buildLatestMessageConsumptionAllocation({
+  const allocationResult = buildLatestMessageConsumptionAllocation({
     actions,
     billedCredits,
     dustRunIds,
@@ -269,13 +269,13 @@ export function buildLatestAvailableMessageConsumptionDetails({
     runs,
     usages,
   });
-  if (!allocation) {
+  if (allocationResult.isErr()) {
     return null;
   }
 
   return buildMessageConsumptionDetails({
     actions,
-    allocation,
+    allocation: allocationResult.value,
     toolDetailsOverridesByActionModelId,
     toolsAttributedToAgentWork,
   });

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
@@ -422,7 +422,7 @@ async function persistMessageConsumptionAttribution(
           transaction,
         }
       );
-    const allocation = buildLatestMessageConsumptionAllocation({
+    const allocationResult = buildLatestMessageConsumptionAllocation({
       actions,
       billedCredits,
       dustRunIds,
@@ -430,12 +430,13 @@ async function persistMessageConsumptionAttribution(
       runs,
       usages,
     });
-    if (!allocation) {
+    if (allocationResult.isErr()) {
       return false;
     }
 
     await AgentMessageConsumptionItemResource.setReconciledCreditAmounts(auth, {
-      reconciledCreditAmountByItem: allocation.reconciledCreditAmounts.byItem,
+      reconciledCreditAmountByItem:
+        allocationResult.value.reconciledCreditAmounts.byItem,
       transaction,
     });
     return true;


### PR DESCRIPTION
## Description

Propagate errors and log it once if we can't create agent message consumption analytics document, so the assert has hopefully more details about why we couldn't generate the documents.

## Tests

existing tests

## Risk

Low

## Deploy Plan

Front only