### PR TITLE
feat(front): log and audit webhook source deletion

### DIFF
--- a/front/admin/audit_log_schemas/webhook_source.deleted.json
+++ b/front/admin/audit_log_schemas/webhook_source.deleted.json
@@ -1,0 +1,15 @@
+{
+  "action": "webhook_source.deleted",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "webhook_source"
+    }
+  ],
+  "metadata": {
+    "provider": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -112,6 +112,7 @@
   "wake_up.created": 1,
   "wake_up.expired": 1,
   "wake_up.fired": 1,
+  "webhook_source.deleted": 1,
   "workspace.advanced_model_access_updated": 1,
   "workspace.analytics_updated": 1,
   "workspace.audit_logs_updated": 1,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -174,6 +174,8 @@ export const AUDIT_ACTIONS = [
   // Slack workflows.
   "slack_workflow.allowed",
   "slack_workflow.revoked",
+
+  "webhook_source.deleted",
   // Files.
   "file.moved",
   "frame.authorized_files_updated",
@@ -434,7 +436,8 @@ type AuditTargetType =
   | "credential"
   | "mcp_connection"
   | "sandbox_env_var"
-  | "frame";
+  | "frame"
+  | "webhook_source";
 
 /**
  * Resource shape required for each audit target type.

--- a/front/lib/api/webhook_source.ts
+++ b/front/lib/api/webhook_source.ts
@@ -2,6 +2,10 @@ import type {
   CustomResourceIconType,
   InternalAllowedIconType,
 } from "@app/components/resources/resources_icons";
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+} from "@app/lib/api/audit/workos_audit";
 import { WEBHOOK_SERVICES } from "@app/lib/api/triggers/built-in-webhooks/services";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
@@ -95,6 +99,30 @@ export async function deleteWebhookSource(
 
   // Delete the webhook source itself.
   await webhookSource.hardDelete(auth, { transaction });
+
+  logger.info(
+    {
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      webhookSourceId: webhookSource.sId,
+      provider: webhookSource.provider,
+    },
+    "Deleted webhook source"
+  );
+
+  void emitAuditLogEvent({
+    auth,
+    action: "webhook_source.deleted",
+    targets: [
+      buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+      buildAuditLogTarget("webhook_source", {
+        sId: webhookSource.sId,
+        name: webhookSource.name,
+      }),
+    ],
+    metadata: {
+      provider: webhookSource.provider ?? "none",
+    },
+  });
 
   return new Ok(undefined);
 }


### PR DESCRIPTION
## Description

Webhook source deletion left no trace: no WorkOS audit event and no log line, unlike other security-sensitive resource deletions (`trigger.deleted`, `datasource.deleted`). Adds:
- an info log in `deleteWebhookSource` recording the workspace, webhook source id, and provider
- a `webhook_source.deleted` audit log event with workspace + webhook_source targets and the provider in metadata
- the corresponding WorkOS schema, registered pre-merge (`schema_versions.json` included)

## Tests

Typechecked.

## Risk

Low. 

## Deploy Plan

Deploy front.