### PR TITLE
[front] enh: index message skill membership in consumption analytics

### DIFF
--- a/front/lib/analytics/agent_message_consumption/document_common.ts
+++ b/front/lib/analytics/agent_message_consumption/document_common.ts
@@ -28,6 +28,7 @@ type AgentMessageConsumptionAnalyticsDocumentMetadata = Pick<
   | "normalized_origin"
   | "parent_message_id"
   | "run_usage_id"
+  | "skill_ids"
   | "space_id"
   | "step_index"
   | "trigger_id"
@@ -51,6 +52,11 @@ export function modelForUsage(
   };
 }
 
+/**
+ * @cc [owner:aubin-tchoi,label:product] message-skill-membership
+ * Every consumption document carries the message's snapshotted skill IDs, including skills
+ * that did not cause a tool call.
+ */
 export function makeBaseDocument(
   metadata: ConsumptionAnalyticsMessageMetadata,
   {
@@ -80,6 +86,7 @@ export function makeBaseDocument(
     normalized_origin: normalizeOrigin(metadata.contextOrigin),
     parent_message_id: metadata.parentMessageId,
     run_usage_id: runUsageModelId.toString(),
+    skill_ids: metadata.skillIds,
     space_id: metadata.spaceId,
     step_index: stepIndex,
     trigger_id: metadata.triggerId,

--- a/front/lib/analytics/agent_message_consumption/documents.test.ts
+++ b/front/lib/analytics/agent_message_consumption/documents.test.ts
@@ -671,6 +671,11 @@ describe("buildAgentMessageConsumptionAnalyticsDocuments", () => {
       },
     });
     expect(toolDocuments[0]?.tool?.attributed_skill_ids).toHaveLength(2);
+    for (const document of documents) {
+      expect(document.skill_ids).toEqual(
+        expect.arrayContaining([skillA.sId, skillB.sId])
+      );
+    }
     expect(
       documents.reduce((total, document) => total + document.credit_micro, 0)
     ).toBe(5_000_000);

--- a/front/lib/analytics/agent_message_consumption/llm_documents.test.ts
+++ b/front/lib/analytics/agent_message_consumption/llm_documents.test.ts
@@ -5,15 +5,17 @@ import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assi
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { RunFactory } from "@app/tests/utils/RunFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { GPT_5_MINI_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import { describe, expect, it } from "vitest";
 
 describe("buildLlmConsumptionDocuments", () => {
-  it("builds one additive document for a model run", async () => {
+  it("builds a model document with snapshotted skills even without tool calls", async () => {
     const { authenticator: auth, workspace } = await createResourceTest({
       role: "admin",
     });
@@ -105,6 +107,28 @@ describe("buildLlmConsumptionDocuments", () => {
       pendingToolItems: [],
     });
 
+    const customSkill = await SkillFactory.create(auth);
+    const globalSkill = await SkillResource.fetchById(auth, "frames");
+    if (!globalSkill) {
+      throw new Error("Expected frames global skill");
+    }
+    await customSkill.enableForAgent(auth, {
+      agentConfiguration: agent,
+      conversation: conversationType,
+    });
+    await globalSkill.enableForAgent(auth, {
+      agentConfiguration: agent,
+      conversation: conversationType,
+    });
+    const snapshot = {
+      agentConfigurationId: agent.sId,
+      agentMessageId: agentMessageModelId,
+      conversationId: conversation.id,
+    };
+    await SkillResource.snapshotConversationSkillsForMessage(auth, snapshot);
+    // A finalization retry must not duplicate membership in the index.
+    await SkillResource.snapshotConversationSkillsForMessage(auth, snapshot);
+
     const input = await loadAgentMessageConsumptionAnalyticsInput(auth, {
       agentMessageId: agentMessage.sId,
     });
@@ -132,6 +156,7 @@ describe("buildLlmConsumptionDocuments", () => {
         completed_at: completedAt.toISOString(),
         consumption_key: `run-usage:${runUsageModelId}`,
         consumption_type: "llm",
+        skill_ids: expect.arrayContaining([customSkill.sId, globalSkill.sId]),
         credit_micro: 5_000_000,
         gross_credit_micro: {
           system: 500_000,
@@ -155,8 +180,10 @@ describe("buildLlmConsumptionDocuments", () => {
         user: {
           id: auth.getNonNullableUser().sId,
           group_ids: [],
+          seat_type: null,
         },
       }),
     ]);
+    expect(input.skillIds).toHaveLength(2);
   });
 });

--- a/front/lib/analytics/agent_message_consumption/load.test.ts
+++ b/front/lib/analytics/agent_message_consumption/load.test.ts
@@ -255,6 +255,7 @@ describe("loadAgentMessageConsumptionAnalyticsInput", () => {
     expect(input?.user).toEqual({
       id: testContext.authenticator.getNonNullableUser().sId,
       group_ids: [group.sId],
+      seat_type: "workspace",
     });
   });
 

--- a/front/lib/analytics/agent_message_consumption/load.ts
+++ b/front/lib/analytics/agent_message_consumption/load.ts
@@ -59,6 +59,7 @@ export type ConsumptionAnalyticsMessageMetadata = {
   messageVersion: number;
   model: AgentMessageAnalyticsModel | null;
   parentMessageId: string | null;
+  skillIds: string[];
   spaceId: string | null;
   triggerId: string | null;
   user: AgentMessageConsumptionAnalyticsUser | null;
@@ -325,6 +326,7 @@ export async function loadAgentMessageConsumptionAnalyticsInput(
       : null,
     parentMessageId: triggeringUserMessage.agenticOriginMessageId ?? null,
     runs,
+    skillIds: [...new Set(skills.map((skill) => skill.sId))],
     skills,
     spaceId:
       conversation.spaceModelId === null

--- a/front/lib/analytics/agent_message_consumption/store.test.ts
+++ b/front/lib/analytics/agent_message_consumption/store.test.ts
@@ -57,6 +57,7 @@ function makeDocument(): AgentMessageConsumptionAnalyticsData {
     message_version: "2",
     model: null,
     run_usage_id: "1",
+    skill_ids: [],
     space_id: null,
     status: "succeeded",
     step_index: 0,

--- a/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
+++ b/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
@@ -15,6 +15,9 @@
     "agent_message_id": {
       "type": "keyword"
     },
+    "skill_ids": {
+      "type": "keyword"
+    },
     "parent_message_id": {
       "type": "keyword"
     },

--- a/front/lib/analytics/migrations/20260907_add_skill_ids_to_agent_message_consumption_analytics_1.http
+++ b/front/lib/analytics/migrations/20260907_add_skill_ids_to_agent_message_consumption_analytics_1.http
@@ -1,0 +1,8 @@
+PUT /front.agent_message_consumption_analytics_1/_mapping
+{
+  "properties": {
+    "skill_ids": {
+      "type": "keyword"
+    }
+  }
+}

--- a/front/scripts/seed/factories/seedConsumptionAnalytics.ts
+++ b/front/scripts/seed/factories/seedConsumptionAnalytics.ts
@@ -309,6 +309,7 @@ type SeedConsumptionBaseFields = Pick<
   | "normalized_origin"
   | "parent_message_id"
   | "run_usage_id"
+  | "skill_ids"
   | "space_id"
   | "status"
   | "step_index"
@@ -349,6 +350,7 @@ function makeBaseFields(
     normalized_origin: normalizeOrigin(message.origin),
     parent_message_id: null,
     run_usage_id: consumptionKey,
+    skill_ids: [],
     space_id: null,
     status: "succeeded",
     step_index: stepIndex,

--- a/front/temporal/analytics_queue/activities/consumption_export.test.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.test.ts
@@ -81,6 +81,7 @@ const LLM_DOC: AgentMessageConsumptionAnalyticsLlmData = {
   },
   parent_message_id: null,
   run_usage_id: "123",
+  skill_ids: [],
   space_id: "space1",
   status: "succeeded",
   step_index: 0,

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -260,6 +260,8 @@ interface AgentMessageConsumptionAnalyticsBaseData
   parent_message_id: string | null;
   model: AgentMessageAnalyticsModel | null;
   run_usage_id: string;
+  // Skills in the message's finalized snapshot, independently of tool attribution.
+  skill_ids: string[];
   space_id: string | null;
   status: string;
   step_index: number;


### PR DESCRIPTION
## Description

Prepare the consumption index for the Manage Skills message count. Add `skill_ids` to every LLM and tool document from the existing finalized message snapshot, including skills used in text-only replies. The loader already fetches these skills, so indexing needs no additional database query.

The query switch is in a dependent PR so historical documents can be backfilled first.

## Tests

- Cover custom/global skills without tool calls, repeated snapshots, and skill IDs on tool documents.
- Tested the mapping and aggregation against local Elasticsearch.

## Risk

- Low. Adds metadata to consumption documents.

## Deploy Plan

1. Apply `front/lib/analytics/migrations/20260907_add_skill_ids_to_agent_message_consumption_analytics_1.http` in both regions.
2. Deploy front.
3. Rerun `front/scripts/backfill_agent_message_consumption_analytics.ts` with `--fromDate` covering the full indexed history and `--execute`, in both regions. Wait for the queued workflows to complete successfully before deploying the dependent read switch.
