### PR TITLE
[Resources] Skip empty user and membership lookups

### DIFF
--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -114,6 +114,21 @@ describe("GroupResource", () => {
     inMemoryCache.clear();
   });
 
+  describe("getActiveMembershipsForGroups", () => {
+    it("returns no memberships without querying for empty groups", async () => {
+      const onQuery = vi.fn();
+      frontSequelize.addHook("afterQuery", "empty-groups", onQuery);
+      try {
+        expect(
+          await GroupResource.getActiveMembershipsForGroups(authenticator, [])
+        ).toEqual({});
+        expect(onQuery).not.toHaveBeenCalled();
+      } finally {
+        frontSequelize.removeHook("afterQuery", "empty-groups");
+      }
+    });
+  });
+
   describe("fetchByModelIds", () => {
     it("filters on group kind when asked", async () => {
       const autoGroup = await GroupResource.makeNew({

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1481,11 +1481,19 @@ export class GroupResource extends BaseResource<GroupModel> {
     return counts;
   }
 
+  /**
+   * @cc [owner:philipperolet,label:performance] empty-groups-skip-membership-queries
+   * Empty groups return no memberships without querying; workspace auth is still required.
+   */
   static async getActiveMembershipsForGroups(
     auth: Authenticator,
     groups: GroupResource[]
   ): Promise<Record<ModelId, ModelId[]>> {
     const owner = auth.getNonNullableWorkspace();
+    if (groups.length === 0) {
+      return {};
+    }
+
     const res = await GroupMembershipModel.findAll({
       where: {
         workspaceId: owner.id,

--- a/front/lib/resources/membership_resource.test.ts
+++ b/front/lib/resources/membership_resource.test.ts
@@ -99,6 +99,7 @@ vi.mock("@app/lib/utils/cache", () => ({
 import { countActiveSeatsForWorkspace } from "@app/lib/api/workspace_seats";
 import { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -111,6 +112,57 @@ function getCacheKeyForWorkspace(workspaceId: string): string {
 }
 
 describe("MembershipResource", () => {
+  describe("getActiveMemberships", () => {
+    it("returns no memberships without querying for empty users, including pagination", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const onQuery = vi.fn();
+      frontSequelize.addHook("afterQuery", "empty-membership-users", onQuery);
+      try {
+        const expected = {
+          memberships: [],
+          total: 0,
+          nextPageParams: undefined,
+        };
+        expect(
+          await MembershipResource.getActiveMemberships({
+            workspace,
+            users: [],
+          })
+        ).toEqual(expected);
+        expect(
+          await MembershipResource.getActiveMemberships({
+            workspace,
+            users: [],
+            paginationParams: {
+              limit: 1,
+              orderColumn: "createdAt",
+              orderDirection: "asc",
+            },
+          })
+        ).toEqual(expected);
+        expect(onQuery).not.toHaveBeenCalled();
+      } finally {
+        frontSequelize.removeHook("afterQuery", "empty-membership-users");
+      }
+    });
+
+    it("returns workspace memberships when users are omitted", async () => {
+      const { workspace, user } = await createResourceTest({ role: "admin" });
+      const { memberships, total } =
+        await MembershipResource.getActiveMemberships({ workspace });
+      expect(memberships.map((m) => m.userId)).toEqual([user.id]);
+      expect(total).toBe(1);
+    });
+
+    it("still requires a workspace or non-empty users", async () => {
+      await expect(
+        MembershipResource.getActiveMemberships({ users: [] })
+      ).rejects.toThrow(
+        "At least one of workspace or userIds must be provided."
+      );
+    });
+  });
+
   describe("caching behavior", () => {
     let authenticator: Authenticator;
     let workspace: LightWorkspaceType;

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -142,6 +142,10 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     return { memberships: orderedResourcesFromModels(rows), total: count };
   }
 
+  /**
+   * @cc [owner:philipperolet,label:performance] empty-users-skip-membership-queries
+   * With a workspace, empty users return no memberships without querying; omitted users do not filter.
+   */
   static async getActiveMemberships({
     users,
     workspace,
@@ -155,6 +159,10 @@ export class MembershipResource extends BaseResource<MembershipModel> {
   }): Promise<MembershipsWithTotal> {
     if (!workspace && !users?.length) {
       throw new Error("At least one of workspace or userIds must be provided.");
+    }
+
+    if (users?.length === 0) {
+      return { memberships: [], total: 0, nextPageParams: undefined };
     }
 
     const whereClause: WhereOptions<InferAttributes<MembershipModel>> = {

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -144,7 +144,8 @@ export class MembershipResource extends BaseResource<MembershipModel> {
 
   /**
    * @cc [owner:philipperolet,label:performance] empty-users-skip-membership-queries
-   * With a workspace, empty users return no memberships without querying; omitted users do not filter.
+   * With a workspace, empty users return no memberships without querying. This does not 
+   *  apply to undefined/null users.
    */
   static async getActiveMemberships({
     users,

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -145,7 +145,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
   /**
    * @cc [owner:philipperolet,label:performance] empty-users-skip-membership-queries
    * With a workspace, empty users return no memberships without querying. This does not 
-   *  apply to undefined/null users.
+   * apply to undefined/null users.
    */
   static async getActiveMemberships({
     users,

--- a/front/lib/resources/user_resource.test.ts
+++ b/front/lib/resources/user_resource.test.ts
@@ -105,6 +105,7 @@ vi.mock("@app/lib/utils/cache", () => ({
 }));
 
 import { Authenticator } from "@app/lib/auth";
+import { frontSequelize } from "@app/lib/resources/storage";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
@@ -125,6 +126,24 @@ describe("UserResource", () => {
     workspace = await WorkspaceFactory.basic();
     user = await UserFactory.basic();
     auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  });
+
+  describe("fetchByModelIds", () => {
+    it("returns no users without querying for empty ids", async () => {
+      const onQuery = vi.fn();
+      frontSequelize.addHook("afterQuery", "empty-user-ids", onQuery);
+      try {
+        expect(await UserResource.fetchByModelIds([])).toEqual([]);
+        expect(onQuery).not.toHaveBeenCalled();
+      } finally {
+        frontSequelize.removeHook("afterQuery", "empty-user-ids");
+      }
+    });
+
+    it("returns users for non-empty ids", async () => {
+      const users = await UserResource.fetchByModelIds([user.id]);
+      expect(users.map((u) => u.id)).toEqual([user.id]);
+    });
   });
 
   describe("searchUsers", () => {

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -165,10 +165,18 @@ export class UserResource extends BaseResource<UserModel> {
     return users.map((user) => new UserResource(UserModel, user.get()));
   }
 
+  /**
+   * @cc [owner:philipperolet,label:performance] empty-user-ids-skip-queries
+   * Empty ids return no users without querying the database.
+   */
   static async fetchByModelIds(
     ids: ModelId[],
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<UserResource[]> {
+    if (ids.length === 0) {
+      return [];
+    }
+
     const users = await UserModel.findAll({
       where: {
         id: ids,


### PR DESCRIPTION
## Description

Follow-up to https://github.com/dust-tt/dust/pull/31889, based independently on main.

Sequelize still sends SQL for empty `IN` arrays. Return early in `UserResource.fetchByModelIds`, `GroupResource.getActiveMembershipsForGroups`, and `MembershipResource.getActiveMemberships` when their input lists are empty, so callers do not need their own guards.

Results and validation stay unchanged: omitted `users` still lists workspace memberships, while `users: []` returns none and still requires a workspace. Paginated empty-user lookups skip both the fetch and count queries.

## Risks

Blast radius: User and membership lookups with empty input lists.
Risk: low

## Deploy Plan

- Deploy front-api and front workers. No migration required.

## Tests

- [x] User, group, membership, and agent resource suites: 122 tests passed.
- [x] New no-query tests fail without the guards and pass with them.
