### PR TITLE
feat(models): add a feature flag to remove access to GPT 6 Astra

### DIFF
--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -16,7 +16,10 @@ import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import { LightWorkspaceFactory } from "@app/tests/utils/LightWorkspaceFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
-import { GPT_5_6_SOL_MODEL_CONFIG } from "@app/types/assistant/models/openai";
+import {
+  GPT_5_6_SOL_MODEL_CONFIG,
+  GPT_6_ASTRA_MODEL_CONFIG,
+} from "@app/types/assistant/models/openai";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { PlanType } from "@app/types/plan";
 import type { RegionType } from "@app/types/region";
@@ -55,6 +58,18 @@ function isSolAvailable(
   featureFlags: WhitelistableFeature[] = []
 ) {
   return isModelAvailable(GPT_5_6_SOL_MODEL_CONFIG, {
+    featureFlags,
+    plan,
+    regionalModelsOnly: TEST_WORKSPACE.regionalModelsOnly,
+    region: TEST_REGION,
+  });
+}
+
+function isAstraAvailable(
+  plan: PlanType,
+  featureFlags: WhitelistableFeature[] = []
+) {
+  return isModelAvailable(GPT_6_ASTRA_MODEL_CONFIG, {
     featureFlags,
     plan,
     regionalModelsOnly: TEST_WORKSPACE.regionalModelsOnly,
@@ -353,6 +368,49 @@ describe("isModelAvailable", () => {
         region: TEST_REGION,
       })
     ).toBe(false);
+  });
+
+  it("should return false when the model matches an unavailableIfOneOf condition, even if another condition grants access", () => {
+    const model = createMockModel({
+      availableIfOneOf: { featureFlag: "deepseek_feature" },
+      unavailableIfOneOf: { featureFlag: "disable_gpt_6_astra" },
+      largeModel: false,
+    });
+    const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
+
+    expect(
+      isModelAvailable(model, {
+        featureFlags: ["deepseek_feature", "disable_gpt_6_astra"],
+        plan,
+        regionalModelsOnly: TEST_WORKSPACE.regionalModelsOnly,
+        region: TEST_REGION,
+      })
+    ).toBe(false);
+  });
+
+  it("should return true when the model matches no unavailableIfOneOf condition", () => {
+    const model = createMockModel({
+      unavailableIfOneOf: { featureFlag: "disable_gpt_6_astra" },
+      availableIfOneOf: undefined,
+      largeModel: false,
+    });
+    const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
+
+    expect(
+      isModelAvailable(model, {
+        featureFlags: [],
+        plan,
+        regionalModelsOnly: TEST_WORKSPACE.regionalModelsOnly,
+        region: TEST_REGION,
+      })
+    ).toBe(true);
+  });
+
+  it("should hide GPT 6 Astra from a credit-priced workspace with the disable_gpt_6_astra flag", () => {
+    const plan = createMockPlan(CREDIT_PRICED_BUSINESS_PLAN_CODE);
+
+    expect(isAstraAvailable(plan)).toBe(true);
+    expect(isAstraAvailable(plan, ["disable_gpt_6_astra"])).toBe(false);
   });
 });
 

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -27,7 +27,21 @@ function checkModelSpecificAccessRules(
     plan: PlanType | null;
   }
 ): boolean {
-  const { availableIfOneOf, largeModel } = modelConfiguration;
+  const { availableIfOneOf, largeModel, unavailableIfOneOf } =
+    modelConfiguration;
+
+  // Opt-out check: matching a model-specific unavailability rule vetoes every
+  // grant below.
+  if (unavailableIfOneOf) {
+    const { featureFlag } = unavailableIfOneOf;
+
+    const matchesFeatureFlagCondition =
+      featureFlag !== undefined && featureFlags.includes(featureFlag);
+
+    if (matchesFeatureFlagCondition) {
+      return false;
+    }
+  }
 
   // First check: downgraded plans only have access to the small models.
   if (largeModel && !isUpgraded(plan)) {
@@ -61,6 +75,12 @@ function checkModelSpecificAccessRules(
   return true;
 }
 
+/**
+ * @cc [owner:Nils-Fedrigo,label:product] unavailable-feature-flag-vetoes-availability
+ * A model must be reported unavailable whenever it satisfies one of its
+ * `unavailableIfOneOf` conditions, whatever `availableIfOneOf`, `plan`, `region` or
+ * `regionalModelsOnly` would otherwise grant.
+ */
 // Returns true if the model is available to the workspace for build.
 export function isModelAvailable(
   m: ModelConfigurationType,

--- a/front/types/assistant/models/openai.ts
+++ b/front/types/assistant/models/openai.ts
@@ -471,6 +471,9 @@ export const GPT_6_ASTRA_MODEL_CONFIG: ModelConfigurationType = {
     plansWithAdvancedModels: true,
     featureFlag: "claude_4_5_opus_feature",
   },
+  unavailableIfOneOf: {
+    featureFlag: "disable_gpt_6_astra",
+  },
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
   tokenizer: { type: "tiktoken", base: "o200k_base" },

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -172,13 +172,7 @@ export type ModelConfigurationType = Omit<
     // If set, model is available if feature flag is enabled.
     featureFlag?: WhitelistableFeature;
   };
-  // Mirror image of `availableIfOneOf`: an opt-out that pulls a model back from
-  // a workspace without touching its availability conditions.
-  // If undefined or empty, no opt-out applies.
-  // If defined, model is unavailable as soon as it satisfies one of the
-  // conditions, whatever `availableIfOneOf` and the plan would grant.
   unavailableIfOneOf?: {
-    // If set, model is unavailable if feature flag is enabled.
     featureFlag?: WhitelistableFeature;
   };
   // Pre-requisite: must be available.

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -79,6 +79,10 @@ const AvailabilityConditionSchema = z.object({
   featureFlag: WhitelistableFeatureSchema.optional(),
 });
 
+const UnavailabilityConditionSchema = z.object({
+  featureFlag: WhitelistableFeatureSchema.optional(),
+});
+
 const CustomAvailabilityConditionSchema = z.object({
   featureFlag: WhitelistableFeatureSchema.optional(),
 });
@@ -136,6 +140,7 @@ export const ModelConfigurationSchema = z.object({
   // Specify if the model is available in specific regions.
   regionalAvailability: z.record(z.enum(SUPPORTED_REGIONS), z.boolean()),
   availableIfOneOf: AvailabilityConditionSchema.optional(),
+  unavailableIfOneOf: UnavailabilityConditionSchema.optional(),
   customAvailableIf: CustomAvailabilityConditionSchema.optional(),
 });
 
@@ -165,6 +170,15 @@ export type ModelConfigurationType = Omit<
     // If set to true, model is available for plans with advanced models access.
     plansWithAdvancedModels?: boolean;
     // If set, model is available if feature flag is enabled.
+    featureFlag?: WhitelistableFeature;
+  };
+  // Mirror image of `availableIfOneOf`: an opt-out that pulls a model back from
+  // a workspace without touching its availability conditions.
+  // If undefined or empty, no opt-out applies.
+  // If defined, model is unavailable as soon as it satisfies one of the
+  // conditions, whatever `availableIfOneOf` and the plan would grant.
+  unavailableIfOneOf?: {
+    // If set, model is unavailable if feature flag is enabled.
     featureFlag?: WhitelistableFeature;
   };
   // Pre-requisite: must be available.

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -66,6 +66,12 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "self_serve",
     owner: "fontanierh",
   },
