### PR TITLE
Admin access: admin_can_see_private_entities feature flag lifts the agent and skill redaction

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/export/yaml.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/export/yaml.test.ts
@@ -1,5 +1,6 @@
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { setupAgentOwner } from "@app/tests/utils/AgentOwnerFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { honoApp } from "@front-api/app";
@@ -29,6 +30,26 @@ describe("GET /api/w/:wId/assistant/agent_configurations/:aId/export/yaml", () =
     expect(response.status).toBe(404);
     const data = await response.json();
     expect(data.error.type).toBe("agent_configuration_not_found");
+  });
+
+  it("exports an unpublished agent to a non-editor admin with the admin_can_see_private_entities flag", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await SpaceFactory.defaults(auth);
+    await FeatureFlagFactory.basic(auth, "admin_can_see_private_entities");
+
+    const { agentOwnerAuth } = await setupAgentOwner(workspace, "user");
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      agentOwnerAuth,
+      { scope: "hidden" }
+    );
+
+    const response = await exportYaml(workspace, agent.sId);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.yamlContent).toContain(agent.instructions);
   });
 
   it("exports an agent to one of its editors", async () => {

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
@@ -8,6 +8,7 @@ import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { setupAgentOwner } from "@app/tests/utils/AgentOwnerFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -394,6 +395,35 @@ describe("GET /api/w/:wId/assistant/agent_configurations/:aId - agents the calle
     expect(response.status).toBe(404);
     const data = await response.json();
     expect(data.error.type).toBe("agent_configuration_not_found");
+  });
+
+  it("returns the full agent to a non-editor admin with the admin_can_see_private_entities flag", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+      method: "GET",
+    });
+    await SpaceFactory.defaults(auth);
+    await FeatureFlagFactory.basic(auth, "admin_can_see_private_entities");
+
+    const { agentOwner, agentOwnerAuth } = await setupAgentOwner(
+      workspace,
+      "user"
+    );
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    await restrictedSpace.addMembers(auth, { userIds: [agentOwner.sId] });
+    // Both restrictions at once: unpublished, and built on a space the admin cannot read.
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      agentOwnerAuth,
+      { scope: "hidden", requestedSpaceIds: [restrictedSpace.id] }
+    );
+
+    const response = await get(workspace, agent.sId);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.agentConfiguration.sId).toBe(agent.sId);
+    expect(data.agentConfiguration.canRead).toBe(true);
+    expect(data.agentConfiguration.instructions).toBe(agent.instructions);
   });
 
   it("returns not found to an admin for an agent that does not exist", async () => {

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/skills.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/skills.test.ts
@@ -1,6 +1,7 @@
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { setupAgentOwner } from "@app/tests/utils/AgentOwnerFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
@@ -15,6 +16,31 @@ function getSkills(workspace: { sId: string }, aId: string) {
 }
 
 describe("GET /api/w/:wId/assistant/agent_configurations/:aId/skills", () => {
+  it("lists the skills of an unpublished agent to an admin with the admin_can_see_private_entities flag", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await FeatureFlagFactory.basic(auth, "admin_can_see_private_entities");
+    const { agentOwnerAuth } = await setupAgentOwner(workspace, "user");
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      agentOwnerAuth,
+      { scope: "hidden" }
+    );
+    const skill = await SkillFactory.create(agentOwnerAuth, {
+      name: "Owner's Skill",
+    });
+    await SkillFactory.linkToAgent(agentOwnerAuth, {
+      skillId: skill.id,
+      agentConfigurationId: agent.id,
+    });
+
+    const response = await getSkills(workspace, agent.sId);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.skills.map((s: { sId: string }) => s.sId)).toEqual([skill.sId]);
+  });
+
   it("should return 404 for an unpublished agent the caller cannot read", async () => {
     const { workspace } = await createPrivateApiMockRequest({
       role: "admin",

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
@@ -1,4 +1,5 @@
-import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { getAgentConfigurationForDetails } from "@app/lib/api/assistant/configuration/agent";
+import { canAdminSeePrivateEntities } from "@app/lib/api/assistant/configuration/private_entities";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { GetAgentSkillsResponseBody } from "@app/types/api/assistant/configuration/skills";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -22,10 +23,10 @@ app.get(
     const auth = ctx.get("auth");
     const { aId } = ctx.req.valid("param");
 
-    const agent = await getAgentConfiguration(auth, {
-      agentId: aId,
-      variant: "full",
-    });
+    // Skills carry their instructions: they are as private as the agent's own prompt. Admins get
+    // the agents they cannot read redacted (`canRead` false), or in full with the
+    // `admin_can_see_private_entities` feature flag; see `getAgentConfigurationForDetails`.
+    const agent = await getAgentConfigurationForDetails(auth, { agentId: aId });
     if (!agent || !agent.canRead) {
       return apiError(ctx, {
         status_code: 404,
@@ -36,7 +37,12 @@ app.get(
       });
     }
 
-    const skills = await SkillResource.listByAgentConfiguration(auth, agent);
+    // With the flag, the skills built on spaces the admin cannot read are listed too.
+    const skills = await SkillResource.listByAgentConfiguration(auth, agent, {
+      permissionFiltering: (await canAdminSeePrivateEntities(auth))
+        ? "dangerously_skip"
+        : "strict",
+    });
     return ctx.json({ skills: skills.map((s) => s.toJSON(auth)) });
   }
 );

--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -323,6 +323,35 @@ describe("GET /api/w/:wId/skills/:sId", () => {
     ).toEqual([skillOwner.sId]);
   });
 
+  it("returns a skill built on a space the admin cannot read in full with the admin_can_see_private_entities flag", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await FeatureFlagFactory.basic(auth, "admin_can_see_private_entities");
+    const skillOwner = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, skillOwner, {
+      role: "user",
+    });
+    const skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      skillOwner.sId,
+      workspace.sId
+    );
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    await restrictedSpace.addMembers(auth, { userIds: [skillOwner.sId] });
+    const restrictedSkill = await SkillFactory.create(skillOwnerAuth, {
+      name: "Restricted Space Skill",
+      instructions: "Secret guidelines",
+      requestedSpaceIds: [restrictedSpace.id],
+    });
+
+    const response = await getSkill(workspace, restrictedSkill.sId);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.skill.canRead).toBe(true);
+    expect(data.skill.instructions).toBe("Secret guidelines");
+  });
+
   it("returns 404 for a skill built on a space a non-admin cannot read", async () => {
     const { workspace } = await createPrivateApiMockRequest({
       role: "builder",

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -365,6 +365,40 @@ describe("GET /api/w/:wId/skills", () => {
     expect(skills.filter((s) => s.canRead)).not.toHaveLength(0);
   });
 
+  it("lists skills built on spaces the admin cannot read in full with the admin_can_see_private_entities flag", async () => {
+    const { workspace, auth } = await setupTest("admin");
+    await FeatureFlagFactory.basic(auth, "admin_can_see_private_entities");
+
+    const skillOwner = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, skillOwner, {
+      role: "user",
+    });
+    const skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      skillOwner.sId,
+      workspace.sId
+    );
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    await restrictedSpace.addMembers(auth, { userIds: [skillOwner.sId] });
+    await SkillFactory.create(skillOwnerAuth, {
+      name: "Restricted Space Skill",
+      availability: "workspace_users",
+      requestedSpaceIds: [restrictedSpace.id],
+    });
+
+    const response = await getSkills(workspace, {
+      bypassEditorVisibility: "true",
+    });
+    expect(response.status).toBe(200);
+    const skills: SkillWithoutInstructionsAndToolsType[] = (
+      await response.json()
+    ).skills;
+    const restrictedSkill = skills.find(
+      (s) => s.name === "Restricted Space Skill"
+    );
+    expect(restrictedSkill).toBeDefined();
+    expect(restrictedSkill!.canRead).toBe(true);
+  });
+
   it("rejects bypassEditorVisibility for non-admins", async () => {
     const { workspace } = await setupTest("user");
 

--- a/front/lib/api/actions/servers/workspace_management/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_management/tools/index.test.ts
@@ -4,6 +4,7 @@ import { TOOLS } from "@app/lib/api/actions/servers/workspace_management/tools";
 import { archiveAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -359,6 +360,31 @@ describe("workspace_management tools", () => {
       expect(text).toContain("Restricted Space Agent");
       expect(text).toContain("private");
       expect(text).not.toContain("Test Instructions");
+    });
+
+    it("returns the instructions of an unpublished agent to an admin with the admin_can_see_private_entities flag", async () => {
+      const { workspace, authenticator } = await createResourceTest({
+        role: "admin",
+      });
+      await FeatureFlagFactory.basic(
+        authenticator,
+        "admin_can_see_private_entities"
+      );
+      const agentOwnerAuth = await createOtherMemberAuth(workspace);
+      const agent = await AgentConfigurationFactory.createTestAgent(
+        agentOwnerAuth,
+        { name: "Unpublished Agent", scope: "hidden" }
+      );
+
+      const text = await callTool(
+        "get_agent_details",
+        { agentId: agent.sId },
+        authenticator
+      );
+
+      expect(text).toContain("Unpublished Agent");
+      expect(text).toContain("Test Instructions");
+      expect(text).not.toContain("private");
     });
 
     it("does not reveal an unpublished agent to a non-editor member", async () => {

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -15,7 +15,7 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
-import { Authenticator } from "@app/lib/auth";
+import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { getModelsForAuth } from "@app/lib/model_tiers/enabled_models";
 import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
@@ -462,8 +462,20 @@ export async function getAgentConfigurationForDetails(
   }
 
   // Either not readable (unpublished, not an editor) or filtered out by a space the admin is not a
-  // member of: refetch without the space filtering to redact it. The light variant is enough, the
-  // full one only adds fields the redaction drops.
+  // member of. With the `admin_can_see_private_entities` feature flag the admin gets it in full;
+  // otherwise it is refetched without the space filtering to be redacted.
+  if (await hasFeatureFlag(auth, "admin_can_see_private_entities")) {
+    const fullAgent =
+      agent ??
+      (await getAgentConfiguration(auth, {
+        agentId,
+        variant: "full",
+        dangerouslySkipPermissionFiltering: true,
+      }));
+    return fullAgent ? { ...fullAgent, canRead: true } : null;
+  }
+
+  // The light variant is enough, the full one only adds fields the redaction drops.
   const restrictedAgent =
     agent ??
     (await getAgentConfiguration(auth, {

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -8,6 +8,7 @@ import {
   isSelfHostedImageWithValidContentType,
   redactPrivateAgentConfigurationFields,
 } from "@app/lib/api/assistant/configuration/helpers";
+import { canAdminSeePrivateEntities } from "@app/lib/api/assistant/configuration/private_entities";
 import { getGlobalAgents } from "@app/lib/api/assistant/global_agents/global_agents";
 import { agentConfigurationWasUpdatedBy } from "@app/lib/api/assistant/recent_authors";
 import {
@@ -15,7 +16,7 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
-import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { getModelsForAuth } from "@app/lib/model_tiers/enabled_models";
 import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
@@ -464,7 +465,7 @@ export async function getAgentConfigurationForDetails(
   // Either not readable (unpublished, not an editor) or filtered out by a space the admin is not a
   // member of. With the `admin_can_see_private_entities` feature flag the admin gets it in full;
   // otherwise it is refetched without the space filtering to be redacted.
-  if (await hasFeatureFlag(auth, "admin_can_see_private_entities")) {
+  if (await canAdminSeePrivateEntities(auth)) {
     const fullAgent =
       agent ??
       (await getAgentConfiguration(auth, {

--- a/front/lib/api/assistant/configuration/private_entities.ts
+++ b/front/lib/api/assistant/configuration/private_entities.ts
@@ -1,0 +1,17 @@
+import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
+
+/**
+ * Whether the caller may see the private data (prompt, skills, knowledge, files) of the agents and
+ * skills they cannot read: a workspace admin, in a workspace with the
+ * `admin_can_see_private_entities` feature flag. Everyone else gets those entities redacted or
+ * filtered out.
+ */
+export async function canAdminSeePrivateEntities(
+  auth: Authenticator
+): Promise<boolean> {
+  return (
+    auth.isAdmin() &&
+    (await hasFeatureFlag(auth, "admin_can_see_private_entities"))
+  );
+}

--- a/front/lib/api/assistant/configuration/yaml_export.ts
+++ b/front/lib/api/assistant/configuration/yaml_export.ts
@@ -9,6 +9,7 @@ import {
 import { AgentYAMLConverter } from "@app/lib/agent_yaml_converter/converter";
 import type { AgentYAMLConfig } from "@app/lib/agent_yaml_converter/schemas";
 import { getAgentConfigurationContext } from "@app/lib/api/assistant/configuration/context";
+import { canAdminSeePrivateEntities } from "@app/lib/api/assistant/configuration/private_entities";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -26,14 +27,19 @@ export async function getAgentConfigurationAsYAMLConfig(
   auth: Authenticator,
   agentId: string
 ): Promise<Result<AgentYAMLConfig, APIErrorWithContentfulStatusCode>> {
-  const contextResult = await getAgentConfigurationContext(auth, agentId);
+  // Admins with the `admin_can_see_private_entities` feature flag export the agents they cannot
+  // read too (unpublished, or built on spaces they are not a member of), skills included.
+  const seePrivateEntities = await canAdminSeePrivateEntities(auth);
+  const contextResult = await getAgentConfigurationContext(auth, agentId, {
+    dangerouslySkipPermissionFiltering: seePrivateEntities,
+  });
   if (contextResult.isErr()) {
     return contextResult;
   }
 
   const { agentConfiguration, editorUsers, skills } = contextResult.value;
 
-  if (!agentConfiguration.canRead) {
+  if (!agentConfiguration.canRead && !seePrivateEntities) {
     return new Err({
       status_code: 404,
       api_error: {

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -20,6 +20,7 @@ import { serializeSkillTag } from "@app/lib/skills/format";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
@@ -2244,6 +2245,27 @@ describe("SkillResource", () => {
         })
       ).rejects.toThrow("Only admins");
       expect(await SkillResource.fetchById(builderAuth, skill.sId)).toBeNull();
+    });
+
+    it("returns the full skill to an admin with the admin_can_see_private_entities flag", async () => {
+      // Enabled first: the workspace flags are cached once read.
+      await FeatureFlagFactory.basic(
+        testContext.authenticator,
+        "admin_can_see_private_entities"
+      );
+      const { skill } = await createRestrictedSkill();
+
+      const fetched = await SkillResource.fetchById(
+        testContext.authenticator,
+        skill.sId,
+        { permissionFiltering: "redact_unreadable" }
+      );
+
+      expect(fetched).not.toBeNull();
+      expect(fetched!.canRead(testContext.authenticator)).toBe(true);
+      expect(fetched!.toJSON(testContext.authenticator).instructions).toBe(
+        "Secret guidelines"
+      );
     });
 
     it("returns null for an unknown skill", async () => {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -738,6 +738,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         if (!auth.isAdmin()) {
           throw new Error("Only admins can fetch the skills they cannot read.");
         }
+        // With the `admin_can_see_private_entities` feature flag, admins get the skills they
+        // cannot read in full instead of redacted.
+        if (await hasFeatureFlag(auth, "admin_can_see_private_entities")) {
+          allowedCustomSkills = customSkills;
+          break;
+        }
         const readableIds = new Set(
           (await this.filterReadable(auth, customSkills, { transaction })).map(
             (skill) => skill.id

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -297,6 +297,12 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "dust_only",
     owner: "PopDaph",
   },
+  admin_can_see_private_entities: {
+    description:
+      "Let workspace admins see the content (instructions, tools, knowledge, files) of the agents and skills they cannot read, instead of a redacted view",
+    stage: "ask_owner",
+    owner: "fabiencelier",
+  },
   skill_favorites: {
     description:
       "Enable user favorites for skills, including favorite controls and runtime skill availability.",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -795,6 +795,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "legacy_billing"
   | "plan_mode"
   | "pod_frame_tabs"
+  | "admin_can_see_private_entities"
   | "skill_favorites"
   | "poke_mcp"
   | "restricted_spaces_in_input_bar"


### PR DESCRIPTION
## Description

add a new flag `admin_can_see_private_entities` to bypass the visibility restrictions for admin when the workspace requires it.
Asmin can always see anything by adding themself as editor or agent and members of the space, this flag allow them to see everything without these requirements which may not scale for large organisations requiring to check all agents.

## Tests

 - added unit test
 - tested locally

## Risk

low, all behind a feature flag which can be removed

## Deploy Plan

deploy front
