### PR TITLE
[Tests] Avoid Google auth in the Vertex retry-policy test

### DIFF
--- a/front/lib/model_constructors/stream/clients/anthropic.test.ts
+++ b/front/lib/model_constructors/stream/clients/anthropic.test.ts
@@ -1,8 +1,12 @@
 // @vitest-environment node
 
+import AnthropicVertex from "@anthropic-ai/vertex-sdk";
 import { AnthropicClaudeSonnetFourDotSixEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_sonnet_four_dot_six_eu_agent_platform";
 import { AnthropicClaudeSonnetFourDotSixGlobalAnthropicStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_sonnet_four_dot_six_global_anthropic";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+// The real Vertex constructor starts Google credential discovery even without an API call.
+vi.mock("@anthropic-ai/vertex-sdk", () => ({ default: vi.fn() }));
 
 describe("AnthropicStream", () => {
   it("disables SDK retries so the agent loop owns retry attempts", () => {
@@ -14,11 +18,12 @@ describe("AnthropicStream", () => {
   });
 
   it("disables Vertex SDK retries so the agent loop owns retry attempts", () => {
-    const endpoint =
-      new AnthropicClaudeSonnetFourDotSixEuropeAgentPlatformStream({
-        AGENT_PLATFORM_PROJECT_ID: "test-project",
-      });
+    new AnthropicClaudeSonnetFourDotSixEuropeAgentPlatformStream({
+      AGENT_PLATFORM_PROJECT_ID: "test-project",
+    });
 
-    expect(Reflect.get(endpoint, "client")).toMatchObject({ maxRetries: 0 });
+    expect(AnthropicVertex).toHaveBeenCalledWith(
+      expect.objectContaining({ maxRetries: 0 })
+    );
   });
 });


### PR DESCRIPTION
## Description

Fixes a test regression introduced by https://github.com/dust-tt/dust/pull/31992.

The Vertex retry-policy test constructs a real SDK client, which immediately starts Google credential discovery. Without credentials, the resulting unhandled rejection fails front test shard 5 even though every assertion passes; the JUnit-only reporter hides the error.

Mock the Vertex SDK constructor and verify it receives `maxRetries: 0`. Production code is unchanged. 

## Risks

Blast radius: Anthropic Vertex retry-policy unit test only.
Risk: low

## Deploy Plan

- No deployment or migration required; test-only change.

## Tests

- [x] Both Anthropic retry-policy tests pass with Google credentials deliberately unavailable.
- [x] Full front shard 5 on Node 24.16.0: 1,169 passed, 10 skipped, no unhandled errors, with Google credentials deliberately unavailable.
