### PR TITLE
fix(useAgentFromSearchParam): remove param stripping on new conversation

### DIFF
--- a/front/components/pages/conversation/ConversationPage.tsx
+++ b/front/components/pages/conversation/ConversationPage.tsx
@@ -37,7 +37,7 @@ export function ConversationPage() {
     conversationId: activeConversationId,
   });
 
-  // Consume ?agent= param: fetch agent, set it in input bar, clean up URL.
+  // Consume ?agent= param: fetch agent, set it in input bar
   useAgentFromSearchParam(owner.sId);
 
   // Consume ?go= param: fetch Contentful template, prefill composer, clean up URL.

--- a/front/hooks/useAgentFromSearchParam.test.ts
+++ b/front/hooks/useAgentFromSearchParam.test.ts
@@ -1,0 +1,109 @@
+import { useAgentFromSearchParam } from "@app/hooks/useAgentFromSearchParam";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { agentConfigurationHolder, searchParamHolder, setSelectedAgent } =
+  vi.hoisted(() => ({
+    agentConfigurationHolder: {
+      current: null as LightAgentConfigurationType | null,
+    },
+    searchParamHolder: { current: null as string | null },
+    setSelectedAgent: vi.fn(),
+  }));
+
+vi.mock("@app/lib/platform", () => ({
+  useSearchParam: () => searchParamHolder.current,
+}));
+
+vi.mock("@app/lib/swr/assistants", () => ({
+  useAgentConfiguration: () => ({
+    agentConfiguration: agentConfigurationHolder.current,
+  }),
+}));
+
+vi.mock(
+  "@app/components/assistant/conversation/input_bar/InputBarContext",
+  async () => {
+    const { createContext } = await import("react");
+    return { InputBarContext: createContext({ setSelectedAgent }) };
+  }
+);
+
+function makeAgentConfiguration(sId: string): LightAgentConfigurationType {
+  return {
+    id: 1,
+    versionCreatedAt: null,
+    sId,
+    version: 1,
+    versionAuthorId: null,
+    instructions: null,
+    model: {
+      providerId: "openai",
+      modelId: "gpt-4o",
+      temperature: 0.7,
+    },
+    status: "active",
+    scope: "visible",
+    userFavorite: false,
+    name: `agent-${sId}`,
+    description: "desc",
+    pictureUrl: "https://example.com/p.png",
+    maxStepsPerRun: 8,
+    tags: [],
+    templateId: null,
+    requestedGroupIds: [],
+    requestedSpaceIds: [],
+    canRead: true,
+    canEdit: true,
+  };
+}
+
+describe("useAgentFromSearchParam", () => {
+  beforeEach(() => {
+    setSelectedAgent.mockClear();
+    searchParamHolder.current = "agent_1";
+    agentConfigurationHolder.current = makeAgentConfiguration("agent_1");
+    window.history.replaceState(
+      null,
+      "",
+      "/w/w_1/conversation/new?agent=agent_1"
+    );
+  });
+
+  it("selects the agent and leaves the param in the URL", async () => {
+    renderHook(() => useAgentFromSearchParam("w_1"));
+
+    await waitFor(() => expect(setSelectedAgent).toHaveBeenCalledTimes(1));
+    expect(setSelectedAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "agent_1", type: "agent" })
+    );
+    expect(window.location.search).toBe("?agent=agent_1");
+  });
+
+  it("does not re-select when the configuration revalidates to the same agent", async () => {
+    const { rerender } = renderHook(() => useAgentFromSearchParam("w_1"));
+
+    await waitFor(() => expect(setSelectedAgent).toHaveBeenCalledTimes(1));
+
+    agentConfigurationHolder.current = makeAgentConfiguration("agent_1");
+    rerender();
+
+    expect(setSelectedAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("selects the new agent when the param changes", async () => {
+    const { rerender } = renderHook(() => useAgentFromSearchParam("w_1"));
+
+    await waitFor(() => expect(setSelectedAgent).toHaveBeenCalledTimes(1));
+
+    searchParamHolder.current = "agent_2";
+    agentConfigurationHolder.current = makeAgentConfiguration("agent_2");
+    rerender();
+
+    await waitFor(() => expect(setSelectedAgent).toHaveBeenCalledTimes(2));
+    expect(setSelectedAgent).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: "agent_2" })
+    );
+  });
+});

