### PR TITLE
[front] Make the ask-question composer collapsible

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -5,6 +5,7 @@ import { InputBar } from "@app/components/assistant/conversation/input_bar/Input
 import { InputBarMessageNavigation } from "@app/components/assistant/conversation/input_bar/InputBarMessageNavigation";
 import { INPUT_BAR_COMPACT_NAV_ENTER_ANIMATION_CLASSES } from "@app/components/assistant/conversation/input_bar/inputBarCompactStyles";
 import { useInputBarCompactMode } from "@app/components/assistant/conversation/input_bar/useInputBarCompactMode";
+import { useUserAnswerCollapse } from "@app/components/assistant/conversation/input_bar/useUserAnswerCollapse";
 import type {
   VirtuosoMessage,
   VirtuosoMessageListContext,
@@ -346,6 +347,14 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
   );
   const inputBarContentKey =
     userAnswerRequiredItem?.blockedAction.actionId ?? "input-bar";
+
+  const {
+    isCollapsed: isUserAnswerCollapsed,
+    toggleCollapsed: toggleUserAnswerCollapsed,
+  } = useUserAnswerCollapse({
+    questionId: userAnswerRequiredItem?.blockedAction.actionId ?? null,
+    bottomOffset,
+  });
 
   // Keep blockedActionIndex in sync when blockedActions array changes.
   useEffect(() => {
@@ -705,6 +714,8 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
                 }
                 owner={context.owner}
                 retryHandler={retryUserAnswerRequired}
+                isCollapsed={isUserAnswerCollapsed}
+                onToggleCollapsed={toggleUserAnswerCollapsed}
               />
             ) : (
               <InputBar

--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -162,18 +162,21 @@ vi.mock("@dust-tt/sparkle", () => {
     disabled,
     isLoading,
     "aria-label": ariaLabel,
+    "aria-expanded": ariaExpanded,
   }: {
     label?: string;
     onClick?: () => void;
     disabled?: boolean;
     isLoading?: boolean;
     "aria-label"?: string;
+    "aria-expanded"?: boolean;
   }) => (
     <button
       type="button"
       onClick={onClick}
       disabled={disabled || isLoading}
       aria-label={ariaLabel}
+      aria-expanded={ariaExpanded}
     >
       {label ?? ariaLabel}
     </button>
@@ -181,10 +184,14 @@ vi.mock("@dust-tt/sparkle", () => {
 
   const Spinner = () => <div>Loading</div>;
   const ArrowUp = () => null;
+  const ChevronDown = () => null;
+  const ChevronUp = () => null;
 
   return {
     ArrowUp,
     Button,
+    ChevronDown,
+    ChevronUp,
     Card,
     Counter,
     cn,
@@ -671,5 +678,74 @@ describe("UserAnswerRequired", () => {
         },
       });
     });
+  });
+
+  it("only shows the collapse toggle when a toggle handler is provided", () => {
+    const { rerender } = render(
+      <UserAnswerRequired
+        blockedAction={makeBlockedAction()}
+        triggeringUser={null}
+        owner={owner}
+        retryHandler={retryHandlerMock}
+      />
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /Collapse question/i })
+    ).not.toBeInTheDocument();
+
+    const onToggleCollapsed = vi.fn();
+    rerender(
+      <UserAnswerRequired
+        blockedAction={makeBlockedAction()}
+        triggeringUser={null}
+        owner={owner}
+        retryHandler={retryHandlerMock}
+        isCollapsed={false}
+        onToggleCollapsed={onToggleCollapsed}
+      />
+    );
+
+    const toggle = screen.getByRole("button", { name: /Collapse question/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.click(toggle);
+
+    expect(onToggleCollapsed).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the answer body and ignores keyboard shortcuts while collapsed", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <UserAnswerRequired
+        blockedAction={makeBlockedAction()}
+        triggeringUser={null}
+        owner={owner}
+        retryHandler={retryHandlerMock}
+        isCollapsed
+        onToggleCollapsed={vi.fn()}
+      />
+    );
+
+    const keyboardContainer = getKeyboardContainer(container);
+    const toggle = screen.getByRole("button", { name: /Expand question/i });
+    const body = container.querySelector("#user-answer-body-action_1");
+
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(body).toHaveClass("invisible", "grid-rows-[0fr]");
+
+    await waitFor(() => expect(keyboardContainer).toHaveFocus());
+
+    // Escape would otherwise skip the question, a printable key would start a
+    // custom response and Enter would submit the highlighted option.
+    fireEvent.keyDown(keyboardContainer, { key: "Escape" });
+    await user.keyboard("a");
+    fireEvent.keyDown(keyboardContainer, { key: "Enter" });
+
+    expect(answerQuestionMock).not.toHaveBeenCalled();
+    expect(screen.getByPlaceholderText(/Tell the agent/i)).toHaveValue("");
+    expect(screen.getByRole("button", { name: /Alpha/i })).toHaveClass(
+      "bg-primary-100"
+    );
   });
 });

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -6,7 +6,15 @@ import type { UserQuestionAnswer } from "@app/lib/actions/types";
 import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
