### PR TITLE
Group awu cap: only retrieve the limit when requested

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/groups/index.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/groups/index.test.ts
@@ -35,6 +35,23 @@ async function createGroupWithMember() {
   return { workspace, group };
 }
 
+async function createCappedGroup() {
+  const { workspace } = await createPrivateApiMockRequest({
+    isSuperUser: true,
+    role: "admin",
+  });
+  const group = await GroupFactory.regularManual(
+    workspace,
+    "Poke capped group"
+  );
+  const capRes = await group.updatePoolCap(9876);
+  if (capRes.isErr()) {
+    throw capRes.error;
+  }
+
+  return { workspace, group };
+}
+
 describe("GET /api/poke/workspaces/:wId/groups", () => {
   it("excludes revoked workspace members from group counts", async () => {
     const { workspace, group } = await createGroupWithMember();
@@ -49,6 +66,45 @@ describe("GET /api/poke/workspaces/:wId/groups", () => {
       (g: { sId: string }) => g.sId === group.sId
     );
     expect(responseGroup?.memberCount).toBe(1);
+  });
+
+  it("omits poolCapAwuCredits unless withPoolCaps=true is requested", async () => {
+    const { workspace, group } = await createCappedGroup();
+
+    const response = await honoApp.request(
+      `/api/poke/workspaces/${workspace.sId}/groups`
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    const responseGroup = data.groups.find(
+      (g: { sId: string }) => g.sId === group.sId
+    );
+    expect(responseGroup).toBeDefined();
+    expect(responseGroup.poolCapAwuCredits).toBeUndefined();
+  });
+
+  it("returns poolCapAwuCredits when withPoolCaps=true is requested", async () => {
+    const { workspace, group } = await createCappedGroup();
+
+    const response = await honoApp.request(
+      `/api/poke/workspaces/${workspace.sId}/groups?withPoolCaps=true`
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    const responseGroup = data.groups.find(
+      (g: { sId: string }) => g.sId === group.sId
+    );
+    expect(responseGroup?.poolCapAwuCredits).toBe(9876);
+    // Groups without a cap row report null, not undefined.
+    const otherGroups = data.groups.filter(
+      (g: { sId: string }) => g.sId !== group.sId
+    );
+    expect(otherGroups.length).toBeGreaterThan(0);
+    for (const other of otherGroups) {
+      expect(other.poolCapAwuCredits).toBeNull();
+    }
   });
 });
 

--- a/front-api/routes/poke/workspaces/[wId]/groups/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/groups/index.ts
@@ -9,10 +9,7 @@ import groupId from "./[groupId]";
 
 const ListGroupsQuerySchema = z.object({
   // When "true", each group also carries its pool cap (one extra batched
-  // query). Accepted but not yet honored: the cap is still returned
-  // unconditionally so front-end bundles that predate the flag keep working.
-  // A follow-up makes the cap conditional on this flag, once the bundles
-  // sending it are deployed everywhere.
+  // query). Omitted otherwise: only the pool usage view reads it.
   withPoolCaps: z.enum(["true", "false"]).optional(),
 });
 
@@ -25,23 +22,14 @@ app.get(
   validate("query", ListGroupsQuerySchema),
   async (ctx): HandlerResult<PokeListGroups> => {
     const auth = ctx.get("auth");
+    const { withPoolCaps } = ctx.req.valid("query");
 
     const groups = await GroupResource.listAllWorkspaceGroups(auth);
-    const memberCounts = await GroupResource.getMemberCountsForGroups(
-      auth,
-      groups
-    );
-    const poolCaps = await GroupResource.getPoolCapAwuCreditsForGroups(
-      auth,
-      groups
-    );
 
     return ctx.json({
-      groups: groups.map((group) => ({
-        ...group.toJSON(),
-        memberCount: memberCounts.get(group.id) ?? 0,
-        poolCapAwuCredits: poolCaps.get(group.id) ?? null,
-      })),
+      groups: await GroupResource.toJSONWithMemberCounts(auth, groups, {
+        withPoolCaps: withPoolCaps === "true",
+      }),
     });
   }
 );

--- a/front-api/routes/w/[wId]/groups/index.test.ts
+++ b/front-api/routes/w/[wId]/groups/index.test.ts
@@ -40,6 +40,88 @@ describe("GET /api/w/:wId/groups", () => {
     expect(body.groups[0].memberIds).toBeUndefined();
   });
 
+  it("omits poolCapAwuCredits unless withPoolCaps=true is requested", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const sales = await GroupFactory.regularManual(workspace, "Sales");
+    const capRes = await sales.updatePoolCap(1234);
+    if (capRes.isErr()) {
+      throw capRes.error;
+    }
+
+    const response = await getGroupsRequest(workspace.sId, {
+      kind: "regular_manual",
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.groups).toHaveLength(1);
+    expect(body.groups[0].poolCapAwuCredits).toBeUndefined();
+  });
+
+  it("returns poolCapAwuCredits when withPoolCaps=true is requested", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const capped = await GroupFactory.regularManual(workspace, "Capped");
+    const capRes = await capped.updatePoolCap(1234);
+    if (capRes.isErr()) {
+      throw capRes.error;
+    }
+    await GroupFactory.regularManual(workspace, "Uncapped");
+
+    const response = await getGroupsRequest(workspace.sId, {
+      kind: "regular_manual",
+      withPoolCaps: "true",
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    // A group without a row reports null, distinct from the field being absent.
+    // The endpoint does not order its results, so match by name.
+    expect(body.groups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "Capped", poolCapAwuCredits: 1234 }),
+        expect.objectContaining({ name: "Uncapped", poolCapAwuCredits: null }),
+      ])
+    );
+    expect(body.groups).toHaveLength(2);
+  });
+
+  it("returns poolCapAwuCredits alongside memberIds when both flags are set", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const alice = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, alice, { role: "user" });
+    const sales = await GroupFactory.regularManual(workspace, "Sales");
+    await GroupFactory.withMembers(adminAuth, sales, [alice]);
+    const capRes = await sales.updatePoolCap(4321);
+    if (capRes.isErr()) {
+      throw capRes.error;
+    }
+
+    const response = await getGroupsRequest(workspace.sId, {
+      kind: "regular_manual",
+      withMembers: "true",
+      withPoolCaps: "true",
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.groups).toEqual([
+      expect.objectContaining({
+        sId: sales.sId,
+        memberIds: [alice.sId],
+        poolCapAwuCredits: 4321,
+      }),
+    ]);
+  });
+
   it("returns memberIds when withMembers=true is requested", async () => {
     const { workspace } = await createPrivateApiMockRequest({
       role: "admin",

--- a/front-api/routes/w/[wId]/groups/index.ts
+++ b/front-api/routes/w/[wId]/groups/index.ts
@@ -4,7 +4,10 @@ import {
   CreateGroupBodySchema,
   type PostGroupResponseBody,
 } from "@app/types/api/groups/manage";
-import type { GroupKind, GroupType } from "@app/types/groups";
+import type {
+  GroupKind,
+  GroupTypeWithOptionalPoolCap,
+} from "@app/types/groups";
 import {
   GroupKindCodec,
   isUserVisibleGroupKind,
@@ -21,10 +24,7 @@ import groupDetail from "./[groupId]";
 import spendLimit from "./[groupId]/spend_limit";
 
 export type GetGroupsResponseBody = {
-  groups: (GroupType & {
-    memberCount: number;
-    poolCapAwuCredits: number | null;
-  })[];
+  groups: GroupTypeWithOptionalPoolCap[];
 };
 
 const GetGroupsQuerySchema = z.object({
@@ -33,10 +33,7 @@ const GetGroupsQuerySchema = z.object({
   // query) instead of just memberCount.
   withMembers: z.enum(["true", "false"]).optional(),
   // When "true", each group also carries its pool cap (one extra batched
-  // query). Accepted but not yet honored: the cap is still returned
-  // unconditionally so front-end bundles that predate the flag keep working.
-  // A follow-up makes the cap conditional on this flag, once the bundles
-  // sending it are deployed everywhere.
+  // query). Omitted otherwise: only the spend-limit admin views read it.
   withPoolCaps: z.enum(["true", "false"]).optional(),
 });
 
@@ -49,7 +46,7 @@ app.get(
   validate("query", GetGroupsQuerySchema),
   async (ctx): HandlerResult<GetGroupsResponseBody> => {
     const auth = ctx.get("auth");
-    const { kind, withMembers } = ctx.req.valid("query");
+    const { kind, withMembers, withPoolCaps } = ctx.req.valid("query");
 
     const requestedKinds: GroupKind[] = kind
       ? Array.isArray(kind)
@@ -66,21 +63,13 @@ app.get(
       groupKinds,
     });
 
-    const groupsJSON =
-      withMembers === "true"
-        ? await GroupResource.fetchJSONWithMembers(auth, groups)
-        : await GroupResource.toJSONWithMemberCounts(auth, groups);
-
-    const poolCaps = await GroupResource.getPoolCapAwuCreditsForGroups(
-      auth,
-      groups
-    );
+    const options = { withPoolCaps: withPoolCaps === "true" };
 
     return ctx.json({
-      groups: groupsJSON.map((group) => ({
-        ...group,
-        poolCapAwuCredits: poolCaps.get(group.id) ?? null,
-      })),
+      groups:
+        withMembers === "true"
+          ? await GroupResource.fetchJSONWithMembers(auth, groups, options)
+          : await GroupResource.toJSONWithMemberCounts(auth, groups, options),
     });
   }
 );

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -252,7 +252,14 @@ export function PoolUsagePage() {
 
   const { data: allGroups } = usePokeGroups({ owner, withPoolCaps: true });
   const groups = useMemo(
-    () => allGroups.filter((group) => isCapEligibleGroupKind(group.kind)),
+    () =>
+      allGroups
+        .filter((group) => isCapEligibleGroupKind(group.kind))
+        // Present because this page requests `withPoolCaps`.
+        .map((group) => ({
+          ...group,
+          poolCapAwuCredits: group.poolCapAwuCredits ?? null,
+        })),
     [allGroups]
   );
   const selectedGroupName = groups.find(

--- a/front/components/workspace/GroupsUsageTable.tsx
+++ b/front/components/workspace/GroupsUsageTable.tsx
@@ -92,7 +92,8 @@ export function GroupsUsageTable({
         groupId: group.sId,
         name: group.name,
         memberCount: group.memberCount,
-        poolCapAwuCredits: group.poolCapAwuCredits,
+        // Present because this table requests `withPoolCaps`.
+        poolCapAwuCredits: group.poolCapAwuCredits ?? null,
       })),
     [groups]
   );

--- a/front/lib/api/poke/groups.ts
+++ b/front/lib/api/poke/groups.ts
@@ -1,11 +1,14 @@
 import type { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
-import type { GroupType } from "@app/types/groups";
+import type {
+  GroupType,
+  GroupTypeWithOptionalPoolCap,
+} from "@app/types/groups";
 import type { UserTypeWithWorkspaces } from "@app/types/user";
 
 export type PokeListGroups = {
-  groups: (GroupType & { poolCapAwuCredits: number | null })[];
+  groups: GroupTypeWithOptionalPoolCap[];
 };
 
 export type PokeGetGroupDetails = {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -29,6 +29,7 @@ import type {
 import type {
   GroupKind,
   GroupType,
+  GroupTypeWithOptionalPoolCap,
   UserVisibleGroupKind,
 } from "@app/types/groups";
 import {
@@ -2828,22 +2829,44 @@ export class GroupResource extends BaseResource<GroupModel> {
     };
   }
 
+  // Resolves the caps only when the caller asked for them: it is one extra
+  // batched query, and most group listings never read the cap.
+  private static async getPoolCapsIfRequested(
+    auth: Authenticator,
+    groups: GroupResource[],
+    withPoolCaps: boolean
+  ): Promise<Map<ModelId, number> | null> {
+    if (!withPoolCaps) {
+      return null;
+    }
+    return GroupResource.getPoolCapAwuCreditsForGroups(auth, groups);
+  }
+
   /**
    * Batched counterpart of `toJSONWithMemberCount`: resolves the member counts of all the groups in
    * a single query instead of one per group.
    */
   static async toJSONWithMemberCounts(
     auth: Authenticator,
-    groups: GroupResource[]
-  ): Promise<GroupType[]> {
+    groups: GroupResource[],
+    { withPoolCaps = false }: { withPoolCaps?: boolean } = {}
+  ): Promise<GroupTypeWithOptionalPoolCap[]> {
     const memberCounts = await GroupResource.getMemberCountsForGroups(
       auth,
       groups
+    );
+    const poolCaps = await GroupResource.getPoolCapsIfRequested(
+      auth,
+      groups,
+      withPoolCaps
     );
 
     return groups.map((group) => ({
       ...group.toJSON(),
       memberCount: memberCounts.get(group.id) ?? 0,
+      ...(poolCaps
+        ? { poolCapAwuCredits: poolCaps.get(group.id) ?? null }
+        : {}),
     }));
   }
 
@@ -2854,13 +2877,19 @@ export class GroupResource extends BaseResource<GroupModel> {
    */
   static async fetchJSONWithMembers(
     auth: Authenticator,
-    groups: GroupResource[]
-  ): Promise<(GroupType & { memberIds: string[] })[]> {
+    groups: GroupResource[],
+    { withPoolCaps = false }: { withPoolCaps?: boolean } = {}
+  ): Promise<(GroupTypeWithOptionalPoolCap & { memberIds: string[] })[]> {
     const membershipsByGroup =
       await GroupResource.getActiveMembershipsForGroups(auth, groups);
     const userModelIds = [...new Set(Object.values(membershipsByGroup).flat())];
     const users = await UserResource.fetchByModelIds(userModelIds);
     const sIdByModelId = new Map(users.map((user) => [user.id, user.sId]));
+    const poolCaps = await GroupResource.getPoolCapsIfRequested(
+      auth,
+      groups,
+      withPoolCaps
+    );
 
     return groups.map((group) => {
       const memberIds = removeNulls(
@@ -2872,6 +2901,9 @@ export class GroupResource extends BaseResource<GroupModel> {
         ...group.toJSON(),
         memberCount: memberIds.length,
         memberIds,
+        ...(poolCaps
+          ? { poolCapAwuCredits: poolCaps.get(group.id) ?? null }
+          : {}),
       };
     });
   }

--- a/front/lib/swr/groups.ts
+++ b/front/lib/swr/groups.ts
@@ -32,9 +32,9 @@ export function useGroups({
   // Also resolves each group's member sIds (one extra batched query
   // server-side) instead of just its memberCount.
   withMembers?: boolean;
-  // Declares that this caller reads `poolCapAwuCredits`. The cap is still
-  // returned unconditionally, so callers that omit this keep working; a
-  // follow-up makes it conditional once every bundle sends the flag.
+  // Also resolves each group's pool cap (one extra batched query server-side).
+  // Without it `poolCapAwuCredits` is absent from the response, so any caller
+  // that reads the cap must set this.
   withPoolCaps?: boolean;
   disabled?: boolean;
 }) {

--- a/front/poke/swr/groups.ts
+++ b/front/poke/swr/groups.ts
@@ -8,9 +8,9 @@ export function usePokeGroups({
   owner,
   withPoolCaps,
 }: PokeConditionalFetchProps & {
-  // Declares that this caller reads `poolCapAwuCredits`. The cap is still
-  // returned unconditionally, so callers that omit this keep working; a
-  // follow-up makes it conditional once every bundle sends the flag.
+  // Also resolves each group's pool cap (one extra batched query server-side).
+  // Without it `poolCapAwuCredits` is absent from the response, so any caller
+  // that reads the cap must set this.
   withPoolCaps?: boolean;
 }) {
   const { fetcher } = useFetcher();

--- a/front/types/api/groups.ts
+++ b/front/types/api/groups.ts
@@ -1,5 +1,5 @@
-import type { GroupType } from "@app/types/groups";
+import type { GroupTypeWithOptionalPoolCap } from "@app/types/groups";
 
 export type GetGroupsResponseBody = {
-  groups: (GroupType & { poolCapAwuCredits: number | null })[];
+  groups: GroupTypeWithOptionalPoolCap[];
 };

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -107,6 +107,11 @@ export type GroupType = {
   memberIds?: string[];
 };
 
+export type GroupTypeWithOptionalPoolCap = GroupType & {
+  // `undefined` means "not requested", while `null` means "no cap".
+  poolCapAwuCredits?: number | null;
+};
+
 export const GroupKindCodec = z.enum([
   "global",
   "regular_auto",


### PR DESCRIPTION
## Description

honour the flag so the we only query for the group caps when needed (way less often than we query for groups)

## Tests

added unit tests

## Risk

low
front ends have already been using the flag so no frontend should do the wrong query

## Deploy Plan

deploy front
