### PR TITLE
Create all front Elasticsearch indices in one command

### DIFF
--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -16,15 +16,21 @@ export const AGENT_DOCUMENT_OUTPUTS_ALIAS_NAME = "front.agent_document_outputs";
 export const CONVERSATION_SEARCH_ALIAS_NAME = "front.conversation_search";
 
 /**
- * Mapping of index names to their directory locations.
- * This allows different features to organize their indices in feature-specific directories.
+ * Registry of front-owned indices: where the settings/mappings files live and
+ * the current version. A version bump here must ship with the matching
+ * [name]_[version].settings.[region].json and [name]_[version].mappings.json.
  */
-export const INDEX_DIRECTORIES: Record<string, string> = {
-  agent_document_outputs: "lib/analytics/indices",
-  agent_message_analytics: "lib/analytics/indices",
-  agent_message_consumption_analytics: "lib/analytics/indices",
-  conversation_search: "lib/conversation_search/indices",
-  user_search: "lib/user_search/indices",
+export const INDEX_REGISTRY: Record<
+  string,
+  { directory: string; version: number }
+> = {
+  agent_document_outputs: { directory: "lib/analytics/indices", version: 1 },
+  agent_message_analytics: { directory: "lib/analytics/indices", version: 2 },
+  agent_message_consumption_analytics: {
+    directory: "lib/analytics/indices",
+    version: 1,
+  },
+  user_search: { directory: "lib/user_search/indices", version: 1 },
 };
 
 export interface ElasticsearchBaseDocument {

--- a/front/scripts/create_elasticsearch_index.ts
+++ b/front/scripts/create_elasticsearch_index.ts
@@ -1,4 +1,4 @@
-import { getClient, INDEX_DIRECTORIES } from "@app/lib/api/elasticsearch";
+import { getClient, INDEX_REGISTRY } from "@app/lib/api/elasticsearch";
 import { makeScript } from "@app/scripts/helpers";
 import { EnvironmentConfig } from "@app/types/shared/utils/config";
 import * as fs from "fs";
@@ -6,27 +6,27 @@ import * as path from "path";
 import * as readline from "readline";
 
 /**
- * Script to create an ElasticSearch index for front service
+ * Script to create ElasticSearch indices for front service
  *
  * Usage:
- * tsx front/scripts/create_elasticsearch_index.ts --index-name agent_message_analytics --index-version 1 [--skip-confirmation] [--remove-previous-alias] [--execute]
+ * tsx front/scripts/create_elasticsearch_index.ts [--index-name agent_message_analytics] [--index-version 1] [--skip-confirmation] [--remove-previous-alias] [--execute]
  *
- * The script looks up the index directory from INDEX_DIRECTORIES in lib/api/elasticsearch.ts
- * Then loads settings and mappings from [directory]/[index_name]_[version].settings.[region].json and [directory]/[index_name]_[version].mappings.json
- * Creates the index at front.[index_name]_[version], and sets the alias to front.[index_name]
+ * Without --index-name, creates every index in INDEX_REGISTRY at its current version, skipping the ones that already exist.
+ * INDEX_REGISTRY in lib/api/elasticsearch.ts holds each index's directory and current version.
+ * Settings and mappings are loaded from [directory]/[index_name]_[version].settings.[region].json and [directory]/[index_name]_[version].mappings.json.
+ * Creates each index at front.[index_name]_[version], and sets the alias to front.[index_name]
  */
 
 makeScript(
   {
     indexName: {
       type: "string",
-      describe: "The index name (without the version)",
-      demandOption: true,
+      describe:
+        "The index name (without the version), all registered indices when omitted",
     },
     indexVersion: {
       type: "number",
-      describe: "The version of the index",
-      demandOption: true,
+      describe: "The version of the index, the registered version when omitted",
     },
     skipConfirmation: {
       type: "boolean",
@@ -43,174 +43,210 @@ makeScript(
     { indexName, indexVersion, skipConfirmation, removePreviousAlias, execute },
     logger
   ) => {
-    if (removePreviousAlias && indexVersion === 1) {
-      throw new Error("Cannot remove previous alias for version 1");
+    if (!indexName && (indexVersion !== undefined || removePreviousAlias)) {
+      throw new Error(
+        "--index-version and --remove-previous-alias require --index-name"
+      );
     }
-
-    const indexFullname = `front.${indexName}_${indexVersion}`;
-    const indexAlias = `front.${indexName}`;
-    const indexPreviousFullname = `front.${indexName}_${indexVersion - 1}`;
 
     const region =
       EnvironmentConfig.getOptionalEnvVariable("NODE_ENV") === "development"
         ? "local"
         : EnvironmentConfig.getEnvVariable("REGION");
 
-    logger.info("Configuration:");
-    logger.info(`  Index name: ${indexFullname}`);
-    logger.info(`  Alias: ${indexAlias}`);
-    logger.info(`  Region: ${region}`);
-    logger.info(`  Remove previous alias: ${removePreviousAlias}`);
-    if (removePreviousAlias) {
-      logger.info(`  Previous index: ${indexPreviousFullname}`);
+    let targets: Array<{ name: string; version: number; directory: string }>;
+    if (indexName) {
+      const entry = INDEX_REGISTRY[indexName];
+      if (!entry) {
+        throw new Error(
+          `Index '${indexName}' is not configured in INDEX_REGISTRY. ` +
+            `Available indices: ${Object.keys(INDEX_REGISTRY).join(", ")}`
+        );
+      }
+      targets = [
+        {
+          name: indexName,
+          version: indexVersion ?? entry.version,
+          directory: entry.directory,
+        },
+      ];
+    } else {
+      targets = Object.entries(INDEX_REGISTRY).map(([name, entry]) => ({
+        name,
+        version: entry.version,
+        directory: entry.directory,
+      }));
+    }
+
+    if (removePreviousAlias && targets[0].version === 1) {
+      throw new Error("Cannot remove previous alias for version 1");
     }
 
     const client = await getClient();
 
-    const indexExists = await client.indices.exists({
-      index: indexFullname,
-    });
+    const createOne = async (target: {
+      name: string;
+      version: number;
+      directory: string;
+    }) => {
+      const indexFullname = `front.${target.name}_${target.version}`;
+      const indexAlias = `front.${target.name}`;
+      const indexPreviousFullname = `front.${target.name}_${target.version - 1}`;
 
-    if (indexExists) {
-      throw new Error(`Index ${indexFullname} already exists`);
-    }
-
-    // Get the directory for this index from the mapping
-    const indexDirectory = INDEX_DIRECTORIES[indexName];
-    if (!indexDirectory) {
-      throw new Error(
-        `Index '${indexName}' is not configured in INDEX_DIRECTORIES. ` +
-          `Available indices: ${Object.keys(INDEX_DIRECTORIES).join(", ")}`
-      );
-    }
-
-    const settingsPath = path.join(
-      __dirname,
-      `../${indexDirectory}/${indexName}_${indexVersion}.settings.${region}.json`
-    );
-    const mappingsPath = path.join(
-      __dirname,
-      `../${indexDirectory}/${indexName}_${indexVersion}.mappings.json`
-    );
-
-    let settingsRaw: string;
-    let mappingsRaw: string;
-
-    try {
-      settingsRaw = fs.readFileSync(settingsPath, "utf8");
-    } catch (err) {
-      throw new Error(
-        `Failed to read settings file at ${settingsPath}: ${err}`
-      );
-    }
-
-    try {
-      mappingsRaw = fs.readFileSync(mappingsPath, "utf8");
-    } catch (err) {
-      throw new Error(
-        `Failed to read mappings file at ${mappingsPath}: ${err}`
-      );
-    }
-
-    let settings: Record<string, unknown>;
-    let mappings: Record<string, unknown>;
-
-    try {
-      settings = JSON.parse(settingsRaw);
-    } catch (err) {
-      throw new Error(
-        `Failed to parse settings file at ${settingsPath}: ${err}`
-      );
-    }
-
-    try {
-      mappings = JSON.parse(mappingsRaw);
-    } catch (err) {
-      throw new Error(
-        `Failed to parse mappings file at ${mappingsPath}: ${err}`
-      );
-    }
-
-    if (!skipConfirmation && execute) {
-      logger.info(
-        `CHECK: Create index '${indexFullname}' with alias '${indexAlias}' in region '${region}' (remove previous alias: ${removePreviousAlias})? (y to confirm)`
-      );
-
-      const rl = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout,
-      });
-
-      const answer = await new Promise<string>((resolve) => {
-        rl.question("", (input) => {
-          rl.close();
-          resolve(input.trim());
-        });
-      });
-
-      if (answer !== "y") {
-        throw new Error("Aborted");
+      logger.info("Configuration:");
+      logger.info(`  Index name: ${indexFullname}`);
+      logger.info(`  Alias: ${indexAlias}`);
+      logger.info(`  Region: ${region}`);
+      logger.info(`  Remove previous alias: ${removePreviousAlias}`);
+      if (removePreviousAlias) {
+        logger.info(`  Previous index: ${indexPreviousFullname}`);
       }
-    }
 
-    if (!execute) {
-      logger.info(
-        `[DRY RUN] Would create index ${indexFullname} and alias ${indexAlias}`
-      );
-      return;
-    }
-
-    logger.info(`Creating index ${indexFullname}...`);
-
-    const indexCreationResponse = await client.indices.create({
-      index: indexFullname,
-      settings,
-      mappings,
-    });
-
-    if (!indexCreationResponse.acknowledged) {
-      throw new Error(
-        `Failed to create index: ${JSON.stringify(indexCreationResponse)}`
-      );
-    }
-
-    logger.info(`✅ Index created: ${indexFullname}`);
-
-    const aliasActions: Array<
-      | { add: { index: string; alias: string; is_write_index: boolean } }
-      | { remove: { index: string; alias: string } }
-    > = [
-      {
-        add: {
-          index: indexFullname,
-          alias: indexAlias,
-          is_write_index: true,
-        },
-      },
-    ];
-
-    if (removePreviousAlias) {
-      aliasActions.push({
-        remove: {
-          index: indexPreviousFullname,
-          alias: indexAlias,
-        },
+      const indexExists = await client.indices.exists({
+        index: indexFullname,
       });
-    }
 
-    logger.info(`Creating alias ${indexAlias}...`);
+      if (indexExists) {
+        if (indexName) {
+          throw new Error(`Index ${indexFullname} already exists`);
+        }
+        logger.info(`Index ${indexFullname} already exists, skipping`);
+        return;
+      }
 
-    const aliasCreationResponse = await client.indices.updateAliases({
-      actions: aliasActions,
-    });
-
-    if (!aliasCreationResponse.acknowledged) {
-      throw new Error(
-        `Failed to create alias: ${JSON.stringify(aliasCreationResponse)}`
+      const settingsPath = path.join(
+        __dirname,
+        `../${target.directory}/${target.name}_${target.version}.settings.${region}.json`
       );
+      const mappingsPath = path.join(
+        __dirname,
+        `../${target.directory}/${target.name}_${target.version}.mappings.json`
+      );
+
+      let settingsRaw: string;
+      let mappingsRaw: string;
+
+      try {
+        settingsRaw = fs.readFileSync(settingsPath, "utf8");
+      } catch (err) {
+        throw new Error(
+          `Failed to read settings file at ${settingsPath}: ${err}`
+        );
+      }
+
+      try {
+        mappingsRaw = fs.readFileSync(mappingsPath, "utf8");
+      } catch (err) {
+        throw new Error(
+          `Failed to read mappings file at ${mappingsPath}: ${err}`
+        );
+      }
+
+      let settings: Record<string, unknown>;
+      let mappings: Record<string, unknown>;
+
+      try {
+        settings = JSON.parse(settingsRaw);
+      } catch (err) {
+        throw new Error(
+          `Failed to parse settings file at ${settingsPath}: ${err}`
+        );
+      }
+
+      try {
+        mappings = JSON.parse(mappingsRaw);
+      } catch (err) {
+        throw new Error(
+          `Failed to parse mappings file at ${mappingsPath}: ${err}`
+        );
+      }
+
+      if (!skipConfirmation && execute) {
+        logger.info(
+          `CHECK: Create index '${indexFullname}' with alias '${indexAlias}' in region '${region}' (remove previous alias: ${removePreviousAlias})? (y to confirm)`
+        );
+
+        const rl = readline.createInterface({
+          input: process.stdin,
+          output: process.stdout,
+        });
+
+        const answer = await new Promise<string>((resolve) => {
+          rl.question("", (input) => {
+            rl.close();
+            resolve(input.trim());
+          });
+        });
+
+        if (answer !== "y") {
+          throw new Error("Aborted");
+        }
+      }
+
+      if (!execute) {
+        logger.info(
+          `[DRY RUN] Would create index ${indexFullname} and alias ${indexAlias}`
+        );
+        return;
+      }
+
+      logger.info(`Creating index ${indexFullname}...`);
+
+      const indexCreationResponse = await client.indices.create({
+        index: indexFullname,
+        settings,
+        mappings,
+      });
+
+      if (!indexCreationResponse.acknowledged) {
+        throw new Error(
+          `Failed to create index: ${JSON.stringify(indexCreationResponse)}`
+        );
+      }
+
+      logger.info(`✅ Index created: ${indexFullname}`);
+
+      const aliasActions: Array<
+        | { add: { index: string; alias: string; is_write_index: boolean } }
+        | { remove: { index: string; alias: string } }
+      > = [
+        {
+          add: {
+            index: indexFullname,
+            alias: indexAlias,
+            is_write_index: true,
+          },
+        },
+      ];
+
+      if (removePreviousAlias) {
+        aliasActions.push({
+          remove: {
+            index: indexPreviousFullname,
+            alias: indexAlias,
+          },
+        });
+      }
+
+      logger.info(`Creating alias ${indexAlias}...`);
+
+      const aliasCreationResponse = await client.indices.updateAliases({
+        actions: aliasActions,
+      });
+
+      if (!aliasCreationResponse.acknowledged) {
+        throw new Error(
+          `Failed to create alias: ${JSON.stringify(aliasCreationResponse)}`
+        );
+      }
+
+      logger.info(`✅ Alias created: ${indexAlias}`);
+    };
+
+    for (const target of targets) {
+      await createOne(target);
     }
 
-    logger.info(`✅ Alias created: ${indexAlias}`);
     logger.info("🎉 Index creation complete!");
   }
 );


### PR DESCRIPTION
## Description

Bringing up a new cluster means recreating every front index by hand, and knowing each index's current version is tribal knowledge (analytics is at 2, the rest at 1, nothing in code says so). The index registry now carries the current version alongside the directory, and the creation script run without arguments creates every registered index at its current version, skipping the ones that already exist so it is safe to re-run. Passing an index name keeps today's single-index behavior unchanged.

This also removes conversation_search from the registry: the feature was removed in #28208 and its mappings files with it, so the entry could only make the script crash. The alias constant stays for the deletion script.

## Tests

Typecheck passes. Not yet run against a live cluster, the first real exercise will be the cell-00002 bring-up where all four indices are missing, in dry-run mode first.

## Risk

Script and registry only, no serving path reads the registry. Safe to rollback.

## Deploy Plan

Nothing to deploy, tooling only. Run on the cell-00002 prodbox after merge.