### PR TITLE
Pause BigQuery connectors on policy violations

### DIFF
--- a/connectors/src/connectors/bigquery/temporal/cast_known_errors.test.ts
+++ b/connectors/src/connectors/bigquery/temporal/cast_known_errors.test.ts
@@ -1,0 +1,97 @@
+import {
+  ExternalOAuthTokenError,
+  ThirdPartyConfigurationError,
+} from "@connectors/lib/error";
+import type {
+  ActivityExecuteInput,
+  ActivityInboundCallsInterceptor,
+  Next,
+} from "@temporalio/worker";
+import { describe, expect, it, vi } from "vitest";
+
+import { BigQueryCastKnownErrorsInterceptor } from "./cast_known_errors";
+
+const input = { args: [], headers: {} } satisfies ActivityExecuteInput;
+
+describe("BigQueryCastKnownErrorsInterceptor", () => {
+  it("classifies a VPC Service Controls denial as a terminal configuration error", async () => {
+    const message =
+      "VPC Service Controls: Request is prohibited by organization's policy. " +
+      "vpcServiceControlsUniqueIdentifier: test-violation-id.";
+    const error = Object.assign(new Error(message), {
+      name: "ApiError",
+      code: 403,
+      errors: [{ domain: "global", message, reason: "policyViolation" }],
+    });
+    const next = vi.fn(async () => {
+      throw error;
+    }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+
+    const execution = new BigQueryCastKnownErrorsInterceptor().execute(
+      input,
+      next
+    );
+
+    await expect(execution).rejects.toThrow(ThirdPartyConfigurationError);
+    await expect(execution).rejects.toHaveProperty("cause", error);
+  });
+
+  it.each([
+    { code: 403, reason: "rateLimitExceeded" },
+    { code: 403, reason: "accessDenied" },
+    { code: 500, reason: "policyViolation" },
+    { code: 503, reason: "backendError" },
+  ])("preserves $code $reason errors for existing retry handling", async ({
+    code,
+    reason,
+  }) => {
+    const error = Object.assign(new Error("BigQuery request failed"), {
+      name: "ApiError",
+      code,
+      errors: [{ reason }],
+    });
+    const next = vi.fn(async () => {
+      throw error;
+    }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+
+    await expect(
+      new BigQueryCastKnownErrorsInterceptor().execute(input, next)
+    ).rejects.toBe(error);
+  });
+
+  it("preserves errors without structured policy details", async () => {
+    const error = Object.assign(new Error("Request is prohibited"), {
+      code: 403,
+    });
+    const next = vi.fn(async () => {
+      throw error;
+    }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+
+    await expect(
+      new BigQueryCastKnownErrorsInterceptor().execute(input, next)
+    ).rejects.toBe(error);
+  });
+
+  it("still classifies revoked accounts as OAuth errors", async () => {
+    const error = new Error("invalid_grant: Invalid grant: account not found");
+    const next = vi.fn(async () => {
+      throw error;
+    }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+
+    await expect(
+      new BigQueryCastKnownErrorsInterceptor().execute(input, next)
+    ).rejects.toThrow(ExternalOAuthTokenError);
+  });
+
+  it("returns successful activity results unchanged", async () => {
+    const result = { synced: true };
+    const next = vi.fn(async () => result) satisfies Next<
+      ActivityInboundCallsInterceptor,
+      "execute"
+    >;
+
+    await expect(
+      new BigQueryCastKnownErrorsInterceptor().execute(input, next)
+    ).resolves.toBe(result);
+  });
+});

--- a/connectors/src/connectors/bigquery/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/bigquery/temporal/cast_known_errors.ts
@@ -26,15 +26,15 @@ function isBigQueryPolicyViolationError(err: unknown): err is Error {
   );
 }
 
+/**
+ * @cc [label:error-handling] bigquery-error-classification
+ * Map recognized authentication and provider configuration failures to `ExternalOAuthTokenError`
+ * and `ThirdPartyConfigurationError`, respectively. Return successful activity results and rethrow
+ * unrecognized errors unchanged.
+ */
 export class BigQueryCastKnownErrorsInterceptor
   implements ActivityInboundCallsInterceptor
 {
-  /**
-   * @cc [label:error-handling] bigquery-error-classification
-   * Map recognized authentication and provider configuration failures to `ExternalOAuthTokenError`
-   * and `ThirdPartyConfigurationError`, respectively. Return successful activity results and rethrow
-   * unrecognized errors unchanged.
-   */
   async execute(
     input: ActivityExecuteInput,
     next: Next<ActivityInboundCallsInterceptor, "execute">
@@ -43,7 +43,8 @@ export class BigQueryCastKnownErrorsInterceptor
       return await next(input);
     } catch (err: unknown) {
       if (err instanceof GaxiosError) {
-        // Check for invalid_grant error which indicates the account/authorization is no longer valid
+        // Check for invalid_grant error which indicates the account/authorization is no longer
+        // valid
         if (
           err.response?.data &&
           typeof err.response.data === "object" &&

--- a/connectors/src/connectors/bigquery/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/bigquery/temporal/cast_known_errors.ts
@@ -1,4 +1,7 @@
-import { ExternalOAuthTokenError } from "@connectors/lib/error";
+import {
+  ExternalOAuthTokenError,
+  ThirdPartyConfigurationError,
+} from "@connectors/lib/error";
 import type {
   ActivityExecuteInput,
   ActivityInboundCallsInterceptor,
@@ -6,9 +9,32 @@ import type {
 } from "@temporalio/worker";
 import { GaxiosError } from "googleapis-common";
 
+function isBigQueryPolicyViolationError(err: unknown): err is Error {
+  return (
+    err instanceof Error &&
+    "code" in err &&
+    err.code === 403 &&
+    "errors" in err &&
+    Array.isArray(err.errors) &&
+    err.errors.some(
+      (error: unknown) =>
+        typeof error === "object" &&
+        error !== null &&
+        "reason" in error &&
+        error.reason === "policyViolation"
+    )
+  );
+}
+
 export class BigQueryCastKnownErrorsInterceptor
   implements ActivityInboundCallsInterceptor
 {
+  /**
+   * @cc [label:error-handling] bigquery-error-classification
+   * Map recognized authentication and provider configuration failures to `ExternalOAuthTokenError`
+   * and `ThirdPartyConfigurationError`, respectively. Return successful activity results and rethrow
+   * unrecognized errors unchanged.
+   */
   async execute(
     input: ActivityExecuteInput,
     next: Next<ActivityInboundCallsInterceptor, "execute">
@@ -39,6 +65,10 @@ export class BigQueryCastKnownErrorsInterceptor
         err.message.includes("invalid_grant: Invalid grant: account not found")
       ) {
         throw new ExternalOAuthTokenError(err);
+      }
+
+      if (isBigQueryPolicyViolationError(err)) {
+        throw new ThirdPartyConfigurationError(err);
       }
 
       throw err;

--- a/connectors/src/lib/temporal_monitoring.test.ts
+++ b/connectors/src/lib/temporal_monitoring.test.ts
@@ -1,3 +1,4 @@
+import { BigQueryCastKnownErrorsInterceptor } from "@connectors/connectors/bigquery/temporal/cast_known_errors";
 import { Context, type Info } from "@temporalio/activity";
 import {
   noopMetricMeter,
@@ -224,6 +225,48 @@ describe("ActivityInboundLogInterceptor", () => {
     );
     expect(mocks.pauseAndStop).toHaveBeenCalledWith({
       reason: "Stopped on workspace_can_use_product_required_error",
+    });
+  });
+
+  it("pauses BigQuery when its activity encounters a policy violation", async () => {
+    mocks.fetchById.mockResolvedValue({
+      dataSourceId: "data-source-id",
+      id: 42,
+      type: "bigquery",
+      workspaceId: "workspace-id",
+    });
+    const interceptor = new ActivityInboundLogInterceptor(
+      makeActivityContext("bigquerySyncWorkflow"),
+      logger,
+      "bigquery"
+    );
+    const error = Object.assign(
+      new Error(
+        "VPC Service Controls: Request is prohibited by organization's policy."
+      ),
+      { code: 403, errors: [{ reason: "policyViolation" }] }
+    );
+    const input = {
+      args: [],
+      headers: {},
+    } satisfies ActivityExecuteInput;
+    const activity = vi.fn(async () => {
+      throw error;
+    }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+    const next = vi.fn((activityInput: ActivityExecuteInput) =>
+      new BigQueryCastKnownErrorsInterceptor().execute(activityInput, activity)
+    ) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+
+    await expect(interceptor.execute(input, next)).rejects.toThrow(
+      ThirdPartyConfigurationError
+    );
+
+    expect(mocks.syncFailed).toHaveBeenCalledWith(
+      42,
+      "third_party_internal_error"
+    );
+    expect(mocks.pauseAndStop).toHaveBeenCalledWith({
+      reason: "Stopped on ThirdPartyConfigurationError",
     });
   });
 


### PR DESCRIPTION
## Description

BigQuery sync activities keep retrying when VPC Service Controls rejects requests with HTTP 403 and the structured `policyViolation` reason. The BigQuery interceptor currently misses this Google Cloud `ApiError` shape.

Classify these failures as `ThirdPartyConfigurationError` so the existing activity handler marks the connector `third_party_internal_error`, pauses it, and stops its workflows. Preserve the original error as the cause, including its VPC Service Controls unique identifier, for troubleshooting.

The [Google VPC Service Controls troubleshooting guide](https://docs.cloud.google.com/vpc-service-controls/docs/retrieve-troubleshoot-errors) identifies this BigQuery error:

> 403: VPC Service Controls: Request is prohibited by organization's policy.

The guide also explains how an administrator can use the unique identifier to locate the denial in Cloud Audit Logs.

## Tests

Ran the BigQuery error-classification and Temporal monitoring tests: 13 tests passed. Both the captured-error classification test and the interceptor-chain pause test fail before the fix and pass afterward. Coverage includes preserving rate-limit and other unrecognized failures, existing OAuth handling, successful activity results, and the original error cause.

## Risk

Low. The new classification requires HTTP 403 and a structured `policyViolation` reason and uses the existing configuration-error pause path. The customer must correct the Google Cloud policy before synchronization can resume.

## Deploy Plan

Deploy `connectors`, including the BigQuery workers. Affected running connectors will pause on their next matching activity failure after rollout.
