### PR TITLE
Remove useless region from workos cookies and update to use cell from claim.

### DIFF
--- a/front-api/routes/workos/[action].ts
+++ b/front-api/routes/workos/[action].ts
@@ -3,10 +3,10 @@ import {
   emitAuditLogEvent,
   emitAuditLogEventDirect,
 } from "@app/lib/api/audit/workos_audit";
+import { config as cellsConfig } from "@app/lib/api/cells/config";
 import { checkUserCellAffinity } from "@app/lib/api/cells/lookup";
 import config from "@app/lib/api/config";
 import { performLogin } from "@app/lib/api/login";
-import { config as multiRegionsConfig } from "@app/lib/api/regions/config";
 import { authenticateWithWorkOSCode } from "@app/lib/api/workos/authenticate";
 import { getWorkOS } from "@app/lib/api/workos/client";
 import type { SessionCookie } from "@app/lib/api/workos/user";
@@ -24,8 +24,7 @@ import { statsDMetrics } from "@app/lib/utils/statsd";
 import { extractUTMParams } from "@app/lib/utils/utm";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
-import type { RegionType } from "@app/types/region";
-import { SUPPORTED_REGIONS } from "@app/types/region";
+import { type CellInfo, isCellType, SUPPORTED_CELLS } from "@app/types/cell";
 import { isDevelopment } from "@app/types/shared/env";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -419,10 +418,6 @@ async function handleCallback(ctx: Context) {
       sessionData: sealedSession,
       organizationId,
       authenticationMethod,
-      region:
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        decodedPayload["https://dust.tt/region"] ||
-        multiRegionsConfig.getCurrentRegion(),
       workspaceId: decodedPayload["https://dust.tt/workspaceId"],
     };
 
@@ -433,10 +428,12 @@ async function handleCallback(ctx: Context) {
       ttl: 0,
     });
 
-    const currentRegion = multiRegionsConfig.getCurrentRegion();
-    let targetRegion: RegionType | null = "us-central1";
+    const currentCell = cellsConfig.getCurrentCell();
+    let targetCell: CellInfo = cellsConfig.getCellInfo("cell-00000");
 
-    const userSessionRegion = sessionCookie.region;
+    const cellClaim = decodedPayload["https://dust.tt/cell"];
+    const userSessionCellName =
+      isString(cellClaim) && isCellType(cellClaim) ? cellClaim : null;
     const validatedReturnTo = validateRelativePath(stateObj.returnTo);
     const sanitizedReturnTo = validatedReturnTo.valid
       ? validatedReturnTo.sanitizedPath
@@ -458,11 +455,10 @@ async function handleCallback(ctx: Context) {
       }
     }
 
