### PR TITLE
Gate Poke pool-usage premium-message columns by feature flag

### DIFF
--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -185,11 +185,6 @@ export function PoolUsagePage() {
   const activeSubscription = workspaceInfo?.activeSubscription;
   const isLegacyPremiumMessagePlan =
     !!activeSubscription && !isCreditPricedPlan(activeSubscription.plan);
-  // Whether the pool/Metronome columns apply is driven by the `legacy_billing`
-  // feature flag (`hasMetronomeFeature`) rather than the subscription's actual
-  // contract state, so this stays in sync with the flag immediately instead of
-  // trailing subscription/contract provisioning. Poke-only ("compact" variant);
-  // the customer-facing usage table doesn't use this flag.
   const isLegacyWithoutPoolOrMetronome =
     isLegacyPremiumMessagePlan && !workspaceInfo?.hasMetronomeFeature;
   const showPoolSection =
@@ -429,7 +424,7 @@ export function PoolUsagePage() {
                   isSeatBased
                   showSpendLimit
                   hasPool={hasPool}
-                  showPremiumMessageUsage={isLegacyWithoutPoolOrMetronome}
+                  isPremiumMessagePlan={isLegacyWithoutPoolOrMetronome}
                   showPremiumMessageColumn={
                     !!workspaceInfo?.hasEnforcePremiumModelMessageLimitFeature
                   }

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -33,10 +33,7 @@ import {
   SEAT_TYPE_ORDER,
   toBaseSeatType,
 } from "@app/types/memberships";
-import {
-  isCreditPricedPlan,
-  isSubscriptionMetronomeBilled,
-} from "@app/types/plan";
+import { isCreditPricedPlan } from "@app/types/plan";
 import {
   AlertCircle,
   Button,
@@ -186,12 +183,15 @@ export function PoolUsagePage() {
 
   const { data: workspaceInfo } = usePokeWorkspaceInfo({ owner });
   const activeSubscription = workspaceInfo?.activeSubscription;
-  const hasMetronomeContract =
-    !!activeSubscription && isSubscriptionMetronomeBilled(activeSubscription);
   const isLegacyPremiumMessagePlan =
     !!activeSubscription && !isCreditPricedPlan(activeSubscription.plan);
+  // Whether the pool/Metronome columns apply is driven by the `legacy_billing`
+  // feature flag (`hasMetronomeFeature`) rather than the subscription's actual
+  // contract state, so this stays in sync with the flag immediately instead of
+  // trailing subscription/contract provisioning. Poke-only ("compact" variant);
+  // the customer-facing usage table doesn't use this flag.
   const isLegacyWithoutPoolOrMetronome =
-    isLegacyPremiumMessagePlan && !hasMetronomeContract;
+    isLegacyPremiumMessagePlan && !workspaceInfo?.hasMetronomeFeature;
   const showPoolSection =
     !!activeSubscription && !isLegacyWithoutPoolOrMetronome;
 

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -430,6 +430,12 @@ export function PoolUsagePage() {
                   showSpendLimit
                   hasPool={hasPool}
                   showPremiumMessageUsage={isLegacyWithoutPoolOrMetronome}
+                  showPremiumMessageColumn={
+                    !!workspaceInfo?.hasEnforcePremiumModelMessageLimitFeature
+                  }
+                  showFairUseCreditsColumn={
+                    !workspaceInfo?.hasDisableFairUseAwuLimitFeature
+                  }
                   readOnly
                   onChangeSeat={noopOnMember}
                   onOpenChangeSeatRecap={setChangeSeatRecapMember}

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -1104,6 +1104,8 @@ function buildCreditPlanColumns({
   variant,
   hasPool,
   showPremiumMessageUsage,
+  showPremiumMessageColumn,
+  showFairUseCreditsColumn,
   premiumMessageWindowDays,
   fairUseWindowDays,
 }: {
@@ -1111,9 +1113,21 @@ function buildCreditPlanColumns({
   variant: MembersUsageTableVariant;
   hasPool: boolean;
   showPremiumMessageUsage: boolean;
+  // Whether to actually render the premium-message / fair-use-credits
+  // columns, independently of `showPremiumMessageUsage` (which also governs
+  // the seat-column swap below). Defaults to `showPremiumMessageUsage` so
+  // callers that don't pass them keep the previous coupled behavior.
+  showPremiumMessageColumn: boolean;
+  showFairUseCreditsColumn: boolean;
   premiumMessageWindowDays: number;
   fairUseWindowDays: number | null;
 }): ColumnDef<RowData, string>[] {
+  const creditsUsageColumn = showPremiumMessageUsage
+    ? showPremiumMessageColumn
+      ? buildPremiumMessageUsageColumn(premiumMessageWindowDays)
+      : null
+    : buildPoolCreditUsageColumn(creditsResetAt, variant, hasPool);
+
   return [
     // Premium message plans have no seats: every member is billed per
     // message, so the seat columns have nothing to show.
@@ -1130,15 +1144,14 @@ function buildCreditPlanColumns({
               return [seatTypeColumn];
           }
         })()),
-    {
-      ...(showPremiumMessageUsage
-        ? buildPremiumMessageUsageColumn(premiumMessageWindowDays)
-        : buildPoolCreditUsageColumn(creditsResetAt, variant, hasPool)),
-      meta: { className: "w-56" },
-    },
+    ...(creditsUsageColumn
+      ? [{ ...creditsUsageColumn, meta: { className: "w-56" } }]
+      : []),
     // Premium message plans also carry a fixed AWU credit allowance for
     // usage on non-premium models, alongside the rolling message limit.
-    ...(showPremiumMessageUsage && fairUseWindowDays !== null
+    ...(showPremiumMessageUsage &&
+    showFairUseCreditsColumn &&
+    fairUseWindowDays !== null
       ? [buildFairUseCreditsColumn(fairUseWindowDays)]
       : []),
     ...(variant === "compact" && !showPremiumMessageUsage
@@ -1156,6 +1169,8 @@ function buildColumns({
   variant,
   hasPool,
   showPremiumMessageUsage,
+  showPremiumMessageColumn,
+  showFairUseCreditsColumn,
   premiumMessageWindowDays,
   fairUseWindowDays,
 }: {
@@ -1167,6 +1182,8 @@ function buildColumns({
   variant: MembersUsageTableVariant;
   hasPool: boolean;
   showPremiumMessageUsage: boolean;
+  showPremiumMessageColumn: boolean;
+  showFairUseCreditsColumn: boolean;
   premiumMessageWindowDays: number;
   fairUseWindowDays: number | null;
 }): ColumnDef<RowData, string>[] {
@@ -1181,6 +1198,8 @@ function buildColumns({
           variant,
           hasPool,
           showPremiumMessageUsage,
+          showPremiumMessageColumn,
+          showFairUseCreditsColumn,
           premiumMessageWindowDays,
           fairUseWindowDays,
         })
@@ -1243,6 +1262,12 @@ interface MembersUsageTableProps {
   // "compact" (poke) variant's credit column header.
   hasPool?: boolean;
   showPremiumMessageUsage?: boolean;
+  // Independently hide the premium-message / fair-use-credits columns even
+  // when `showPremiumMessageUsage` is true (e.g. driven by the
+  // `enforce_premium_model_message_limit` / `disable_fair_use_awu_limit`
+  // feature flags in Poke). Both default to `showPremiumMessageUsage`.
+  showPremiumMessageColumn?: boolean;
+  showFairUseCreditsColumn?: boolean;
   userModelTierSelectionByUserId?: Record<string, UserModelTierSelection>;
   userAllowedModelTiersByUserId?: Record<string, ModelsTierName[]>;
   groupModelTiersByGroupId?: Record<string, ModelsTierName[]>;
@@ -1283,6 +1308,8 @@ export function MembersUsageTable({
   variant = "legacy",
   hasPool = true,
   showPremiumMessageUsage = false,
+  showPremiumMessageColumn = showPremiumMessageUsage,
+  showFairUseCreditsColumn = showPremiumMessageUsage,
   userModelTierSelectionByUserId = EMPTY_USER_MODEL_TIER_SELECTION_BY_USER_ID,
   userAllowedModelTiersByUserId = EMPTY_USER_ALLOWED_MODEL_TIERS_BY_USER_ID,
   groupModelTiersByGroupId = EMPTY_GROUP_MODEL_TIERS_BY_GROUP_ID,
@@ -1476,6 +1503,8 @@ export function MembersUsageTable({
         variant,
         hasPool,
         showPremiumMessageUsage,
+        showPremiumMessageColumn,
+        showFairUseCreditsColumn,
         premiumMessageWindowDays,
         fairUseWindowDays,
       }),
@@ -1489,6 +1518,8 @@ export function MembersUsageTable({
       hasPool,
       premiumMessageWindowDays,
       showPremiumMessageUsage,
+      showPremiumMessageColumn,
+      showFairUseCreditsColumn,
       fairUseWindowDays,
     ]
   );

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -1103,7 +1103,7 @@ function buildCreditPlanColumns({
   creditsResetAt,
   variant,
   hasPool,
-  showPremiumMessageUsage,
+  isPremiumMessagePlan,
   showPremiumMessageColumn,
   showFairUseCreditsColumn,
   premiumMessageWindowDays,
@@ -1112,17 +1112,13 @@ function buildCreditPlanColumns({
   creditsResetAt: string | null;
   variant: MembersUsageTableVariant;
   hasPool: boolean;
-  showPremiumMessageUsage: boolean;
-  // Whether to actually render the premium-message / fair-use-credits
-  // columns, independently of `showPremiumMessageUsage` (which also governs
-  // the seat-column swap below). Defaults to `showPremiumMessageUsage` so
-  // callers that don't pass them keep the previous coupled behavior.
+  isPremiumMessagePlan: boolean;
   showPremiumMessageColumn: boolean;
   showFairUseCreditsColumn: boolean;
   premiumMessageWindowDays: number;
   fairUseWindowDays: number | null;
 }): ColumnDef<RowData, string>[] {
-  const creditsUsageColumn = showPremiumMessageUsage
+  const creditsUsageColumn = isPremiumMessagePlan
     ? showPremiumMessageColumn
       ? buildPremiumMessageUsageColumn(premiumMessageWindowDays)
       : null
@@ -1131,7 +1127,7 @@ function buildCreditPlanColumns({
   return [
     // Premium message plans have no seats: every member is billed per
     // message, so the seat columns have nothing to show.
-    ...(showPremiumMessageUsage
+    ...(isPremiumMessagePlan
       ? []
       : (() => {
           switch (variant) {
@@ -1149,14 +1145,12 @@ function buildCreditPlanColumns({
       : []),
     // Premium message plans also carry a fixed AWU credit allowance for
     // usage on non-premium models, alongside the rolling message limit.
-    ...(showPremiumMessageUsage &&
+    ...(isPremiumMessagePlan &&
     showFairUseCreditsColumn &&
     fairUseWindowDays !== null
       ? [buildFairUseCreditsColumn(fairUseWindowDays)]
       : []),
-    ...(variant === "compact" && !showPremiumMessageUsage
-      ? [offPaceColumn]
-      : []),
+    ...(variant === "compact" && !isPremiumMessagePlan ? [offPaceColumn] : []),
   ];
 }
 
@@ -1168,7 +1162,7 @@ function buildColumns({
   creditsResetAt,
   variant,
   hasPool,
-  showPremiumMessageUsage,
+  isPremiumMessagePlan,
   showPremiumMessageColumn,
   showFairUseCreditsColumn,
   premiumMessageWindowDays,
@@ -1181,7 +1175,7 @@ function buildColumns({
   creditsResetAt: string | null;
   variant: MembersUsageTableVariant;
   hasPool: boolean;
-  showPremiumMessageUsage: boolean;
+  isPremiumMessagePlan: boolean;
   showPremiumMessageColumn: boolean;
   showFairUseCreditsColumn: boolean;
   premiumMessageWindowDays: number;
@@ -1197,7 +1191,7 @@ function buildColumns({
           creditsResetAt,
           variant,
           hasPool,
-          showPremiumMessageUsage,
+          isPremiumMessagePlan,
           showPremiumMessageColumn,
           showFairUseCreditsColumn,
           premiumMessageWindowDays,
@@ -1261,11 +1255,11 @@ interface MembersUsageTableProps {
   // Whether the workspace has an active credit pool. Only affects the
   // "compact" (poke) variant's credit column header.
   hasPool?: boolean;
-  showPremiumMessageUsage?: boolean;
+  isPremiumMessagePlan?: boolean;
   // Independently hide the premium-message / fair-use-credits columns even
-  // when `showPremiumMessageUsage` is true (e.g. driven by the
+  // when `isPremiumMessagePlan` is true (e.g. driven by the
   // `enforce_premium_model_message_limit` / `disable_fair_use_awu_limit`
-  // feature flags in Poke). Both default to `showPremiumMessageUsage`.
+  // feature flags in Poke). Both default to `isPremiumMessagePlan`.
   showPremiumMessageColumn?: boolean;
   showFairUseCreditsColumn?: boolean;
   userModelTierSelectionByUserId?: Record<string, UserModelTierSelection>;
@@ -1307,9 +1301,9 @@ export function MembersUsageTable({
   showModelTiersColumn = false,
   variant = "legacy",
   hasPool = true,
-  showPremiumMessageUsage = false,
-  showPremiumMessageColumn = showPremiumMessageUsage,
-  showFairUseCreditsColumn = showPremiumMessageUsage,
+  isPremiumMessagePlan = false,
+  showPremiumMessageColumn = isPremiumMessagePlan,
+  showFairUseCreditsColumn = isPremiumMessagePlan,
   userModelTierSelectionByUserId = EMPTY_USER_MODEL_TIER_SELECTION_BY_USER_ID,
   userAllowedModelTiersByUserId = EMPTY_USER_ALLOWED_MODEL_TIERS_BY_USER_ID,
   groupModelTiersByGroupId = EMPTY_GROUP_MODEL_TIERS_BY_GROUP_ID,
@@ -1386,7 +1380,7 @@ export function MembersUsageTable({
           })(),
           hasUserLevelModelTiersOverride: resolvedModelTiers?.source === "user",
           menuItems: [
-            ...(showSeatAndCredits && !hasSeat && !showPremiumMessageUsage
+            ...(showSeatAndCredits && !hasSeat && !isPremiumMessagePlan
               ? [
                   {
                     kind: "item" as const,
@@ -1472,7 +1466,7 @@ export function MembersUsageTable({
       groupNameToId,
       readOnly,
       showSeatAndCredits,
-      showPremiumMessageUsage,
+      isPremiumMessagePlan,
       seatActionsDisabled,
       onChangeSeat,
       onRemoveSeat,
@@ -1502,7 +1496,7 @@ export function MembersUsageTable({
         creditsResetAt,
         variant,
         hasPool,
-        showPremiumMessageUsage,
+        isPremiumMessagePlan,
         showPremiumMessageColumn,
         showFairUseCreditsColumn,
         premiumMessageWindowDays,
@@ -1517,7 +1511,7 @@ export function MembersUsageTable({
       variant,
       hasPool,
       premiumMessageWindowDays,
-      showPremiumMessageUsage,
+      isPremiumMessagePlan,
       showPremiumMessageColumn,
       showFairUseCreditsColumn,
       fairUseWindowDays,

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -1257,9 +1257,7 @@ interface MembersUsageTableProps {
   hasPool?: boolean;
   isPremiumMessagePlan?: boolean;
   // Independently hide the premium-message / fair-use-credits columns even
-  // when `isPremiumMessagePlan` is true (e.g. driven by the
-  // `enforce_premium_model_message_limit` / `disable_fair_use_awu_limit`
-  // feature flags in Poke). Both default to `isPremiumMessagePlan`.
+  // when `isPremiumMessagePlan` is true.
   showPremiumMessageColumn?: boolean;
   showFairUseCreditsColumn?: boolean;
   userModelTierSelectionByUserId?: Record<string, UserModelTierSelection>;

--- a/front/lib/api/poke/workspace_info.ts
+++ b/front/lib/api/poke/workspace_info.ts
@@ -75,11 +75,10 @@ export type PokeWorkspaceInfo = {
   extensionConfig: ExtensionConfigurationType | null;
   hasDummyFeature: boolean;
   hasMetronomeFeature: boolean;
-  // Whether the premium-model message cap is enforced on this workspace. See
-  // the `enforce_premium_model_message_limit` feature flag.
+  // Whether the premium-model message cap is enforced on this workspace.
   hasEnforcePremiumModelMessageLimitFeature: boolean;
   // Whether the per-user fair-use AWU credit limit is disabled on this
-  // workspace. See the `disable_fair_use_awu_limit` feature flag.
+  // workspace.
   hasDisableFairUseAwuLimitFeature: boolean;
   membersCount: number;
   inactiveMembersCount: number;

--- a/front/lib/api/poke/workspace_info.ts
+++ b/front/lib/api/poke/workspace_info.ts
@@ -75,6 +75,12 @@ export type PokeWorkspaceInfo = {
   extensionConfig: ExtensionConfigurationType | null;
   hasDummyFeature: boolean;
   hasMetronomeFeature: boolean;
+  // Whether the premium-model message cap is enforced on this workspace. See
+  // the `enforce_premium_model_message_limit` feature flag.
+  hasEnforcePremiumModelMessageLimitFeature: boolean;
+  // Whether the per-user fair-use AWU credit limit is disabled on this
+  // workspace. See the `disable_fair_use_awu_limit` feature flag.
+  hasDisableFairUseAwuLimitFeature: boolean;
   membersCount: number;
   inactiveMembersCount: number;
   metronomeCustomerId: string | null;
@@ -263,6 +269,16 @@ export async function getPokeWorkspaceInfo(
 
   const hasMetronomeFeature = await isMetronomeBillingEnabled(auth);
 
+  const hasEnforcePremiumModelMessageLimitFeature = await hasFeatureFlag(
+    auth,
+    "enforce_premium_model_message_limit"
+  );
+
+  const hasDisableFairUseAwuLimitFeature = await hasFeatureFlag(
+    auth,
+    "disable_fair_use_awu_limit"
+  );
+
   const pendingSubscriptionResource =
     await SubscriptionResource.fetchPendingByWorkspaceModelId(
       workspaceResource.id
@@ -316,6 +332,8 @@ export async function getPokeWorkspaceInfo(
     activeSubscription,
     hasDummyFeature,
     hasMetronomeFeature,
+    hasEnforcePremiumModelMessageLimitFeature,
+    hasDisableFairUseAwuLimitFeature,
     membersCount,
     inactiveMembersCount: allMembersCount - membersCount,
     metronomeCustomerId: workspaceResource.metronomeCustomerId ?? null,


### PR DESCRIPTION
## Description

The Poke pool-usage members table decided whether to show the legacy premium-message columns from subscription/contract state instead of the feature flags that actually govern that billing mode:

- Whether the workspace is on legacy premium-message billing at all now follows the `legacy_billing` feature flag (via `hasMetronomeFeature`) instead of `isSubscriptionMetronomeBilled(activeSubscription)`, so it stays in sync with the flag instead of trailing contract provisioning.
- The "Premium messages" column only renders when `enforce_premium_model_message_limit` is on for the workspace.
- The "Fair Usage Credits" column hides when `disable_fair_use_awu_limit` is on for the workspace.

Both new flags are decoupled from the existing `showPremiumMessageUsage` prop (which still governs the seat-vs-premium-message column layout) via two new optional `MembersUsageTable` props, `showPremiumMessageColumn` / `showFairUseCreditsColumn`, defaulting to `showPremiumMessageUsage` so no other caller changes behavior.

Poke-only (`variant=\"compact\"`); the customer-facing usage table is unaffected.

## Tests

Verified with `npx tsgo --noEmit` and `biome check` on the changed files. Not exercised end-to-end in the browser (would require toggling these flags on a real workspace via Poke).

## Risk

Low — scoped to the Poke admin pool-usage page only.