### PR TITLE
[front] fix: BigQuery connect Save button stuck loading before credentials

### DIFF
--- a/front/lib/swr/bigquery.ts
+++ b/front/lib/swr/bigquery.ts
@@ -20,6 +20,7 @@ export function useBigQueryLocations({
     }); // Serialize with body to ensure uniqueness.
   }, [url, credentials]);
 
+  const disabled = !credentials;
   const { data, error, mutate } = useSWRWithDefaults<
     string,
     PostCheckBigQueryLocationsResponseBody
@@ -32,12 +33,12 @@ export function useBigQueryLocations({
 
       return fetcherWithBody([url, { credentials }, "POST"]);
     },
-    { disabled: !credentials }
+    { disabled }
   );
 
   return {
     locations: data?.locations ?? undefined,
-    isLocationsLoading: !error && !data,
+    isLocationsLoading: !error && !data && !disabled,
     isLocationsError: !!error,
     error: error?.error,
     mutateLocations: mutate,


### PR DESCRIPTION
## Description

Fixes #31964.

The BigQuery connection setup modal's **Save** button rendered disabled and in a loading (spinner) state *before any credentials were entered*, so the connection could not be created.

The fix gates `isLocationsLoading` on `disabled` flag , so it reports not-loading until credentials are provided.

## Tests

Manual reasoning + type-check. Before: opening the BigQuery connect modal shows Save disabled + spinning with no credentials. After: Save is simply disabled (no spinner) until a valid service-account JSON is pasted, at which point the location check runs and drives the button state as intended. No behavioral change once credentials are present.

## Risk

Very low — one-line change to a derived loading boolean in a single SWR hook used only by the BigQuery connection modal.

## Deploy Plan

Standard front deploy. No migration, no config, no feature flag.