-    // TODO(single-tenant) Move this whole file to cell.
     if (invite) {
-      targetRegion = currentRegion;
-    } else if (userSessionRegion) {
-      targetRegion = userSessionRegion;
+      targetCell = currentCell;
+    } else if (userSessionCellName) {
+      targetCell = cellsConfig.getCellInfo(userSessionCellName);
     } else {
       const cellWithAffinityRes = await checkUserCellAffinity({
         email: user.email,
@@ -472,26 +468,25 @@ async function handleCallback(ctx: Context) {
         throw cellWithAffinityRes.error;
       }
       if (cellWithAffinityRes.value) {
-        targetRegion = cellWithAffinityRes.value.region;
+        targetCell = cellWithAffinityRes.value;
       } else {
-        targetRegion = multiRegionsConfig.getCurrentRegion();
+        targetCell = cellsConfig.getCurrentCell();
       }
     }
 
-    if (targetRegion && !SUPPORTED_REGIONS.includes(targetRegion)) {
+    if (targetCell && !SUPPORTED_CELLS.includes(targetCell.name)) {
       logger.error(
-        { targetRegion, currentRegion },
-        "Invalid target region during WorkOS callback"
+        { targetCell: targetCell, currentCell: currentCell },
+        "Invalid target cell during WorkOS callback"
       );
-      targetRegion = multiRegionsConfig.getCurrentRegion();
+      targetCell = cellsConfig.getCurrentCell();
     }
 
-    if (targetRegion !== currentRegion) {
+    if (targetCell !== currentCell) {
       logger.info(
-        { targetRegion, currentRegion },
-        "Redirecting to correct region"
+        { targetCell: targetCell, currentCell: currentCell },
+        "Redirecting to correct cell"
       );
-      const targetRegionInfo = multiRegionsConfig.getOtherRegionInfo();
       const params = new URLSearchParams();
       const returnTo = sanitizedReturnTo ?? "/api/login";
       params.set("returnTo", returnTo);
@@ -500,7 +495,7 @@ async function handleCallback(ctx: Context) {
       }
       return redirect(
         ctx,
-        `${targetRegionInfo.url}/api/workos/login?${params.toString()}`
+        `${targetCell.url}/api/workos/login?${params.toString()}`
       );
     }
 

--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -8,7 +8,6 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { cacheWithRedis } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
-import type { RegionType } from "@app/types/region";
 import { isDevelopment } from "@app/types/shared/env";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -27,7 +26,6 @@ export type SessionCookie = {
   sessionData: string;
   organizationId?: string;
   authenticationMethod: WorkOSAuthenticationResponse["authenticationMethod"];
-  region: RegionType;
   workspaceId: string;
 };
 
@@ -107,8 +105,7 @@ export async function _getRefreshedCookie(
   session: ReturnType<WorkOS["userManagement"]["loadSealedSession"]>,
   organizationId: string | undefined,
   authenticationMethod: string | undefined,
-  workspaceId: string | undefined,
-  region: RegionType
+  workspaceId: string | undefined
 ): Promise<string | null> {
   if (await isWorkOSRefreshCircuitOpen()) {
     throw new WorkOSRefreshCircuitOpenError();
@@ -135,7 +132,6 @@ export async function _getRefreshedCookie(
         sessionData: r.sealedSession,
         organizationId,
         authenticationMethod,
-        region,
         workspaceId,
       },
       {
@@ -206,7 +202,6 @@ async function maybeProactiveRefresh({
   organizationId,
   authenticationMethod,
   workspaceId,
-  region,
 }: {
   accessToken: string;
   workOSSessionCookie: string;
@@ -214,7 +209,6 @@ async function maybeProactiveRefresh({
   organizationId: string | undefined;
   authenticationMethod: string | undefined;
   workspaceId: string | undefined;
-  region: RegionType;
 }): Promise<string | null> {
   const expSeconds = getAccessTokenExpirySeconds(accessToken);
   const nowSeconds = Math.floor(Date.now() / 1000);
@@ -235,8 +229,7 @@ async function maybeProactiveRefresh({
     session,
     organizationId,
     authenticationMethod,
-    workspaceId,
-    region
+    workspaceId
   );
 }
 
@@ -326,15 +319,10 @@ export async function getWorkOSSessionFromCookie(
   cookie: string | undefined;
   session: SessionWithUser | undefined;
 }> {
-  const {
-    sessionData,
-    organizationId,
-    authenticationMethod,
-    workspaceId,
-    region,
-  } = await unsealData<SessionCookie>(workOSSessionCookie, {
-    password: config.getWorkOSCookiePassword(),
-  });
+  const { sessionData, organizationId, authenticationMethod, workspaceId } =
+    await unsealData<SessionCookie>(workOSSessionCookie, {
+      password: config.getWorkOSCookiePassword(),
+    });
 
   if (!sessionData) {
     return {
@@ -361,8 +349,7 @@ export async function getWorkOSSessionFromCookie(
           session,
           organizationId,
           authenticationMethod,
-          workspaceId,
-          region
+          workspaceId
         )
       );
       if (refreshedCookie) {
@@ -400,7 +387,6 @@ export async function getWorkOSSessionFromCookie(
           organizationId,
           authenticationMethod,
           workspaceId,
-          region,
         })
     );
 


### PR DESCRIPTION
## Description

Remove `region` from the sealed `SessionCookie` and route WorkOS callbacks from the `https://dust.tt/cell` claim. `front-api` now resolves and validates `CellInfo` through `cellsConfig`, preserving invite, affinity, and current-cell fallbacks while redirecting to the correct cell URL.

## Tests

No new tests added. GitHub CI is running lint, TypeScript checks, and test shards for the updated auth paths.

## Risk

Low-to-medium risk: auth routing depends on valid cell claims and cell configuration. Invalid or missing claims fall back to workspace affinity or the current cell; rollback is a code revert.

## Deploy Plan

Deploy `front-api` and `front` together. No SQL migrations or infrastructure changes. Verify WorkOS login, cookie refresh, and cross-cell redirects after rollout.