### PR TITLE
feat: persist automations page tab in the URL

### DIFF
--- a/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
@@ -4,6 +4,7 @@ import { AutomationsTriggersTable } from "@app/components/workspace/analytics/au
 import { SlackWorkflowsTab } from "@app/components/workspace/analytics/automations/SlackWorkflowsTab";
 import type { AutomationsFilter } from "@app/components/workspace/analytics/automationsFilter";
 import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
+import { useQueryParams } from "@app/hooks/useQueryParams";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
@@ -33,7 +34,11 @@ export function AnalyticsAutomationsPage() {
     DEFAULT_CONSUMPTION_PERIOD
   );
   const [filter, setFilter] = useState<AutomationsFilter>({});
-  const [tab, setTab] = useState<AutomationsTab>("triggers");
+  const { tab: tabParam } = useQueryParams(["tab"]);
+  const tab: AutomationsTab =
+    tabParam.value === "slack-workflows" ? "slack-workflows" : "triggers";
+  const setTab = (next: AutomationsTab) =>
+    tabParam.setParam(next === "triggers" ? undefined : next);
 
   const canManageSlackWorkflows =
     isAdmin(owner) && isCreditPricedPlan(subscription.plan);


### PR DESCRIPTION
## Description

The automations page (Triggers / Slack workflows) kept its active tab in local component state only. Reloading the page, using browser back/forward, or sharing a link to the Slack workflows tab always dropped you back on Triggers.

Switched the tab state to the `?tab=` query param, using the same convention already in place on the members page (`useQueryParams`). Default (Triggers) omits the param; selecting Slack workflows sets `?tab=slack-workflows`.

## Tests

Manually verified: switching tabs updates the URL, reloading on `?tab=slack-workflows` restores that tab, and browser back/forward moves between tabs.

## Risk

Low. Purely additive URL state on an existing client-only tab switch; no API or data changes.

## Deploy Plan

Deploy front.