### PR TITLE
[front] fix: hide API key credits for legacy plans

### DIFF
--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -301,7 +301,7 @@ export function APIKeysPageContent({ owner, period }: APIKeysPageContentProps) {
           period={period}
           isLoading={isKeysLoading}
           isError={!!isKeysError}
-          showAnalyticsConsumption
+          showAnalyticsConsumption={showCreditMonthlyCap}
           isRevoking={isRevoking}
           isGenerating={isGenerating}
           onRevoke={handleRevoke}


### PR DESCRIPTION
## Description

Hide the API keys table's Credits column for non-credit-based plans by using the existing plan check. Legacy workspaces show their monthly dollar cap instead.

We already had everything ready to support legacy plans, only was not hooked up at all.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