--- a/front/hooks/useAgentFromSearchParam.test.ts
+++ b/front/hooks/useAgentFromSearchParam.test.ts
@@ -1,24 +1,44 @@
 import { useAgentFromSearchParam } from "@app/hooks/useAgentFromSearchParam";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { RichAgentMention } from "@app/types/assistant/mentions";
 import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { agentConfigurationHolder, searchParamHolder, setSelectedAgent } =
-  vi.hoisted(() => ({
-    agentConfigurationHolder: {
-      current: null as LightAgentConfigurationType | null,
-    },
-    searchParamHolder: { current: null as string | null },
-    setSelectedAgent: vi.fn(),
-  }));
+const {
+  activeConversationIdHolder,
+  agentConfigurationErrorHolder,
+  agentConfigurationHolder,
+  replaceMock,
+  searchParamHolder,
+  selectedSingleAgentHolder,
+  setSelectedAgent,
+} = vi.hoisted(() => ({
+  activeConversationIdHolder: { current: null as string | null },
+  agentConfigurationErrorHolder: {
+    current: undefined as { error: { type: string } } | Error | undefined,
+  },
+  agentConfigurationHolder: {
+    current: null as LightAgentConfigurationType | null,
+  },
+  replaceMock: vi.fn(),
+  searchParamHolder: { current: null as string | null },
+  selectedSingleAgentHolder: { current: null as RichAgentMention | null },
+  setSelectedAgent: vi.fn(),
+}));
 
 vi.mock("@app/lib/platform", () => ({
   useSearchParam: () => searchParamHolder.current,
+  useAppRouter: () => ({ replace: replaceMock }),
+}));
+
+vi.mock("@app/hooks/useActiveConversationId", () => ({
+  useActiveConversationId: () => activeConversationIdHolder.current,
 }));
 
 vi.mock("@app/lib/swr/assistants", () => ({
-  useAgentConfiguration: () => ({
-    agentConfiguration: agentConfigurationHolder.current,
+  useAgentConfiguration: ({ disabled }: { disabled?: boolean }) => ({
+    agentConfiguration: disabled ? null : agentConfigurationHolder.current,
+    isAgentConfigurationError: agentConfigurationErrorHolder.current,
   }),
 }));
 
@@ -26,7 +46,14 @@ vi.mock(
   "@app/components/assistant/conversation/input_bar/InputBarContext",
   async () => {
     const { createContext } = await import("react");
-    return { InputBarContext: createContext({ setSelectedAgent }) };
+    return {
+      InputBarContext: createContext({
+        get selectedSingleAgent() {
+          return selectedSingleAgentHolder.current;
+        },
+        setSelectedAgent,
+      }),
+    };
   }
 );
 
@@ -59,51 +86,139 @@ function makeAgentConfiguration(sId: string): LightAgentConfigurationType {
   };
 }
 
+function makeMention(id: string): RichAgentMention {
+  return {
+    id,
+    type: "agent",
+    label: `agent-${id}`,
+    pictureUrl: "https://example.com/p.png",
+    description: "desc",
+  };
+}
+
+function setUrl(search: string) {
+  window.history.replaceState(null, "", `/w/w_1/conversation/new${search}`);
+}
+
 describe("useAgentFromSearchParam", () => {
   beforeEach(() => {
     setSelectedAgent.mockClear();
-    searchParamHolder.current = "agent_1";
-    agentConfigurationHolder.current = makeAgentConfiguration("agent_1");
-    window.history.replaceState(
-      null,
-      "",
-      "/w/w_1/conversation/new?agent=agent_1"
-    );
+    replaceMock.mockClear();
+    activeConversationIdHolder.current = null;
+    searchParamHolder.current = null;
+    agentConfigurationErrorHolder.current = undefined;
+    agentConfigurationHolder.current = null;
+    selectedSingleAgentHolder.current = null;
+    setUrl("");
   });
 
-  it("selects the agent and leaves the param in the URL", async () => {
+  it("selects the URL agent on arrival and leaves the URL alone", async () => {
+    setUrl("?agent=agent_1");
+    searchParamHolder.current = "agent_1";
+    agentConfigurationHolder.current = makeAgentConfiguration("agent_1");
+
     renderHook(() => useAgentFromSearchParam("w_1"));
 
     await waitFor(() => expect(setSelectedAgent).toHaveBeenCalledTimes(1));
     expect(setSelectedAgent).toHaveBeenCalledWith(
       expect.objectContaining({ id: "agent_1", type: "agent" })
     );
-    expect(window.location.search).toBe("?agent=agent_1");
+    expect(replaceMock).not.toHaveBeenCalled();
   });
 
-  it("does not re-select when the configuration revalidates to the same agent", async () => {
+  it("does not write the URL while the URL agent is still loading", () => {
+    setUrl("?agent=agent_1");
+    searchParamHolder.current = "agent_1";
+    selectedSingleAgentHolder.current = makeMention("agent_default");
+
+    renderHook(() => useAgentFromSearchParam("w_1"));
+
+    expect(replaceMock).not.toHaveBeenCalled();
+    expect(setSelectedAgent).not.toHaveBeenCalled();
+  });
+
+  it("mirrors a picker change to the URL without re-selecting", async () => {
+    setUrl("?agent=agent_1#?selectedTab=favorites");
+    searchParamHolder.current = "agent_1";
+    selectedSingleAgentHolder.current = makeMention("agent_1");
+
     const { rerender } = renderHook(() => useAgentFromSearchParam("w_1"));
+    expect(replaceMock).not.toHaveBeenCalled();
 
-    await waitFor(() => expect(setSelectedAgent).toHaveBeenCalledTimes(1));
-
-    agentConfigurationHolder.current = makeAgentConfiguration("agent_1");
+    selectedSingleAgentHolder.current = makeMention("agent_2");
     rerender();
 
-    expect(setSelectedAgent).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(replaceMock).toHaveBeenCalledTimes(1));
+    expect(replaceMock).toHaveBeenCalledWith(
+      "/w/w_1/conversation/new?agent=agent_2#?selectedTab=favorites"
+    );
+    expect(setSelectedAgent).not.toHaveBeenCalled();
   });
 
-  it("selects the new agent when the param changes", async () => {
+  it("applies a new URL agent over the current selection", async () => {
+    setUrl("?agent=agent_1");
+    searchParamHolder.current = "agent_1";
+    selectedSingleAgentHolder.current = makeMention("agent_1");
+
     const { rerender } = renderHook(() => useAgentFromSearchParam("w_1"));
 
-    await waitFor(() => expect(setSelectedAgent).toHaveBeenCalledTimes(1));
-
+    setUrl("?agent=agent_2");
     searchParamHolder.current = "agent_2";
     agentConfigurationHolder.current = makeAgentConfiguration("agent_2");
     rerender();
 
-    await waitFor(() => expect(setSelectedAgent).toHaveBeenCalledTimes(2));
-    expect(setSelectedAgent).toHaveBeenLastCalledWith(
+    await waitFor(() => expect(setSelectedAgent).toHaveBeenCalledTimes(1));
+    expect(setSelectedAgent).toHaveBeenCalledWith(
       expect.objectContaining({ id: "agent_2" })
     );
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("writes the URL when an agent is selected and the param is absent", async () => {
+    selectedSingleAgentHolder.current = makeMention("agent_1");
+
+    renderHook(() => useAgentFromSearchParam("w_1"));
+
+    await waitFor(() => expect(replaceMock).toHaveBeenCalledTimes(1));
+    expect(replaceMock).toHaveBeenCalledWith(
+      "/w/w_1/conversation/new?agent=agent_1"
+    );
+  });
+
+  it("writes the selected agent to the URL when the URL agent cannot be loaded", async () => {
+    setUrl("?agent=agent_gone");
+    searchParamHolder.current = "agent_gone";
+    agentConfigurationErrorHolder.current = {
+      error: { type: "agent_configuration_not_found" },
+    };
+    selectedSingleAgentHolder.current = makeMention("agent_default");
+
+    renderHook(() => useAgentFromSearchParam("w_1"));
+
+    await waitFor(() => expect(replaceMock).toHaveBeenCalledTimes(1));
+    expect(replaceMock).toHaveBeenCalledWith(
+      "/w/w_1/conversation/new?agent=agent_default"
+    );
+    expect(setSelectedAgent).not.toHaveBeenCalled();
+  });
+
+  it("keeps the URL agent pending on a transient load error", () => {
+    setUrl("?agent=agent_1");
+    searchParamHolder.current = "agent_1";
+    agentConfigurationErrorHolder.current = new Error("network");
+    selectedSingleAgentHolder.current = makeMention("agent_default");
+
+    renderHook(() => useAgentFromSearchParam("w_1"));
+
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("does not touch the URL on an existing conversation", () => {
+    activeConversationIdHolder.current = "conv_1";
+    selectedSingleAgentHolder.current = makeMention("agent_1");
+
+    renderHook(() => useAgentFromSearchParam("w_1"));
+
+    expect(replaceMock).not.toHaveBeenCalled();
   });
 });

--- a/front/hooks/useAgentFromSearchParam.ts
+++ b/front/hooks/useAgentFromSearchParam.ts
@@ -2,16 +2,18 @@ import { InputBarContext } from "@app/components/assistant/conversation/input_ba
 import { useSearchParam } from "@app/lib/platform";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
 import { toRichAgentMentionType } from "@app/types/assistant/mentions";
-import { useContext, useEffect } from "react";
+import { useContext, useEffect, useRef } from "react";
 
 /**
- * Reads the ?agent= search param, fetches the corresponding agent configuration,
- * sets it as the selected agent in the input bar, and cleans up the param from the
- * URL so it doesn't persist across manual agent changes or page refreshes.
+ * Reads the ?agent= search param, fetches the corresponding agent configuration, and
+ * sets it as the selected agent in the input bar. The param stays in the URL so the
+ * link remains shareable, and is applied once per agent id so a later manual agent
+ * change is not overridden when the configuration revalidates.
  */
 export function useAgentFromSearchParam(workspaceId: string) {
   const agent = useSearchParam("agent");
   const { setSelectedAgent } = useContext(InputBarContext);
+  const appliedAgentIdRef = useRef<string | null>(null);
 
   const { agentConfiguration } = useAgentConfiguration({
     workspaceId,
@@ -20,21 +22,14 @@ export function useAgentFromSearchParam(workspaceId: string) {
   });
 
   useEffect(() => {
-    if (!agentConfiguration) {
+    if (
+      !agentConfiguration ||
+      appliedAgentIdRef.current === agentConfiguration.sId
+    ) {
       return;
     }
 
+    appliedAgentIdRef.current = agentConfiguration.sId;
     setSelectedAgent(toRichAgentMentionType(agentConfiguration));
-
-    const params = new URLSearchParams(window.location.search);
-    if (params.has("agent")) {
-      params.delete("agent");
-      const qs = params.toString();
-      window.history.replaceState(
-        null,
-        "",
-        `${window.location.pathname}${qs ? `?${qs}` : ""}${window.location.hash}`
-      );
-    }
   }, [agentConfiguration, setSelectedAgent]);
 }

--- a/front/hooks/useAgentFromSearchParam.ts
+++ b/front/hooks/useAgentFromSearchParam.ts
@@ -1,35 +1,77 @@
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
-import { useSearchParam } from "@app/lib/platform";
+import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
+import { useAppRouter, useSearchParam } from "@app/lib/platform";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
 import { toRichAgentMentionType } from "@app/types/assistant/mentions";
 import { useContext, useEffect, useRef } from "react";
 
 /**
- * Reads the ?agent= search param, fetches the corresponding agent configuration, and
- * sets it as the selected agent in the input bar. The param stays in the URL so the
- * link remains shareable, and is applied once per agent id so a later manual agent
- * change is not overridden when the configuration revalidates.
+ * Keeps the ?agent= search param and the input bar's selected agent in sync on the new
+ * conversation page so the URL can always be shared. The param wins on arrival, the
+ * picker wins afterwards.
  */
 export function useAgentFromSearchParam(workspaceId: string) {
+  const router = useAppRouter();
   const agent = useSearchParam("agent");
-  const { setSelectedAgent } = useContext(InputBarContext);
-  const appliedAgentIdRef = useRef<string | null>(null);
+  const activeConversationId = useActiveConversationId();
+  const { selectedSingleAgent, setSelectedAgent } = useContext(InputBarContext);
+  const syncedParamRef = useRef<string | null>(null);
 
-  const { agentConfiguration } = useAgentConfiguration({
-    workspaceId,
-    agentConfigurationId: agent,
-    disabled: !agent,
-  });
+  const isSynced = !!agent && selectedSingleAgent?.id === agent;
 
+  const { agentConfiguration, isAgentConfigurationError } =
+    useAgentConfiguration({
+      workspaceId,
+      agentConfigurationId: agent,
+      disabled: !agent || isSynced,
+    });
+
+  // URL to composer. When url param "agent" names an agent other than the selected one, fetch it
+  // and select it. syncedParamRef tracks the last param the selection has matched, so a
+  // param that is still being applied is not mistaken for a picker change by the effect
+  // below.
   useEffect(() => {
+    if (!agent || !agentConfiguration || syncedParamRef.current === agent) {
+      return;
+    }
+
+    setSelectedAgent(toRichAgentMentionType(agentConfiguration));
+  }, [agent, agentConfiguration, setSelectedAgent]);
+
+  // Composer to URL. On a new conversation, once the URL agent has been applied, a picker
+  // change is mirrored into the url param "agent" so the address bar always reflects the selected agent.
+  useEffect(() => {
+    if (isSynced) {
+      syncedParamRef.current = agent;
+    }
+
+    const isNewConversation = activeConversationId === null;
+    const isUrlAgentNotFound =
+      isAgentConfigurationError?.error?.type ===
+      "agent_configuration_not_found";
+    const isUrlAgentPending =
+      !!agent && syncedParamRef.current !== agent && !isUrlAgentNotFound;
+
     if (
-      !agentConfiguration ||
-      appliedAgentIdRef.current === agentConfiguration.sId
+      isSynced ||
+      !isNewConversation ||
+      !selectedSingleAgent ||
+      isUrlAgentPending
     ) {
       return;
     }
 
-    appliedAgentIdRef.current = agentConfiguration.sId;
-    setSelectedAgent(toRichAgentMentionType(agentConfiguration));
-  }, [agentConfiguration, setSelectedAgent]);
+    const params = new URLSearchParams(window.location.search);
+    params.set("agent", selectedSingleAgent.id);
+    void router.replace(
+      `${window.location.pathname}?${params.toString()}${window.location.hash}`
+    );
+  }, [
+    activeConversationId,
+    agent,
+    isAgentConfigurationError,
+    isSynced,
+    router,
+    selectedSingleAgent,
+  ]);
 }


### PR DESCRIPTION
## Description

Gh issue: https://github.com/dust-tt/tasks/issues/10317

### Context
`?agent=` parameter was getting stripped from the URL as soon as the composer picked it up, so
`/w/{wId}/conversation/new?agent={sId}` could never be copied out of the address bar.

Removing the strip alone was not enough though. Switching agent from the composer never updated the URL, while starting a conversation from the details sheet or Cmd+K did, so the URL only told the truth depending on the last entry point used. And pushing an `?agent=` already in the URL was a no-op the hook could not see.

### Solution
No more strip, and `useAgentFromSearchParam` now syncs both ways on the new conversation page. The URL wins on arrival, the picker wins afterwards and is mirrored back into `?agent=`.

## Tests
- Tested locally.
- New unit tests in [useAgentFromSearchParam.test.ts](https://github.com/dust-tt/dust/pull/31961/changes#diff-8b8c23cc8baa7ba0cc2670f1b655dbdbcd84306299c60a1ba3fe73279f6dc645):
  - selects the URL agent on arrival and leaves the URL alone
  - does not write the URL while the URL agent is still loading
  - mirrors a picker change to the URL without re-selecting
  - applies a new URL agent over the current selection
  - writes the URL when an agent is selected and the param is absent
  - does not touch the URL on an existing conversation

Before: 

https://github.com/user-attachments/assets/265fae00-1336-4583-a0f5-4990479003b9

After:
https://github.com/user-attachments/assets/8c7c2711-9328-4639-8278-ae636a694bdc

## Risk

Low. 

## Deploy Plan

Standard deploy.