+  disable_gpt_6_astra: {
+    description:
+      "Remove access to the GPT 6 Astra model: it is hidden from the model picker and rejected at message time, whatever the workspace plan and other flags",
+    stage: "self_serve",
+    owner: "Nils-Fedrigo",
+  },
   dust_agent_sonnet_5_default: {
     description: "Use Claude Sonnet 5 as the default model for the @dust agent",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -759,6 +759,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "exa_people_and_company"
   | "disable_computer_feature"
   | "disable_formatting_prompt"
+  | "disable_gpt_6_astra"
   | "disable_run_logs"
   | "discord_bot"
   | "dummy_feature_for_flag_testing"


### PR DESCRIPTION
## Description

See context here https://app.plain.com/workspace/w_01KJG5G96PGBWD5YG61BFEDSJ3/thread/th_01M1XBDKZWG5YAXDCV9N6W1388/

Adds a `disable_gpt_6_astra` feature flag that removes GPT 6 Astra from a workspace: once
enabled, the model disappears from the model picker and is refused at message time.

To do this without hardcoding a model anywhere in the access logic, model configurations gain
an optional `unavailableIfFeatureFlag` field. It is the mirror image of the existing
`availableIfOneOf`: an opt-out switch checked first in `checkModelSpecificAccessRules`, which
vetoes every other grant (upgraded plan, credit-priced plan, `plansWithAdvancedModels` and
`claude_4_5_opus_feature`). `GPT_6_ASTRA_MODEL_CONFIG` is the first model to declare it, and
the next model kill switch is a one-liner.

Because the veto sits in `isModelAvailable`, it applies everywhere model access is decided
rather than only in the UI:

- the picker (`/api/w/:wId/models` → `getAvailableModelsForWorkspace` → `filterEnabledModels`)
  stops returning the model,
- posting a message on an agent configured on Astra is rejected in `postUserMessage`,
- `resolveModel` / `selectEnabledModel` skip a user selection of Astra and fall through to the
  next candidate.

Astra is not part of any `MODEL_STREAMS` candidate pool nor of `PREFERRED_LARGE_MODEL_CONFIGS`,
so no auto/stream tier can route to it behind the flag.

Also documents the veto as a code contract on `isModelAvailable`, and mirrors the new flag into
the `@dust-tt/client` `WhitelistableFeature` union (additive, it is a `FlexibleEnumSchema`).

## Tests

Three cases added to `front/lib/assistant.test.ts`: the flag vetoes a model that another
condition would otherwise grant, absence of the flag leaves the model available, and the real
`GPT_6_ASTRA_MODEL_CONFIG` flips from available to unavailable on a credit-priced plan.
`lib/assistant.test.ts` and the model availability / tier suites pass locally.

## Risk

Low, and the flag is off everywhere by default so the change is a no-op until it is enabled on
a workspace. Worth knowing before enabling it: an agent already configured on Astra in that
workspace will fail to answer with "The model is not supported." — the same behavior as any
model becoming unavailable through a plan downgrade or a provider being un-whitelisted. Agents
should be moved off Astra before, or right after, flipping the flag.

## Deploy Plan

Nothing specific — no migration, and the flag is enabled per workspace from Poke.
