### PR TITLE
Detect root SKILL.md in repository skill imports

### DIFF
--- a/front/lib/api/skills/detection/github/parsing.test.ts
+++ b/front/lib/api/skills/detection/github/parsing.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  collectGitHubAttachments,
+  findGitHubSkillDirectories,
+} from "./parsing";
+import type { GitHubTreeEntry } from "./types";
+
+function makeTreeEntry(
+  path: string,
+  opts: { size?: number; type?: "blob" | "tree" } = {}
+): GitHubTreeEntry {
+  return {
+    path,
+    type: opts.type ?? "blob",
+    sha: `sha-${path}`,
+    size: opts.size ?? 100,
+    url: `https://api.github.com/repos/test/repo/git/blobs/sha-${path}`,
+  };
+}
+
+describe("findGitHubSkillDirectories", () => {
+  test("includes repository root SKILL.md alongside nested skills", () => {
+    const tree = [
+      makeTreeEntry("SKILL.md"),
+      makeTreeEntry("README.md"),
+      makeTreeEntry("skills/validate/SKILL.md"),
+      makeTreeEntry("skills/validate/helper.py"),
+    ];
+
+    const { skillDirs, fileEntries } = findGitHubSkillDirectories(tree);
+
+    expect(skillDirs.map((dir) => dir.skillMdPath)).toEqual([
+      "SKILL.md",
+      "skills/validate/SKILL.md",
+    ]);
+    expect(skillDirs[0]).toMatchObject({
+      dirPath: ".",
+      skillMdPath: "SKILL.md",
+      skillMdSha: "sha-SKILL.md",
+    });
+
+    const rootAttachments = collectGitHubAttachments(fileEntries, skillDirs[0]);
+    expect(rootAttachments).toEqual([
+      {
+        path: "README.md",
+        sizeBytes: 100,
+        contentType: "text/markdown",
+        sha: "sha-README.md",
+      },
+    ]);
+  });
+});

--- a/front/lib/api/skills/detection/parsing.test.ts
+++ b/front/lib/api/skills/detection/parsing.test.ts
@@ -99,15 +99,23 @@ describe("findSkillDirectories", () => {
     });
   });
 
-  test("prefers nested skills over SKILL.md at the root", () => {
+  test("includes SKILL.md at the root alongside nested skills", () => {
     const entries: FileEntry[] = [
       { path: "SKILL.md", sizeBytes: 100 },
       { path: "sub/SKILL.md", sizeBytes: 100 },
     ];
 
     const dirs = findSkillDirectories(entries);
-    expect(dirs).toHaveLength(1);
-    expect(dirs[0].skillMdPath).toBe("sub/SKILL.md");
+    expect(dirs).toEqual([
+      {
+        dirPath: ".",
+        skillMdPath: "SKILL.md",
+      },
+      {
+        dirPath: "sub",
+        skillMdPath: "sub/SKILL.md",
+      },
+    ]);
   });
 
   test("deduplicates directories with both skill.md and SKILL.md", () => {
@@ -157,5 +165,28 @@ describe("collectAttachments", () => {
     });
 
     expect(attachments).toEqual([]);
+  });
+
+  test("does not collect files from nested skill directories", () => {
+    const attachments = collectAttachments(
+      [
+        { path: "SKILL.md", sizeBytes: 100 },
+        { path: "helper.py", sizeBytes: 500 },
+        { path: "skills/foo/SKILL.md", sizeBytes: 100 },
+        { path: "skills/foo/helper.py", sizeBytes: 500 },
+      ],
+      {
+        dirPath: ".",
+        skillMdPath: "SKILL.md",
+      }
+    );
+
+    expect(attachments).toEqual([
+      {
+        path: "helper.py",
+        sizeBytes: 500,
+        contentType: "text/x-python",
+      },
+    ]);
   });
 });