-import { ArrowUp, Button, cn, OptionCard, Spinner } from "@dust-tt/sparkle";
+import {
+  ArrowUp,
+  Button,
+  ChevronDown,
+  ChevronUp,
+  cn,
+  OptionCard,
+  Spinner,
+} from "@dust-tt/sparkle";
 import { useReducedMotion } from "framer-motion";
 import type { KeyboardEvent } from "react";
 import { useEffect, useRef, useState } from "react";
@@ -18,6 +26,10 @@ interface UserAnswerRequiredProps {
   triggeringUser: UserType | null;
   owner: LightWorkspaceType;
   retryHandler: () => Promise<void>;
+  // When provided, the card shows a collapse toggle in its top right corner and
+  // only renders the question text while collapsed.
+  isCollapsed?: boolean;
+  onToggleCollapsed?: () => void;
 }
 
 type SubmissionState = {
@@ -44,6 +56,8 @@ export function UserAnswerRequired({
   triggeringUser,
   owner,
   retryHandler,
+  isCollapsed = false,
+  onToggleCollapsed,
 }: UserAnswerRequiredProps) {
   const { user } = useAuth();
   const { removeCompletedAction } = useBlockedActionsContext();
@@ -71,6 +85,8 @@ export function UserAnswerRequired({
     answerDraft.answerToSubmit?.customResponse !== undefined;
 
   const isSubmitting = submission !== null;
+  const isCollapsible = onToggleCollapsed !== undefined;
+  const answerBodyId = `user-answer-body-${blockedAction.actionId}`;
 
   // Reset the keyboard cursor and focus when a new blocked action replaces the current one.
   // biome-ignore lint/correctness/useExhaustiveDependencies: blockedAction.actionId is an intentional reset trigger
@@ -201,6 +217,10 @@ export function UserAnswerRequired({
   }
 
   function handleContainerKeyDownCapture(e: KeyboardEvent<HTMLDivElement>) {
+    if (isCollapsed) {
+      return;
+    }
+
     if (e.key === "Escape") {
       e.preventDefault();
       e.stopPropagation();
@@ -222,7 +242,7 @@ export function UserAnswerRequired({
   }
 
   function handleContainerKeyDown(e: KeyboardEvent<HTMLDivElement>) {
-    if (isEditableTarget(e.target)) {
+    if (isCollapsed || isEditableTarget(e.target)) {
       return;
     }
 
@@ -288,110 +308,143 @@ export function UserAnswerRequired({
         }
       }}
       className={cn(
-        "flex flex-col gap-4 rounded-2xl border border-dark bg-background p-5 outline-hidden",
+        "flex flex-col rounded-2xl border border-dark bg-background p-5 outline-hidden",
         "ease-enter motion-reduce:animate-none",
         submission?.phase === "exiting" &&
           "animate-out fill-mode-forwards fade-out-0 duration-exit",
         isKeyboardNavigating && "cursor-none"
       )}
     >
-      <div className="text-base font-medium leading-tight text-foreground">
-        {question.question}
-      </div>
-      <div className="relative min-h-16">
+      <div className="flex items-start justify-between gap-3">
         <div
-          aria-hidden={isSubmitting}
           className={cn(
-            "flex flex-col gap-2 transition-opacity ease-enter motion-reduce:transition-none",
-            isSubmitting
-              ? "opacity-0 duration-exit"
-              : "opacity-100 duration-enter"
+            "min-w-0 text-base font-medium leading-tight text-foreground",
+            isCollapsed && "truncate"
           )}
         >
-          {question.options.map((option, index) => (
-            <OptionCard
-              key={index}
-              label={option.label}
-              description={option.description}
-              counterValue={index + 1}
-              selected={answerDraft.selectedOptions.includes(index)}
-              disableHover={isKeyboardNavigating}
-              selectionIndicator={question.multiSelect ? "checkbox" : "radio"}
-              onFocusCapture={() => activateOption(index)}
-              onMouseEnter={() => activateOption(index)}
+          {question.question}
+        </div>
+        {isCollapsible && (
+          <Button
+            icon={isCollapsed ? ChevronUp : ChevronDown}
+            variant="ghost"
+            size="xs"
+            className="-mr-1.5 -mt-1.5 shrink-0"
+            aria-label={isCollapsed ? "Expand question" : "Collapse question"}
+            aria-expanded={!isCollapsed}
+            aria-controls={answerBodyId}
+            tooltip={isCollapsed ? "Expand" : "Collapse"}
+            onClick={onToggleCollapsed}
+          />
+        )}
+      </div>
+      <div
+        id={answerBodyId}
+        className={cn(
+          "grid transition-[grid-template-rows,visibility] duration-enter ease-enter motion-reduce:transition-none",
+          isCollapsed ? "invisible grid-rows-[0fr]" : "grid-rows-[1fr]"
+        )}
+      >
+        {/* -m-1/p-1 leaves room for focus rings inside the clipping box. */}
+        <div className="-m-1 flex min-h-0 flex-col gap-4 overflow-hidden p-1 pt-5">
+          <div className="relative min-h-16">
+            <div
+              aria-hidden={isSubmitting}
               className={cn(
-                activeOptionIndex === index &&
-                  !isCustomResponseActive &&
-                  !answerDraft.selectedOptions.includes(index) &&
-                  "bg-primary-100",
-                isKeyboardNavigating && "cursor-none"
+                "flex flex-col gap-2 transition-opacity ease-enter motion-reduce:transition-none",
+                isSubmitting
+                  ? "opacity-0 duration-exit"
+                  : "opacity-100 duration-enter"
               )}
-              onClick={() => handleOptionClick(index)}
+            >
+              {question.options.map((option, index) => (
+                <OptionCard
+                  key={index}
+                  label={option.label}
+                  description={option.description}
+                  counterValue={index + 1}
+                  selected={answerDraft.selectedOptions.includes(index)}
+                  disableHover={isKeyboardNavigating}
+                  selectionIndicator={
+                    question.multiSelect ? "checkbox" : "radio"
+                  }
+                  onFocusCapture={() => activateOption(index)}
+                  onMouseEnter={() => activateOption(index)}
+                  className={cn(
+                    activeOptionIndex === index &&
+                      !isCustomResponseActive &&
+                      !answerDraft.selectedOptions.includes(index) &&
+                      "bg-primary-100",
+                    isKeyboardNavigating && "cursor-none"
+                  )}
+                  onClick={() => handleOptionClick(index)}
+                  disabled={isSubmitting}
+                />
+              ))}
+              <OptionCard
+                type="input"
+                selected={isCustomResponseActive}
+                disableHover={isKeyboardNavigating}
+                className={cn(isKeyboardNavigating && "cursor-none")}
+                inputRef={customResponseInputRef}
+                id={`custom-response-${blockedAction.actionId}`}
+                name="custom-response"
+                placeholder="Tell the agent what to do differently"
+                value={answerDraft.customResponse}
+                disabled={isSubmitting}
+                onFocus={() => {
+                  setIsCustomResponseFocused(true);
+                  answerDraft.selectCustomResponse();
+                }}
+                onBlur={() => setIsCustomResponseFocused(false)}
+                onChange={(value) => answerDraft.updateCustomResponse(value)}
+                onKeyDown={handleCustomResponseKeyDown}
+              />
+            </div>
+            <div
+              role={isSubmitting ? "status" : undefined}
+              aria-hidden={!isSubmitting}
+              className={cn(
+                "absolute inset-0 flex items-center justify-center transition-opacity ease-enter motion-reduce:transition-none",
+                isSubmitting
+                  ? "opacity-100 duration-exit"
+                  : "pointer-events-none opacity-0 duration-enter"
+              )}
+            >
+              <Spinner size="lg" />
+              <span className="sr-only">
+                {submission?.kind === "skip"
+                  ? "Skipping question"
+                  : "Submitting answer"}
+              </span>
+            </div>
+          </div>
+          {errorMessage && (
+            <div className="text-sm font-medium text-warning-800">
+              {errorMessage}
+            </div>
+          )}
+          <div className="flex items-center justify-between gap-3">
+            <Button
+              label="Skip"
+              variant="outline"
+              size="sm"
+              onClick={handleSkip}
+              isLoading={submission?.kind === "skip"}
               disabled={isSubmitting}
             />
-          ))}
-          <OptionCard
-            type="input"
-            selected={isCustomResponseActive}
-            disableHover={isKeyboardNavigating}
-            className={cn(isKeyboardNavigating && "cursor-none")}
-            inputRef={customResponseInputRef}
-            id={`custom-response-${blockedAction.actionId}`}
-            name="custom-response"
-            placeholder="Tell the agent what to do differently"
-            value={answerDraft.customResponse}
-            disabled={isSubmitting}
-            onFocus={() => {
-              setIsCustomResponseFocused(true);
-              answerDraft.selectCustomResponse();
-            }}
-            onBlur={() => setIsCustomResponseFocused(false)}
-            onChange={(value) => answerDraft.updateCustomResponse(value)}
-            onKeyDown={handleCustomResponseKeyDown}
-          />
+            <Button
+              icon={ArrowUp}
+              variant="highlight"
+              size="sm"
+              isLoading={submission?.kind === "answer"}
+              disabled={isSubmitting || answerDraft.answerToSubmit === null}
+              onClick={handleSubmit}
+              aria-label="Send answer"
+              className="rounded-full"
+            />
+          </div>
         </div>
-        <div
-          role={isSubmitting ? "status" : undefined}
-          aria-hidden={!isSubmitting}
-          className={cn(
-            "absolute inset-0 flex items-center justify-center transition-opacity ease-enter motion-reduce:transition-none",
-            isSubmitting
-              ? "opacity-100 duration-exit"
-              : "pointer-events-none opacity-0 duration-enter"
-          )}
-        >
-          <Spinner size="lg" />
-          <span className="sr-only">
-            {submission?.kind === "skip"
-              ? "Skipping question"
-              : "Submitting answer"}
-          </span>
-        </div>
-      </div>
-      {errorMessage && (
-        <div className="text-sm font-medium text-warning-800">
-          {errorMessage}
-        </div>
-      )}
-      <div className="flex items-center justify-between gap-3">
-        <Button
-          label="Skip"
-          variant="outline"
-          size="sm"
-          onClick={handleSkip}
-          isLoading={submission?.kind === "skip"}
-          disabled={isSubmitting}
-        />
-        <Button
-          icon={ArrowUp}
-          variant="highlight"
-          size="sm"
-          isLoading={submission?.kind === "answer"}
-          disabled={isSubmitting || answerDraft.answerToSubmit === null}
-          onClick={handleSubmit}
-          aria-label="Send answer"
-          className="rounded-full"
-        />
       </div>
     </div>
   );

--- a/front/components/assistant/conversation/input_bar/useUserAnswerCollapse.test.ts
+++ b/front/components/assistant/conversation/input_bar/useUserAnswerCollapse.test.ts
@@ -1,0 +1,130 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useUserAnswerCollapse } from "./useUserAnswerCollapse";
+
+function renderCollapse({
+  questionId = "action_1",
+  bottomOffset = 0,
+}: {
+  questionId?: string | null;
+  bottomOffset?: number;
+} = {}) {
+  return renderHook(
+    (props: { questionId: string | null; bottomOffset: number }) =>
+      useUserAnswerCollapse(props),
+    { initialProps: { questionId, bottomOffset } }
+  );
+}
+
+describe("useUserAnswerCollapse", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts expanded at the bottom of the conversation", () => {
+    const { result } = renderCollapse();
+
+    expect(result.current.isCollapsed).toBe(false);
+  });
+
+  it("collapses when scrolling away from the bottom and expands when coming back", () => {
+    const { result, rerender } = renderCollapse();
+
+    rerender({ questionId: "action_1", bottomOffset: 400 });
+    expect(result.current.isCollapsed).toBe(true);
+
+    // Still far from the bottom: stays collapsed.
+    rerender({ questionId: "action_1", bottomOffset: 60 });
+    expect(result.current.isCollapsed).toBe(true);
+
+    rerender({ questionId: "action_1", bottomOffset: 0 });
+    expect(result.current.isCollapsed).toBe(false);
+  });
+
+  it("does not collapse for small scroll offsets near the bottom", () => {
+    const { result, rerender } = renderCollapse();
+
+    rerender({ questionId: "action_1", bottomOffset: 60 });
+
+    expect(result.current.isCollapsed).toBe(false);
+  });
+
+  it("lets the manual toggle override the scroll position until the next transition", () => {
+    const { result, rerender } = renderCollapse();
+
+    act(() => result.current.toggleCollapsed());
+    expect(result.current.isCollapsed).toBe(true);
+
+    // Re-rendering at the bottom is not a transition: the manual choice sticks.
+    vi.advanceTimersByTime(1_000);
+    rerender({ questionId: "action_1", bottomOffset: 0 });
+    expect(result.current.isCollapsed).toBe(true);
+
+    // Scrolling away then back to the bottom expands it again.
+    rerender({ questionId: "action_1", bottomOffset: 400 });
+    expect(result.current.isCollapsed).toBe(true);
+    rerender({ questionId: "action_1", bottomOffset: 0 });
+    expect(result.current.isCollapsed).toBe(false);
+
+    // Expanding manually while scrolled away sticks until the bottom is reached.
+    rerender({ questionId: "action_1", bottomOffset: 400 });
+    act(() => result.current.toggleCollapsed());
+    vi.advanceTimersByTime(1_000);
+    rerender({ questionId: "action_1", bottomOffset: 600 });
+    expect(result.current.isCollapsed).toBe(false);
+  });
+
+  it("ignores the scroll location shift caused by toggling", () => {
+    const { result, rerender } = renderCollapse();
+
+    // Expanding the card shrinks the viewport, which reads as a large offset.
+    act(() => result.current.toggleCollapsed());
+    rerender({ questionId: "action_1", bottomOffset: 250 });
+    expect(result.current.isCollapsed).toBe(true);
+
+    act(() => result.current.toggleCollapsed());
+    rerender({ questionId: "action_1", bottomOffset: 250 });
+    expect(result.current.isCollapsed).toBe(false);
+
+    // Once the grace window is over, real scrolling takes effect again.
+    vi.advanceTimersByTime(1_000);
+    rerender({ questionId: "action_1", bottomOffset: 300 });
+    expect(result.current.isCollapsed).toBe(true);
+  });
+
+  it("forgets the manual collapse when a different question takes over", () => {
+    const { result, rerender } = renderCollapse();
+
+    act(() => result.current.toggleCollapsed());
+    expect(result.current.isCollapsed).toBe(true);
+
+    rerender({ questionId: "action_2", bottomOffset: 0 });
+    expect(result.current.isCollapsed).toBe(false);
+  });
+
+  it("collapses a new question right away when the reader is scrolled up", () => {
+    const { result, rerender } = renderCollapse();
+
+    rerender({ questionId: "action_1", bottomOffset: 400 });
+    act(() => result.current.toggleCollapsed());
+    expect(result.current.isCollapsed).toBe(false);
+
+    vi.advanceTimersByTime(1_000);
+    rerender({ questionId: "action_2", bottomOffset: 400 });
+    expect(result.current.isCollapsed).toBe(true);
+  });
+
+  it("stays expanded while no question is shown", () => {
+    const { result, rerender } = renderCollapse({ questionId: null });
+
+    rerender({ questionId: null, bottomOffset: 400 });
+
+    expect(result.current.isCollapsed).toBe(false);
+  });
+});

--- a/front/components/assistant/conversation/input_bar/useUserAnswerCollapse.ts
+++ b/front/components/assistant/conversation/input_bar/useUserAnswerCollapse.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// Hysteresis around the bottom of the conversation: the card collapses once the
+// reader has scrolled further than this from the bottom...
+const SCROLL_COLLAPSE_THRESHOLD_PX = 120;
+// ...and expands again once they are back within this distance of it.
+const SCROLL_EXPAND_THRESHOLD_PX = 24;
+// Toggling changes the composer height, which shifts the scroll location.
+// Ignore location updates for a short window so that shift is not mistaken
+// for the user scrolling.
+const TOGGLE_SCROLL_GRACE_MS = 300;
+
+interface UseUserAnswerCollapseOptions {
+  // Identifies the question currently shown in the composer, null when the
+  // composer is not in ask-question mode. The collapsed state resets whenever
+  // a different question takes over.
+  questionId: string | null;
+  // Distance in px between the bottom of the message list and the bottom of
+  // the viewport, as reported by Virtuoso (0 when scrolled to the bottom).
+  bottomOffset: number;
+}
+
+// Collapses the ask-question card while the reader scrolls up through the
+// conversation and expands it again when they reach the bottom. The manual
+// toggle wins in between: auto-collapse/expand only fire on the transition
+// between "at the bottom" and "scrolled away".
+export function useUserAnswerCollapse({
+  questionId,
+  bottomOffset,
+}: UseUserAnswerCollapseOptions) {
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const isAtBottomRef = useRef(true);
+  const ignoreScrollUntilRef = useRef(0);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: questionId is an intentional reset trigger
+  useEffect(() => {
+    setIsCollapsed(false);
+    isAtBottomRef.current = true;
+    ignoreScrollUntilRef.current = 0;
+  }, [questionId]);
+
+  useEffect(() => {
+    if (questionId === null) {
+      return;
+    }
+
+    if (Date.now() < ignoreScrollUntilRef.current) {
+      return;
+    }
+
+    if (isAtBottomRef.current && bottomOffset > SCROLL_COLLAPSE_THRESHOLD_PX) {
+      isAtBottomRef.current = false;
+      setIsCollapsed(true);
+    } else if (
+      !isAtBottomRef.current &&
+      bottomOffset < SCROLL_EXPAND_THRESHOLD_PX
+    ) {
+      isAtBottomRef.current = true;
+      setIsCollapsed(false);
+    }
+  }, [questionId, bottomOffset]);
+
+  const toggleCollapsed = useCallback(() => {
+    ignoreScrollUntilRef.current = Date.now() + TOGGLE_SCROLL_GRACE_MS;
+    setIsCollapsed((prev) => !prev);
+  }, []);
+
+  return { isCollapsed, toggleCollapsed };
+}


### PR DESCRIPTION
## Description

The ask-question card (`UserAnswerRequired`) can take a lot of vertical space, making it annoying to scroll up through a long conversation. This PR adds a collapsible behaviour to the card:

- A new `useUserAnswerCollapse` hook tracks the scroll position via `bottomOffset` (already exposed by the Virtuoso list context) and auto-collapses the card when the user scrolls more than ~100 px away from the bottom, then re-expands it when they scroll back.
- A `ChevronDown / ChevronUp` toggle button is shown in the top-right corner of the card so the user can also collapse/expand manually; a manual choice is preserved until the next scroll-away → scroll-back transition.
- While collapsed the card shows only the question text (truncated), hides the answer body with a CSS `grid-rows` transition, and suppresses all keyboard shortcuts (Escape, Enter, printable keys) so they fall through to the rest of the UI.
- `AgentInputBar` wires the hook result into `UserAnswerRequired` via two new optional props (`isCollapsed`, `onToggleCollapsed`).

## Tests

- New `useUserAnswerCollapse.test.ts` covers all scroll/manual-toggle interactions (auto-collapse, auto-expand, manual override stickiness, viewport-shift guard after toggle).
- Existing `UserAnswerRequired.test.tsx` extended with two new cases: toggle visibility and keyboard-shortcut suppression while collapsed.
- Tested manually in the conversation UI.

## Risk

Low — the collapse props are optional, so existing usages of `UserAnswerRequired` that don't pass them are unaffected. The CSS transition uses `grid-template-rows` which is well-supported; `motion-reduce` users get an instant switch.

## Deploy Plan

Deploy front.