### PR TITLE
fix(front): restore the EU-hosted flag in the model picker

### DIFF
--- a/front/components/model_picker/ModelPickerContent.tsx
+++ b/front/components/model_picker/ModelPickerContent.tsx
@@ -11,8 +11,10 @@ import {
   getModelLockTooltip,
   getTierLockReason,
   getTierResolvedModelLabel,
+  isTierResolvedModelHostedInRegion,
   isTierSelected,
 } from "@app/components/model_picker/modelPickerUtils";
+import { RegionalFlag } from "@app/components/shared/RegionalFlag";
 import type {
   EnabledModelConfigurationType,
   ModelStreamResolutionsType,
@@ -22,6 +24,7 @@ import type {
   ModelMakerIdType,
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
+import type { RegionType } from "@app/types/region";
 import {
   Button,
   ChevronDown,
@@ -41,6 +44,9 @@ interface ModelPickerContentProps {
   ignoreTierRestrictions: boolean;
   tiers: ModelTierDefinition[];
   degradedModelIds: ReadonlySet<string>;
+  // Region whose hosting flag is shown next to the models hosted there; `null`
+  // when the workspace has no hosting region to advertise.
+  hostingRegion: RegionType | null;
   makerGroups: MakerGroup[];
   streamModels: EnabledModelConfigurationType[];
   streams: ModelStreamResolutionsType | null;
@@ -70,6 +76,7 @@ export function ModelPickerContent({
   ignoreTierRestrictions,
   tiers,
   degradedModelIds,
+  hostingRegion,
   makerGroups,
   streamModels,
   streams,
@@ -116,6 +123,13 @@ export function ModelPickerContent({
             />
           );
         }
+        // A tier row names the model it currently resolves to, so it carries
+        // the same hosting flag as that model's own row would.
+        const regionalFlag =
+          hostingRegion !== null &&
+          isTierResolvedModelHostedInRegion(tier, streams, hostingRegion) ? (
+            <RegionalFlag region={hostingRegion} />
+          ) : null;
         return (
           <DropdownMenuItem
             key={tier.id}
@@ -124,8 +138,9 @@ export function ModelPickerContent({
             className="text-foreground"
             endComponent={
               <div className="flex items-center gap-3">
-                <span className="whitespace-nowrap text-xs text-muted-foreground">
+                <span className="flex items-center gap-1.5 whitespace-nowrap text-xs text-muted-foreground">
                   {getTierResolvedModelLabel(tier.id, streams)}
+                  {regionalFlag}
                 </span>
                 {isSelected && (
                   <ModelPickerSelectionIndicator
@@ -163,6 +178,7 @@ export function ModelPickerContent({
           ignoreTierRestrictions={ignoreTierRestrictions}
           lockPremiumEfforts={lockPremiumEfforts}
           degradedModelIds={degradedModelIds}
+          hostingRegion={hostingRegion}
           expandedMakerId={expandedMakerId}
           onToggleMaker={onToggleMaker}
           onSelectModel={onSelectModel}

--- a/front/components/model_picker/ModelPickerContent.tsx
+++ b/front/components/model_picker/ModelPickerContent.tsx
@@ -44,8 +44,6 @@ interface ModelPickerContentProps {
   ignoreTierRestrictions: boolean;
   tiers: ModelTierDefinition[];
   degradedModelIds: ReadonlySet<string>;
-  // Region whose hosting flag is shown next to the models hosted there; `null`
-  // when the workspace has no hosting region to advertise.
   hostingRegion: RegionType | null;
   makerGroups: MakerGroup[];
   streamModels: EnabledModelConfigurationType[];
@@ -123,8 +121,6 @@ export function ModelPickerContent({
             />
           );
         }
-        // A tier row names the model it currently resolves to, so it carries
-        // the same hosting flag as that model's own row would.
         const regionalFlag =
           hostingRegion !== null &&
           isTierResolvedModelHostedInRegion(tier, streams, hostingRegion) ? (

--- a/front/components/model_picker/ModelPickerMakersView.tsx
+++ b/front/components/model_picker/ModelPickerMakersView.tsx
@@ -43,8 +43,6 @@ interface ModelPickerMakersViewProps {
   // credit-based plan).
   lockPremiumEfforts: boolean;
   degradedModelIds: ReadonlySet<string>;
-  // Region whose hosting flag is shown next to the models hosted there; `null`
-  // when the workspace has no hosting region to advertise.
   hostingRegion: RegionType | null;
   // Which maker is expanded inline. Only read on width-constrained clients,
   // where makers can't be submenus.

--- a/front/components/model_picker/ModelPickerMakersView.tsx
+++ b/front/components/model_picker/ModelPickerMakersView.tsx
@@ -10,9 +10,11 @@ import {
   getInitialEffort,
   getModelKey,
   getModelLockReason,
+  isModelHostedInRegion,
   isModelSelection,
 } from "@app/components/model_picker/modelPickerUtils";
 import { getModelMakerLogo } from "@app/components/providers/types";
+import { RegionalFlag } from "@app/components/shared/RegionalFlag";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useCanHover, useIsWidthConstrained } from "@app/lib/swr/useIsMobile";
 import { getModelMakerDisplayName } from "@app/types/assistant/models/providers";
@@ -21,6 +23,7 @@ import type {
   ModelMakerIdType,
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
+import type { RegionType } from "@app/types/region";
 import {
   ChevronDown,
   ChevronRight,
@@ -40,6 +43,9 @@ interface ModelPickerMakersViewProps {
   // credit-based plan).
   lockPremiumEfforts: boolean;
   degradedModelIds: ReadonlySet<string>;
+  // Region whose hosting flag is shown next to the models hosted there; `null`
+  // when the workspace has no hosting region to advertise.
+  hostingRegion: RegionType | null;
   // Which maker is expanded inline. Only read on width-constrained clients,
   // where makers can't be submenus.
   expandedMakerId: ModelMakerIdType | null;
@@ -57,6 +63,7 @@ export function ModelPickerMakersView({
   ignoreTierRestrictions,
   lockPremiumEfforts,
   degradedModelIds,
+  hostingRegion,
   expandedMakerId,
   onToggleMaker,
   onSelectModel,
@@ -104,6 +111,12 @@ export function ModelPickerMakersView({
           isDefault={isDefault}
           lockReason={lockReason}
           isDegraded={degradedModelIds.has(model.modelId)}
+          regionalFlag={
+            hostingRegion !== null &&
+            isModelHostedInRegion(model, hostingRegion) ? (
+              <RegionalFlag region={hostingRegion} />
+            ) : null
+          }
           inset={useInlineMakers}
           effort={effort}
           effortStops={getEffortStops(model, { lockPremiumEfforts })}

--- a/front/components/model_picker/ModelPickerModelRow.test.tsx
+++ b/front/components/model_picker/ModelPickerModelRow.test.tsx
@@ -1,5 +1,6 @@
 import { ModelPickerModelRow } from "@app/components/model_picker/ModelPickerModelRow";
 import { getEffortStops } from "@app/components/model_picker/modelPickerUtils";
+import { RegionalFlag } from "@app/components/shared/RegionalFlag";
 import { CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import {
@@ -10,6 +11,7 @@ import {
 } from "@dust-tt/sparkle";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 vi.mock(import("@app/components/sparkle/ThemeContext"), () => ({
@@ -21,9 +23,14 @@ const MODEL: ModelConfigurationType = CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG;
 interface TestMenuProps {
   onSelectModel: (model: ModelConfigurationType) => void;
   onOpenChange: (open: boolean) => void;
+  regionalFlag?: ReactNode;
 }
 
-function TestMenu({ onSelectModel, onOpenChange }: TestMenuProps) {
+function TestMenu({
+  onSelectModel,
+  onOpenChange,
+  regionalFlag = null,
+}: TestMenuProps) {
   return (
     <DropdownMenu defaultOpen onOpenChange={onOpenChange}>
       <DropdownMenuTrigger asChild>
@@ -36,6 +43,7 @@ function TestMenu({ onSelectModel, onOpenChange }: TestMenuProps) {
           isDefault={false}
           lockReason={null}
           isDegraded={false}
+          regionalFlag={regionalFlag}
           effort={MODEL.defaultReasoningEffort}
           effortStops={getEffortStops(MODEL, { lockPremiumEfforts: false })}
           onSelectModel={onSelectModel}
@@ -72,5 +80,17 @@ describe("ModelPickerModelRow", () => {
 
     expect(onSelectModel).toHaveBeenCalledWith(MODEL);
     expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("shows the hosting flag it is given, so EU rows stay self-verifiable", async () => {
+    render(
+      <TestMenu
+        onSelectModel={vi.fn()}
+        onOpenChange={vi.fn()}
+        regionalFlag={<RegionalFlag region="europe-west1" />}
+      />
+    );
+
+    expect(await screen.findByAltText("EU")).toBeInTheDocument();
   });
 });

--- a/front/components/model_picker/ModelPickerModelRow.tsx
+++ b/front/components/model_picker/ModelPickerModelRow.tsx
@@ -24,8 +24,6 @@ interface ModelPickerModelRowProps {
   isDefault: boolean;
   lockReason: ModelLockReason | null;
   isDegraded: boolean;
-  // The hosting flag shown next to the model name (e.g. 🇪🇺 for an EU-hosted
-  // model), or `null` when the model has no hosting region to advertise.
   regionalFlag: ReactNode | null;
   effort: ReasoningEffort | null;
   effortStops: EffortStop[];

--- a/front/components/model_picker/ModelPickerModelRow.tsx
+++ b/front/components/model_picker/ModelPickerModelRow.tsx
@@ -15,7 +15,7 @@ import type {
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
 import { DropdownMenuItem, Icon, Lock01 } from "@dust-tt/sparkle";
-import type { ComponentType } from "react";
+import type { ComponentType, ReactNode } from "react";
 import { useRef } from "react";
 
 interface ModelPickerModelRowProps {
@@ -24,6 +24,9 @@ interface ModelPickerModelRowProps {
   isDefault: boolean;
   lockReason: ModelLockReason | null;
   isDegraded: boolean;
+  // The hosting flag shown next to the model name (e.g. 🇪🇺 for an EU-hosted
+  // model), or `null` when the model has no hosting region to advertise.
+  regionalFlag: ReactNode | null;
   effort: ReasoningEffort | null;
   effortStops: EffortStop[];
   icon?: ComponentType;
@@ -41,6 +44,7 @@ export function ModelPickerModelRow({
   isDefault,
   lockReason,
   isDegraded,
+  regionalFlag,
   effort,
   effortStops,
   icon,
@@ -62,7 +66,10 @@ export function ModelPickerModelRow({
         disabled
         tooltip={getModelLockTooltip(lockReason)}
         endComponent={
-          <Icon visual={Lock01} size="sm" className="text-muted-foreground" />
+          <div className="flex items-center gap-2">
+            {regionalFlag}
+            <Icon visual={Lock01} size="sm" className="text-muted-foreground" />
+          </div>
         }
       />
     );
@@ -71,8 +78,9 @@ export function ModelPickerModelRow({
   // A degraded model stays pickable, so it takes the lock's slot with an info
   // icon rather than being disabled.
   const endComponent =
-    isSelected || isDegraded ? (
+    regionalFlag !== null || isSelected || isDegraded ? (
       <div className="flex items-center gap-2">
+        {regionalFlag}
         {isDegraded && <DegradedInfoIcon />}
         {isSelected && (
           <>

--- a/front/components/model_picker/modelPickerUtils.test.ts
+++ b/front/components/model_picker/modelPickerUtils.test.ts
@@ -3,11 +3,17 @@ import {
   getEffortStops,
   getEffortStopTooltip,
   getInitialEffort,
+  getModelTier,
   getTierLockReason,
+  isModelHostedInRegion,
   isPremiumModel,
+  isTierResolvedModelHostedInRegion,
   PREMIUM_MODEL_LOCKED_TOOLTIP,
 } from "@app/components/model_picker/modelPickerUtils";
-import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
+import type {
+  EnabledModelConfigurationType,
+  ModelStreamResolutionsType,
+} from "@app/types/api/assistant/models";
 import {
   CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
   CLAUDE_OPUS_4_8_MODEL_ID,
@@ -24,7 +30,10 @@ import {
 import { GEMINI_2_5_PRO_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
 import { getTierForModel } from "@app/types/assistant/models/model_tiers";
 import { O1_MODEL_CONFIG } from "@app/types/assistant/models/openai";
-import type { ModelIdType } from "@app/types/assistant/models/types";
+import type {
+  ModelConfigurationType,
+  ModelIdType,
+} from "@app/types/assistant/models/types";
 import { describe, expect, it } from "vitest";
 
 const GATED = { lockPremiumEfforts: true };
@@ -229,6 +238,65 @@ describe("modelPickerUtils premium gating", () => {
           getInitialEffort(GEMINI_2_5_PRO_MODEL_CONFIG, GATED)
         )
       ).not.toBe("premium");
+    });
+  });
+});
+
+describe("modelPickerUtils regional hosting flag", () => {
+  const streamResolutions = (
+    model: ModelConfigurationType
+  ): ModelStreamResolutionsType => {
+    const resolution = {
+      providerId: model.providerId,
+      modelId: model.modelId,
+      displayName: model.displayName,
+      reasoningEffort: model.defaultReasoningEffort,
+    };
+    return {
+      [AUTO_FAST_MODEL_ID]: resolution,
+      [AUTO_MODEL_ID]: resolution,
+      [AUTO_COMPLEX_MODEL_ID]: resolution,
+    };
+  };
+
+  describe("isModelHostedInRegion", () => {
+    it("follows the model's own regional availability", () => {
+      expect(
+        isModelHostedInRegion(
+          CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
+          "europe-west1"
+        )
+      ).toBe(true);
+      expect(
+        isModelHostedInRegion(GEMINI_2_5_PRO_MODEL_CONFIG, "europe-west1")
+      ).toBe(false);
+    });
+  });
+
+  describe("isTierResolvedModelHostedInRegion", () => {
+    const standardTier = getModelTier("standard");
+
+    it("follows the availability of the model the tier resolves to", () => {
+      expect(
+        isTierResolvedModelHostedInRegion(
+          standardTier,
+          streamResolutions(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG),
+          "europe-west1"
+        )
+      ).toBe(true);
+      expect(
+        isTierResolvedModelHostedInRegion(
+          standardTier,
+          streamResolutions(GEMINI_2_5_PRO_MODEL_CONFIG),
+          "europe-west1"
+        )
+      ).toBe(false);
+    });
+
+    it("claims nothing while the resolutions are still in flight", () => {
+      expect(
+        isTierResolvedModelHostedInRegion(standardTier, null, "europe-west1")
+      ).toBe(false);
     });
   });
 });

--- a/front/components/model_picker/modelPickerUtils.ts
+++ b/front/components/model_picker/modelPickerUtils.ts
@@ -1,4 +1,7 @@
-import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
+import {
+  getSupportedModelConfig,
+  getSupportedModelConfigs,
+} from "@app/lib/llms/model_configurations";
 import type {
   EnabledModelConfigurationType,
   ModelStreamResolutionsType,
@@ -24,6 +27,7 @@ import type {
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
 import { getAvailableReasoningEfforts } from "@app/types/assistant/models/types";
+import type { RegionType } from "@app/types/region";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import capitalize from "lodash/capitalize";
 
@@ -42,6 +46,18 @@ const MODEL_TIER_LOCKED_TOOLTIP =
 
 export function getDegradedModelTooltip(displayName: string): string {
   return `${displayName} is unstable right now. You may want to select another model.`;
+}
+
+/**
+ * @cc [owner:Nils-Fedrigo,label:product] regional-flag-follows-availability
+ * The picker shows `region`'s hosting flag on a model if and only if that
+ * model's `regionalAvailability[region]` is `true`.
+ */
+export function isModelHostedInRegion(
+  model: ModelConfigurationType,
+  region: RegionType
+): boolean {
+  return model.regionalAvailability[region] === true;
 }
 
 // The three primary picks of the model picker. Each tier is backed by a
@@ -168,6 +184,27 @@ export function getTierResolvedModelLabel(
     resolution.displayName,
     resolution.reasoningEffort
   );
+}
+
+// `isModelHostedInRegion` for the concrete model a tier currently resolves to.
+// That resolution moves as models are added or degraded, so the flag speaks for
+// the resolution the row is displaying and nothing more.
+export function isTierResolvedModelHostedInRegion(
+  tier: ModelTierDefinition,
+  streams: ModelStreamResolutionsType | null,
+  region: RegionType
+): boolean {
+  const resolution = streams?.[tier.metaModelId];
+  if (!resolution) {
+    return false;
+  }
+  const model = getSupportedModelConfigs().find(
+    (config) =>
+      config.providerId === resolution.providerId &&
+      config.modelId === resolution.modelId
+  );
+
+  return model !== undefined && isModelHostedInRegion(model, region);
 }
 
 // What the picker is currently showing, decoupled from the payload we send:

--- a/front/components/model_picker/useModelPickerModels.ts
+++ b/front/components/model_picker/useModelPickerModels.ts
@@ -1,6 +1,7 @@
 import type { MakerGroup } from "@app/components/model_picker/modelPickerUtils";
 import { MODEL_TIERS } from "@app/components/model_picker/modelPickerUtils";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useCellContext } from "@app/lib/auth/CellContext";
 import { getSupportedModelConfigs } from "@app/lib/llms/model_configurations";
 import { useModels } from "@app/lib/swr/models";
 import { isModelStreamId } from "@app/types/assistant/models/auto";
@@ -20,6 +21,13 @@ type ModelPickerMenuMode = "select" | "filter";
 
 const EMPTY_DEGRADED_MODEL_IDS: ReadonlySet<string> = new Set();
 
+/**
+ * @cc [owner:Nils-Fedrigo,label:product] hosting-region-only-when-guaranteed
+ * `modelProps.hostingRegion` is the current cell's region when the workspace
+ * runs models on Dust-managed regional hosting, and `null` otherwise —
+ * `use_vertex_for_supported_models` disabled, or a BYOK plan whose models run
+ * on the customer's own provider keys.
+ */
 // The model lists every surface rendering `ModelPickerContent` offers, and what
 // the member is allowed to pick from them.
 export function useModelPickerModels({
@@ -60,6 +68,16 @@ export function useModelPickerModels({
   const degradedModelIds = showDegradations
     ? allDegradedModelIds
     : EMPTY_DEGRADED_MODEL_IDS;
+
+  // The region whose flag the picker shows next to the models hosted there. EU
+  // customers rely on it to self-verify data residency: the "EU-hosted models
+  // only" toggle already hard-filters the catalog, so the flag is reassurance
+  // rather than enforcement.
+  const { cellInfo } = useCellContext();
+  const hostingRegion =
+    hasFeature("use_vertex_for_supported_models") && !subscription.plan.isByok
+      ? cellInfo.region
+      : null;
 
   // Concrete models (meta-models are surfaced as tiers instead).
   const allModels = useMemo<ModelConfigurationType[]>(() => {
@@ -128,6 +146,7 @@ export function useModelPickerModels({
       ignoreTierRestrictions: isFilterMode,
       tiers,
       degradedModelIds,
+      hostingRegion,
       makerGroups,
       allModels,
       streamModels,


### PR DESCRIPTION
## Description

<img width="1073" height="762" alt="Screenshot 2026-09-08 at 10 16 27" src="https://github.com/user-attachments/assets/6a45aeb1-ef52-4598-b135-d8b4b9fc4a89" />


The tiered model picker shipped in #29436 stopped rendering `RegionalFlag`, so EU
workspaces lost the 🇪🇺 badge that the previous agent-builder list showed next to
EU-hosted models (added in #25865, extended in #28592). The "EU-hosted models only"
toggle still hard-filters the catalog, so this was never a residency regression —
customers simply could no longer self-verify residency from the UI and escalated
instead. Fixes dust-tt/tasks#10208.

The flag is back, on the same gate the old list used
(`use_vertex_for_supported_models` and a non-BYOK plan — BYOK models run on the
customer's own provider keys, so we make no hosting claim there):

- `useModelPickerModels` exposes `hostingRegion` through `modelProps`, so every
  surface spreading it (input bar, agent builder, bulk "Set model", models filter)
  picks the flag up.
- Each model row under "More models" carries the flag when the model's
  `regionalAvailability` is `true` for that region — including locked rows, next to
  the padlock.
- The Basic / Standard / Premium rows carry it too, based on the model they
  currently resolve to. Those rows name a concrete model, so flagging only the
  "More models" rows would have read as "the recommendations are *not* EU-hosted".

## Tests

- Unit coverage for the two new predicates in `modelPickerUtils.test.ts`
  (`isModelHostedInRegion`, `isTierResolvedModelHostedInRegion`, including the
  in-flight-resolutions case), plus a render assertion in
  `ModelPickerModelRow.test.tsx` that the row surfaces the flag it is given.
- `npm run test -- components/model_picker` → 26 passing.
- Worth a manual pass on an EU cell with `use_vertex_for_supported_models` on: the
  flag should appear on every EU-hosted model row and on the tier rows whose
  resolved model is EU-hosted, and nowhere at all on a US cell or a BYOK plan.

BTW : The flag now appears on *every* EU-hosted model, so a
workspace with "EU-hosted models only" enabled sees it on every row.
