### PR TITLE
Pause Google Drive connectors on admin policy errors

### DIFF
--- a/connectors/src/lib/oauth.test.ts
+++ b/connectors/src/lib/oauth.test.ts
@@ -1,0 +1,85 @@
+import { apiConfig } from "@connectors/lib/api/config";
+import { ExternalOAuthTokenError } from "@connectors/lib/error";
+import logger from "@connectors/logger/logger";
+import type { OAuthProvider } from "@connectors/types";
+import { OAuthAPI } from "@connectors/types";
+import { Err } from "@dust-tt/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getOAuthConnectionAccessTokenWithThrow } from "./oauth";
+
+const adminPolicyMessage = `Unknown error: Request failed for provider google_drive. Status: 400. Message {
+  "error": "admin_policy_enforced",
+  "error_description": "a"
+}.`;
+
+describe("getOAuthConnectionAccessTokenWithThrow", () => {
+  beforeEach(() => {
+    vi.spyOn(apiConfig, "getOAuthAPIConfig").mockReturnValue({
+      url: "https://oauth.example.com",
+      apiKey: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    { name: "admin policy enforcement", message: adminPolicyMessage },
+    { name: "a restricted account", message: "Account Restricted" },
+  ])("classifies $name as an OAuth access error", async ({ message }) => {
+    vi.spyOn(OAuthAPI.prototype, "getAccessToken").mockResolvedValueOnce(
+      new Err({ code: "provider_access_token_refresh_error", message })
+    );
+
+    await expect(
+      getOAuthConnectionAccessTokenWithThrow({
+        logger,
+        provider: "google_drive",
+        connectionId: "test-connection",
+      })
+    ).rejects.toThrow(ExternalOAuthTokenError);
+  });
+
+  it.each([
+    {
+      provider: "google_drive",
+      code: "provider_access_token_refresh_error",
+      message: "temporarily_unavailable",
+    },
+    {
+      provider: "microsoft",
+      code: "provider_access_token_refresh_error",
+      message: adminPolicyMessage,
+    },
+    {
+      provider: "google_drive",
+      code: "unexpected_network_error",
+      message: adminPolicyMessage,
+    },
+  ] satisfies {
+    provider: OAuthProvider;
+    code: string;
+    message: string;
+  }[])("keeps unrelated $provider $code failures retryable", async ({
+    provider,
+    code,
+    message,
+  }) => {
+    vi.spyOn(OAuthAPI.prototype, "getAccessToken").mockResolvedValueOnce(
+      new Err({ code, message })
+    );
+
+    const token = getOAuthConnectionAccessTokenWithThrow({
+      logger,
+      provider,
+      connectionId: "test-connection",
+    });
+
+    await expect(token).rejects.toThrow(
+      `Error retrieving access token from ${provider}: code=${code} message=${message}`
+    );
+    await expect(token).rejects.not.toBeInstanceOf(ExternalOAuthTokenError);
+  });
+});

--- a/connectors/src/lib/oauth.ts
+++ b/connectors/src/lib/oauth.ts
@@ -4,9 +4,11 @@ import type { OAuthConnectionType, OAuthProvider } from "@connectors/types";
 import { getOAuthConnectionAccessToken } from "@connectors/types";
 import type { LoggerInterface } from "@dust-tt/client";
 
-// Most connectors are built on the assumption that errors are thrown with special handling of
-// selected errors such as ExternalOauthTokenError. This function is used to retrieve an OAuth
-// connection access token and throw an ExternalOauthTokenError if the token is revoked.
+/**
+ * @cc [label:error-handling] google-drive-admin-policy-error
+ * Google Drive token refresh failures containing `admin_policy_enforced` must throw
+ * `ExternalOAuthTokenError` to trigger the connector's existing pause-and-stop handling.
+ */
 export async function getOAuthConnectionAccessTokenWithThrow({
   logger,
   provider,
@@ -44,9 +46,11 @@ export async function getOAuthConnectionAccessTokenWithThrow({
       (tokRes.error.code === "provider_access_token_refresh_error" &&
         (tokRes.error.message.includes("invalid_grant") ||
           tokRes.error.message.includes("invalid_client"))) ||
-      // Happens with google drive
+      // Happens with Google Drive.
       (tokRes.error.code === "provider_access_token_refresh_error" &&
-        tokRes.error.message.includes("Account Restricted"))
+        (tokRes.error.message.includes("Account Restricted") ||
+          (provider === "google_drive" &&
+            tokRes.error.message.includes("admin_policy_enforced"))))
     ) {
       throw new ExternalOAuthTokenError(new Error(tokRes.error.message));
     } else {

--- a/connectors/src/lib/oauth.ts
+++ b/connectors/src/lib/oauth.ts
@@ -7,7 +7,8 @@ import type { LoggerInterface } from "@dust-tt/client";
 /**
  * @cc [label:error-handling] oauth-access-token-or-error
  * Return the retrieved token and connection data on success. Revoked tokens, missing connections,
- * and recognized provider authorization failures must throw `ExternalOAuthTokenError`; other OAuth
+ * and recognized provider authorization failures, including platform-specific handling for
+ * Confluence, Microsoft, Gong, and Google Drive, must throw `ExternalOAuthTokenError`. Other OAuth
  * failures must throw `Error` with the provider, error code, and message.
  */
 export async function getOAuthConnectionAccessTokenWithThrow({

--- a/connectors/src/lib/oauth.ts
+++ b/connectors/src/lib/oauth.ts
@@ -6,10 +6,9 @@ import type { LoggerInterface } from "@dust-tt/client";
 
 /**
  * @cc [label:error-handling] oauth-access-token-or-error
- * Return the retrieved token and connection data on success. Revoked tokens, missing connections,
- * and recognized provider authorization failures, including platform-specific handling for
- * Confluence, Microsoft, Gong, and Google Drive, must throw `ExternalOAuthTokenError`. Other OAuth
- * failures must throw `Error` with the provider, error code, and message.
+ * Return the retrieved token and connection data from `oauth` on success. Generic `oauth` errors
+ * and well-known provider specific error codes throw `ExternalOAuthTokenError`. Other unrecognized
+ * OAuth failures throw regular `Error` (generally leading to retries).
  */
 export async function getOAuthConnectionAccessTokenWithThrow({
   logger,
@@ -39,6 +38,7 @@ export async function getOAuthConnectionAccessTokenWithThrow({
     );
 
     if (
+      // Generic oauth error codes
       tokRes.error.code === "token_revoked_error" ||
       tokRes.error.code === "connection_not_found" ||
       // Happens with confluence

--- a/connectors/src/lib/oauth.ts
+++ b/connectors/src/lib/oauth.ts
@@ -5,9 +5,10 @@ import { getOAuthConnectionAccessToken } from "@connectors/types";
 import type { LoggerInterface } from "@dust-tt/client";
 
 /**
- * @cc [label:error-handling] google-drive-admin-policy-error
- * Google Drive token refresh failures containing `admin_policy_enforced` must throw
- * `ExternalOAuthTokenError` to trigger the connector's existing pause-and-stop handling.
+ * @cc [label:error-handling] oauth-access-token-or-error
+ * Return the retrieved token and connection data on success. Revoked tokens, missing connections,
+ * and recognized provider authorization failures must throw `ExternalOAuthTokenError`; other OAuth
+ * failures must throw `Error` with the provider, error code, and message.
  */
 export async function getOAuthConnectionAccessTokenWithThrow({
   logger,

--- a/connectors/src/lib/temporal_monitoring.test.ts
+++ b/connectors/src/lib/temporal_monitoring.test.ts
@@ -64,6 +64,7 @@ vi.mock("dd-trace", () => ({
 import logger from "@connectors/logger/logger";
 
 import {
+  ExternalOAuthTokenError,
   RemoteDatabaseConnectionNotReadonlyError,
   ThirdPartyConfigurationError,
 } from "./error";
@@ -78,7 +79,7 @@ const temporalLogger = {
   warn: vi.fn(),
 } satisfies TemporalLogger;
 
-function makeActivityContext() {
+function makeActivityContext(workflowType = "snowflakeSyncWorkflow") {
   const info = {
     activityId: "activity-id",
     activityNamespace: "default",
@@ -98,7 +99,7 @@ function makeActivityContext() {
       workflowId: "workflow-id",
     },
     workflowNamespace: "default",
-    workflowType: "snowflakeSyncWorkflow",
+    workflowType,
   } satisfies Info;
 
   return new Context(
@@ -131,6 +132,37 @@ describe("ActivityInboundLogInterceptor", () => {
         setTag: vi.fn(),
       })
     );
+  });
+
+  it("marks Google Drive OAuth failures and pauses the connector", async () => {
+    mocks.fetchById.mockResolvedValue({
+      dataSourceId: "data-source-id",
+      id: 42,
+      type: "google_drive",
+      workspaceId: "workspace-id",
+    });
+    const interceptor = new ActivityInboundLogInterceptor(
+      makeActivityContext("googleDriveIncrementalSyncV2"),
+      logger,
+      "google_drive"
+    );
+    const error = new ExternalOAuthTokenError(
+      new Error("admin_policy_enforced")
+    );
+    const input = {
+      args: [],
+      headers: {},
+    } satisfies ActivityExecuteInput;
+    const next = vi.fn(async () => {
+      throw error;
+    }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+
+    await expect(interceptor.execute(input, next)).rejects.toBe(error);
+
+    expect(mocks.syncFailed).toHaveBeenCalledWith(42, "oauth_token_revoked");
+    expect(mocks.pauseAndStop).toHaveBeenCalledWith({
+      reason: "Stopped on ExternalOAuthTokenError",
+    });
   });
 
   it("marks Snowflake read-only failures and pauses the connector", async () => {


### PR DESCRIPTION
## Description

Google Drive OAuth refresh failures with `admin_policy_enforced` currently surface as generic errors, leaving sync activities retrying for days. Classify this Google-specific refresh error as `ExternalOAuthTokenError` so the existing handler marks the connector `oauth_token_revoked`, pauses it, and stops its workflows.

Google documents [`admin_policy_enforced`](https://developers.google.com/identity/protocols/oauth2/web-server#authorization-errors-admin-policy-enforced) as:

> The Google Account is unable to authorize one or more scopes requested due to the policies of their Google Workspace administrator.

The [refresh token documentation](https://developers.google.com/identity/protocols/oauth2#expiration) also explicitly lists this error when an administrator restricts a service requested by the app.

## Tests

Ran the OAuth and Temporal monitoring regression tests: 9 tests passed. The captured Google policy-error test fails before the fix and passes afterward. Coverage includes existing account restrictions, provider/error scoping, transient failures, and the automatic pause handler.

## Risk

Low. Uses the existing OAuth failure and pause path. Google Workspace policy must be corrected before the connection can be restored.

## Deploy Plan

Deploy `connectors`, including the Google Drive workers. Affected running connectors will pause on their next `admin_policy_enforced` failure after rollout.