--- a/front/lib/api/skills/detection/parsing.ts
+++ b/front/lib/api/skills/detection/parsing.ts
@@ -83,14 +83,10 @@ function extractFrontmatter(
 
 /**
  * Scans file entries for directories containing a SKILL.md (case-insensitive).
- * Prefers nested skill directories, and falls back to a root-level SKILL.md
- * only when no nested skills were found. This avoids treating a whole
- * multi-skill repository as attachments for a root skill.
  */
 export function findSkillDirectories(entries: FileEntry[]): SkillDirectory[] {
   const skillDirs: SkillDirectory[] = [];
   const seenDirs = new Set<string>();
-  let rootSkillDir: SkillDirectory | null = null;
 
   for (const entry of entries) {
     if (path.basename(entry.path).toLowerCase() !== SKILL_MD_FILENAME) {
@@ -98,11 +94,6 @@ export function findSkillDirectories(entries: FileEntry[]): SkillDirectory[] {
     }
 
     const dirPath = path.dirname(entry.path);
-    if (dirPath === ".") {
-      rootSkillDir ??= { dirPath, skillMdPath: entry.path };
-      continue;
-    }
-
     // Avoid duplicates if a directory has both skill.md and SKILL.md.
     if (seenDirs.has(dirPath)) {
       continue;
@@ -110,10 +101,6 @@ export function findSkillDirectories(entries: FileEntry[]): SkillDirectory[] {
     seenDirs.add(dirPath);
 
     skillDirs.push({ dirPath, skillMdPath: entry.path });
-  }
-
-  if (skillDirs.length === 0 && rootSkillDir) {
-    return [rootSkillDir];
   }
 
   return skillDirs;
@@ -124,13 +111,37 @@ export function collectAttachments(
   skillDir: SkillDirectory
 ): DetectedSkillAttachment[] {
   const attachments: DetectedSkillAttachment[] = [];
+  const nestedSkillDirs = findSkillDirectories(entries)
+    .map((dir) => dir.dirPath)
+    .filter((dirPath) => {
+      if (dirPath === skillDir.dirPath) {
+        return false;
+      }
+
+      const rel = path.relative(skillDir.dirPath, dirPath);
+
+      return rel.length > 0 && !rel.startsWith("..") && !path.isAbsolute(rel);
+    });
 
   for (const entry of entries) {
     if (entry.path === skillDir.skillMdPath) {
       continue;
     }
     const rel = path.relative(skillDir.dirPath, entry.path);
-    if (rel.startsWith("..")) {
+    if (rel.startsWith("..") || path.isAbsolute(rel)) {
+      continue;
+    }
+    if (
+      nestedSkillDirs.some((dirPath) => {
+        const nestedRel = path.relative(dirPath, entry.path);
+
+        return (
+          nestedRel.length > 0 &&
+          !nestedRel.startsWith("..") &&
+          !path.isAbsolute(nestedRel)
+        );
+      })
+    ) {
       continue;
     }
     const contentType = getSkillAttachmentContentType(entry);

--- a/front/lib/api/skills/detection/zip/detect_skills.test.ts
+++ b/front/lib/api/skills/detection/zip/detect_skills.test.ts
@@ -79,6 +79,34 @@ describe("detectSkillsFromZip", () => {
     }
   });
 
+  test("detects repository root skill alongside nested skills", () => {
+    const zipBuffer = buildZipBuffer({
+      "repo-main/SKILL.md": makeSkillMd("root", "Root skill", "Do root work."),
+      "repo-main/README.md": "# Root readme",
+      "repo-main/skills/foo/SKILL.md": makeSkillMd(
+        "foo",
+        "Foo skill",
+        "Do foo."
+      ),
+      "repo-main/skills/foo/helper.py": "print('hello')",
+    });
+
+    const result = detectSkillsFromZip({ zipBuffer });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.map((s) => s.name)).toEqual(["root", "foo"]);
+      expect(result.value[0].skillMdPath).toBe("repo-main/SKILL.md");
+      expect(result.value[0].attachments).toEqual([
+        {
+          path: "repo-main/README.md",
+          sizeBytes: 13,
+          contentType: "text/markdown",
+          originalEntryName: "repo-main/README.md",
+        },
+      ]);
+    }
+  });
+
   test("detects a single skill directory at the top level", () => {
     const zipBuffer = buildZipBuffer({
       "my-skill/SKILL.md": makeSkillMd("foo", "Foo skill", "Do foo."),


### PR DESCRIPTION
## Summary
- include a repository-root `SKILL.md` when scanning skill directories, even when nested skills are also present
- keep attachment collection scoped by excluding files that belong to nested skill directories
- add regression coverage for shared parsing, GitHub tree parsing, and GitHub-style zip detection

Fixes #30668

## Tests
- `NODE_ENV=test npx vitest --run --config vitest.skill-detection.config.mjs lib/api/skills/detection/parsing.test.ts lib/api/skills/detection/github/parsing.test.ts lib/api/skills/detection/zip/detect_skills.test.ts` (temporary no-DB config used for pure parser tests, then removed)
- `npx biome check --write --error-on-warnings front/lib/api/skills/detection/parsing.ts front/lib/api/skills/detection/parsing.test.ts front/lib/api/skills/detection/github/parsing.test.ts front/lib/api/skills/detection/zip/detect_skills.test.ts`
- `git diff --check`

Not run locally:
- default `npm test -- ...`: the front Vitest global setup requires `TEST_FRONT_DATABASE_URI` / `TEST_REDIS_URI` even for parser-only tests