### PR TITLE
[front] perf: omit TOASTed columns from `agent_configurations` in skill queries

### DIFF
--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -2914,6 +2914,11 @@ describe("SkillResource", () => {
       const usageB = usageMap.get(skillB.sId)!;
       expect(usageB.count).toBe(1);
       expect(usageB.agents[0].name).toBe("Agent 1");
+
+      const singleUsageA = await skillA.fetchUsage(testContext.authenticator);
+      const singleUsageB = await skillB.fetchUsage(testContext.authenticator);
+      expect(singleUsageA).toEqual(usageA);
+      expect(singleUsageB).toEqual(usageB);
     });
 
     it("returns empty map for empty input", async () => {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -132,6 +132,11 @@ type SkillReferenceTarget = {
   status: SkillStatus;
 };
 
+type AgentUsageAttributes = Pick<
+  Attributes<AgentConfigurationModel>,
+  "id" | "sId" | "name" | "pictureUrl"
+>;
+
 type ReplaceSkillReferenceTagsOptions = {
   html?: boolean;
 };
@@ -2337,12 +2342,20 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
   }
 
-  private async listActiveAgents(
-    auth: Authenticator
-  ): Promise<AgentConfigurationModel[]> {
+  /**
+   * @cc [owner:aubin-tchoi,label:performance] select-requested-agent-attributes
+   * `listActiveAgents` selects only the agent attributes requested by its caller.
+   */
+  private async listActiveAgents<
+    K extends keyof Attributes<AgentConfigurationModel>,
+  >(
+    auth: Authenticator,
+    { attributes }: { attributes: K[] }
+  ): Promise<Pick<Attributes<AgentConfigurationModel>, K>[]> {
     const workspace = auth.getNonNullableWorkspace();
 
     const agentSkills = await AgentSkillModel.findAll({
+      attributes: ["agentConfigurationId"],
       where: {
         ...this.skillReference,
         workspaceId: workspace.id,
@@ -2356,6 +2369,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const agentConfigIds = agentSkills.map((as) => as.agentConfigurationId);
 
     return AgentConfigurationModel.findAll({
+      attributes,
       where: {
         id: { [Op.in]: agentConfigIds },
         workspaceId: workspace.id,
@@ -2365,7 +2379,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   async fetchUsage(auth: Authenticator): Promise<AgentsUsageType> {
-    const agents = await this.listActiveAgents(auth);
+    const agents = await this.listActiveAgents(auth, {
+      attributes: ["sId", "name", "pictureUrl"],
+    });
 
     const sortedAgents = agents
       .map((agent) => ({
@@ -2404,7 +2420,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return;
     }
 
-    const agents = await this.listActiveAgents(auth);
+    const agents = await this.listActiveAgents(auth, {
+      attributes: ["id", "requestedSpaceIds"],
+    });
 
     if (agents.length === 0) {
       // No agents are using this skill, skip.
@@ -2774,10 +2792,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   /**
    * Batch version of listActiveAgents, returns active agents grouped by skill sId.
    */
+  /**
+   * @cc [owner:aubin-tchoi,label:performance] select-usage-agent-attributes
+   * `batchListActiveAgents` selects only agent identifiers and usage display fields.
+   */
   private static async batchListActiveAgents(
     auth: Authenticator,
     skills: SkillResource[]
-  ): Promise<Map<string, AgentConfigurationModel[]>> {
+  ): Promise<Map<string, AgentUsageAttributes[]>> {
     if (skills.length === 0) {
       return new Map();
     }
@@ -2792,6 +2814,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     // Single query: all agent-skill associations for the given skills.
     const agentSkills = await AgentSkillModel.findAll({
+      attributes: ["agentConfigurationId", "customSkillId", "globalSkillId"],
       where: {
         workspaceId: workspace.id,
         [Op.or]: removeNulls([
@@ -2814,6 +2837,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       ...new Set(agentSkills.map((as) => as.agentConfigurationId)),
     ];
     const agentConfigs = await AgentConfigurationModel.findAll({
+      attributes: ["id", "sId", "name", "pictureUrl"],
       where: {
         id: { [Op.in]: uniqueAgentConfigIds },
         workspaceId: workspace.id,
@@ -2828,7 +2852,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       skills.filter((s) => !s.globalSId).map((s) => [s.id, s.sId])
     );
 
-    const result = new Map<string, AgentConfigurationModel[]>();
+    const result = new Map<string, AgentUsageAttributes[]>();
     for (const as of agentSkills) {
       const skillId = as.customSkillId
         ? sIdByCustomId.get(as.customSkillId)

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2342,12 +2342,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
   }
 
-  private async listActiveAgents<
-    K extends keyof Attributes<AgentConfigurationModel>,
-  >(
-    auth: Authenticator,
-    { attributes }: { attributes: K[] }
-  ): Promise<Pick<Attributes<AgentConfigurationModel>, K>[]> {
+  private async listActiveAgents(
+    auth: Authenticator
+  ): Promise<
+    Pick<
+      Attributes<AgentConfigurationModel>,
+      "id" | "sId" | "name" | "pictureUrl" | "requestedSpaceIds"
+    >[]
+  > {
     const workspace = auth.getNonNullableWorkspace();
 
     const agentSkills = await AgentSkillModel.findAll({
@@ -2365,7 +2367,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const agentConfigIds = agentSkills.map((as) => as.agentConfigurationId);
 
     return AgentConfigurationModel.findAll({
-      attributes,
+      attributes: ["id", "sId", "name", "pictureUrl", "requestedSpaceIds"],
       where: {
         id: { [Op.in]: agentConfigIds },
         workspaceId: workspace.id,
@@ -2375,9 +2377,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   async fetchUsage(auth: Authenticator): Promise<AgentsUsageType> {
-    const agents = await this.listActiveAgents(auth, {
-      attributes: ["sId", "name", "pictureUrl"],
-    });
+    const agents = await this.listActiveAgents(auth);
 
     const sortedAgents = agents
       .map((agent) => ({
@@ -2416,9 +2416,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return;
     }
 
-    const agents = await this.listActiveAgents(auth, {
-      attributes: ["id", "requestedSpaceIds"],
-    });
+    const agents = await this.listActiveAgents(auth);
 
     if (agents.length === 0) {
       // No agents are using this skill, skip.
@@ -2430,7 +2428,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
 
     const workspace = auth.getNonNullableWorkspace();
-    const agentIds = agents.map((a) => a.id);
+    const agentModelIds = agents.map((a) => a.id);
 
     let actionsByAgentModelId = new Map<
       ModelId,
@@ -2440,13 +2438,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     if (spaceIdsRemovedFromThisSkill.length > 0) {
       actionsByAgentModelId = await fetchMCPServerActionConfigurations(auth, {
-        configurationIds: agentIds,
+        configurationIds: agentModelIds,
         variant: "full",
       });
 
       const agentSkillModels = await AgentSkillModel.findAll({
         where: {
-          agentConfigurationId: { [Op.in]: agentIds },
+          agentConfigurationId: { [Op.in]: agentModelIds },
           workspaceId: workspace.id,
         },
       });

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -134,7 +134,7 @@ type SkillReferenceTarget = {
 
 type AgentUsageAttributes = Pick<
   Attributes<AgentConfigurationModel>,
-  "id" | "sId" | "name" | "pictureUrl"
+  "id" | "sId" | "name" | "pictureUrl" | "requestedSpaceIds"
 >;
 
 type ReplaceSkillReferenceTagsOptions = {
@@ -2344,12 +2344,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   private async listActiveAgents(
     auth: Authenticator
-  ): Promise<
-    Pick<
-      Attributes<AgentConfigurationModel>,
-      "id" | "sId" | "name" | "pictureUrl" | "requestedSpaceIds"
-    >[]
-  > {
+  ): Promise<AgentUsageAttributes[]> {
     const workspace = auth.getNonNullableWorkspace();
 
     const agentSkills = await AgentSkillModel.findAll({
@@ -2827,7 +2822,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       ...new Set(agentSkills.map((as) => as.agentConfigurationId)),
     ];
     const agentConfigs = await AgentConfigurationModel.findAll({
-      attributes: ["id", "sId", "name", "pictureUrl"],
+      attributes: ["id", "sId", "name", "pictureUrl", "requestedSpaceIds"],
       where: {
         id: { [Op.in]: uniqueAgentConfigIds },
         workspaceId: workspace.id,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2342,10 +2342,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
   }
 
-  /**
-   * @cc [owner:aubin-tchoi,label:performance] select-requested-agent-attributes
-   * `listActiveAgents` selects only the agent attributes requested by its caller.
-   */
   private async listActiveAgents<
     K extends keyof Attributes<AgentConfigurationModel>,
   >(
@@ -2791,10 +2787,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   /**
    * Batch version of listActiveAgents, returns active agents grouped by skill sId.
-   */
-  /**
-   * @cc [owner:aubin-tchoi,label:performance] select-usage-agent-attributes
-   * `batchListActiveAgents` selects only agent identifiers and usage display fields.
    */
   private static async batchListActiveAgents(
     auth: Authenticator,


### PR DESCRIPTION
## Description

Looking at this [trace](https://app.datadoghq.eu/apm/traces?query=env%3Aprod%20service%3Afront%20%40http.route%3A%2Fapi%2Fw%2F%5C%3AwId%2Fskills%20%40http.method%3AGET&agg_m=count&agg_m_source=base&agg_t=count&cols=service%2Cresource_name%2C%40duration%2C%40http.method%2C%40http.status_code%2C%40_span.count%2C%40_duration.by_service&colsTraces=service%2Cresource_name%2C%40duration%2C%40_span.count%2C%40_duration.by_service&fromUser=false&graphType=waterfall&historicalData=true&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=desc&sort_by=%40duration&sort_order=desc&spanID=4104059190792313049&spanType=all&storage=hot&target-span=a&timeHint=1788734691854&tq_query_translation_version=v0&trace=AwAAAaB45VoOIRRxdQAAABhBYUI0NVhWQ0FBRFd4c0tuaDZkLTBmUTQAAAAkMTFhMDc5MTUtNGU3Yy00MTA3LWI5ODktODU2MWU1NGE0NmIzAAjHaQ&traceID=6a9dece10000000038f48c16fc5a58d9&traceQuery=a&view=spans&viz=stream&start=1788612743711&end=1788785543711&paused=false), in the `/api/w/:wId/skills` endpoint part of the latency (>2s) comes from the `SELECT` on `agent_configurations`. It's used for skill usage and fetches full agent configurations, including unused TOASTed columns.

This PR selects only the fields each caller needs in `listActiveAgents` and the batch usage query, with return types matching the selected attributes.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
