### PR TITLE
[connectors] google_drive: retry 403 "User rate limit exceeded" instead of skipping the drive

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
@@ -18,6 +18,7 @@ import {
   getCachedLabels,
   getDriveClient,
   getInternalId,
+  isGoogleDriveRateLimitError,
   isSharedDriveNotFoundError,
 } from "@connectors/connectors/google_drive/temporal/utils";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
@@ -361,7 +362,17 @@ export async function incrementalSync(
 
     return { nextPageToken, newFolders };
   } catch (e) {
+    // A 403 can also mean a transient rate-limit/quota exhaustion ("User rate limit
+    // exceeded."). Those must be re-thrown so Temporal retries with backoff, not
+    // treated as a permanent loss of access to the drive (which would silently skip
+    // the drive and leave it stale).
     if (
+      isGoogleDriveRateLimitError(e) ||
+      (e instanceof WithRetriesError &&
+        e.errors.every((error) => isGoogleDriveRateLimitError(error.error)))
+    ) {
+      throw e;
+    } else if (
       (e instanceof GaxiosError && e.response?.status === 403) ||
       (e instanceof WithRetriesError &&
         e.errors.every(

--- a/connectors/src/connectors/google_drive/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/google_drive/temporal/cast_known_errors.ts
@@ -1,3 +1,4 @@
+import { isGoogleDriveRateLimitError } from "@connectors/connectors/google_drive/temporal/utils";
 import {
   ExternalOAuthTokenError,
   ProviderWorkflowError,
@@ -72,6 +73,17 @@ export class GoogleDriveCastKnownErrorsInterceptor
     } catch (err: unknown) {
       if (isGoogleDriveInsufficientPermissionsError(err)) {
         throw new ExternalOAuthTokenError(err);
+      }
+
+      // Google returns 403 (not 429) for user rate-limit/quota exhaustion, e.g. "User
+      // rate limit exceeded.". Map it to a retryable rate_limit_error like the 429 case.
+      if (isGoogleDriveRateLimitError(err)) {
+        throw new ProviderWorkflowError(
+          "google_drive",
+          "403: Rate Limit Error",
+          "rate_limit_error",
+          err
+        );
       }
 
       if (err instanceof GaxiosError) {

--- a/connectors/src/connectors/google_drive/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/google_drive/temporal/cast_known_errors.ts
@@ -75,12 +75,13 @@ export class GoogleDriveCastKnownErrorsInterceptor
         throw new ExternalOAuthTokenError(err);
       }
 
-      // Google returns 403 (not 429) for user rate-limit/quota exhaustion, e.g. "User
-      // rate limit exceeded.". Map it to a retryable rate_limit_error like the 429 case.
+      // Google usually returns 403 (not 429) for user rate-limit/quota exhaustion, e.g.
+      // "User rate limit exceeded.". Map it to a retryable rate_limit_error like the 429
+      // case. The helper also matches genuine 429s, so use the real status in the message.
       if (isGoogleDriveRateLimitError(err)) {
         throw new ProviderWorkflowError(
           "google_drive",
-          "403: Rate Limit Error",
+          `${err.response?.status}: Rate Limit Error`,
           "rate_limit_error",
           err
         );

--- a/connectors/src/connectors/google_drive/temporal/utils.test.ts
+++ b/connectors/src/connectors/google_drive/temporal/utils.test.ts
@@ -1,5 +1,25 @@
-import { isFileTooLargeToDownloadError } from "@connectors/connectors/google_drive/temporal/utils";
+import {
+  isFileTooLargeToDownloadError,
+  isGoogleDriveRateLimitError,
+} from "@connectors/connectors/google_drive/temporal/utils";
+import { GaxiosError } from "googleapis-common";
 import { describe, expect, it } from "vitest";
+
+// Builds an object that passes the `instanceof GaxiosError` guard with the given
+// HTTP status and error payload, mirroring how googleapis surfaces API errors.
+function makeGaxiosError(status: number, reason?: string): GaxiosError {
+  return Object.assign(Object.create(GaxiosError.prototype), {
+    message: "Google API error",
+    response: {
+      status,
+      data: {
+        error: reason
+          ? { errors: [{ reason, message: "User rate limit exceeded." }] }
+          : {},
+      },
+    },
+  });
+}
 
 describe("isFileTooLargeToDownloadError", () => {
   it("detects the node-fetch max-size error raised when maxContentLength is exceeded", () => {
@@ -50,5 +70,40 @@ describe("isFileTooLargeToDownloadError", () => {
     ).toBe(false);
     expect(isFileTooLargeToDownloadError("not an error")).toBe(false);
     expect(isFileTooLargeToDownloadError(null)).toBe(false);
+  });
+});
+
+describe("isGoogleDriveRateLimitError", () => {
+  it("detects a 403 'User rate limit exceeded' error", () => {
+    expect(
+      isGoogleDriveRateLimitError(makeGaxiosError(403, "userRateLimitExceeded"))
+    ).toBe(true);
+  });
+
+  it("detects other rate-limit reasons on 403 and 429", () => {
+    expect(
+      isGoogleDriveRateLimitError(makeGaxiosError(403, "rateLimitExceeded"))
+    ).toBe(true);
+    expect(
+      isGoogleDriveRateLimitError(makeGaxiosError(429, "rateLimitExceeded"))
+    ).toBe(true);
+  });
+
+  it("does not confuse a 403 permission loss with a rate limit", () => {
+    expect(
+      isGoogleDriveRateLimitError(
+        makeGaxiosError(403, "insufficientFilePermissions")
+      )
+    ).toBe(false);
+    // 403 with no structured reason (bare permission denial).
+    expect(isGoogleDriveRateLimitError(makeGaxiosError(403))).toBe(false);
+  });
+
+  it("returns false for unrelated statuses and non-Gaxios errors", () => {
+    expect(
+      isGoogleDriveRateLimitError(makeGaxiosError(404, "rateLimitExceeded"))
+    ).toBe(false);
+    expect(isGoogleDriveRateLimitError(new Error("boom"))).toBe(false);
+    expect(isGoogleDriveRateLimitError(null)).toBe(false);
   });
 });

--- a/connectors/src/connectors/google_drive/temporal/utils.ts
+++ b/connectors/src/connectors/google_drive/temporal/utils.ts
@@ -405,3 +405,42 @@ export function isSharedDriveNotFoundError(error: unknown): boolean {
 
   return false;
 }
+
+// Google answers 403 (and sometimes 429) for rate-limit/quota exhaustion, with a
+// `reason` such as `userRateLimitExceeded` or `rateLimitExceeded` (message: "User rate
+// limit exceeded."). These are transient and must be retried, not confused with a
+// permanent loss of access (which is also a 403).
+const GOOGLE_DRIVE_RATE_LIMIT_REASONS = new Set([
+  "userRateLimitExceeded",
+  "rateLimitExceeded",
+  "sharingRateLimitExceeded",
+  "dailyLimitExceeded",
+  "quotaExceeded",
+]);
+
+export function isGoogleDriveRateLimitError(error: unknown): boolean {
+  if (!(error instanceof GaxiosError)) {
+    return false;
+  }
+
+  const status = error.response?.status;
+  if (status !== 403 && status !== 429) {
+    return false;
+  }
+
+  const errorData = error.response?.data?.error;
+  if (!errorData) {
+    return false;
+  }
+
+  const errors = errorData.errors;
+  if (Array.isArray(errors)) {
+    return errors.some(
+      (err) =>
+        typeof err.reason === "string" &&
+        GOOGLE_DRIVE_RATE_LIMIT_REASONS.has(err.reason)
+    );
+  }
+
+  return false;
+}

--- a/connectors/src/connectors/google_drive/temporal/utils.ts
+++ b/connectors/src/connectors/google_drive/temporal/utils.ts
@@ -418,7 +418,9 @@ const GOOGLE_DRIVE_RATE_LIMIT_REASONS = new Set([
   "quotaExceeded",
 ]);
 
-export function isGoogleDriveRateLimitError(error: unknown): boolean {
+export function isGoogleDriveRateLimitError(
+  error: unknown
+): error is GaxiosError {
   if (!(error instanceof GaxiosError)) {
     return false;
   }


### PR DESCRIPTION
## Description

Fixes intermittent "Google Drive connector not syncing" ([tasks#10311](https://github.com/dust-tt/tasks/issues/10311)), where syncs stall with `User rate limit exceeded.` errors.

**Root cause:** Google Drive returns **HTTP 403** (not 429) for user rate-limit/quota exhaustion, with `reason: "userRateLimitExceeded"` (message `"User rate limit exceeded."`). The `incrementalSync` activity's top-level `catch` treated **any** 403 as *"Looks like we lost access to this drive. Skipping"* and returned `undefined`. The workflow reads `undefined` as "no more pages" and stops **without advancing the sync page token** — so a transient rate-limit silently halts the drive's incremental sync and leaves it stale. Separately, the activity interceptor only mapped **429** to a retryable `rate_limit_error`, so 403 rate-limits bypassed it entirely.

The spreadsheets path already documents this exact trap (`spreadsheets.ts:745`), but the incremental-sync path never applied the same disambiguation.

**Changes:**
- `utils.ts`: new `isGoogleDriveRateLimitError()` helper matching 403/429 with rate-limit reasons (`userRateLimitExceeded`, `rateLimitExceeded`, `sharingRateLimitExceeded`, `dailyLimitExceeded`, `quotaExceeded`).
- `incremental_sync.ts`: re-throw rate-limit errors (bare `GaxiosError` and the `WithRetriesError` wrapper) **before** the "lost access → skip" branch, so Temporal retries with backoff instead of silently skipping the drive.
- `cast_known_errors.ts`: map 403 rate-limit errors to a retryable `rate_limit_error`, consistent with the existing 429 handling (clean classification + metrics).

## Tests

- Added 8 focused unit tests for `isGoogleDriveRateLimitError` (403/429 detection, permission-loss vs. rate-limit disambiguation, non-Gaxios inputs) in `utils.test.ts`. All pass.
- `tsc --noEmit` clean on the touched files.

## Risk

Low. The change narrows an existing overly-broad 403 handler: genuine permission-loss 403s still skip the drive as before; only rate-limit/quota 403s now retry instead of being swallowed. Retries use Temporal's default exponential backoff. Interceptor ordering (cast before log) is unchanged and matches the existing 429 path.

## Deploy Plan

Standard connectors deploy. No migration, no config change.