### PR TITLE
Fix CLI generated file parsing and expose Pod instructions

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/index.test.ts
@@ -1,3 +1,4 @@
+import { DustFileSystem } from "@app/lib/api/file_system";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentMCPServerConfigurationFactory } from "@app/tests/utils/AgentMCPServerConfigurationFactory";
@@ -9,12 +10,29 @@ import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
 import { WebhookSourceViewFactory } from "@app/tests/utils/WebhookSourceViewFactory";
+import { Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import assert from "assert";
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 function getSpace(workspace: { sId: string }, spaceId: string) {
   return honoApp.request(`/api/w/${workspace.sId}/spaces/${spaceId}`);
+}
+
+function patchSpace(
+  workspace: { sId: string },
+  spaceId: string,
+  body: unknown
+) {
+  return honoApp.request(`/api/w/${workspace.sId}/spaces/${spaceId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
 }
 
 describe("GET /api/w/:wId/spaces/:spaceId", () => {
@@ -139,5 +157,71 @@ describe("GET /api/w/:wId/spaces/:spaceId", () => {
     expect(space.categories.actions.count).toBe(0);
     expect(space.categories.actions.usage.count).toBe(0);
     expect(space.categories.actions.usage.skills).toEqual([]);
+  });
+
+  it("returns Pod instructions from AGENTS.md", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const projectSpace = await SpaceFactory.project(workspace);
+
+    const readBuffer = vi
+      .fn()
+      .mockResolvedValue(new Ok(Buffer.from("Use the Pod runbook.", "utf8")));
+    vi.spyOn(DustFileSystem, "fromScopedPath").mockResolvedValue(
+      new Ok({
+        readBuffer,
+      } as unknown as DustFileSystem)
+    );
+
+    const response = await getSpace(workspace, projectSpace.sId);
+
+    expect(response.status).toBe(200);
+    const { space } = await response.json();
+    expect(space.instructions).toBe("Use the Pod runbook.");
+  });
+});
+
+describe("PATCH /api/w/:wId/spaces/:spaceId", () => {
+  it("updates Pod instructions in AGENTS.md", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const projectSpace = await SpaceFactory.project(workspace);
+    const write = vi.fn().mockResolvedValue(new Ok({}));
+    vi.spyOn(DustFileSystem, "fromScopedPath").mockResolvedValue(
+      new Ok({
+        write,
+      } as unknown as DustFileSystem)
+    );
+
+    const response = await patchSpace(workspace, projectSpace.sId, {
+      instructions: "Prefer concise answers.",
+    });
+
+    expect(response.status).toBe(200);
+    const { space } = await response.json();
+    expect(space.instructions).toBe("Prefer concise answers.");
+    expect(write).toHaveBeenCalledWith(
+      `pod-${projectSpace.sId}/AGENTS.md`,
+      "Prefer concise answers.",
+      "text/markdown"
+    );
+  });
+
+  it("rejects instructions on non-project spaces", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const regularSpace = await SpaceFactory.regular(workspace);
+
+    const response = await patchSpace(workspace, regularSpace.sId, {
+      instructions: "Not a Pod.",
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.message).toBe(
+      "Instructions for Agents are only available for Pods."
+    );
   });
 });

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
@@ -4,6 +4,10 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import {
+  readPodAgentsMdContent,
+  writePodAgentsMdContent,
+} from "@app/lib/api/projects/agents_md";
+import {
   getSpaceCategoriesWithUsage,
   softDeleteSpaceAndLaunchScrubWorkflow,
 } from "@app/lib/api/spaces";
@@ -148,6 +152,10 @@ const app = workspaceApp();
  *                         description:
  *                           type: string
  *                           nullable: true
+ *                         instructions:
+ *                           type: string
+ *                           nullable: true
+ *                           description: Pod-wide Instructions for Agents, stored as AGENTS.md in the Pod's files.
  *                         archivedAt:
  *                           type: integer
  *                           nullable: true
@@ -213,6 +221,9 @@ const app = workspaceApp();
  *             properties:
  *               name:
  *                 type: string
+ *               instructions:
+ *                 type: string
+ *                 description: Pod-wide Instructions for Agents, stored as AGENTS.md in the Pod's files.
  *               content:
  *                 type: array
  *                 items:
@@ -329,9 +340,12 @@ app.get(
     // are the two put together.
     const groups = await space.toGroupAccessesJSON(auth);
 
-    const meta = space.isProject()
-      ? await ProjectMetadataResource.fetchBySpace(auth, space)
-      : undefined;
+    const [meta, instructions] = space.isProject()
+      ? await Promise.all([
+          ProjectMetadataResource.fetchBySpace(auth, space),
+          readPodAgentsMdContent(auth, space.sId),
+        ])
+      : [undefined, null];
 
     const [enrichedSpace] = await SpaceResource.enrichSpacesWithAccess(auth, [
       space,
@@ -350,6 +364,7 @@ app.get(
         description: meta?.description ?? null,
         archivedAt: meta?.archivedAt?.getTime() ?? null,
         // Automated task generation removed; keep fields hardcoded for API compat.
+        instructions,
         todoGenerationEnabled: false,
         lastTodoAnalysisAt: null,
         pinnedFramePath: meta?.pinnedFramePath ?? null,
@@ -382,7 +397,7 @@ app.patch(
       });
     }
 
-    const { content, name } = ctx.req.valid("json");
+    const { content, instructions, name } = ctx.req.valid("json");
 
     if (content) {
       const currentViews = await DataSourceViewResource.listBySpace(
@@ -452,6 +467,55 @@ app.patch(
         });
       }
     }
+
+    if (instructions !== undefined) {
+      if (!space.isProject()) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Instructions for Agents are only available for Pods.",
+          },
+        });
+      }
+
+      const writeResult = await writePodAgentsMdContent(
+        auth,
+        space.sId,
+        instructions
+      );
+      if (writeResult.isErr()) {
+        const error = writeResult.error;
+        const statusCode =
+          error.code === "unauthorized"
+            ? 403
+            : error.code === "not_found"
+              ? 404
+              : error.code === "internal" || error.code === "too_many_mounts"
+                ? 500
+                : 400;
+
+        return apiError(ctx, {
+          status_code: statusCode,
+          api_error: {
+            type:
+              statusCode === 403
+                ? "workspace_auth_error"
+                : statusCode === 404
+                  ? "file_not_found"
+                  : statusCode === 500
+                    ? "internal_server_error"
+                    : "invalid_request_error",
+            message: error.message,
+          },
+        });
+      }
+
+      return ctx.json({
+        space: { ...space.toJSON(), instructions },
+      });
+    }
+
     return ctx.json({ space: space.toJSON() });
   }
 );

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -146,8 +146,15 @@ export type ActionGeneratedFilePathType = ActionGeneratedFileBase & {
   filePath: string;
 };
 
+export type ActionGeneratedLegacyDBFileType = ActionGeneratedFileBase & {
+  contentType: AllSupportedFileContentType;
+  fileId: null;
+  filePath?: never;
+};
+
 export type ActionGeneratedFileType =
   | ActionGeneratedDBFileType
+  | ActionGeneratedLegacyDBFileType
   | ActionGeneratedFilePathType;
 
 // A persisted tool output item in the generic shape returned by both AgentMCPActionResource and

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -83,7 +83,7 @@ export const POD_MANAGER_TOOLS_METADATA = [
   {
     name: EDIT_INFORMATION_TOOL_NAME,
     description:
-      "Edit Pod information: title, description, and/or access. " +
+      "Edit Pod information: title, description, instructions, and/or access. " +
       "Provide at least one field to update. Descriptions must be plain text only (no markdown, HTML, or formatting). " +
       "Access can be set to open or restricted; open Pods are subject to workspace policy.",
     schema: {
@@ -93,6 +93,13 @@ export const POD_MANAGER_TOOLS_METADATA = [
         .optional()
         .describe(
           "New Pod description. Must be plain text only (no markdown, HTML, or other formatting). Keep it brief and concise: 1-2 short sentences max."
+        ),
+      instructions: z
+        .string()
+        .max(8192)
+        .optional()
+        .describe(
+          "New Pod-wide Instructions for Agents, stored as AGENTS.md in the Pod's files."
         ),
       access: z
         .enum(["restricted", "open"])

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -52,6 +52,10 @@ import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch"
 import config from "@app/lib/api/config";
 import { DustFileSystem, SCOPED_PREFIX_POD } from "@app/lib/api/file_system";
 import {
+  readPodAgentsMdContent,
+  writePodAgentsMdContent,
+} from "@app/lib/api/projects/agents_md";
+import {
   addContentNodeToProject,
   listProjectContextAttachments,
   removeContentNodesFromProject,
@@ -264,15 +268,16 @@ export function createProjectManagerTools(
           );
         }
 
-        const { title, description, access } = params;
+        const { title, description, instructions, access } = params;
         if (
           title === undefined &&
           description === undefined &&
+          instructions === undefined &&
           access === undefined
         ) {
           return new Err(
             new MCPError(
-              "At least one of title, description, or access must be provided",
+              "At least one of title, description, instructions, or access must be provided",
               { tracked: false }
             )
           );
@@ -295,6 +300,19 @@ export function createProjectManagerTools(
 
         if (description !== undefined) {
           updates.description = description;
+        }
+
+        if (instructions !== undefined) {
+          const instructionsRes = await writePodAgentsMdContent(
+            auth,
+            pod.sId,
+            instructions
+          );
+          if (instructionsRes.isErr()) {
+            return new Err(
+              new MCPError(instructionsRes.error.message, { tracked: false })
+            );
+          }
         }
 
         if (access !== undefined) {
@@ -348,6 +366,7 @@ export function createProjectManagerTools(
           makeSuccessResponse({
             success: true,
             ...updates,
+            ...(instructions !== undefined ? { instructions } : {}),
             message: "Pod information updated successfully.",
           })
         );
@@ -704,6 +723,7 @@ export function createProjectManagerTools(
               url: projectUrl,
               access: (await pod.isRestricted(auth)) ? "restricted" : "open",
               description: metadata?.description ?? null,
+              instructions: await readPodAgentsMdContent(auth, pod.sId),
               pinnedFramePath: metadata?.pinnedFramePath ?? null,
               defaultAgent,
               contentNodes,

--- a/front/lib/api/actions/servers/pod_manager/types.ts
+++ b/front/lib/api/actions/servers/pod_manager/types.ts
@@ -18,6 +18,7 @@ export const PodManagerUpdateMembersInputSchema = z.object({
 export const PodManagerEditInformationInputSchema = z.object({
   title: z.string().optional(),
   description: z.string().optional(),
+  instructions: z.string().max(8192).optional(),
   access: PodAccessSchema.optional(),
   pinnedFramePath: z.string().nullable().optional(),
   dustPod: DustPodConfigurationSchema.optional(),

--- a/front/lib/api/projects/agents_md.test.ts
+++ b/front/lib/api/projects/agents_md.test.ts
@@ -2,6 +2,7 @@ import { DustFileSystem, DustFileSystemError } from "@app/lib/api/file_system";
 import {
   formatPodAgentsMdPromptSection,
   readPodAgentsMdContent,
+  writePodAgentsMdContent,
 } from "@app/lib/api/projects/agents_md";
 import {
   getPodAgentsMdScopedPath,
@@ -15,7 +16,11 @@ import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { Err, Ok } from "@app/types/shared/result";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("readPodAgentsMdContent", () => {
   it("returns null when the file does not exist", async () => {
@@ -108,6 +113,53 @@ describe("readPodAgentsMdContent", () => {
     expect(result).toBeNull();
     expect(warnSpy).not.toHaveBeenCalled();
     warnSpy.mockRestore();
+  });
+});
+
+describe("writePodAgentsMdContent", () => {
+  it("writes AGENTS.md content to the Pod file system", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const podId = "pod_test";
+    const scopedPath = getPodAgentsMdScopedPath(podId);
+    const write = vi.fn().mockResolvedValue(new Ok({}));
+
+    vi.spyOn(DustFileSystem, "fromScopedPath").mockResolvedValue(
+      new Ok({
+        write,
+      } as unknown as DustFileSystem)
+    );
+
+    const result = await writePodAgentsMdContent(
+      auth,
+      podId,
+      "Always cite sources."
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(DustFileSystem.fromScopedPath).toHaveBeenCalledWith(
+      auth,
+      scopedPath
+    );
+    expect(write).toHaveBeenCalledWith(
+      scopedPath,
+      "Always cite sources.",
+      "text/markdown"
+    );
+  });
+
+  it("rejects instructions longer than the Pod settings limit", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const result = await writePodAgentsMdContent(
+      auth,
+      "pod_test",
+      "x".repeat(POD_AGENTS_MD_MAX_CHARACTER_COUNT + 1)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("invalid_path");
+    }
+    expect(DustFileSystem.fromScopedPath).not.toHaveBeenCalled();
   });
 });
 

--- a/front/lib/api/projects/agents_md.ts
+++ b/front/lib/api/projects/agents_md.ts
@@ -5,6 +5,9 @@ import {
 } from "@app/lib/api/projects/constants";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
+import { DustFileSystemError } from "@app/types/file_system";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 
 export async function readPodAgentsMdContent(
   auth: Authenticator,
@@ -45,6 +48,38 @@ export async function readPodAgentsMdContent(
   }
 
   return content;
+}
+
+export async function writePodAgentsMdContent(
+  auth: Authenticator,
+  podId: string,
+  content: string
+): Promise<Result<void, DustFileSystemError>> {
+  if (content.length > POD_AGENTS_MD_MAX_CHARACTER_COUNT) {
+    return new Err(
+      new DustFileSystemError(
+        "invalid_path",
+        `Instructions must be ${POD_AGENTS_MD_MAX_CHARACTER_COUNT} characters or fewer.`
+      )
+    );
+  }
+
+  const scopedPath = getPodAgentsMdScopedPath(podId);
+  const fsResult = await DustFileSystem.fromScopedPath(auth, scopedPath);
+  if (fsResult.isErr()) {
+    return fsResult;
+  }
+
+  const writeResult = await fsResult.value.write(
+    scopedPath,
+    content,
+    "text/markdown"
+  );
+  if (writeResult.isErr()) {
+    return writeResult;
+  }
+
+  return new Ok(undefined);
 }
 
 export function formatPodAgentsMdPromptSection(content: string): string {

--- a/front/types/api/spaces.ts
+++ b/front/types/api/spaces.ts
@@ -14,6 +14,7 @@ export const ContentSchema = z.object({
 export const PatchSpaceRequestBodySchema = z.object({
   name: z.string().optional(),
   content: z.array(ContentSchema).optional(),
+  instructions: z.string().max(8192).optional(),
 });
 
 export const PostNotionSyncPayloadSchema = z.object({
@@ -104,6 +105,7 @@ export type RichSpaceType = EnrichedSpaceType & {
   isEditor: boolean;
   // Useful in case of projects
   description: string | null;
+  instructions: string | null;
   archivedAt: number | null;
   /** Background todo suggestions from project activity (project spaces only). */
   todoGenerationEnabled: boolean;
@@ -120,7 +122,7 @@ export type GetSpaceResponseBody = {
 };
 
 export type PatchSpaceResponseBody = {
-  space: SpaceType;
+  space: SpaceType & { instructions?: string | null };
 };
 
 /**

--- a/sdks/js/src/index.test.ts
+++ b/sdks/js/src/index.test.ts
@@ -4,7 +4,7 @@ import { createServer } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { DustAPI } from "./index";
-import type { LoggerInterface } from "./types";
+import { ActionGeneratedFileSchema, type LoggerInterface } from "./types";
 
 const RETRY_LOG_MESSAGE =
   "DustAPI retrying fetch after connection closed before response";
@@ -174,5 +174,33 @@ describe("DustAPI fetch retry on connection closed before response", () => {
     expect(res.isErr()).toBe(true);
     expect(server.connectionCount()).toBe(1);
     expect(logger.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("ActionGeneratedFileSchema", () => {
+  it("keeps path-only generated file records intact", () => {
+    const result = ActionGeneratedFileSchema.safeParse({
+      title: "report.bin",
+      snippet: null,
+      contentType: "application/x-custom",
+      fileId: null,
+      filePath: "conversation-test/report.bin",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.filePath).toBe("conversation-test/report.bin");
+    }
+  });
+
+  it("accepts legacy generated file records with a null fileId", () => {
+    const result = ActionGeneratedFileSchema.safeParse({
+      title: "report.txt",
+      snippet: null,
+      contentType: "text/plain",
+      fileId: null,
+    });
+
+    expect(result.success).toBe(true);
   });
 });

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -982,7 +982,7 @@ const ActionGeneratedFileBaseSchema = z.object({
   isInProjectContext: z.boolean().optional(),
 });
 
-const ActionGeneratedFileSchema = z.union([
+export const ActionGeneratedFileSchema = z.union([
   // File backed by a Dust FileResource: always a supported content type.
   ActionGeneratedFileBaseSchema.extend({
     contentType: ActionGeneratedFileContentTypeSchema,
@@ -993,6 +993,11 @@ const ActionGeneratedFileSchema = z.union([
     contentType: z.string(),
     fileId: z.null(),
     filePath: z.string(),
+  }),
+  // Legacy FileResource-backed records may have lost their FileResource id.
+  ActionGeneratedFileBaseSchema.extend({
+    contentType: ActionGeneratedFileContentTypeSchema,
+    fileId: z.null(),
   }),
 ]);
 


### PR DESCRIPTION
## Summary
- tolerate legacy generated-file action records where `fileId` is null, so CLI resume does not reject the conversation schema
- expose Pod Instructions for Agents on `GET`/`PATCH /api/w/:wId/spaces/:spaceId` by reading/writing Pod `AGENTS.md`
- add the same instructions read/write path to pod_manager get/edit information tools

Fixes #28803
Fixes #29496

## Tests
- `npm test -- src/index.test.ts` (in `sdks/js`)
- `npm run --workspace @dust-tt/client tsgo -- --noEmit`
- `npm run build --workspace @dust-tt/client`
- `npx biome check --write --error-on-warnings ...`
- `git diff --check`

Not run locally:
- front API route tests: `TEST_FRONT_DATABASE_URI` / `TEST_REDIS_URI` are not configured
- pre-commit hook: `front-typecheck` is blocked by unresolved local `@dust-tt/sparkle`, and `front-api-docs-check` could not resolve `registry.npmjs.org` from the sandbox