### PR TITLE
Create all core Elasticsearch indices in one command

### DIFF
--- a/core/bin/elasticsearch/create_index.rs
+++ b/core/bin/elasticsearch/create_index.rs
@@ -43,33 +43,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
     if args.index_name.is_none() && (args.index_version.is_some() || args.remove_previous_alias) {
-        return Err(
-            anyhow::anyhow!("--index-version and --remove-previous-alias require --index-name")
-                .into(),
-        );
+        return Err(anyhow::anyhow!(
+            "--index-version and --remove-previous-alias require --index-name"
+        )
+        .into());
     }
 
     let targets: Vec<(String, u32)> = match &args.index_name {
         Some(index_name) => {
             let index_version = match args.index_version {
                 Some(v) => v,
-                None => {
-                    INDEX_VERSIONS
-                        .iter()
-                        .find(|(name, _)| name == index_name)
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "Index '{}' is not configured in INDEX_VERSIONS. Available indices: {}",
-                                index_name,
-                                INDEX_VERSIONS
-                                    .iter()
-                                    .map(|(name, _)| *name)
-                                    .collect::<Vec<_>>()
-                                    .join(", ")
-                            )
-                        })?
-                        .1
-                }
+                None => registered_version(index_name)?,
             };
             vec![(index_name.clone(), index_version)]
         }
@@ -111,6 +95,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+fn registered_version(index_name: &str) -> Result<u32, Box<dyn std::error::Error>> {
+    match INDEX_VERSIONS.iter().find(|(name, _)| name == &index_name) {
+        Some((_, version)) => Ok(*version),
+        None => {
+            let available = INDEX_VERSIONS
+                .iter()
+                .map(|(name, _)| *name)
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(anyhow::anyhow!(
+                "Index '{}' is not configured in INDEX_VERSIONS. Available indices: {}",
+                index_name,
+                available
+            )
+            .into())
+        }
+    }
 }
 
 async fn create_index(

--- a/core/bin/elasticsearch/create_index.rs
+++ b/core/bin/elasticsearch/create_index.rs
@@ -1,18 +1,24 @@
 use std::collections::HashMap;
 
 use clap::Parser;
-use dust::search_stores::search_store::ElasticsearchSearchStore;
+use dust::search_stores::search_store::{ElasticsearchSearchStore, INDEX_VERSIONS};
 use elasticsearch::indices::{IndicesCreateParts, IndicesExistsParts};
 use http::StatusCode;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    #[arg(long, help = "The index name (without the version)")]
-    index_name: String,
+    #[arg(
+        long,
+        help = "The index name (without the version), all registered indices when omitted"
+    )]
+    index_name: Option<String>,
 
-    #[arg(long, help = "The version of the index")]
-    index_version: u32,
+    #[arg(
+        long,
+        help = "The version of the index, the registered version when omitted"
+    )]
+    index_version: Option<u32>,
 
     #[arg(long, help = "Skip confirmation")]
     skip_confirmation: bool,
@@ -22,28 +28,60 @@ struct Args {
 }
 
 /*
- * Create an index in Elasticsearch for core
+ * Create indices in Elasticsearch for core
  *
  * Usage:
- * cargo run --bin create_index -- --index-name <index_name> --index-version <version> [--skip-confirmation] [--remove-previous-alias]
+ * cargo run --bin elasticsearch_create_index -- [--index-name <index_name>] [--index-version <version>] [--skip-confirmation] [--remove-previous-alias]
  *
+ * Without --index-name, creates every index in INDEX_VERSIONS at its current version, skipping the ones that already exist.
  * Look for index settings and mappings in src/search_stores/indices/[index_name]_[version].settings.[region].json
- * Create the index with the given settings and mappings at [index_name]_[version], and set the alias to [index_name]
+ * Create each index with the given settings and mappings at [index_name]_[version], and set the alias to [index_name]
  */
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // parse args and env vars
     let args = Args::parse();
-    let index_name = args.index_name;
-    let index_version = args.index_version;
-    let remove_previous_alias = args.remove_previous_alias;
 
