### PR TITLE
dust-hive: Novu per-cell placeholders in generated env

### DIFF
--- a/x/henry/dust-hive/src/lib/envgen.ts
+++ b/x/henry/dust-hive/src/lib/envgen.ts
@@ -88,6 +88,11 @@ export TEXT_EXTRACTION_URL=http://localhost:${ports.apacheTika}
 export VIZ_PUBLIC_URL=http://localhost:${ports.viz}
 export ALLOWED_VISUALIZATION_ORIGIN=http://localhost:3000,http://localhost:3011,http://localhost:${ports.front},http://localhost:${ports.frontSpaApp}
 
+# === Novu (front reads per-cell variables; placeholders keep the app booting locally) ===
+export NEXT_PUBLIC_NOVU_APPLICATION_IDENTIFIER_CELL_00000=dummy
+export NEXT_PUBLIC_NOVU_API_URL_US=https://api.novu.co
+export NEXT_PUBLIC_NOVU_WEBSOCKET_API_URL_US=wss://ws.novu.co
+
 # === Region & auth overrides (used by front cross-region and Dust CLI) ===
 export DUST_US_URL=http://localhost:${ports.front}
 export DUST_EU_URL=http://localhost:${ports.front}


### PR DESCRIPTION
## Description

Since #31952 front reads Novu config per cell (`NEXT_PUBLIC_NOVU_APPLICATION_IDENTIFIER_CELL_00000`, `NEXT_PUBLIC_NOVU_API_URL_US`, `NEXT_PUBLIC_NOVU_WEBSOCKET_API_URL_US`) and throws when they're missing, so a dust-hive front crashes on load with "NEXT_PUBLIC_NOVU_APPLICATION_IDENTIFIER for cell is not set".

The generated env now exports placeholders for the three so the app boots. Notifications won't connect locally, same as before.

## Tests

`bun run check` passes. Applied to the aug-2 env, restarted front-spa-app, the app loads again.

## Risk

None, dev tooling only.

## Deploy Plan

None.
