### PR TITLE
Data sources carry their Qdrant shard key, collections declare their layout

### DIFF
--- a/core/bin/qdrant/count_points_per_data_source.rs
+++ b/core/bin/qdrant/count_points_per_data_source.rs
@@ -5,7 +5,7 @@ use csv::Writer;
 use dust::{
     data_sources::{
         data_source::{DataSource, DataSourceConfig},
-        qdrant::{QdrantClients, QdrantTenant, SHARD_KEY_COUNT},
+        qdrant::{QdrantClients, QdrantTenant},
     },
     project::Project,
     stores::{postgres::PostgresStore, store::Store},
@@ -15,7 +15,7 @@ use std::env;
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    /// Shard key id to scan (0..SHARD_KEY_COUNT). If provided, only data sources that
+    /// Shard key id to scan (the numeric part of key_<n>). If provided, only data sources that
     /// map to this shard key will be counted. If omitted, all data sources are counted.
     #[arg(short, long)]
     shard_key_id: Option<u64>,
@@ -24,12 +24,6 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
-
-    if let Some(shard_key_id) = args.shard_key_id {
-        if shard_key_id >= SHARD_KEY_COUNT {
-            return Err(anyhow!("shard_key_id must be in [0, {})", SHARD_KEY_COUNT));
-        }
-    }
 
     let store = PostgresStore::new(
         &env::var("CORE_DATABASE_URI").map_err(|_| anyhow!("CORE_DATABASE_URI is required"))?,

--- a/core/bin/qdrant/count_points_per_data_source.rs
+++ b/core/bin/qdrant/count_points_per_data_source.rs
@@ -59,9 +59,8 @@ async fn main() -> Result<()> {
             .filter(|row| {
                 let internal_id: String = row.get(2);
                 let config_json: String = row.get(3);
-                let config: DataSourceConfig = match serde_json::from_str(&config_json) {
-                    Ok(config) => config,
-                    Err(_) => return false,
+                let Ok(config) = serde_json::from_str::<DataSourceConfig>(&config_json) else {
+                    return false;
                 };
                 let tenant = QdrantTenant {
                     internal_id: &internal_id,

--- a/core/bin/qdrant/count_points_per_data_source.rs
+++ b/core/bin/qdrant/count_points_per_data_source.rs
@@ -5,7 +5,7 @@ use csv::Writer;
 use dust::{
     data_sources::{
         data_source::{DataSource, DataSourceConfig},
-        qdrant::{DustQdrantClient, QdrantClients, SHARD_KEY_COUNT},
+        qdrant::{QdrantClients, QdrantTenant, SHARD_KEY_COUNT},
     },
     project::Project,
     stores::{postgres::PostgresStore, store::Store},
@@ -58,7 +58,19 @@ async fn main() -> Result<()> {
             .iter()
             .filter(|row| {
                 let internal_id: String = row.get(2);
-                match DustQdrantClient::shard_key_id_from_internal_id(&internal_id) {
+                let config_json: String = row.get(3);
+                let config: DataSourceConfig = match serde_json::from_str(&config_json) {
+                    Ok(config) => config,
+                    Err(_) => return false,
+                };
+                let tenant = QdrantTenant {
+                    internal_id: &internal_id,
+                    shard_keys: &config.qdrant_config.shard_keys,
+                };
+                match qdrant_clients
+                    .client(config.qdrant_config.cluster)
+                    .shard_key_id(&tenant)
+                {
                     Ok(key_id) => key_id == shard_key_id,
                     Err(_) => false,
                 }
@@ -139,12 +151,7 @@ async fn main() -> Result<()> {
         let qdrant_client = ds.main_qdrant_client(&qdrant_clients);
 
         let (point_count_str, error_str) = match qdrant_client
-            .count_points(
-                &ds.embedder_config(),
-                &ds.internal_id().to_string(),
-                None,
-                false,
-            )
+            .count_points(&ds.embedder_config(), &ds.qdrant_tenant(), None, false)
             .await
         {
             Ok(response) => {

--- a/core/bin/qdrant/create_collection.rs
+++ b/core/bin/qdrant/create_collection.rs
@@ -34,6 +34,18 @@ struct Args {
     /// Name of the cluster.
     #[arg(short, long)]
     cluster: QdrantCluster,
+
+    /// Number of shard keys. Data sources hash into them, one key per data source.
+    #[arg(long, default_value_t = SHARD_KEY_COUNT)]
+    shard_key_count: u64,
+
+    /// Number of shards behind each shard key, spread across the nodes.
+    #[arg(long, default_value_t = 2)]
+    shards_per_key: u32,
+
+    /// Number of copies of each shard.
+    #[arg(long, default_value_t = 2)]
+    replication_factor: u32,
 }
 
 async fn create_indexes_for_collection(
@@ -89,11 +101,10 @@ async fn create_indexes_for_collection(
     Ok(())
 }
 
-async fn create_qdrant_collection(
-    cluster: QdrantCluster,
-    provider_id: ProviderID,
-    model_id: SupportedEmbedderModels,
-) -> Result<()> {
+async fn create_qdrant_collection(args: &Args) -> Result<()> {
+    let cluster = args.cluster;
+    let provider_id = args.provider;
+    let model_id = args.model.clone();
     let qdrant_clients = QdrantClients::build().await?;
     let client = qdrant_clients.client(cluster);
     let raw_client = client.raw_client();
@@ -151,8 +162,8 @@ async fn create_qdrant_collection(
     if use_sharding {
         builder = builder
             .sharding_method(qdrant::ShardingMethod::Custom.into())
-            .shard_number(2)
-            .replication_factor(2)
+            .shard_number(args.shards_per_key)
+            .replication_factor(args.replication_factor)
             .write_consistency_factor(1);
     }
 
@@ -172,8 +183,8 @@ async fn create_qdrant_collection(
 
     // Only create shard keys when sharding is enabled
     if use_sharding {
-        // Then, we create the 24 shard_keys.
-        for i in 0..SHARD_KEY_COUNT {
+        // Then, we create the shard keys.
+        for i in 0..args.shard_key_count {
             let shard_key = format!("{}_{}", client.shard_key_prefix(), i);
 
             let operation_result = raw_client
@@ -228,12 +239,10 @@ async fn main() -> Result<(), anyhow::Error> {
         std::process::exit(1);
     }
 
-    create_qdrant_collection(args.cluster, args.provider, args.model)
-        .await
-        .map_err(|e| {
-            eprintln!("Error creating collection: {}", e);
-            e
-        })?;
+    create_qdrant_collection(&args).await.map_err(|e| {
+        eprintln!("Error creating collection: {}", e);
+        e
+    })?;
 
     Ok(())
 }

--- a/core/bin/qdrant/create_collection.rs
+++ b/core/bin/qdrant/create_collection.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, Result};
 use clap::Parser;
 use dust::{
-    data_sources::qdrant::{QdrantClients, QdrantCluster, SHARD_KEY_COUNT},
+    data_sources::qdrant::{QdrantClients, QdrantCluster, LEGACY_SHARD_KEY_COUNT},
     providers::{
         embedder::{EmbedderProvidersModelMap, SupportedEmbedderModels},
         provider::{provider, ProviderID},
@@ -36,7 +36,7 @@ struct Args {
     cluster: QdrantCluster,
 
     /// Number of shard keys. Data sources hash into them, one key per data source.
-    #[arg(long, default_value_t = SHARD_KEY_COUNT)]
+    #[arg(long, default_value_t = LEGACY_SHARD_KEY_COUNT)]
     shard_key_count: u64,
 
     /// Number of shards behind each shard key, spread across the nodes.

--- a/core/bin/qdrant/delete_orphaned_points.rs
+++ b/core/bin/qdrant/delete_orphaned_points.rs
@@ -38,7 +38,7 @@ async fn delete_orphaned_points_for_document_id(
     };
 
     qdrant_client
-        .delete_points(&ds.embedder_config(), &ds.internal_id().to_string(), filter)
+        .delete_points(&ds.embedder_config(), &ds.qdrant_tenant(), filter)
         .await?;
 
     println!(

--- a/core/bin/qdrant/migrator.rs
+++ b/core/bin/qdrant/migrator.rs
@@ -144,16 +144,28 @@ async fn set_shadow_write(
 
     let mut config = ds.config().clone();
 
-    config.qdrant_config = QdrantDataSourceConfig {
-        cluster: config.qdrant_config.cluster,
-        shadow_write_cluster: Some(QdrantCluster::from_str(cluster.as_str())?),
-    };
+    let shadow_write_cluster = QdrantCluster::from_str(cluster.as_str())?;
+    config.qdrant_config.shadow_write_cluster = Some(shadow_write_cluster);
 
-    // Create collection on shadow_write_cluster.
-    let shadow_write_qdrant_client = match ds.shadow_write_qdrant_client(&qdrant_clients) {
-        Some(client) => client,
-        None => unreachable!(),
-    };
+    // The shadow cluster's collection decides the data source's key there.
+    let shadow_write_qdrant_client = qdrant_clients.client(shadow_write_cluster);
+    match shadow_write_qdrant_client
+        .assign_shard_key(ds.embedder_config(), ds.internal_id())
+        .await?
+    {
+        Some(key) => {
+            config
+                .qdrant_config
+                .shard_keys
+                .insert(shadow_write_cluster, key);
+        }
+        None => {
+            config
+                .qdrant_config
+                .shard_keys
+                .remove(&shadow_write_cluster);
+        }
+    }
 
     utils::done(&format!(
         "Created data source on shadow_write_cluster: \
@@ -238,10 +250,13 @@ async fn clear_shadow_write(
     // Remove shadow_write_cluster from config.
     let mut config = ds.config().clone();
 
-    config.qdrant_config = QdrantDataSourceConfig {
-        cluster: config.qdrant_config.cluster,
-        shadow_write_cluster: None,
-    };
+    if let Some(shadow_write_cluster) = config.qdrant_config.shadow_write_cluster {
+        config
+            .qdrant_config
+            .shard_keys
+            .remove(&shadow_write_cluster);
+    }
+    config.qdrant_config.shadow_write_cluster = None;
 
     ds.update_config(store, &config).await?;
 
@@ -408,6 +423,7 @@ async fn commit_shadow_write(
         Some(cluster) => QdrantDataSourceConfig {
             cluster,
             shadow_write_cluster: Some(config.qdrant_config.cluster),
+            shard_keys: config.qdrant_config.shard_keys.clone(),
         },
         None => Err(anyhow!("No shadow write cluster to commit"))?,
     };

--- a/core/bin/qdrant/shard_key_breakdown.rs
+++ b/core/bin/qdrant/shard_key_breakdown.rs
@@ -16,7 +16,7 @@ use anyhow::{anyhow, Error, Result};
 use clap::Parser;
 use dust::data_sources::{
     data_source::DataSourceConfig,
-    qdrant::{env_var_prefix_for_cluster, DustQdrantClient, QdrantClients, QdrantCluster},
+    qdrant::{env_var_prefix_for_cluster, QdrantClients, QdrantCluster, QdrantTenant},
 };
 use dust::stores::{postgres::PostgresStore, store::Store};
 use regex::Regex;
@@ -466,14 +466,17 @@ async fn gather_data_source_counts(
             }
         };
 
-        let shard_key_id = match DustQdrantClient::shard_key_id_from_internal_id(&internal_id) {
-            Ok(shard_key_id) => shard_key_id,
+        let tenant = QdrantTenant {
+            internal_id: &internal_id,
+            shard_keys: &config.qdrant_config.shard_keys,
+        };
+        let shard_key = match qdrant_client.shard_key_name(&tenant) {
+            Ok(shard_key) => shard_key,
             Err(_) => {
                 skipped += 1;
                 continue;
             }
         };
-        let shard_key = format!("{}_{}", qdrant_client.shard_key_prefix(), shard_key_id);
 
         let collection = qdrant_client.collection_name(&config.embedder_config.embedder);
         *counts.entry((collection, shard_key.clone())).or_insert(0) += 1;

--- a/core/bin/qdrant/test/fill_random_points.rs
+++ b/core/bin/qdrant/test/fill_random_points.rs
@@ -3,8 +3,8 @@
 //
 // Fills a Qdrant collection with random points spread over fake data sources, for local testing
 // of shard-key operations (e.g. qdrant_reshard). Data sources are assigned to shard keys the same
-// way production does (blake3(internal_id) % SHARD_KEY_COUNT via DustQdrantClient), so points
-// spread over all shard keys:
+// way production does (blake3(internal_id) modulo the collection's own key count, read from
+// Qdrant), so points spread over all shard keys:
 //
 //   fill_random_points --provider openai --model text-embedding-3-large-1536 \
 //     --cluster cluster-0 --data-sources 96 --points-per-data-source 1000
@@ -17,7 +17,7 @@ use clap::Parser;
 use dust::{
     data_sources::{
         data_source::EmbedderConfig,
-        qdrant::{env_var_prefix_for_cluster, QdrantClients, QdrantCluster},
+        qdrant::{env_var_prefix_for_cluster, QdrantClients, QdrantCluster, QdrantTenant},
         splitter::SplitterID,
     },
     providers::{
@@ -28,6 +28,7 @@ use dust::{
 };
 use qdrant_client::{qdrant, Payload};
 use rand::Rng;
+use std::collections::HashMap;
 use uuid::Uuid;
 
 #[derive(Parser, Debug)]
@@ -122,7 +123,22 @@ async fn main() -> Result<()> {
         let internal_id = blake3::hash(format!("fill_random_points-{}", d).as_bytes())
             .to_hex()
             .to_string();
-        let shard_key = client.shard_key_name(&internal_id)?;
+        // Routed like production: the collection's own key list decides the key.
+        let mut shard_keys = HashMap::new();
+        let shard_key = match client
+            .assign_shard_key(&embedder_config, &internal_id)
+            .await?
+        {
+            Some(key) => {
+                shard_keys.insert(client.cluster, key.clone());
+                key
+            }
+            None => "none".to_string(),
+        };
+        let tenant = QdrantTenant {
+            internal_id: &internal_id,
+            shard_keys: &shard_keys,
+        };
 
         let mut upserted = 0;
         while upserted < args.points_per_data_source {
@@ -152,7 +168,7 @@ async fn main() -> Result<()> {
                 .collect::<Vec<_>>();
 
             client
-                .upsert_points(&embedder_config, &internal_id, points)
+                .upsert_points(&embedder_config, &tenant, points)
                 .await?;
             upserted += batch_size;
         }

--- a/core/bin/qdrant/test/fill_random_points.rs
+++ b/core/bin/qdrant/test/fill_random_points.rs
@@ -28,7 +28,7 @@ use dust::{
 };
 use qdrant_client::{qdrant, Payload};
 use rand::Rng;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use uuid::Uuid;
 
 #[derive(Parser, Debug)]
@@ -124,17 +124,14 @@ async fn main() -> Result<()> {
             .to_hex()
             .to_string();
         // Routed like production: the collection's own key list decides the key.
-        let mut shard_keys = HashMap::new();
-        let shard_key = match client
+        let assigned = client
             .assign_shard_key(&embedder_config, &internal_id)
-            .await?
-        {
-            Some(key) => {
-                shard_keys.insert(client.cluster, key.clone());
-                key
-            }
-            None => "none".to_string(),
-        };
+            .await?;
+        let shard_keys: BTreeMap<_, _> = assigned
+            .iter()
+            .map(|key| (client.cluster, key.clone()))
+            .collect();
+        let shard_key = assigned.as_deref().unwrap_or("none");
         let tenant = QdrantTenant {
             internal_id: &internal_id,
             shard_keys: &shard_keys,

--- a/core/src/api/data_sources.rs
+++ b/core/src/api/data_sources.rs
@@ -157,7 +157,16 @@ pub async fn data_sources_register(
     Json(payload): Json<DataSourcesRegisterPayload>,
 ) -> (StatusCode, Json<APIResponse>) {
     let project = project::Project::new_from_id(project_id);
-    let ds = data_source::DataSource::new(&project, &payload.config, &payload.name);
+    let mut ds = data_source::DataSource::new(&project, &payload.config, &payload.name);
+
+    if let Err(e) = ds.assign_qdrant_shard_keys(&state.qdrant_clients).await {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal_server_error",
+            "Failed to assign a Qdrant shard key to the data source",
+            Some(e),
+        );
+    }
 
     match ds
         .register(state.store.clone(), state.search_store.clone())

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -481,12 +481,11 @@ impl DataSource {
         ];
         for cluster in clusters.into_iter().flatten() {
             let client = qdrant_clients.client(cluster);
-            let key = match client
+            let Some(key) = client
                 .assign_shard_key(self.embedder_config(), &self.internal_id)
                 .await?
-            {
-                Some(key) => key,
-                None => continue,
+            else {
+                continue;
             };
             if let Some(shadow_embedder) = &self.config.embedder_config.shadow_embedder {
                 let shadow_keys = client.shard_key_names(shadow_embedder).await?;

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -1,6 +1,6 @@
 use super::file_storage_document::FileStorageDocument;
 use super::node::ProviderVisibility;
-use super::qdrant::{DustQdrantClient, QdrantCluster};
+use super::qdrant::{DustQdrantClient, QdrantCluster, QdrantTenant};
 use crate::consts::DATA_SOURCE_DOCUMENT_SYSTEM_TAG_PREFIX;
 use crate::data_sources::qdrant::{QdrantClients, QdrantDataSourceConfig};
 use crate::data_sources::splitter::{splitter, SplitterID};
@@ -465,6 +465,45 @@ impl DataSource {
         self.config.qdrant_config.cluster
     }
 
+    pub fn qdrant_tenant(&self) -> QdrantTenant<'_> {
+        QdrantTenant {
+            internal_id: &self.internal_id,
+            shard_keys: &self.config.qdrant_config.shard_keys,
+        }
+    }
+
+    // Once at creation: every cluster the data source writes to hands out the key its collection
+    // layout dictates. A shadow embedder collection must agree on that key.
+    pub async fn assign_qdrant_shard_keys(&mut self, qdrant_clients: &QdrantClients) -> Result<()> {
+        let clusters = [
+            Some(self.main_qdrant_cluster()),
+            self.shadow_write_qdrant_cluster(),
+        ];
+        for cluster in clusters.into_iter().flatten() {
+            let client = qdrant_clients.client(cluster);
+            let key = match client
+                .assign_shard_key(self.embedder_config(), &self.internal_id)
+                .await?
+            {
+                Some(key) => key,
+                None => continue,
+            };
+            if let Some(shadow_embedder) = &self.config.embedder_config.shadow_embedder {
+                let shadow_keys = client.shard_key_names(shadow_embedder).await?;
+                if !shadow_keys.contains(&key) {
+                    Err(anyhow!(
+                        "Shard key {} missing from collection {} on cluster {}",
+                        key,
+                        client.collection_name(shadow_embedder),
+                        cluster
+                    ))?;
+                }
+            }
+            self.config.qdrant_config.shard_keys.insert(cluster, key);
+        }
+        Ok(())
+    }
+
     pub fn shadow_write_qdrant_cluster(&self) -> Option<QdrantCluster> {
         self.config.qdrant_config.shadow_write_cluster
     }
@@ -632,7 +671,7 @@ impl DataSource {
                 match qdrant_client
                     .set_payload(
                         embedder_config,
-                        &self.internal_id,
+                        &self.qdrant_tenant(),
                         filter.clone(),
                         payload.clone(),
                     )
@@ -661,7 +700,7 @@ impl DataSource {
         }
 
         qdrant_client
-            .set_payload(embedder_config, &self.internal_id, filter, payload)
+            .set_payload(embedder_config, &self.qdrant_tenant(), filter, payload)
             .await?;
 
         Ok(())
@@ -901,7 +940,7 @@ impl DataSource {
                 let scroll_results = qdrant_client
                     .scroll(
                         embedder_config,
-                        &self.internal_id,
+                        &self.qdrant_tenant(),
                         Some(qdrant::Filter {
                             must_not: vec![],
                             should: vec![],
@@ -1064,7 +1103,7 @@ impl DataSource {
 
         match self.shadow_write_qdrant_client(&qdrant_clients) {
             Some(qdrant_client) => match qdrant_client
-                .delete_points(embedder_config, &self.internal_id, filter.clone())
+                .delete_points(embedder_config, &self.qdrant_tenant(), filter.clone())
                 .await
             {
                 Ok(_) => {
@@ -1089,7 +1128,7 @@ impl DataSource {
         }
 
         qdrant_client
-            .delete_points(embedder_config, &self.internal_id, filter)
+            .delete_points(embedder_config, &self.qdrant_tenant(), filter)
             .await?;
 
         let deletion_duration = utils::now() - now;
@@ -1148,7 +1187,7 @@ impl DataSource {
                 match self.shadow_write_qdrant_client(&qdrant_clients) {
                     Some(qdrant_client) => {
                         match qdrant_client
-                            .upsert_points(embedder_config, &self.internal_id, chunk.clone())
+                            .upsert_points(embedder_config, &self.qdrant_tenant(), chunk.clone())
                             .await
                         {
                             Ok(_) => {
@@ -1174,7 +1213,7 @@ impl DataSource {
                 }
 
                 qdrant_client
-                    .upsert_points(embedder_config, &self.internal_id, chunk)
+                    .upsert_points(embedder_config, &self.qdrant_tenant(), chunk)
                     .await?;
             }
         }
@@ -1340,7 +1379,7 @@ impl DataSource {
                 let results = qdrant_client
                     .search_points(
                         self.embedder_config(),
-                        &self.internal_id,
+                        &self.qdrant_tenant(),
                         vec,
                         f,
                         top_k as u64,
@@ -1518,7 +1557,7 @@ impl DataSource {
                             let results_expand = match qdrant_client
                                 .scroll(
                                     &data_source.embedder_config(),
-                                    &data_source.internal_id,
+                                    &data_source.qdrant_tenant(),
                                     Some(filter),
                                     Some(new_offsets_count),
                                     None,
@@ -1654,7 +1693,7 @@ impl DataSource {
         info!(
             data_source_internal_id = self.internal_id(),
             qdrant_shard_key = qdrant_client
-                .shard_key_name(&self.internal_id)
+                .shard_key_name(&self.qdrant_tenant())
                 .unwrap_or_else(|_| "unknown".to_string()),
             document_count = documents.len(),
             chunk_count = documents.iter().map(|d| d.chunks.len()).sum::<usize>(),
@@ -1740,7 +1779,7 @@ impl DataSource {
                 let mut r = qdrant_client
                     .scroll(
                         &self.embedder_config(),
-                        &self.internal_id,
+                        &self.qdrant_tenant(),
                         Some(qdrant_batch_filter.clone()),
                         Some(qdrant_page_size),
                         page_offset,
@@ -1926,7 +1965,7 @@ impl DataSource {
 
         match self.shadow_write_qdrant_client(&qdrant_clients) {
             Some(qdrant_client) => match qdrant_client
-                .delete_points(embedder_config, &self.internal_id, filter.clone())
+                .delete_points(embedder_config, &self.qdrant_tenant(), filter.clone())
                 .await
             {
                 Ok(_) => {
@@ -1953,7 +1992,7 @@ impl DataSource {
         }
 
         match qdrant_client
-            .delete_points(embedder_config, &self.internal_id, filter)
+            .delete_points(embedder_config, &self.qdrant_tenant(), filter)
             .await
         {
             Ok(_) => {
@@ -2126,7 +2165,7 @@ impl DataSource {
         let store = store.clone();
 
         qdrant_client
-            .delete_all_points_for_internal_id(self.embedder_config(), &self.internal_id)
+            .delete_all_points_for_internal_id(self.embedder_config(), &self.qdrant_tenant())
             .await?;
 
         info!(

--- a/core/src/data_sources/qdrant.rs
+++ b/core/src/data_sources/qdrant.rs
@@ -1,9 +1,9 @@
 use crate::utils::ParseError;
 use anyhow::{anyhow, Result};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
 use std::str::FromStr;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use parking_lot::Mutex;
 use qdrant_client::{
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 
 use super::data_source::EmbedderConfig;
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Deserialize, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Deserialize, Eq, Hash, PartialOrd, Ord)]
 pub enum QdrantCluster {
     #[serde(rename = "cluster-0")]
     Cluster0,
@@ -81,25 +81,15 @@ pub struct QdrantDataSourceConfig {
     pub shadow_write_cluster: Option<QdrantCluster>,
     // Shard key of the data source in each cluster, assigned at creation from the key list of the
     // cluster's collection. Absent for data sources created before, routed by the legacy hash.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub shard_keys: HashMap<QdrantCluster, String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub shard_keys: BTreeMap<QdrantCluster, String>,
 }
 
 // What a request needs to know about its data source: the tenant filter value and the shard key.
+#[derive(Clone, Copy, Debug)]
 pub struct QdrantTenant<'a> {
     pub internal_id: &'a str,
-    pub shard_keys: &'a HashMap<QdrantCluster, String>,
-}
-
-impl<'a> QdrantTenant<'a> {
-    // A data source known by its internal id only, routed by the legacy hash.
-    pub fn legacy(internal_id: &'a str) -> Self {
-        static EMPTY: OnceLock<HashMap<QdrantCluster, String>> = OnceLock::new();
-        QdrantTenant {
-            internal_id,
-            shard_keys: EMPTY.get_or_init(HashMap::new),
-        }
-    }
+    pub shard_keys: &'a BTreeMap<QdrantCluster, String>,
 }
 
 impl QdrantClients {
@@ -198,7 +188,10 @@ impl DustQdrantClient {
         // to get a u64 out of it so we take the first 16 characters which will turn into a fully
         // random u64. Taking the modulo `key_count` will give us a random shard key. 16=2^4 and
         // 64/4=16 so u64 is represented by 16 hexadecimal characters.
-        let h: u64 = u64::from_str_radix(&internal_id[0..16], 16)?;
+        let prefix = internal_id
+            .get(0..16)
+            .ok_or_else(|| anyhow!("Internal id too short: {}", internal_id))?;
+        let h: u64 = u64::from_str_radix(prefix, 16)?;
         Ok(h % key_count)
     }
 
@@ -221,10 +214,10 @@ impl DustQdrantClient {
     pub fn shard_key_id(&self, tenant: &QdrantTenant) -> Result<u64> {
         let name = self.shard_key_name(tenant)?;
         let prefix = format!("{}_", self.shard_key_prefix());
-        match name.strip_prefix(&prefix) {
-            Some(id) => Ok(id.parse::<u64>()?),
-            None => Err(anyhow!("Unexpected shard key name {}", name)),
-        }
+        let id = name
+            .strip_prefix(&prefix)
+            .ok_or_else(|| anyhow!("Unexpected shard key name {}", name))?;
+        Ok(id.parse::<u64>()?)
     }
 
     fn shard_key(&self, tenant: &QdrantTenant) -> Result<shard_key::Key> {
@@ -234,8 +227,7 @@ impl DustQdrantClient {
     fn shard_key_names_from_cluster_info(
         info: &qdrant::CollectionClusterInfoResponse,
     ) -> Vec<String> {
-        let mut keys = info
-            .local_shards
+        info.local_shards
             .iter()
             .filter_map(|s| s.shard_key.as_ref())
             .chain(
@@ -247,10 +239,9 @@ impl DustQdrantClient {
                 Some(shard_key::Key::Keyword(name)) => Some(name.clone()),
                 _ => None,
             })
-            .collect::<Vec<_>>();
-        keys.sort();
-        keys.dedup();
-        keys
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
     }
 
     // Shard keys of the collection, empty when it has no custom sharding.
@@ -284,22 +275,22 @@ impl DustQdrantClient {
         let collection = self.collection_name(embedder_config);
         let keys = self.shard_key_names(embedder_config).await?;
         if keys.is_empty() {
-            return Err(anyhow!(
+            Err(anyhow!(
                 "Collection {} on cluster {} has no shard keys",
                 collection,
                 self.cluster
-            ));
+            ))?;
         }
         let id = Self::shard_key_id_from_internal_id(internal_id, keys.len() as u64)?;
         let name = format!("{}_{}", self.shard_key_prefix(), id);
         if !keys.contains(&name) {
-            return Err(anyhow!(
+            Err(anyhow!(
                 "Collection {} on cluster {} has {} shard keys but none named {}",
                 collection,
                 self.cluster,
                 keys.len(),
                 name
-            ));
+            ))?;
         }
         Ok(Some(name))
     }

--- a/core/src/data_sources/qdrant.rs
+++ b/core/src/data_sources/qdrant.rs
@@ -3,7 +3,7 @@ use anyhow::{anyhow, Result};
 use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use parking_lot::Mutex;
 use qdrant_client::{
@@ -25,6 +25,9 @@ pub enum QdrantCluster {
 }
 
 // See: https://app.notion.com/p/dust-tt/Design-Doc-Qdrant-re-arch-d0ebdd6ae8244ff593cdf10f08988c27
+// Key count of the collections created before data sources stored their shard key. A data source
+// without a stored key still hashes into these. Newer collections declare their own count and the
+// data sources created against them carry their key in `QdrantDataSourceConfig::shard_keys`.
 pub const SHARD_KEY_COUNT: u64 = 24;
 
 static QDRANT_CLUSTER_VARIANTS: &[QdrantCluster] = &[QdrantCluster::Cluster0];
@@ -76,6 +79,27 @@ pub struct QdrantClients {
 pub struct QdrantDataSourceConfig {
     pub cluster: QdrantCluster,
     pub shadow_write_cluster: Option<QdrantCluster>,
+    // Shard key of the data source in each cluster, assigned at creation from the key list of the
+    // cluster's collection. Absent for data sources created before, routed by the legacy hash.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub shard_keys: HashMap<QdrantCluster, String>,
+}
+
+// What a request needs to know about its data source: the tenant filter value and the shard key.
+pub struct QdrantTenant<'a> {
+    pub internal_id: &'a str,
+    pub shard_keys: &'a HashMap<QdrantCluster, String>,
+}
+
+impl<'a> QdrantTenant<'a> {
+    // A data source known by its internal id only, routed by the legacy hash.
+    pub fn legacy(internal_id: &'a str) -> Self {
+        static EMPTY: OnceLock<HashMap<QdrantCluster, String>> = OnceLock::new();
+        QdrantTenant {
+            internal_id,
+            shard_keys: EMPTY.get_or_init(HashMap::new),
+        }
+    }
 }
 
 impl QdrantClients {
@@ -115,6 +139,7 @@ impl QdrantClients {
                         client: Arc::new(client),
                         cluster: *cluster,
                         use_sharding,
+                        shard_key_names: Arc::new(Mutex::new(HashMap::new())),
                     },
                 ))
             },
@@ -142,6 +167,8 @@ pub struct DustQdrantClient {
     client: Arc<Qdrant>,
     pub cluster: QdrantCluster,
     use_sharding: bool,
+    // Shard keys per collection as Qdrant reports them, read once per process.
+    shard_key_names: Arc<Mutex<HashMap<String, Vec<String>>>>,
 }
 
 impl DustQdrantClient {
@@ -166,31 +193,121 @@ impl DustQdrantClient {
         )
     }
 
-    pub fn shard_key_id_from_internal_id(internal_id: &str) -> Result<u64> {
+    pub fn shard_key_id_from_internal_id(internal_id: &str, key_count: u64) -> Result<u64> {
         // `internal_id` is the hexadecimal representation of a blake3 hash (massive number). We want
         // to get a u64 out of it so we take the first 16 characters which will turn into a fully
-        // random u64. Taking the modulo SHARD_KEY_COUNT will give us a random shard key. 16=2^4 and
+        // random u64. Taking the modulo `key_count` will give us a random shard key. 16=2^4 and
         // 64/4=16 so u64 is represented by 16 hexadecimal characters.
         let h: u64 = u64::from_str_radix(&internal_id[0..16], 16)?;
-        Ok(h % SHARD_KEY_COUNT)
+        Ok(h % key_count)
     }
 
-    pub fn shard_key_name(&self, internal_id: &String) -> Result<String> {
+    fn legacy_shard_key_name(&self, internal_id: &str) -> Result<String> {
         Ok(format!(
             "{}_{}",
             self.shard_key_prefix(),
-            Self::shard_key_id_from_internal_id(internal_id)?
+            Self::shard_key_id_from_internal_id(internal_id, SHARD_KEY_COUNT)?
         ))
     }
 
-    fn shard_key(&self, internal_id: &String) -> Result<shard_key::Key> {
-        Ok(self.shard_key_name(internal_id)?.into())
+    // The stored key for this cluster when the data source has one, the legacy hash otherwise.
+    pub fn shard_key_name(&self, tenant: &QdrantTenant) -> Result<String> {
+        match tenant.shard_keys.get(&self.cluster) {
+            Some(key) => Ok(key.clone()),
+            None => self.legacy_shard_key_name(tenant.internal_id),
+        }
+    }
+
+    pub fn shard_key_id(&self, tenant: &QdrantTenant) -> Result<u64> {
+        let name = self.shard_key_name(tenant)?;
+        let prefix = format!("{}_", self.shard_key_prefix());
+        match name.strip_prefix(&prefix) {
+            Some(id) => Ok(id.parse::<u64>()?),
+            None => Err(anyhow!("Unexpected shard key name {}", name)),
+        }
+    }
+
+    fn shard_key(&self, tenant: &QdrantTenant) -> Result<shard_key::Key> {
+        Ok(self.shard_key_name(tenant)?.into())
+    }
+
+    fn shard_key_names_from_cluster_info(
+        info: &qdrant::CollectionClusterInfoResponse,
+    ) -> Vec<String> {
+        let mut keys = info
+            .local_shards
+            .iter()
+            .filter_map(|s| s.shard_key.as_ref())
+            .chain(
+                info.remote_shards
+                    .iter()
+                    .filter_map(|s| s.shard_key.as_ref()),
+            )
+            .filter_map(|k| match &k.key {
+                Some(shard_key::Key::Keyword(name)) => Some(name.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        keys.sort();
+        keys.dedup();
+        keys
+    }
+
+    // Shard keys of the collection, empty when it has no custom sharding.
+    pub async fn shard_key_names(&self, embedder_config: &EmbedderConfig) -> Result<Vec<String>> {
+        let collection = self.collection_name(embedder_config);
+        if let Some(keys) = self.shard_key_names.lock().get(&collection) {
+            return Ok(keys.clone());
+        }
+        let info = self
+            .client
+            .collection_cluster_info(collection.clone())
+            .await
+            .map_err(|e| anyhow!("Error getting collection cluster info: {}", e))?;
+        let keys = Self::shard_key_names_from_cluster_info(&info);
+        if !keys.is_empty() {
+            self.shard_key_names.lock().insert(collection, keys.clone());
+        }
+        Ok(keys)
+    }
+
+    // The key a new data source gets in this cluster: the collection's keys are counted and the
+    // internal id hashed into them. The layout is read from Qdrant, never configured twice.
+    pub async fn assign_shard_key(
+        &self,
+        embedder_config: &EmbedderConfig,
+        internal_id: &str,
+    ) -> Result<Option<String>> {
+        if !self.use_sharding {
+            return Ok(None);
+        }
+        let collection = self.collection_name(embedder_config);
+        let keys = self.shard_key_names(embedder_config).await?;
+        if keys.is_empty() {
+            return Err(anyhow!(
+                "Collection {} on cluster {} has no shard keys",
+                collection,
+                self.cluster
+            ));
+        }
+        let id = Self::shard_key_id_from_internal_id(internal_id, keys.len() as u64)?;
+        let name = format!("{}_{}", self.shard_key_prefix(), id);
+        if !keys.contains(&name) {
+            return Err(anyhow!(
+                "Collection {} on cluster {} has {} shard keys but none named {}",
+                collection,
+                self.cluster,
+                keys.len(),
+                name
+            ));
+        }
+        Ok(Some(name))
     }
 
     // Inject the `data_source_internal_id` to the filter to ensure tenant separation. This
     // implementation ensures data separation of our users' data.
     // /!\ Modify with extreme caution.
-    fn apply_tenant_filter(&self, internal_id: &String, filter: &mut qdrant::Filter) -> () {
+    fn apply_tenant_filter(&self, internal_id: &str, filter: &mut qdrant::Filter) -> () {
         filter.must.push(
             qdrant::FieldCondition {
                 key: "data_source_internal_id".to_string(),
@@ -208,19 +325,19 @@ impl DustQdrantClient {
     pub async fn delete_all_points_for_internal_id(
         &self,
         embedder_config: &EmbedderConfig,
-        internal_id: &String,
+        tenant: &QdrantTenant<'_>,
     ) -> Result<()> {
         // Create a default filter and ensure tenant separation to delete all the points
         // associated with the data source.
         let mut filter = qdrant::Filter::default();
-        self.apply_tenant_filter(internal_id, &mut filter);
+        self.apply_tenant_filter(tenant.internal_id, &mut filter);
 
         let mut builder =
             DeletePointsBuilder::new(self.collection_name(embedder_config)).points(filter);
 
         // Only use shard key selector when sharding is enabled
         if self.use_sharding {
-            builder = builder.shard_key_selector(vec![self.shard_key(internal_id)?]);
+            builder = builder.shard_key_selector(vec![self.shard_key(tenant)?]);
         }
 
         self.client.delete_points(builder).await?;
@@ -241,18 +358,18 @@ impl DustQdrantClient {
     pub async fn delete_points(
         &self,
         embedder_config: &EmbedderConfig,
-        internal_id: &String,
+        tenant: &QdrantTenant<'_>,
         mut filter: qdrant::Filter,
     ) -> Result<qdrant::PointsOperationResponse> {
         // Inject the `data_source_internal_id` to the filter to ensure tenant separation.
-        self.apply_tenant_filter(internal_id, &mut filter);
+        self.apply_tenant_filter(tenant.internal_id, &mut filter);
 
         let mut builder =
             DeletePointsBuilder::new(self.collection_name(embedder_config)).points(filter);
 
         // Only use shard key selector when sharding is enabled
         if self.use_sharding {
-            builder = builder.shard_key_selector(vec![self.shard_key(internal_id)?]);
+            builder = builder.shard_key_selector(vec![self.shard_key(tenant)?]);
         }
 
         self.client
@@ -264,7 +381,7 @@ impl DustQdrantClient {
     pub async fn scroll(
         &self,
         embedder_config: &EmbedderConfig,
-        internal_id: &String,
+        tenant: &QdrantTenant<'_>,
         filter: Option<qdrant::Filter>,
         limit: Option<u32>,
         offset: Option<qdrant::PointId>,
@@ -272,14 +389,14 @@ impl DustQdrantClient {
     ) -> Result<qdrant::ScrollResponse> {
         // If we don't have a filter create an empty one to ensure tenant separation.
         let mut filter = filter.unwrap_or_default();
-        self.apply_tenant_filter(internal_id, &mut filter);
+        self.apply_tenant_filter(tenant.internal_id, &mut filter);
 
         let mut builder =
             ScrollPointsBuilder::new(self.collection_name(embedder_config)).filter(filter);
 
         // Only use shard key selector when sharding is enabled
         if self.use_sharding {
-            builder = builder.shard_key_selector(vec![self.shard_key(internal_id)?]);
+            builder = builder.shard_key_selector(vec![self.shard_key(tenant)?]);
         }
 
         if let Some(limit) = limit {
@@ -301,7 +418,7 @@ impl DustQdrantClient {
     pub async fn search_points(
         &self,
         embedder_config: &EmbedderConfig,
-        internal_id: &String,
+        tenant: &QdrantTenant<'_>,
         vector: Vec<f32>,
         filter: Option<qdrant::Filter>,
         limit: u64,
@@ -309,7 +426,7 @@ impl DustQdrantClient {
     ) -> Result<qdrant::SearchResponse> {
         // If we don't have a filter create an empty one to ensure tenant separation.
         let mut filter = filter.unwrap_or_default();
-        self.apply_tenant_filter(internal_id, &mut filter);
+        self.apply_tenant_filter(tenant.internal_id, &mut filter);
 
         let mut builder =
             SearchPointsBuilder::new(self.collection_name(embedder_config), vector, limit)
@@ -317,7 +434,7 @@ impl DustQdrantClient {
 
         // Only use shard key selector when sharding is enabled
         if self.use_sharding {
-            builder = builder.shard_key_selector(vec![self.shard_key(internal_id)?]);
+            builder = builder.shard_key_selector(vec![self.shard_key(tenant)?]);
         }
 
         if let Some(with_payload) = with_payload {
@@ -333,13 +450,13 @@ impl DustQdrantClient {
     pub async fn count_points(
         &self,
         embedder_config: &EmbedderConfig,
-        internal_id: &String,
+        tenant: &QdrantTenant<'_>,
         filter: Option<qdrant::Filter>,
         exact: bool,
     ) -> Result<qdrant::CountResponse> {
         // If we don't have a filter create an empty one to ensure tenant separation.
         let mut filter = filter.unwrap_or_default();
-        self.apply_tenant_filter(internal_id, &mut filter);
+        self.apply_tenant_filter(tenant.internal_id, &mut filter);
 
         let mut builder = CountPointsBuilder::new(self.collection_name(embedder_config))
             .filter(filter)
@@ -347,7 +464,7 @@ impl DustQdrantClient {
 
         // Only use shard key selector when sharding is enabled
         if self.use_sharding {
-            builder = builder.shard_key_selector(vec![self.shard_key(internal_id)?]);
+            builder = builder.shard_key_selector(vec![self.shard_key(tenant)?]);
         }
 
         self.client
@@ -359,14 +476,14 @@ impl DustQdrantClient {
     pub async fn upsert_points(
         &self,
         embedder_config: &EmbedderConfig,
-        internal_id: &String,
+        tenant: &QdrantTenant<'_>,
         points: Vec<qdrant::PointStruct>,
     ) -> Result<qdrant::PointsOperationResponse> {
         let mut builder = UpsertPointsBuilder::new(self.collection_name(embedder_config), points);
 
         // Only use shard key selector when sharding is enabled
         if self.use_sharding {
-            builder = builder.shard_key_selector(vec![self.shard_key(internal_id)?]);
+            builder = builder.shard_key_selector(vec![self.shard_key(tenant)?]);
         }
 
         self.client
@@ -378,12 +495,12 @@ impl DustQdrantClient {
     pub async fn set_payload(
         &self,
         embedder_config: &EmbedderConfig,
-        internal_id: &String,
+        tenant: &QdrantTenant<'_>,
         mut filter: qdrant::Filter,
         payload: Payload,
     ) -> Result<qdrant::PointsOperationResponse> {
         // Inject the `internal_id` to the filter to ensure tenant separation.
-        self.apply_tenant_filter(internal_id, &mut filter);
+        self.apply_tenant_filter(tenant.internal_id, &mut filter);
 
         let mut builder =
             SetPayloadPointsBuilder::new(self.collection_name(embedder_config), payload)
@@ -391,7 +508,7 @@ impl DustQdrantClient {
 
         // Only use shard key selector when sharding is enabled
         if self.use_sharding {
-            builder = builder.shard_key_selector(vec![self.shard_key(internal_id)?]);
+            builder = builder.shard_key_selector(vec![self.shard_key(tenant)?]);
         }
 
         self.client
@@ -409,20 +526,80 @@ impl DustQdrantClient {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_balanced_shard_keys() {
-        let keys = (0..(SHARD_KEY_COUNT * 192))
+    fn hashed_ids(n: u64) -> Vec<String> {
+        (0..n)
             .map(|i| {
                 let mut hasher = blake3::Hasher::new();
                 hasher.update(format!("{}", i).as_bytes());
-                let internal_id = format!("{}", hasher.finalize().to_hex());
-                DustQdrantClient::shard_key_id_from_internal_id(&internal_id).unwrap()
+                format!("{}", hasher.finalize().to_hex())
             })
-            .collect::<Vec<_>>();
-        for i in 0..SHARD_KEY_COUNT {
-            // We test all keys have at least 128 points.
-            let key_count = keys.iter().filter(|&&x| x == i).count();
-            assert!(key_count >= 128);
+            .collect()
+    }
+
+    #[test]
+    fn test_balanced_shard_keys() {
+        for key_count in [SHARD_KEY_COUNT, 3, 1] {
+            let keys = hashed_ids(key_count * 192)
+                .iter()
+                .map(|id| DustQdrantClient::shard_key_id_from_internal_id(id, key_count).unwrap())
+                .collect::<Vec<_>>();
+            for i in 0..key_count {
+                // We test all keys have at least 128 points.
+                let hits = keys.iter().filter(|&&x| x == i).count();
+                assert!(hits >= 128);
+            }
+            assert!(keys.iter().all(|&x| x < key_count));
         }
+    }
+
+    fn local_shard(id: u32, key: Option<&str>) -> qdrant::LocalShardInfo {
+        qdrant::LocalShardInfo {
+            shard_id: id,
+            shard_key: key.map(|k| shard_key::Key::Keyword(k.to_string()).into()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_shard_key_names_from_cluster_info() {
+        let info = qdrant::CollectionClusterInfoResponse {
+            local_shards: vec![local_shard(0, Some("key_1")), local_shard(1, Some("key_0"))],
+            remote_shards: vec![qdrant::RemoteShardInfo {
+                shard_id: 2,
+                shard_key: Some(shard_key::Key::Keyword("key_2".to_string()).into()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        assert_eq!(
+            DustQdrantClient::shard_key_names_from_cluster_info(&info),
+            vec!["key_0", "key_1", "key_2"]
+        );
+
+        let plain = qdrant::CollectionClusterInfoResponse {
+            local_shards: vec![local_shard(0, None)],
+            ..Default::default()
+        };
+        assert!(DustQdrantClient::shard_key_names_from_cluster_info(&plain).is_empty());
+    }
+
+    #[test]
+    fn test_config_without_shard_keys_still_parses() {
+        let config: QdrantDataSourceConfig =
+            serde_json::from_str(r#"{"cluster":"cluster-0","shadow_write_cluster":null}"#).unwrap();
+        assert!(config.shard_keys.is_empty());
+        assert_eq!(
+            serde_json::to_string(&config).unwrap(),
+            r#"{"cluster":"cluster-0","shadow_write_cluster":null}"#
+        );
+
+        let mut with_key = config.clone();
+        with_key
+            .shard_keys
+            .insert(QdrantCluster::Cluster0, "key_2".to_string());
+        let json = serde_json::to_string(&with_key).unwrap();
+        assert!(json.contains(r#""shard_keys":{"cluster-0":"key_2"}"#));
+        let back: QdrantDataSourceConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, with_key);
     }
 }

--- a/core/src/data_sources/qdrant.rs
+++ b/core/src/data_sources/qdrant.rs
@@ -25,10 +25,10 @@ pub enum QdrantCluster {
 }
 
 // See: https://app.notion.com/p/dust-tt/Design-Doc-Qdrant-re-arch-d0ebdd6ae8244ff593cdf10f08988c27
-// Key count of the collections created before data sources stored their shard key. A data source
-// without a stored key still hashes into these. Newer collections declare their own count and the
-// data sources created against them carry their key in `QdrantDataSourceConfig::shard_keys`.
-pub const SHARD_KEY_COUNT: u64 = 24;
+// Key count of the collections created before data sources stored their shard key. Only for the
+// fallback route of data sources without a stored key: a collection declares its own key count and
+// new data sources carry their key in `QdrantDataSourceConfig::shard_keys`. Do not use elsewhere.
+pub const LEGACY_SHARD_KEY_COUNT: u64 = 24;
 
 static QDRANT_CLUSTER_VARIANTS: &[QdrantCluster] = &[QdrantCluster::Cluster0];
 
@@ -199,7 +199,7 @@ impl DustQdrantClient {
         Ok(format!(
             "{}_{}",
             self.shard_key_prefix(),
-            Self::shard_key_id_from_internal_id(internal_id, SHARD_KEY_COUNT)?
+            Self::shard_key_id_from_internal_id(internal_id, LEGACY_SHARD_KEY_COUNT)?
         ))
     }
 
@@ -529,7 +529,7 @@ mod tests {
 
     #[test]
     fn test_balanced_shard_keys() {
-        for key_count in [SHARD_KEY_COUNT, 3, 1] {
+        for key_count in [LEGACY_SHARD_KEY_COUNT, 3, 1] {
             let keys = hashed_ids(key_count * 192)
                 .iter()
                 .map(|id| DustQdrantClient::shard_key_id_from_internal_id(id, key_count).unwrap())

--- a/front/types/core/data_source.ts
+++ b/front/types/core/data_source.ts
@@ -20,6 +20,8 @@ export type CoreAPIDataSourceConfig = {
   qdrant_config: {
     cluster: QdrantCluster;
     shadow_write_cluster: QdrantCluster | null;
+    // Assigned by core at creation, absent on data sources created before.
+    shard_keys?: Partial<Record<QdrantCluster, string>>;
   } | null;
 };
 


### PR DESCRIPTION
## Description

A new cell runs one workspace on a three node Qdrant cluster, and the way core routes vectors today was designed for hundreds of workspaces on a big one. Every data source hashes into one of 24 shard keys, a constant compiled into core, and every collection is created with 2 shards behind each key. On the cell that layout means 96 physical shards per collection to hold a handful of data sources, each of them pinned to two shards. We want fewer keys and more shards per key there, and the constant makes that impossible: the key count has to be the same in the binary and in the collection, for every cluster the binary talks to.

So the layout moves to where it belongs, the collection, and the data source remembers where it lives. The creation binary now takes the shard key count, the shards per key and the replication factor as flags, defaulting to what it always did. When a data source is registered, core asks Qdrant which shard keys its collection has, hashes the internal id into that count, and stores the resulting key in the data source's `qdrant_config`, one entry per cluster it writes to. From then on every upsert, search, scroll, count, delete and payload update routes with the stored key. Data sources created before this change have no stored key and keep hashing modulo 24, so nothing moves for them and no backfill is needed. The tenant filter on the data source id is untouched, isolation never depended on the key.

The migrator assigns the shadow cluster's key when a shadow write is set and drops it when removed. The ops tools that computed keys from the constant now read them from the row. Front only learns about the optional field on its type.

## Tests

Unit tests cover the three things that could silently go wrong: the hash stays balanced and in range for 24, 3 and 1 keys, the key list is read correctly from Qdrant's cluster info with local and remote shards and comes back empty for a plain collection, and a config without the new field parses and serializes exactly as before.

Against a local Qdrant in distributed mode, a collection created with 3 keys and 4 shards per key reports 12 shards, 4 under each key. Six fake data sources written with the test fill tool landed on keys 0, 2, 1, 2, 0 and 0, all 120 points counted under those keys, and one data source's 20 points are found under its key and nowhere else. The same id hashed the legacy way would have targeted `key_23`, which that collection does not have. Writing to a standalone Qdrant without shard keys fails at assignment with an explicit message rather than misrouting.

End to end, core-api running locally against a scratch Postgres, the local Elasticsearch and that 3 key Qdrant: registering a data source through the API returned its config with `"shard_keys": {"cluster-0": "key_1"}`, the row in Postgres carries the same, and `key_1` is what the internal id hashes to modulo 3 (modulo 24 would have given `key_4`). A search without a query on that data source scrolled Qdrant through the stored key and answered, the log line for the search reports `qdrant_shard_key="key_1"`, and deleting the data source removed its points through the same key without error.

## Risk

On legacy, no data source changes key, requests are identical, and the collections are created with the same parameters. The one new behaviour is a cluster info call at data source registration, cached per process per collection, and a registration now fails if Qdrant is unreachable, where it used to succeed and fail on the first upsert instead.

Rollback is a plain revert. Data sources registered in between carry a `shard_keys` entry the old code ignores, and since a legacy collection has 24 keys, the stored key and the legacy hash are the same key for them.

The shadow embedder collection must share the layout of the main one on a cluster, the assignment checks that and refuses otherwise.

## Deploy Plan

1. Deploy core to the legacy regions. No behaviour change there.
2. Pin the image on cell-00002 and create its two collections from prodbox with `--shard-key-count 3 --shards-per-key 4`, 24 physical shards per collection instead of 96.
3. First data source on the cell: its row shows `shard_keys: {"cluster-0": "key_<n>"}` with n in 0..2, and its points count under that key in the Qdrant cluster info.
