### PR TITLE
Pause Microsoft connectors on blocked site access

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/cast_known_errors.test.ts
+++ b/connectors/src/connectors/microsoft/temporal/cast_known_errors.test.ts
@@ -1,5 +1,10 @@
-import { ThirdPartyConfigurationError } from "@connectors/lib/error";
+import { MicrosoftThrottlingError } from "@connectors/connectors/microsoft/lib/errors";
+import {
+  ExternalOAuthTokenError,
+  ThirdPartyConfigurationError,
+} from "@connectors/lib/error";
 import { GraphError } from "@microsoft/microsoft-graph-client";
+import { ApplicationFailure } from "@temporalio/common";
 import type {
   ActivityExecuteInput,
   ActivityInboundCallsInterceptor,
@@ -9,7 +14,32 @@ import { describe, expect, it, vi } from "vitest";
 
 import { MicrosoftCastKnownErrorsInterceptor } from "./cast_known_errors";
 
+const input = { args: [], headers: {} } satisfies ActivityExecuteInput;
+
 describe("MicrosoftCastKnownErrorsInterceptor", () => {
+  it("classifies blocked site access as a terminal configuration error", async () => {
+    const message =
+      "Access to this site has been blocked. Please contact the administrator to resolve this problem.";
+    const error = new GraphError(423, message);
+    error.code = "notAllowed";
+    error.body = JSON.stringify({
+      code: "notAllowed",
+      innerError: { code: "resourceLocked" },
+      message,
+    });
+    const next = vi.fn(async () => {
+      throw error;
+    }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+
+    const execution = new MicrosoftCastKnownErrorsInterceptor().execute(
+      input,
+      next
+    );
+
+    await expect(execution).rejects.toThrow(ThirdPartyConfigurationError);
+    await expect(execution).rejects.toHaveProperty("cause", error);
+  });
+
   it("classifies a missing SharePoint license as a terminal configuration error", async () => {
     const error = new GraphError(400, "Tenant does not have a SPO license.");
     const next = vi.fn(async () => {
@@ -17,10 +47,70 @@ describe("MicrosoftCastKnownErrorsInterceptor", () => {
     }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
 
     await expect(
-      new MicrosoftCastKnownErrorsInterceptor().execute(
-        { args: [], headers: {} } satisfies ActivityExecuteInput,
-        next
-      )
-    ).rejects.toEqual(new ThirdPartyConfigurationError(error));
+      new MicrosoftCastKnownErrorsInterceptor().execute(input, next)
+    ).rejects.toThrow(ThirdPartyConfigurationError);
+  });
+
+  it.each([
+    { statusCode: 403, code: "notAllowed" },
+    { statusCode: 423, code: "generalException" },
+    { statusCode: 429, code: "activityLimitReached" },
+    { statusCode: 503, code: "serviceNotAvailable" },
+  ])("preserves $statusCode $code errors for existing retry handling", async ({
+    statusCode,
+    code,
+  }) => {
+    const error = new GraphError(statusCode, "Microsoft Graph request failed");
+    error.code = code;
+    const next = vi.fn(async () => {
+      throw error;
+    }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+
+    await expect(
+      new MicrosoftCastKnownErrorsInterceptor().execute(input, next)
+    ).rejects.toBe(error);
+  });
+
+  it("preserves the retry delay for throttled requests", async () => {
+    const error = new MicrosoftThrottlingError("/sites", 120_000);
+    const next = vi.fn(async () => {
+      throw error;
+    }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+
+    const execution = new MicrosoftCastKnownErrorsInterceptor().execute(
+      input,
+      next
+    );
+
+    await expect(execution).rejects.toThrow(ApplicationFailure);
+    await expect(execution).rejects.toMatchObject({
+      cause: error,
+      nextRetryDelay: 120_000,
+    });
+  });
+
+  it("still classifies sign-in failures as OAuth errors", async () => {
+    const error = new Error(
+      "Error retrieving access token from microsoft: code=provider_access_token_refresh_error AADSTS50173"
+    );
+    const next = vi.fn(async () => {
+      throw error;
+    }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+
+    await expect(
+      new MicrosoftCastKnownErrorsInterceptor().execute(input, next)
+    ).rejects.toThrow(ExternalOAuthTokenError);
+  });
+
+  it("returns successful activity results unchanged", async () => {
+    const result = { gcsFilePath: null, deltaTooLarge: false };
+    const next = vi.fn(async () => result) satisfies Next<
+      ActivityInboundCallsInterceptor,
+      "execute"
+    >;
+
+    await expect(
+      new MicrosoftCastKnownErrorsInterceptor().execute(input, next)
+    ).resolves.toBe(result);
   });
 });

--- a/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
@@ -110,6 +110,12 @@ export function isJSONParsingError(err: unknown): err is Error {
   );
 }
 
+/**
+ * @cc [label:error-handling] microsoft-error-classification
+ * Map recognized authentication and provider configuration failures to `ExternalOAuthTokenError`
+ * and `ThirdPartyConfigurationError`, respectively. Preserve provider-specified retry delays for
+ * throttling, return successful activity results, and rethrow unrecognized errors unchanged.
+ */
 export class MicrosoftCastKnownErrorsInterceptor
   implements ActivityInboundCallsInterceptor
 {
@@ -132,7 +138,7 @@ export class MicrosoftCastKnownErrorsInterceptor
       if (isMicrosoftSignInError(err)) {
         throw new ExternalOAuthTokenError(err);
       }
-      if (isMissingSharePointLicenseError(err)) {
+      if (isMissingSharePointLicenseError(err) || isAccessBlockedError(err)) {
         throw new ThirdPartyConfigurationError(err);
       }
       throw err;

--- a/connectors/src/lib/temporal_monitoring.test.ts
+++ b/connectors/src/lib/temporal_monitoring.test.ts
@@ -1,4 +1,6 @@
 import { BigQueryCastKnownErrorsInterceptor } from "@connectors/connectors/bigquery/temporal/cast_known_errors";
+import { MicrosoftCastKnownErrorsInterceptor } from "@connectors/connectors/microsoft/temporal/cast_known_errors";
+import { GraphError } from "@microsoft/microsoft-graph-client";
 import { Context, type Info } from "@temporalio/activity";
 import {
   noopMetricMeter,
@@ -255,6 +257,47 @@ describe("ActivityInboundLogInterceptor", () => {
     }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
     const next = vi.fn((activityInput: ActivityExecuteInput) =>
       new BigQueryCastKnownErrorsInterceptor().execute(activityInput, activity)
+    ) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+
+    await expect(interceptor.execute(input, next)).rejects.toThrow(
+      ThirdPartyConfigurationError
+    );
+
+    expect(mocks.syncFailed).toHaveBeenCalledWith(
+      42,
+      "third_party_internal_error"
+    );
+    expect(mocks.pauseAndStop).toHaveBeenCalledWith({
+      reason: "Stopped on ThirdPartyConfigurationError",
+    });
+  });
+
+  it("pauses Microsoft when its activity encounters blocked site access", async () => {
+    mocks.fetchById.mockResolvedValue({
+      dataSourceId: "data-source-id",
+      id: 42,
+      type: "microsoft",
+      workspaceId: "workspace-id",
+    });
+    const interceptor = new ActivityInboundLogInterceptor(
+      makeActivityContext("incrementalSyncWorkflowV2"),
+      logger,
+      "microsoft"
+    );
+    const error = new GraphError(
+      423,
+      "Access to this site has been blocked. Please contact the administrator to resolve this problem."
+    );
+    error.code = "notAllowed";
+    const input = {
+      args: [],
+      headers: {},
+    } satisfies ActivityExecuteInput;
+    const activity = vi.fn(async () => {
+      throw error;
+    }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+    const next = vi.fn((activityInput: ActivityExecuteInput) =>
+      new MicrosoftCastKnownErrorsInterceptor().execute(activityInput, activity)
     ) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
 
     await expect(interceptor.execute(input, next)).rejects.toThrow(


### PR DESCRIPTION
## Description

Microsoft delta-sync activities keep retrying when a SharePoint site blocks access with a `GraphError` carrying HTTP 423 and code `notAllowed`. Site discovery already recognizes this error, but the activity interceptor does not classify it when it escapes from synchronization.

Reuse `isAccessBlockedError` to classify these failures as `ThirdPartyConfigurationError`. The existing activity handler then marks the connector `third_party_internal_error`, pauses it, and stops its workflows. Preserve the original Graph error as the cause and document the interceptor's general error-classification contract on the class.

[Microsoft Graph's error documentation](https://learn.microsoft.com/en-us/graph/errors) describes HTTP 423 Locked:

> The resource that is being accessed is locked.

[Microsoft's SharePoint lock-state documentation](https://learn.microsoft.com/en-us/sharepoint/manage-lock-status) describes `NoAccess`:

> NoAccess to prevent users from accessing the site and its content.

The same documentation explains how a SharePoint administrator can change the site's lock state.

## Tests

Ran the Microsoft error-classification and Temporal monitoring suites: 15 tests passed. The captured-error regression and the composed interceptor pause test both fail before the fix and pass afterward. Coverage also checks the original error cause, missing-license and OAuth handling, throttling retry delays, unrecognized Graph errors, and successful activity results.

## Risk

Low. Reuses the existing HTTP 423 / `notAllowed` predicate and configuration-error pause path. Any matching error that escapes an activity will pause the whole connector. Site discovery retains its existing behavior of skipping blocked resources.

## Deploy Plan

Deploy `connectors`, including the Microsoft workers. Affected running connectors will pause on their next matching activity failure after rollout. Restore access to the affected site before resuming synchronization.
