### PR TITLE
TEMP: self-heal stale user_usage rows once Metronome activities unstick

### DIFF
--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -3,6 +3,10 @@ import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/toke
 import type { TokenUsage } from "@app/lib/api/llm/types/events";
 import type { Authenticator } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
+import {
+  USAGE_TYPE_PROGRAMMATIC,
+  USAGE_TYPE_USER,
+} from "@app/lib/metronome/constants";
 import type { UsageType } from "@app/lib/metronome/types";
 import type { ServiceTier } from "@app/lib/model_constructors/types/input/configuration";
 import type { Region } from "@app/lib/model_constructors/types/regions";
@@ -289,6 +293,40 @@ export class RunResource extends BaseResource<RunModel> {
         where: {
           runId: { [Op.in]: runModelIds },
           usageType: null,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+      }
+    );
+  }
+
+  // TEMP(self-heal): corrects rows misclassified "user" by the pre-fix live
+  // classifier for unattributed Slack messages (front/lib/api/programmatic_usage/common.ts's
+  // isProgrammaticUsageFromContext fallback landed after these runs were created).
+  // Only ever promotes user -> programmatic — the recomputed value passed in
+  // by the caller is the same one already used to bill Metronome for these
+  // runs, so this just brings our own ledger back in sync with what was
+  // actually billed. Scoped to exactly the runs the caller just reclassified,
+  // never a blanket overwrite.
+  // TODO(2026-09-21): remove once the stuck-activity backlog has drained
+  // (i.e. once no more emitMetronomeUsageEventsActivity retries land here) —
+  // this whole method and its call site in temporal/usage_queue/activities.ts.
+  static async selfHealSlackUsageTypeForRuns(
+    auth: Authenticator,
+    { runs, usageType }: { runs: RunResource[]; usageType: UsageType }
+  ): Promise<void> {
+    if (usageType !== USAGE_TYPE_PROGRAMMATIC) {
+      return;
+    }
+    const runModelIds = runs.map((run) => run.id);
+    if (runModelIds.length === 0) {
+      return;
+    }
+    await RunUsageModel.update(
+      { usageType: USAGE_TYPE_PROGRAMMATIC },
+      {
+        where: {
+          runId: { [Op.in]: runModelIds },
+          usageType: USAGE_TYPE_USER,
           workspaceId: auth.getNonNullableWorkspace().id,
         },
       }

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -466,6 +466,11 @@ export async function emitMetronomeUsageEventsActivity(
 
   await ingestMetronomeEvents(usageEvents);
 
+  // TEMP(self-heal): see RunResource.selfHealSlackUsageTypeForRuns for why
+  // this exists. Remove this call together with that method once the
+  // stuck-activity backlog has drained after release.
+  await RunResource.selfHealSlackUsageTypeForRuns(auth, { runs, usageType });
+
   // Per-key cap enforcement is pull-based: Metronome spend alerts can't
   // attribute spend by `api_key_name` (it's not the products' presentation
   // group key), so we reconcile the key's credit state from live usage instead


### PR DESCRIPTION
## Description

emitMetronomeUsageEventsActivity already recomputes usage_type fresh on every run (with the new unattributed-Slack fallback), so once this deploy unblocks the currently-stuck activities they'll bill Metronome
correctly as programmatic — but RunUsageModel.usageType for those same runs stays frozen at the old wrong "user" classification, since nothing else touches an already-classified row.

Piggyback the correction on the same activity: it already knows the freshly-recomputed usage_type and the exact runs it's billing, so promote user -> programmatic there once Metronome ingestion succeeds. Scoped narrowly (only that one transition, only the runs just reclassified) so it's safe to drop once the backlog has drained — see the TODO on RunResource.selfHealSlackUsageTypeForRuns.

This only self-heals runs tied to currently-stuck retries (plus all new messages going forward, where it's a no-op). Messages that already succeeded under the old bug, before this release, aren't touched.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://app.notion.com/p/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

**IMPORTANT:** Should be deployed alongside https://github.com/dust-tt/dust/pull/31943