### PR TITLE
[Admin Governance] Tolerate missing editor groups in backfill

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -525,7 +525,7 @@ export class GroupResource extends BaseResource<GroupModel> {
    */
   static async findEditorGroupForAgent(
     auth: Authenticator,
-    agent: LightAgentConfigurationType
+    agent: Pick<LightAgentConfigurationType, "id">
   ): Promise<
     Result<
       GroupResource,

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -525,7 +525,7 @@ export class GroupResource extends BaseResource<GroupModel> {
    */
   static async findEditorGroupForAgent(
     auth: Authenticator,
-    agent: Pick<LightAgentConfigurationType, "id">
+    agent: LightAgentConfigurationType
   ): Promise<
     Result<
       GroupResource,

--- a/front/migrations/20260903_backfill_agent_editor_grants.test.ts
+++ b/front/migrations/20260903_backfill_agent_editor_grants.test.ts
@@ -15,6 +15,61 @@ import { describe, expect, it } from "vitest";
 const logger = baseLogger.child({}, { level: "silent" });
 
 describe("backfillAgentEditorGrants", () => {
+  it("recreates a missing legacy editor group with its author only on execute", async () => {
+    const {
+      authenticator,
+      user: author,
+      workspace,
+    } = await createResourceTest({ role: "admin" });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const legacyGroup = await GroupResource.findEditorGroupForAgent(
+      authenticator,
+      agent
+    );
+    assert(legacyGroup.isOk());
+    expect((await legacyGroup.value.delete(authenticator)).isOk()).toBe(true);
+
+    await expect(
+      backfillAgentEditorGrants({ execute: false, logger, workspace })
+    ).resolves.toMatchObject({
+      editorGrantsToRemove: 0,
+      mismatchedAgentCount: 0,
+    });
+    const afterDryRun = await GroupResource.findEditorGroupForAgent(
+      authenticator,
+      agent
+    );
+    assert(afterDryRun.isErr());
+    expect(afterDryRun.error.code).toBe("group_not_found");
+
+    await expect(
+      backfillAgentEditorGrants({ execute: true, logger, workspace })
+    ).resolves.toMatchObject({
+      editorGrantsToRemove: 0,
+      mismatchedAgentCount: 0,
+    });
+    const restoredGroup = await GroupResource.findEditorGroupForAgent(
+      authenticator,
+      agent
+    );
+    assert(restoredGroup.isOk());
+    expect(
+      (await restoredGroup.value.getActiveMembers(authenticator)).map(
+        ({ id }) => id
+      )
+    ).toEqual([author.id]);
+    await expect(
+      backfillAgentEditorGrants({ execute: true, logger, workspace })
+    ).resolves.toMatchObject({ editorGrantsToAdd: 0, mismatchedAgentCount: 0 });
+    const afterRerun = await GroupResource.findEditorGroupForAgent(
+      authenticator,
+      agent
+    );
+    assert(afterRerun.isOk());
+    expect(afterRerun.value.id).toBe(restoredGroup.value.id);
+  });
+
   it("syncs archived agents from their latest legacy group", async () => {
     const {
       authenticator,

--- a/front/migrations/20260903_backfill_agent_editor_grants.test.ts
+++ b/front/migrations/20260903_backfill_agent_editor_grants.test.ts
@@ -15,12 +15,10 @@ import { describe, expect, it } from "vitest";
 const logger = baseLogger.child({}, { level: "silent" });
 
 describe("backfillAgentEditorGrants", () => {
-  it("recreates a missing legacy editor group with its author only on execute", async () => {
-    const {
-      authenticator,
-      user: author,
-      workspace,
-    } = await createResourceTest({ role: "admin" });
+  it("treats a missing legacy editor group as empty through execute and rerun", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
     const agent =
       await AgentConfigurationFactory.createTestAgent(authenticator);
     const legacyGroup = await GroupResource.findEditorGroupForAgent(
@@ -33,41 +31,29 @@ describe("backfillAgentEditorGrants", () => {
     await expect(
       backfillAgentEditorGrants({ execute: false, logger, workspace })
     ).resolves.toMatchObject({
-      editorGrantsToRemove: 0,
-      mismatchedAgentCount: 0,
+      editorGrantsToRemove: 1,
+      mismatchedAgentCount: 1,
     });
-    const afterDryRun = await GroupResource.findEditorGroupForAgent(
-      authenticator,
-      agent
-    );
-    assert(afterDryRun.isErr());
-    expect(afterDryRun.error.code).toBe("group_not_found");
 
     await expect(
       backfillAgentEditorGrants({ execute: true, logger, workspace })
     ).resolves.toMatchObject({
+      editorGrantsToRemove: 1,
+      mismatchedAgentCount: 0,
+    });
+    await expect(
+      backfillAgentEditorGrants({ execute: true, logger, workspace })
+    ).resolves.toMatchObject({
+      editorGrantsToAdd: 0,
       editorGrantsToRemove: 0,
       mismatchedAgentCount: 0,
     });
-    const restoredGroup = await GroupResource.findEditorGroupForAgent(
-      authenticator,
-      agent
-    );
-    assert(restoredGroup.isOk());
-    expect(
-      (await restoredGroup.value.getActiveMembers(authenticator)).map(
-        ({ id }) => id
-      )
-    ).toEqual([author.id]);
-    await expect(
-      backfillAgentEditorGrants({ execute: true, logger, workspace })
-    ).resolves.toMatchObject({ editorGrantsToAdd: 0, mismatchedAgentCount: 0 });
     const afterRerun = await GroupResource.findEditorGroupForAgent(
       authenticator,
       agent
     );
-    assert(afterRerun.isOk());
-    expect(afterRerun.value.id).toBe(restoredGroup.value.id);
+    assert(afterRerun.isErr());
+    expect(afterRerun.error.code).toBe("group_not_found");
   });
 
   it("syncs archived agents from their latest legacy group", async () => {

--- a/front/migrations/20260903_backfill_agent_editor_grants.ts
+++ b/front/migrations/20260903_backfill_agent_editor_grants.ts
@@ -3,6 +3,7 @@ import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AgentResource } from "@app/lib/resources/agent_resource";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -52,17 +53,43 @@ function userDifference(
   return left.filter(({ id }) => !rightIds.has(id));
 }
 
-async function fetchLegacyEditors(
+async function prepareLegacyEditors(
   auth: Authenticator,
-  configuration: AgentConfigurationModel
+  configuration: AgentConfigurationModel,
+  { execute, logger, workspace }: BackfillSpec
 ): Promise<UserResource[]> {
-  const group = await GroupResource.fetchByAgentConfiguration({
+  const groupResult = await GroupResource.findEditorGroupForAgent(
     auth,
-    agentConfiguration: configuration,
-  });
-  assert(group, "Non-draft agent must have an editor group.");
+    configuration
+  );
+  if (groupResult.isOk()) {
+    return groupResult.value.getActiveMembers(auth);
+  }
+  if (groupResult.error.code !== "group_not_found") {
+    throw groupResult.error;
+  }
 
-  return group.getActiveMembers(auth);
+  logger.warn(
+    { workspaceId: workspace.sId, agentId: configuration.sId, execute },
+    "Missing legacy editor group"
+  );
+  // A few legacy agents lack an editor group. Recreate it with the author, as on agent creation.
+  if (execute) {
+    const group = await withTransaction((transaction) =>
+      GroupResource.makeNewAgentEditorsGroup(auth, configuration, {
+        transaction,
+        authorId: configuration.authorId,
+      })
+    );
+    return group.getActiveMembers(auth);
+  }
+
+  const authors = await UserResource.fetchByModelIds([configuration.authorId]);
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    users: authors,
+    workspace,
+  });
+  return memberships.length > 0 ? authors : [];
 }
 
 async function fetchGrantEditors(
@@ -82,13 +109,14 @@ async function fetchGrantEditors(
   return group ? group.getActiveMembers(auth) : [];
 }
 
-async function fetchEditorState(
+async function prepareEditorState(
   auth: Authenticator,
   agent: AgentResource,
-  configuration: AgentConfigurationModel
+  configuration: AgentConfigurationModel,
+  spec: BackfillSpec
 ): Promise<EditorState> {
   const [legacyEditors, grantEditors] = await Promise.all([
-    fetchLegacyEditors(auth, configuration),
+    prepareLegacyEditors(auth, configuration, spec),
     fetchGrantEditors(auth, agent),
   ]);
 
@@ -160,7 +188,12 @@ async function backfillAgentGrants(
   spec: BackfillSpec
 ): Promise<AgentEditorGrantStats> {
   const agent = AgentResource.fromAgentConfigurationModel(configuration);
-  const initialState = await fetchEditorState(auth, agent, configuration);
+  const initialState = await prepareEditorState(
+    auth,
+    agent,
+    configuration,
+    spec
+  );
   const changes = {
     toAdd: userDifference(
       initialState.legacyEditors,
@@ -176,7 +209,7 @@ async function backfillAgentGrants(
   const hasChanges = changes.toAdd.length > 0 || changes.toRemove.length > 0;
   const finalState =
     spec.execute && hasChanges
-      ? await fetchEditorState(auth, agent, configuration)
+      ? await prepareEditorState(auth, agent, configuration, spec)
       : initialState;
 
   return {

--- a/front/migrations/20260903_backfill_agent_editor_grants.ts
+++ b/front/migrations/20260903_backfill_agent_editor_grants.ts
@@ -3,7 +3,6 @@ import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AgentResource } from "@app/lib/resources/agent_resource";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
-import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -53,43 +52,18 @@ function userDifference(
   return left.filter(({ id }) => !rightIds.has(id));
 }
 
-async function prepareLegacyEditors(
+async function fetchLegacyEditors(
   auth: Authenticator,
-  configuration: AgentConfigurationModel,
-  { execute, logger, workspace }: BackfillSpec
+  configuration: AgentConfigurationModel
 ): Promise<UserResource[]> {
-  const groupResult = await GroupResource.findEditorGroupForAgent(
+  const group = await GroupResource.fetchByAgentConfiguration({
     auth,
-    configuration
-  );
-  if (groupResult.isOk()) {
-    return groupResult.value.getActiveMembers(auth);
-  }
-  if (groupResult.error.code !== "group_not_found") {
-    throw groupResult.error;
-  }
-
-  logger.warn(
-    { workspaceId: workspace.sId, agentId: configuration.sId, execute },
-    "Missing legacy editor group"
-  );
-  // A few legacy agents lack an editor group. Recreate it with the author, as on agent creation.
-  if (execute) {
-    const group = await withTransaction((transaction) =>
-      GroupResource.makeNewAgentEditorsGroup(auth, configuration, {
-        transaction,
-        authorId: configuration.authorId,
-      })
-    );
-    return group.getActiveMembers(auth);
-  }
-
-  const authors = await UserResource.fetchByModelIds([configuration.authorId]);
-  const { memberships } = await MembershipResource.getActiveMemberships({
-    users: authors,
-    workspace,
+    agentConfiguration: configuration,
+    // Some legacy agents have no editor group; tolerate its absence as in deletion flows.
+    isDeletionFlow: true,
   });
-  return memberships.length > 0 ? authors : [];
+
+  return group ? group.getActiveMembers(auth) : [];
 }
 
 async function fetchGrantEditors(
@@ -109,14 +83,13 @@ async function fetchGrantEditors(
   return group ? group.getActiveMembers(auth) : [];
 }
 
-async function prepareEditorState(
+async function fetchEditorState(
   auth: Authenticator,
   agent: AgentResource,
-  configuration: AgentConfigurationModel,
-  spec: BackfillSpec
+  configuration: AgentConfigurationModel
 ): Promise<EditorState> {
   const [legacyEditors, grantEditors] = await Promise.all([
-    prepareLegacyEditors(auth, configuration, spec),
+    fetchLegacyEditors(auth, configuration),
     fetchGrantEditors(auth, agent),
   ]);
 
@@ -188,12 +161,7 @@ async function backfillAgentGrants(
   spec: BackfillSpec
 ): Promise<AgentEditorGrantStats> {
   const agent = AgentResource.fromAgentConfigurationModel(configuration);
-  const initialState = await prepareEditorState(
-    auth,
-    agent,
-    configuration,
-    spec
-  );
+  const initialState = await fetchEditorState(auth, agent, configuration);
   const changes = {
     toAdd: userDifference(
       initialState.legacyEditors,
@@ -209,7 +177,7 @@ async function backfillAgentGrants(
   const hasChanges = changes.toAdd.length > 0 || changes.toRemove.length > 0;
   const finalState =
     spec.execute && hasChanges
-      ? await prepareEditorState(auth, agent, configuration, spec)
+      ? await fetchEditorState(auth, agent, configuration)
       : initialState;
 
   return {


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/31947.

A few historical agents have no legacy editor group, causing the editor-grant backfill to stop. Treat a missing group as an empty editor set, without creating a group or adding the author.

Reuse the lookup's existing `isDeletionFlow` option to allow missing groups. Multiple groups and database errors still fail. The remaining backfill uses the new permission groups, so it does not require a legacy editor group. No shared production code changes.

## Risks

Blast radius: agents missing their legacy editor group during the backfill.
Risk: low — existing new-style editor grants on these agents are removed to match the empty legacy editor set. Dry runs remain read-only.

## Deploy Plan

- Run the updated `migrations/20260903_backfill_agent_editor_grants.ts` with `--execute`.

## Tests

- [x] Missing group: dry run, grant removal, post-write verification, and rerun complete without creating a legacy group.
- [x] Existing archived-agent reconciliation regression.
