### PR TITLE
[front] fix: add seat_type to consumption analytics test expectations

### DIFF
--- a/front/lib/analytics/agent_message_consumption/llm_documents.test.ts
+++ b/front/lib/analytics/agent_message_consumption/llm_documents.test.ts
@@ -155,6 +155,7 @@ describe("buildLlmConsumptionDocuments", () => {
         user: {
           id: auth.getNonNullableUser().sId,
           group_ids: [],
+          seat_type: null,
         },
       }),
     ]);

--- a/front/lib/analytics/agent_message_consumption/load.test.ts
+++ b/front/lib/analytics/agent_message_consumption/load.test.ts
@@ -255,6 +255,7 @@ describe("loadAgentMessageConsumptionAnalyticsInput", () => {
     expect(input?.user).toEqual({
       id: testContext.authenticator.getNonNullableUser().sId,
       group_ids: [group.sId],
+      seat_type: "workspace",
     });
   });
 


### PR DESCRIPTION
## Description

PR #31935 ("add seat_type to es consumption index") added a `seat_type` field to the consumption-analytics user object (`load.ts`) but did not update two tests that assert that object with exact `toEqual` matching. This broke the `front` test suite on `main`.

CI only surfaced the `llm_documents` failure (shard 4) because the workflow cancels the remaining shards on first failure — the `load.test.ts` failure was hiding in a cancelled shard.

Fix: add the missing `seat_type` field to both expected user objects (`null` where the user has no seat, `"workspace"` where they do).

## Tests

Recreated the test DB fresh and ran all 6 front shards locally — all green. The two affected files pass.

## Risk

None. Test-only change (2 lines), aligns expectations with already-shipped behavior.

## Deploy Plan

Merge to main. No migration or config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)