### PR TITLE
Spend caps: free seats never blocked by workspace pool depletion

### DIFF
--- a/front/lib/metronome/user_block.test.ts
+++ b/front/lib/metronome/user_block.test.ts
@@ -186,6 +186,42 @@ describe("isUserBlockedByMetronome", () => {
     expect(blocked).toBe("credits_exhausted");
   });
 
+  it("does not block a 'free' seat when the pool is depleted, even with a stale 'capped' state, once the rate cap clears", async () => {
+    // Regression: a free seat spends from its own lifetime allowance, never the
+    // pool. After a credit regrant the rate limiter clears
+    // (userCapBlockedOverride=false), but the webhook-driven creditState/pool
+    // status can still read stale ("capped"/"depleted"). The seat-type carve-out
+    // must unblock the free seat without waiting on the webhook.
+    mockGetActiveMembershipOfUserInWorkspace.mockResolvedValue({
+      seatType: "free",
+    });
+    redisValues.set("metronome:user_credit_state:ws_test:u_test", "capped");
+    redisValues.set("metronome:pool_credit_status:ws_test", "depleted");
+
+    const blocked = await isUserBlockedByMetronome(workspace, user, {
+      userCapBlockedOverride: false,
+    });
+
+    expect(blocked).toBeNull();
+  });
+
+  it("still blocks a non-free pool seat when the pool is depleted (carve-out is scoped to free seats)", async () => {
+    // Contrast to the free-seat carve-out: a pool seat genuinely draws from the
+    // workspace pool, so pool depletion must still block it even when the rate
+    // cap is clear.
+    mockGetActiveMembershipOfUserInWorkspace.mockResolvedValue({
+      seatType: "pro",
+    });
+    redisValues.set("metronome:user_credit_state:ws_test:u_test", "on_pool");
+    redisValues.set("metronome:pool_credit_status:ws_test", "depleted");
+
+    const blocked = await isUserBlockedByMetronome(workspace, user, {
+      userCapBlockedOverride: false,
+    });
+
+    expect(blocked).toBe("credits_exhausted");
+  });
+
   it("does not block a warned 'on_pool_low_balance' user when pool is active", async () => {
     redisValues.set(
       "metronome:user_credit_state:ws_test:u_test",

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -462,8 +462,19 @@ export async function isUserBlockedByMetronome(
 
   // A user spending from their personal seat balance (`user_seat` /
   // `user_seat_low_balance`) still has their own credits, so workspace pool
-  // depletion must not block them — only their per-user cap can.
-  if (workspacePoolDepleted && isSpendingFromPersonalSeat(userCreditState)) {
+  // depletion must not block them — only their per-user cap can. A free seat is
+  // the same case: it spends from its own lifetime credit allowance (enforced by
+  // the per-user rate cap) and never from the workspace pool, so pool depletion
+  // must not block it either. Keying the free-seat carve-out on `seatType`
+  // (rather than the credit state) matters under the rate-cap flag: it keeps the
+  // free seat's blocking governed solely by the fresh rate-limiter counter, so a
+  // credit regrant unblocks immediately instead of waiting on the webhook that
+  // clears the stale `poolCreditState` / `creditState`.
+  if (
+    workspacePoolDepleted &&
+    (isSpendingFromPersonalSeat(userCreditState) ||
+      membership?.seatType === "free")
+  ) {
     workspacePoolDepleted = false;
   }
 


### PR DESCRIPTION
## Description

A free seat spends from its **own lifetime credit allowance** (enforced by the per-user rate cap, `isFreeSeatLifetimeCapReached`) and **never** from the shared workspace pool. But `isUserBlockedByMetronome` only carved pool depletion out for personal-seat *credit states* (`user_seat` / `user_seat_low_balance`), so a free seat whose `creditState` was `capped` or `on_pool` was still returned as `credits_exhausted` whenever `poolCreditState` showed `depleted`.

Under the `enforce_user_spend_limit_rate_cap` flag this stranded free users after a credit regrant:
- The per-user cap comes from the fresh Redis rate-limiter counter → the input-bar warning clears and the user appears able to post.
- But `deriveBlockedReason` falls through to `workspacePoolDepleted`, which reads the **webhook-updated** `poolCreditState`. It's still `depleted`, so message posting stays blocked on `credits_exhausted` until the webhook eventually clears the stale state. The existing carve-out can't rescue it because the free seat's `creditState` is the equally-stale `capped`.

This extends the carve-out to also exempt free seats **by `seatType`** (structural, not credit-state), so a free seat's block status depends solely on the rate-limiter counter — a regrant unblocks immediately, with no webhook dependency.

The fix is correct in both flag modes: with the flag off, a truly-exhausted free seat is still blocked via `user_cap_reached` (`creditState === "capped"`), so there is no regression; a free seat with remaining lifetime allowance is (correctly) no longer blocked by unrelated pool depletion.

## Tests

Manually reproduced: a capped free user, after regranting credits, had the input bar clear but message posting still returned `credits_exhausted` until the Metronome webhook fired. With this change, posting is unblocked as soon as the rate-limiter counter reflects the regrant. Type-checked with `tsgo`.

## Risk

Low, narrowly scoped to one condition in `isUserBlockedByMetronome`. It only ever *removes* a block for free seats that never consume the pool; it cannot newly block anyone. Rollback is a trivial revert of the single hunk.

## Deploy Plan

Standard front deploy. No migration, no config, no coordinated ordering required.