-    if remove_previous_alias && index_version == 1 {
+    if args.index_name.is_none() && (args.index_version.is_some() || args.remove_previous_alias) {
+        return Err(
+            anyhow::anyhow!("--index-version and --remove-previous-alias require --index-name")
+                .into(),
+        );
+    }
+
+    let targets: Vec<(String, u32)> = match &args.index_name {
+        Some(index_name) => {
+            let index_version = match args.index_version {
+                Some(v) => v,
+                None => {
+                    INDEX_VERSIONS
+                        .iter()
+                        .find(|(name, _)| name == index_name)
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "Index '{}' is not configured in INDEX_VERSIONS. Available indices: {}",
+                                index_name,
+                                INDEX_VERSIONS
+                                    .iter()
+                                    .map(|(name, _)| *name)
+                                    .collect::<Vec<_>>()
+                                    .join(", ")
+                            )
+                        })?
+                        .1
+                }
+            };
+            vec![(index_name.clone(), index_version)]
+        }
+        None => INDEX_VERSIONS
+            .iter()
+            .map(|(name, version)| (name.to_string(), *version))
+            .collect(),
+    };
+
+    if args.remove_previous_alias && targets[0].1 == 1 {
         return Err(anyhow::anyhow!("Cannot remove previous alias for version 1").into());
     }
-    let index_fullname = format!("core.{}_{}", index_name, index_version);
-    let index_alias = format!("core.{}", index_name);
-    let index_previous_fullname = format!("core.{}_{}", index_name, index_version - 1);
 
     let url = std::env::var("ELASTICSEARCH_URL").expect("ELASTICSEARCH_URL must be set");
     let username =
@@ -59,6 +97,35 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // create ES client
     let search_store = ElasticsearchSearchStore::new(&url, &username, &password).await?;
 
+    for (index_name, index_version) in targets {
+        create_index(
+            &search_store,
+            &index_name,
+            index_version,
+            &region,
+            args.index_name.is_some(),
+            args.skip_confirmation,
+            args.remove_previous_alias,
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+async fn create_index(
+    search_store: &ElasticsearchSearchStore,
+    index_name: &str,
+    index_version: u32,
+    region: &str,
+    explicit_index: bool,
+    skip_confirmation: bool,
+    remove_previous_alias: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let index_fullname = format!("core.{}_{}", index_name, index_version);
+    let index_alias = format!("core.{}", index_name);
+    let index_previous_fullname = format!("core.{}_{}", index_name, index_version - 1);
+
     // do not create index if it already exists
     let response = search_store
         .client
@@ -68,7 +135,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     if response.status_code() == StatusCode::OK {
-        return Err(anyhow::anyhow!("Index already exists").into());
+        if explicit_index {
+            return Err(anyhow::anyhow!("Index already exists").into());
+        }
+        println!("Index {} already exists, skipping", index_fullname);
+        return Ok(());
     }
 
     // get index settings and mappings, parse them as json
@@ -76,7 +147,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "src/search_stores/indices/{}_{}.settings.{}.json",
         index_name,
         index_version,
-        region.to_string().to_lowercase()
+        region.to_lowercase()
     );
     let mappings_path = format!(
         "src/search_stores/indices/{}_{}.mappings.json",
@@ -111,7 +182,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // confirm creation
-    if !args.skip_confirmation {
+    if !skip_confirmation {
         println!(
             "CHECK: Create index '{}' with alias '{}' in region '{}' (remove previous alias: {})? (y to confirm)",
             index_fullname, index_alias, region, remove_previous_alias
@@ -165,7 +236,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     match alias_creation_response.status_code() {
-        StatusCode::OK => Ok(()),
+        StatusCode::OK => {
+            println!("Alias created: {}", index_alias);
+            Ok(())
+        }
         _ => {
             let body = alias_creation_response.json::<serde_json::Value>().await?;
             eprintln!("{:?}", body);

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -41,6 +41,10 @@ pub enum SearchNodesError {
     CursorSortMismatch(String),
 }
 
+// Current version of each core-owned index. A version bump here must ship with the matching
+// indices/[name]_[version].settings.[region].json and indices/[name]_[version].mappings.json.
+pub const INDEX_VERSIONS: &[(&str, u32)] = &[("data_sources", 1), ("data_sources_nodes", 4)];
+
 const MAX_PAGE_SIZE: u64 = 1000;
 // Number of hits that is tracked exactly, above this value we only get a lower bound on the hit count.
 // Note: this is the default value.


### PR DESCRIPTION
## Description

Same story as https://github.com/dust-tt/dust/pull/31957 on the front side: the current version of each core index (data_sources at 1, data_sources_nodes at 4) lived only in filenames and memory. A registry constant now sits next to the search store, and the create_index binary run without arguments creates every registered index at its current version, skipping the ones that already exist so it is safe to re-run. Explicit --index-name keeps the current behavior, and --index-version / --remove-previous-alias now require it.

The usage comment also claimed the wrong binary name (create_index, actually elasticsearch_create_index), fixed.

## Tests

cargo check passes. Not yet run against a live cluster, the first real exercise will be the cell-00002 bring-up where both indices are missing.

## Risk

Binary and one pub const, nothing in the serving path. Safe to rollback.

## Deploy Plan

Nothing to deploy, tooling only.