### PR TITLE
feat(llm): collect the model health logs under one component field

### DIFF
--- a/front/lib/api/llm/health/detect.ts
+++ b/front/lib/api/llm/health/detect.ts
@@ -2,11 +2,11 @@ import {
   ERROR_RATIO_THRESHOLD,
   MIN_ATTEMPTS_IN_WINDOW,
 } from "@app/lib/api/llm/health/config";
+import { healthLogger } from "@app/lib/api/llm/health/logger";
 import { logModelHealthTransition } from "@app/lib/api/llm/health/transitions";
 import type { ModelHealthWindowType } from "@app/lib/api/llm/health/types";
 import { readEndpointWindow } from "@app/lib/api/llm/health/window";
 import type { DegradedModelEndpointType } from "@app/lib/model_constructors/types/degradations";
-import logger from "@app/logger/logger";
 import { launchModelHealthRecovery } from "@app/temporal/model_health/client";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -44,7 +44,7 @@ export async function evaluateEndpoint(
 
   const launchRes = await launchModelHealthRecovery(endpoint);
   if (launchRes.isErr()) {
-    logger.error(
+    healthLogger.error(
       {
         err: normalizeError(launchRes.error),
         modelId: endpoint.modelId,

--- a/front/lib/api/llm/health/logger.ts
+++ b/front/lib/api/llm/health/logger.ts
@@ -1,0 +1,12 @@
+import logger from "@app/logger/logger";
+
+/**
+ * Everything the model health breaker logs, under one field.
+ *
+ * Its lines are spread across detection on the request path and the recovery
+ * workflow's probes -- two services, two levels, and in `client.ts` a line with
+ * only a `workflowId` to go on. `component` is what collects them into one
+ * Datadog view and gives a monitor something to group by; the message strings
+ * are not a stable enough key for either.
+ */
+export const healthLogger = logger.child({ component: "model_health" });

--- a/front/lib/api/llm/health/probe.ts
+++ b/front/lib/api/llm/health/probe.ts
@@ -2,13 +2,13 @@ import {
   PROBE_TIMEOUT_MS,
   PROBES_PER_RECOVERY,
 } from "@app/lib/api/llm/health/config";
+import { healthLogger } from "@app/lib/api/llm/health/logger";
 import { dangerouslyGetDustManagedLlmCredentials } from "@app/lib/api/provider_credentials";
 import { DUST_STREAM_ENDPOINTS } from "@app/lib/llms/stream";
 import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
 import type { DegradedModelEndpointType } from "@app/lib/model_constructors/types/degradations";
 import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
 import type { Payload } from "@app/lib/model_constructors/types/input/messages";
-import logger from "@app/logger/logger";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
@@ -132,7 +132,7 @@ async function runSingleProbe(
     return raced;
   }
 
-  logger.info(
+  healthLogger.info(
     {
       modelId: endpoint.modelConfig.modelId,
       providerId: endpoint.modelConfig.providerId,
@@ -160,7 +160,7 @@ export async function probeEndpoint(
 ): Promise<boolean> {
   const constructor = findStreamEndpoint(endpoint);
   if (!constructor) {
-    logger.error(
+    healthLogger.error(
       {
         modelId: endpoint.modelId,
         providerId: endpoint.providerId,
@@ -177,7 +177,7 @@ export async function probeEndpoint(
       healthy = await runSingleProbe(constructor);
     } catch (err) {
       // Provider SDKs are external: a throw is a failed probe, not a bug.
-      logger.info(
+      healthLogger.info(
         {
           err: normalizeError(err),
           modelId: endpoint.modelId,

--- a/front/lib/api/llm/health/transitions.ts
+++ b/front/lib/api/llm/health/transitions.ts
@@ -1,7 +1,7 @@
+import { healthLogger } from "@app/lib/api/llm/health/logger";
 import type { ModelHealthWindowType } from "@app/lib/api/llm/health/types";
 import type { DegradedModelEndpointType } from "@app/lib/model_constructors/types/degradations";
 import { statsDMetrics } from "@app/lib/utils/statsd";
-import logger from "@app/logger/logger";
 
 export type ModelHealthTransitionType =
   | "degraded"
@@ -26,7 +26,7 @@ export function logModelHealthTransition({
 }): void {
   const { modelId, providerId, host } = endpoint;
 
-  logger.info(
+  healthLogger.info(
     {
       modelId,
       providerId,

--- a/front/temporal/model_health/client.ts
+++ b/front/temporal/model_health/client.ts
@@ -1,6 +1,6 @@
+import { healthLogger } from "@app/lib/api/llm/health/logger";
 import type { DegradedModelEndpointType } from "@app/lib/model_constructors/types/degradations";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
-import logger from "@app/logger/logger";
 import {
   QUEUE_NAME,
   recoveryWorkflowId,
@@ -47,7 +47,7 @@ async function describeDegradedSinceMs(
 
     return description.startTime.getTime();
   } catch (err) {
-    logger.error(
+    healthLogger.error(
       { err: normalizeError(err), workflowId },
       "Failed to read the model health recovery workflow start time"
     );


### PR DESCRIPTION
## Description

The breaker's log lines have nothing in common to filter on. They are spread across
detection on the request path (`front`) and the recovery workflow's probes (the
`model_health` worker), at two levels: `modelId` is on five of the six but is not specific
to the breaker, and `describeDegradedSinceMs` only has a `workflowId` to go on.

Adds `healthLogger`, a child logger binding `component: "model_health"`, and routes the six
through it. The Datadog view becomes `@component:model_health` rather than an `OR` of six
message strings, and a log monitor gets a facet it can group by. Message strings are not a
stable enough key for either.

No behaviour change, no new line, no field dropped. Follows the model health stack
(#31877 → #31881).

One deliberate omission: the `ActivityInboundLogInterceptor` in `model_health/worker.ts`
stays on the root logger. Its lines are activity lifecycle rather than breaker state, and
`dd.service` plus the workflow type already identify them. Happy to pull it in if you would
rather the view cover the activity boundary too.

## Tests

Nothing to test: `logger.child` adds a field to lines that already existed, and no suite
asserts on log output (`front/lib/api/llm/health/*.test.ts` mock the modules around these
calls, not the logger).

Local validation was **not** run in the Computer, whose checkout has no dependencies
installed, so typecheck, eslint and prettier are delegated to PR CI. What was run locally:
`git diff` review, `git diff --check` (clean), and a grep confirming no bare `logger.`
reference is left in `front/lib/api/llm/health/` or `model_health/client.ts`.

Post-deploy check: `@component:model_health env:prod` in the Logs Explorer returns the
transition lines.

## Risk

One extra field on six log lines. `component` is already used this way in
`front/temporal/activation/admin/cli.ts` and `front/temporal/agent_inactivity/admin/cli.ts`,
so the pipeline does not treat it specially and it is not a Datadog-reserved key (unlike
`host`, which is why `modelHost` exists).

Self-contained and safe to revert: reverting only puts the six-clause message query back.

## Deploy Plan

Nothing to sequence. Once the first lines land, create the Datadog facet on `@component`
so monitors can group by it, along with `@transition`, `@modelHost`, and `@errorRatio` /
`@degradedForMs` as measures.
