### PR TITLE
fix(webhook-sources): block save until provider connection is ready

### DIFF
--- a/front/components/triggers/WebhookSourceSheet.tsx
+++ b/front/components/triggers/WebhookSourceSheet.tsx
@@ -178,7 +178,9 @@ function WebhookSourceSheetContent({
   const [remoteProviderData, setRemoteProviderData] =
     useState<RemoteProviderData | null>(null);
   const [connectionId, setConnectionId] = useState<string | null>(null);
-  const [isPresetReadyToSubmit, setIsPresetReadyToSubmit] = useState(true);
+  const [isPresetReadyToSubmit, setIsPresetReadyToSubmit] = useState(
+    mode.provider === null
+  );
 
   const { spaces } = useSpacesAsAdmin({
     workspaceId: owner.sId,


### PR DESCRIPTION
## Description

The webhook source creation modal let users click Save before authenticating with the provider. 
The readiness flag (`isPresetReadyToSubmit`) defaulted to `true` regardless of whether a provider was selected, and nothing set it to `false` while the OAuth connection step hadn't completed yet.

Now the flag starts `false` whenever a provider is selected (only the "custom"/no-provider path, which has no OAuth step, starts ready).

## Tests

Nothing ^^

## Risk

Low.

## Deploy Plan

Deploy front.