### PR TITLE
[Admin Governance] Fix skill seed permission filtering option

### DIFF
--- a/front/scripts/seed/factories/seedSkill.ts
+++ b/front/scripts/seed/factories/seedSkill.ts
@@ -38,7 +38,7 @@ export async function seedSkill(
   });
   const [existingSkill] = existingSkillRow
     ? await SkillResource.fetchByModelIds(auth, [existingSkillRow.id], {
-        dangerouslySkipPermissionFiltering: true,
+        permissionFiltering: "dangerously_skip",
       })
     : [];
 


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/31858.

The governance seed passes an obsolete permission-filtering option to `SkillResource.fetchByModelIds`, breaking the front and front-api typechecks on main. Use the current option so reruns can still find seeded skills in spaces the context user cannot read.

## Risks

Blast radius: governance skill seeding only.
Risk: low.

## Deploy Plan

- No deployment or migration required.

## Tests

- [x] Governance seed integration test (`scripts/seed/governance/seed.test.ts`).
