### PR TITLE
[viz] dev frame-ancestors include ALLOWED_VISUALIZATION_ORIGIN

### DIFF
--- a/viz/CONTRACTS
+++ b/viz/CONTRACTS
@@ -1,4 +1,4 @@
-@cc [owner:PopDaph,label:security] allowed-visualization-origins
+@cc [label:security] allowed-visualization-origins
 `ALLOWED_VISUALIZATION_ORIGIN` is the comma-separated list of front origins allowed to embed viz.
 The content page must reject `postMessage` events from any other origin, and in development the
 `frame-ancestors` CSP directive must include these origins. The production `frame-ancestors` list

--- a/viz/CONTRACTS
+++ b/viz/CONTRACTS
@@ -1,0 +1,5 @@
+@cc [owner:PopDaph,label:security] allowed-visualization-origins
+`ALLOWED_VISUALIZATION_ORIGIN` is the comma-separated list of front origins allowed to embed viz.
+The content page must reject `postMessage` events from any other origin, and in development the
+`frame-ancestors` CSP directive must include these origins. The production `frame-ancestors` list
+is fixed in `next.config.mjs` and must not depend on the variable.

--- a/viz/next.config.mjs
+++ b/viz/next.config.mjs
@@ -1,8 +1,25 @@
 /** @type {import('next').NextConfig} */
 const isDev = process.env.NODE_ENV === "development";
 
+// Dev fronts that may embed viz. dust-hive envs run on other ports and list them in
+// ALLOWED_VISUALIZATION_ORIGIN (the same variable the content page checks), so include those too.
+const DEV_FRAME_ANCESTORS = [
+  "http://localhost:3000",
+  "http://localhost:3011",
+  "http://localhost:3012",
+  "chrome-extension://okjldflokifdjecnhbmkdanjjbnmlihg",
+  "http://localhost:16011",
+  ...(process.env.ALLOWED_VISUALIZATION_ORIGIN ?? "")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean),
+];
+
+const PROD_FRAME_ANCESTORS =
+  "https://dust.tt https://app.dust.tt https://eu.dust.tt https://front-edge.dust.tt https://eu.front-edge.dust.tt https://*.preview.dust.tt chrome-extension://okjldflokifdjecnhbmkdanjjbnmlihg chrome-extension://fnkfcndbgingjcbdhaofkcnhcjpljhdn";
+
 const CONTENT_SECURITY_POLICIES = `connect-src 'self'; media-src 'self'; frame-ancestors 'self' https://app.frontapp.com ${
-  isDev ? "http://localhost:3000 http://localhost:3011 http://localhost:3012 chrome-extension://okjldflokifdjecnhbmkdanjjbnmlihg http://localhost:16011" : "https://dust.tt https://app.dust.tt https://eu.dust.tt https://front-edge.dust.tt https://eu.front-edge.dust.tt https://*.preview.dust.tt chrome-extension://okjldflokifdjecnhbmkdanjjbnmlihg chrome-extension://fnkfcndbgingjcbdhaofkcnhcjpljhdn"
+  isDev ? [...new Set(DEV_FRAME_ANCESTORS)].join(" ") : PROD_FRAME_ANCESTORS
 } moz-extension:;`;
 
 const nextConfig = {

--- a/viz/next.config.mjs
+++ b/viz/next.config.mjs
@@ -15,12 +15,22 @@ const DEV_FRAME_ANCESTORS = [
     .filter(Boolean),
 ];
 
-const PROD_FRAME_ANCESTORS =
-  "https://dust.tt https://app.dust.tt https://eu.dust.tt https://front-edge.dust.tt https://eu.front-edge.dust.tt https://*.preview.dust.tt chrome-extension://okjldflokifdjecnhbmkdanjjbnmlihg chrome-extension://fnkfcndbgingjcbdhaofkcnhcjpljhdn";
+const PROD_FRAME_ANCESTORS = [
+  "https://dust.tt",
+  "https://app.dust.tt",
+  "https://eu.dust.tt",
+  "https://front-edge.dust.tt",
+  "https://eu.front-edge.dust.tt",
+  "https://*.preview.dust.tt",
+  "chrome-extension://okjldflokifdjecnhbmkdanjjbnmlihg",
+  "chrome-extension://fnkfcndbgingjcbdhaofkcnhcjpljhdn",
+];
 
-const CONTENT_SECURITY_POLICIES = `connect-src 'self'; media-src 'self'; frame-ancestors 'self' https://app.frontapp.com ${
-  isDev ? [...new Set(DEV_FRAME_ANCESTORS)].join(" ") : PROD_FRAME_ANCESTORS
-} moz-extension:;`;
+const FRAME_ANCESTORS = [
+  ...new Set(isDev ? DEV_FRAME_ANCESTORS : PROD_FRAME_ANCESTORS),
+].join(" ");
+
+const CONTENT_SECURITY_POLICIES = `connect-src 'self'; media-src 'self'; frame-ancestors 'self' https://app.frontapp.com ${FRAME_ANCESTORS} moz-extension:;`;
 
 const nextConfig = {
   async headers() {

--- a/viz/next.config.mjs
+++ b/viz/next.config.mjs
@@ -8,7 +8,6 @@ const DEV_FRAME_ANCESTORS = [
   "http://localhost:3011",
   "http://localhost:3012",
   "chrome-extension://okjldflokifdjecnhbmkdanjjbnmlihg",
-  "http://localhost:16011",
   ...(process.env.ALLOWED_VISUALIZATION_ORIGIN ?? "")
     .split(",")
     .map((origin) => origin.trim())


### PR DESCRIPTION
Frames never load in a dust-hive env: viz's dev `frame-ancestors` CSP is a fixed list (`localhost:3000`, `3011`, `3012`, `16011`), so a front on `localhost:11011` gets `ERR_BLOCKED_BY_RESPONSE` and the panel spins forever. Going through the forwarder on 3011 works, which is why nobody noticed.

In development the list now also includes the origins from `ALLOWED_VISUALIZATION_ORIGIN`, the variable the content page already uses to filter `postMessage` senders and which dust-hive sets to its ports. Production is unchanged. Added a `viz/CONTRACTS` entry tying the two uses of the variable together.

Verified: after restarting viz in the hive, the header lists `http://localhost:11011`.
