### PR TITLE
Disable automatic retries in streaming provider SDKs

### DIFF
--- a/front/lib/model_constructors/stream/clients/anthropic.test.ts
+++ b/front/lib/model_constructors/stream/clients/anthropic.test.ts
@@ -1,0 +1,24 @@
+// @vitest-environment node
+
+import { AnthropicClaudeSonnetFourDotSixEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_sonnet_four_dot_six_eu_agent_platform";
+import { AnthropicClaudeSonnetFourDotSixGlobalAnthropicStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_sonnet_four_dot_six_global_anthropic";
+import { describe, expect, it } from "vitest";
+
+describe("AnthropicStream", () => {
+  it("disables SDK retries so the agent loop owns retry attempts", () => {
+    const endpoint = new AnthropicClaudeSonnetFourDotSixGlobalAnthropicStream({
+      ANTHROPIC_API_KEY: "test-key",
+    });
+
+    expect(Reflect.get(endpoint, "client")).toMatchObject({ maxRetries: 0 });
+  });
+
+  it("disables Vertex SDK retries so the agent loop owns retry attempts", () => {
+    const endpoint =
+      new AnthropicClaudeSonnetFourDotSixEuropeAgentPlatformStream({
+        AGENT_PLATFORM_PROJECT_ID: "test-project",
+      });
+
+    expect(Reflect.get(endpoint, "client")).toMatchObject({ maxRetries: 0 });
+  });
+});

--- a/front/lib/model_constructors/stream/clients/anthropic.ts
+++ b/front/lib/model_constructors/stream/clients/anthropic.ts
@@ -81,6 +81,10 @@ export abstract class AnthropicStream extends WithAnthropicAIInputConverter(
     super();
     this.client = new AnthropicClient({
       apiKey: ANTHROPIC_API_KEY,
+      // The agent loop owns retries so every attempt has a distinct, observable Dust trace.
+      // Hidden SDK retries can populate the prompt cache on an unobserved attempt, then report
+      // only the cache-hit usage of the successful retry.
+      maxRetries: 0,
     });
   }
 

--- a/front/lib/model_constructors/stream/clients/anthropic_agent_platform.ts
+++ b/front/lib/model_constructors/stream/clients/anthropic_agent_platform.ts
@@ -73,6 +73,9 @@ export abstract class AnthropicAgentPlatformStream extends WithAnthropicAIInputC
     this.client = new AnthropicVertex({
       region: this.constructor.regionalEndpoint,
       projectId: AGENT_PLATFORM_PROJECT_ID,
+      // The agent loop owns retries so every attempt is observable and billed
+      // from the usage reported by that exact attempt.
+      maxRetries: 0,
     });
   }
 

--- a/front/lib/model_constructors/stream/clients/fireworks.test.ts
+++ b/front/lib/model_constructors/stream/clients/fireworks.test.ts
@@ -4,6 +4,14 @@ import { DeepSeekDeepSeekV4ProGlobalFireworksStream } from "@app/lib/model_const
 import { describe, expect, it } from "vitest";
 
 describe("FireworksStream", () => {
+  it("disables SDK retries so the agent loop owns retry attempts", () => {
+    const endpoint = new DeepSeekDeepSeekV4ProGlobalFireworksStream({
+      FIREWORKS_API_KEY: "test",
+    });
+
+    expect(Reflect.get(endpoint, "client")).toMatchObject({ maxRetries: 0 });
+  });
+
   it("includes names when replaying parallel tool results", () => {
     const endpoint = new DeepSeekDeepSeekV4ProGlobalFireworksStream({
       FIREWORKS_API_KEY: "test",

--- a/front/lib/model_constructors/stream/clients/fireworks.ts
+++ b/front/lib/model_constructors/stream/clients/fireworks.ts
@@ -55,6 +55,8 @@ export abstract class FireworksStream extends WithOpenAICompletionsInputConverte
     this.client = new OpenAI({
       apiKey: FIREWORKS_API_KEY,
       baseURL: FIREWORKS_BASE_URL,
+      // The agent loop owns retries so every attempt gets its own Dust trace.
+      maxRetries: 0,
     });
   }
 

--- a/front/lib/model_constructors/stream/clients/fireworks_responses.test.ts
+++ b/front/lib/model_constructors/stream/clients/fireworks_responses.test.ts
@@ -30,6 +30,14 @@ const TOOLS = [
 ];
 
 describe("FireworksResponsesStream", () => {
+  it("disables SDK retries so the agent loop owns retry attempts", () => {
+    const endpoint = new MoonshotAiKimiK3GlobalFireworksStream({
+      FIREWORKS_API_KEY: "test",
+    });
+
+    expect(Reflect.get(endpoint, "client")).toMatchObject({ maxRetries: 0 });
+  });
+
   it("replays reasoning and tool calls as Responses input items", () => {
     const endpoint = new MoonshotAiKimiK3GlobalFireworksStream({
       FIREWORKS_API_KEY: "test",

--- a/front/lib/model_constructors/stream/clients/fireworks_responses.ts
+++ b/front/lib/model_constructors/stream/clients/fireworks_responses.ts
@@ -74,6 +74,8 @@ export abstract class FireworksResponsesStream extends WithOpenAIResponsesInputC
     this.client = new OpenAI({
       apiKey: FIREWORKS_API_KEY,
       baseURL: FIREWORKS_BASE_URL,
+      // The agent loop owns retries so every attempt gets its own Dust trace.
+      maxRetries: 0,
     });
   }
 

--- a/front/lib/model_constructors/stream/clients/mistral.test.ts
+++ b/front/lib/model_constructors/stream/clients/mistral.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment node
+
+import { MistralMistralLargeEuropeMistralStream } from "@app/lib/model_constructors/stream/endpoints/mistral_mistral_large_eu_mistral";
+import { describe, expect, it } from "vitest";
+
+describe("MistralStream", () => {
+  it("disables SDK retries so the agent loop owns retry attempts", () => {
+    const endpoint = new MistralMistralLargeEuropeMistralStream({
+      MISTRAL_API_KEY: "test",
+    });
+
+    expect(
+      Reflect.get(Reflect.get(endpoint, "client"), "_options")
+    ).toMatchObject({
+      retryConfig: { strategy: "none" },
+    });
+  });
+});

--- a/front/lib/model_constructors/stream/clients/mistral.ts
+++ b/front/lib/model_constructors/stream/clients/mistral.ts
@@ -29,7 +29,12 @@ export abstract class MistralStream extends WithMistralAIInputConverter(
 
   constructor({ MISTRAL_API_KEY }: Credentials) {
     super();
-    this.client = new Mistral({ apiKey: MISTRAL_API_KEY });
+    this.client = new Mistral({
+      apiKey: MISTRAL_API_KEY,
+      // Keep the SDK's current single-attempt default explicit: the agent loop
+      // owns retries so every attempt gets its own Dust trace.
+      retryConfig: { strategy: "none" },
+    });
   }
 
   async *streamRaw(

--- a/front/lib/model_constructors/stream/clients/openai_responses.test.ts
+++ b/front/lib/model_constructors/stream/clients/openai_responses.test.ts
@@ -46,6 +46,12 @@ const standardOnlyEndpoints = openAIResponsesEndpoints.filter(
 );
 
 describe("OpenAIResponsesStream flex support declarations", () => {
+  it("disables SDK retries so the agent loop owns retry attempts", () => {
+    const endpoint = new flexEndpoint({ OPENAI_API_KEY: "test" });
+
+    expect(Reflect.get(endpoint, "client")).toMatchObject({ maxRetries: 0 });
+  });
+
   // An empty partition would make the `it.each` blocks below silently vacuous.
   it("partitions the endpoints on both sides of the flag", () => {
     expect(flexEndpoints.length).toBeGreaterThan(0);

--- a/front/lib/model_constructors/stream/clients/openai_responses.ts
+++ b/front/lib/model_constructors/stream/clients/openai_responses.ts
@@ -69,6 +69,8 @@ export abstract class OpenAIResponsesStream extends WithOpenAIResponsesInputConv
     this._client ??= new OpenAI({
       apiKey: this.apiKey,
       baseURL: this.baseUrl,
+      // The agent loop owns retries so every attempt gets its own Dust trace.
+      maxRetries: 0,
     });
     return this._client;
   }

--- a/front/lib/model_constructors/stream/clients/xai.test.ts
+++ b/front/lib/model_constructors/stream/clients/xai.test.ts
@@ -1,0 +1,14 @@
+// @vitest-environment node
+
+import { XaiGrokFourDotSixGlobalXaiStream } from "@app/lib/model_constructors/stream/endpoints/xai_grok_four_dot_six_global_xai";
+import { describe, expect, it } from "vitest";
+
+describe("XaiStream", () => {
+  it("disables SDK retries so the agent loop owns retry attempts", () => {
+    const endpoint = new XaiGrokFourDotSixGlobalXaiStream({
+      XAI_API_KEY: "test",
+    });
+
+    expect(Reflect.get(endpoint, "client")).toMatchObject({ maxRetries: 0 });
+  });
+});

--- a/front/lib/model_constructors/stream/clients/xai.ts
+++ b/front/lib/model_constructors/stream/clients/xai.ts
@@ -40,7 +40,12 @@ export abstract class XaiStream extends WithOpenAIResponsesInputConverter(
 
   constructor({ XAI_API_KEY }: Credentials) {
     super();
-    this.client = new OpenAI({ apiKey: XAI_API_KEY, baseURL: XAI_BASE_URL });
+    this.client = new OpenAI({
+      apiKey: XAI_API_KEY,
+      baseURL: XAI_BASE_URL,
+      // The agent loop owns retries so every attempt gets its own Dust trace.
+      maxRetries: 0,
+    });
   }
 
   buildRequestPayload(


### PR DESCRIPTION
## Description

Disable automatic retries inside streaming provider SDK clients so a transport retry cannot happen below Dust's observable agent-loop boundary.

The attribution investigation found an Anthropic usage pattern consistent with an SDK retry: an initial request can populate the prompt cache and fail before returning usage, then the SDK retry succeeds with a cache hit. Dust records only the successful response, making the provider cost appear lower than the tool-result input that had to be written at least once.

This PR:

- sets `maxRetries: 0` for Anthropic, Anthropic Vertex, OpenAI Responses, Fireworks Chat, Fireworks Responses, and xAI streaming clients;
- makes Mistral's existing single-attempt default explicit with `retryConfig: { strategy: "none" }`;
- leaves Google AI Studio and Google Vertex unchanged because the Google Gen AI SDK performs one request when no retry options are supplied;
- adds constructor-level tests that lock the retry policy for every changed provider client.

This is intentionally scoped to automatic SDK retries. OpenAI Flex's explicit, application-level fallback to standard processing remains unchanged.

## Tests

- Focused streaming-provider suite: 53 tests passed across 6 files.
- Added retry-policy coverage for Anthropic, Anthropic Vertex, OpenAI, Fireworks Chat, Fireworks Responses, xAI, and Mistral.
- Biome passed on all changed files.

## Risk

Transient provider failures may surface to the agent loop sooner because the SDK no longer retries them internally. The agent loop still owns retry behavior, with the benefit that each retry is observable and receives its own Dust trace and usage record.

No request payloads, model selection, usage conversion, or pricing logic are changed.

## Deploy Plan

- Standard frontend deployment; no migration or feature flag is required.
- Monitor provider error rates and agent-loop retry rates after deployment.
- Confirm that new attribution failures no longer show cache-hit-only usage without a corresponding observable attempt.
