### PR TITLE
feat(front): use Claude Sonnet 5 as second candidate in auto and auto_fast streams

### DIFF
--- a/front/lib/model_tiers/enabled_models.test.ts
+++ b/front/lib/model_tiers/enabled_models.test.ts
@@ -14,6 +14,7 @@ import {
   CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
   CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+  CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
 import type { ModelStreamIdType } from "@app/types/assistant/models/auto";
 import {
@@ -282,7 +283,7 @@ describe("resolveStreamModel", () => {
 
     expect(resolved.fromPool).toBe(true);
     expect(resolved.model.modelId).toBe(
-      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId
+      CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG.modelId
     );
     expect(resolved.reasoningEffort).toBe("medium");
   });

--- a/front/types/assistant/models/auto.ts
+++ b/front/types/assistant/models/auto.ts
@@ -2,6 +2,7 @@ import {
   CLAUDE_OPUS_4_8_MODEL_ID,
   CLAUDE_OPUS_5_MODEL_ID,
   CLAUDE_SONNET_4_6_MODEL_ID,
+  CLAUDE_SONNET_5_MODEL_ID,
 } from "./anthropic";
 import {
   GEMINI_3_1_FLASH_LITE_MODEL_ID,
@@ -63,7 +64,7 @@ export const MODEL_STREAMS: Record<ModelStreamIdType, ModelStreamCandidate[]> =
       },
       {
         providerId: "anthropic",
-        modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+        modelId: CLAUDE_SONNET_5_MODEL_ID,
         reasoningEffort: "medium",
       },
       {
@@ -110,7 +111,7 @@ export const MODEL_STREAMS: Record<ModelStreamIdType, ModelStreamCandidate[]> =
       },
       {
         providerId: "anthropic",
-        modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+        modelId: CLAUDE_SONNET_5_MODEL_ID,
         reasoningEffort: "light",
       },
       {


### PR DESCRIPTION
## Description

See https://dust4ai.slack.com/archives/C050A0S2Z7F/p1788337077502159 for context

Promotes Claude Sonnet 5 to the second candidate of the `auto` (Standard) and `auto_fast` (Basic) model streams, replacing Claude Sonnet 4.6 at those positions (`medium` effort for `auto`, `light` for `auto_fast`).

Sonnet 5 carries the same tier mapping as Sonnet 4.6 (`light` → cost_efficient, `medium` → balanced), so tier-capped resolution behaves the same. Sonnet 4.6 remains the Basic-tier floor at the end of the `auto` and `auto_complex` streams.

## Risk

Low — pure candidate reordering in the stream tables; instant rollback by reverting the commit. Workspaces where Anthropic is whitelisted and OpenAI is not will now route to Sonnet 5 instead of Sonnet 4.6.
