### PR TITLE
[front] enh: add hash links for user menu dialogs

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -14,6 +14,7 @@ import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversati
 import { useDevMode } from "@app/hooks/useDevMode";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { usePrivacyMask } from "@app/hooks/usePrivacyMask";
+import { useUserMenuModal } from "@app/hooks/useUserMenuModal";
 import { OPEN_USER_ANALYTICS_EVENT } from "@app/lib/analytics/events";
 import config from "@app/lib/api/config";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
@@ -33,12 +34,7 @@ import {
   TRACKING_AREAS,
   trackEvent,
 } from "@app/lib/tracking";
-import {
-  isUserMenuModal,
-  USER_MENU_MODAL_QUERY_PARAM,
-} from "@app/lib/user_menu";
 import { getConversationRoute } from "@app/lib/utils/router";
-import { removeParamFromRouter } from "@app/lib/utils/router_util";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { AgentMention, MentionType } from "@app/types/assistant/mentions";
 import { isAgentMention } from "@app/types/assistant/mentions";
@@ -48,7 +44,6 @@ import {
 } from "@app/types/extension";
 import type { SubscriptionType } from "@app/types/plan";
 import { isDevelopment } from "@app/types/shared/env";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { UserTypeWithWorkspaces, WorkspaceType } from "@app/types/user";
 import { isOnlyAdmin, isOnlyManager, isOnlyUser } from "@app/types/user";
 import { datadogLogs } from "@datadog/browser-logs";
@@ -121,12 +116,9 @@ export function UserMenu({
 }: UserMenuProps) {
   const router = useAppRouter();
   const { featureFlags } = useFeatureFlags();
-  const [settingsOpen, setSettingsOpen] = useState(false);
-  const [toolsOpen, setToolsOpen] = useState(false);
-  const [automationsOpen, setAutomationsOpen] = useState(false);
-  const [analyticsOpen, setAnalyticsOpen] = useState(false);
+  const [userMenuModal, setUserMenuModal] = useUserMenuModal();
   const [userMenuOpen, setUserMenuOpen] = useState(false);
-  const userMenuModal = router.query[USER_MENU_MODAL_QUERY_PARAM];
+  const analyticsOpen = userMenuModal === "personal-usage";
 
   const isFirefox =
     typeof navigator !== "undefined" && /firefox/i.test(navigator.userAgent);
@@ -139,30 +131,11 @@ export function UserMenu({
     shouldShowExtensionMenu(extensionLastUsedAt?.value);
 
   useEffect(() => {
-    const openAnalytics = () => setAnalyticsOpen(true);
+    const openAnalytics = () => setUserMenuModal("personal-usage");
     window.addEventListener(OPEN_USER_ANALYTICS_EVENT, openAnalytics);
     return () =>
       window.removeEventListener(OPEN_USER_ANALYTICS_EVENT, openAnalytics);
-  }, []);
-
-  useEffect(() => {
-    if (!router.isReady || !isUserMenuModal(userMenuModal)) {
-      return;
-    }
-
-    switch (userMenuModal) {
-      case "personal-usage":
-        setAnalyticsOpen(true);
-        break;
-      case "personal-automations":
-        setAutomationsOpen(true);
-        break;
-      default:
-        assertNeverAndIgnore(userMenuModal);
-    }
-
-    void removeParamFromRouter(router, USER_MENU_MODAL_QUERY_PARAM);
-  }, [router, userMenuModal]);
+  }, [setUserMenuModal]);
 
   const sendNotification = useSendNotification();
   const devMode = useDevMode();
@@ -313,33 +286,44 @@ export function UserMenu({
   const handleCreditUsageLearnMore = () => {
     trackUserMenuEvent("credit_usage_learn_more");
     setUserMenuOpen(false);
-    setAnalyticsOpen(true);
+    setUserMenuModal("personal-usage");
   };
 
   return (
     <>
       <UserSettingsPopover
-        open={settingsOpen}
-        onOpenChange={setSettingsOpen}
+        open={userMenuModal === "personal-settings"}
+        onOpenChange={(open) =>
+          setUserMenuModal(open ? "personal-settings" : undefined)
+        }
         owner={owner}
       />
       <UserToolsDialog
-        open={toolsOpen}
-        onOpenChange={setToolsOpen}
+        open={userMenuModal === "personal-tools"}
+        onOpenChange={(open) =>
+          setUserMenuModal(open ? "personal-tools" : undefined)
+        }
         owner={owner}
       />
       <UserAutomationsDialog
-        open={automationsOpen}
-        onOpenChange={setAutomationsOpen}
+        open={userMenuModal === "personal-automations"}
+        onOpenChange={(open) =>
+          setUserMenuModal(open ? "personal-automations" : undefined)
+        }
         owner={owner}
       />
-      <Dialog open={analyticsOpen} onOpenChange={setAnalyticsOpen}>
+      <Dialog
+        open={analyticsOpen}
+        onOpenChange={(open) =>
+          setUserMenuModal(open ? "personal-usage" : undefined)
+        }
+      >
         <DialogContent size="2xl" height="xl" grow>
           <UserAnalyticsPopover
             key={owner.sId}
             open={analyticsOpen}
             owner={owner}
-            onClose={() => setAnalyticsOpen(false)}
+            onClose={() => setUserMenuModal(undefined)}
           />
         </DialogContent>
       </Dialog>
@@ -529,7 +513,7 @@ export function UserMenu({
                 icon={User01}
                 onSelect={() => {
                   trackUserMenuEvent("personal_settings");
-                  setSettingsOpen(true);
+                  setUserMenuModal("personal-settings");
                 }}
               />
               <DropdownMenuItem
@@ -537,7 +521,7 @@ export function UserMenu({
                 icon={ShapesPlus}
                 onSelect={() => {
                   trackUserMenuEvent("tools");
-                  setToolsOpen(true);
+                  setUserMenuModal("personal-tools");
                 }}
               />
               <DropdownMenuItem
@@ -545,7 +529,7 @@ export function UserMenu({
                 icon={Clock}
                 onSelect={() => {
                   trackUserMenuEvent("automations");
-                  setAutomationsOpen(true);
+                  setUserMenuModal("personal-automations");
                 }}
               />
               {/* The credit usage action is the analytics entry point when shown; keep exactly one. */}
@@ -555,7 +539,7 @@ export function UserMenu({
                   icon={BarChart01}
                   onSelect={() => {
                     trackUserMenuEvent("analytics");
-                    setAnalyticsOpen(true);
+                    setUserMenuModal("personal-usage");
                   }}
                 />
               )}

--- a/front/hooks/useUserMenuModal.test.ts
+++ b/front/hooks/useUserMenuModal.test.ts
@@ -1,0 +1,132 @@
+import { useUserMenuModal } from "@app/hooks/useUserMenuModal";
+import { useAppRouter } from "@app/lib/platform";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/platform", () => ({
+  useAppRouter: vi.fn(),
+}));
+
+describe("useUserMenuModal", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/w/workspace-id/conversation/new");
+    vi.mocked(useAppRouter).mockReturnValue({
+      isReady: true,
+      pathname: window.location.pathname,
+      asPath: window.location.pathname,
+      query: {},
+      push: vi.fn(),
+      replace: vi.fn(),
+      back: vi.fn(),
+      reload: vi.fn(),
+      events: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+    });
+  });
+
+  it.each([
+    "personal-usage",
+    "personal-automations",
+    "personal-settings",
+    "personal-tools",
+  ] as const)("opens %s from its hash and preserves unrelated URL state when closing", (modal) => {
+    const baseUrl =
+      "/w/workspace-id/conversation/new?foo=bar#content?view=list";
+    window.history.replaceState(null, "", `${baseUrl}&modal=${modal}`);
+
+    const { result } = renderHook(() => useUserMenuModal());
+    expect(result.current[0]).toBe(modal);
+
+    act(() => result.current[1](undefined));
+    expect(result.current[0]).toBeUndefined();
+    expect(window.location.href).toBe(`${window.location.origin}${baseUrl}`);
+  });
+
+  it("updates the hash on selection and follows hash changes and browser history", async () => {
+    const { result } = renderHook(() => useUserMenuModal());
+
+    act(() => result.current[1]("personal-settings"));
+    expect(window.location.hash).toBe("#?modal=personal-settings");
+
+    act(() => {
+      window.location.hash = "?modal=personal-tools";
+    });
+    await waitFor(() => expect(result.current[0]).toBe("personal-tools"));
+
+    act(() => {
+      window.history.replaceState(null, "", "#?modal=personal-settings");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+    expect(result.current[0]).toBe("personal-settings");
+
+    act(() => {
+      window.history.replaceState(null, "", window.location.pathname);
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+    expect(result.current[0]).toBeUndefined();
+  });
+
+  it("ignores unsupported hash values", () => {
+    window.history.replaceState(null, "", "#?modal=unknown");
+    const { result } = renderHook(() => useUserMenuModal());
+    expect(result.current[0]).toBeUndefined();
+    expect(window.location.hash).toBe("#?modal=unknown");
+  });
+
+  it("follows SPA navigation without a hashchange event", () => {
+    const { result, rerender } = renderHook(() => useUserMenuModal());
+    const router = useAppRouter();
+
+    window.history.pushState(null, "", "#?modal=personal-tools");
+    vi.mocked(useAppRouter).mockReturnValue({
+      ...router,
+      asPath: `${window.location.pathname}${window.location.hash}`,
+    });
+    rerender();
+    expect(result.current[0]).toBe("personal-tools");
+
+    window.history.pushState(null, "", "/w/workspace-id/conversation/other");
+    vi.mocked(useAppRouter).mockReturnValue({
+      ...router,
+      pathname: window.location.pathname,
+      asPath: window.location.pathname,
+    });
+    rerender();
+    expect(result.current[0]).toBeUndefined();
+    expect(window.location.hash).toBe("");
+  });
+
+  it("migrates a legacy query link while preserving query and hash parameters", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "?modal=personal-usage&foo=bar#content?view=list"
+    );
+    const router = useAppRouter();
+    router.query = { modal: "personal-usage", foo: "bar" };
+    vi.mocked(router.replace).mockImplementation(async () => {
+      window.history.replaceState(null, "", "?foo=bar#content?view=list");
+      router.query = { foo: "bar" };
+      return true;
+    });
+
+    const { result } = renderHook(() => useUserMenuModal());
+    await waitFor(() => expect(result.current[0]).toBe("personal-usage"));
+
+    expect(router.replace).toHaveBeenCalledWith(
+      {
+        pathname: router.pathname,
+        query: { foo: "bar" },
+        hash: "#content?view=list",
+      },
+      undefined,
+      { shallow: true }
+    );
+    expect(window.location.search).toBe("?foo=bar");
+    expect(window.location.hash).toBe(
+      "#content?view=list&modal=personal-usage"
+    );
+
+    act(() => result.current[1](undefined));
+    expect(window.location.hash).toBe("#content?view=list");
+  });
+});

--- a/front/hooks/useUserMenuModal.ts
+++ b/front/hooks/useUserMenuModal.ts
@@ -1,0 +1,55 @@
+import { useHashParam } from "@app/hooks/useHashParams";
+import { useAppRouter } from "@app/lib/platform";
+import type { UserMenuModal } from "@app/lib/user_menu";
+import {
+  isUserMenuModal,
+  USER_MENU_MODAL_QUERY_PARAM,
+} from "@app/lib/user_menu";
+import { useEffect } from "react";
+
+/**
+ * @cc [owner:aubin-tchoi,label:product] user-menu-modal-url-state
+ * The hash `modal` parameter selects the user-menu dialog; unsupported values open
+ * none, and closing a dialog removes only that parameter.
+ */
+/**
+ * @cc [owner:aubin-tchoi,label:product] legacy-user-menu-modal-links
+ * Supported query-string `modal` links must open the requested dialog and migrate
+ * to the hash without removing unrelated query or hash parameters.
+ */
+export function useUserMenuModal(): [
+  UserMenuModal | undefined,
+  (modal?: UserMenuModal) => void,
+] {
+  const router = useAppRouter();
+  const [modal, setModal] = useHashParam(USER_MENU_MODAL_QUERY_PARAM);
+  const queryModal = router.query[USER_MENU_MODAL_QUERY_PARAM];
+
+  useEffect(() => {
+    if (!router.isReady) {
+      return;
+    }
+
+    if (isUserMenuModal(queryModal)) {
+      const query = { ...router.query };
+      delete query[USER_MENU_MODAL_QUERY_PARAM];
+
+      void router
+        .replace(
+          { pathname: router.pathname, query, hash: window.location.hash },
+          undefined,
+          { shallow: true }
+        )
+        .then(() => setModal(queryModal));
+      return;
+    }
+
+    // SPA navigation uses pushState, which does not emit hashchange. Read the
+    // current location so a hash written by useHashParam is not overwritten.
+    const [, hashQuery] = window.location.hash.split("?");
+    const hashParams = new URLSearchParams(hashQuery);
+    setModal(hashParams.get(USER_MENU_MODAL_QUERY_PARAM) ?? undefined);
+  }, [router, queryModal, setModal]);
+
+  return [isUserMenuModal(modal) ? modal : undefined, setModal];
+}

--- a/front/lib/user_menu.test.ts
+++ b/front/lib/user_menu.test.ts
@@ -7,10 +7,21 @@ import { describe, expect, it } from "vitest";
 
 describe("user menu links", () => {
   it.each([
-    ["personal-usage", "/w/workspace-id/conversation/new?modal=personal-usage"],
+    [
+      "personal-usage",
+      "/w/workspace-id/conversation/new#?modal=personal-usage",
+    ],
     [
       "personal-automations",
-      "/w/workspace-id/conversation/new?modal=personal-automations",
+      "/w/workspace-id/conversation/new#?modal=personal-automations",
+    ],
+    [
+      "personal-settings",
+      "/w/workspace-id/conversation/new#?modal=personal-settings",
+    ],
+    [
+      "personal-tools",
+      "/w/workspace-id/conversation/new#?modal=personal-tools",
     ],
   ] as const)("builds the %s modal route", (modal, expectedRoute) => {
     expect(getUserMenuModalRoute("workspace-id", modal)).toBe(expectedRoute);
@@ -19,6 +30,8 @@ describe("user menu links", () => {
   it("only accepts supported modal values", () => {
     expect(isUserMenuModal("personal-usage")).toBe(true);
     expect(isUserMenuModal("personal-automations")).toBe(true);
+    expect(isUserMenuModal("personal-settings")).toBe(true);
+    expect(isUserMenuModal("personal-tools")).toBe(true);
     expect(isUserMenuModal("apps")).toBe(false);
     expect(isUserMenuModal(["personal-usage"])).toBe(false);
   });
@@ -26,6 +39,8 @@ describe("user menu links", () => {
   it.each([
     ["personal-usage", "/?goto=personal-usage"],
     ["personal-automations", "/?goto=personal-automations"],
+    ["personal-settings", "/?goto=personal-settings"],
+    ["personal-tools", "/?goto=personal-tools"],
   ] as const)("builds the shareable %s route", (modal, expectedRoute) => {
     expect(getUserMenuModalShareRoute(modal)).toBe(expectedRoute);
   });

--- a/front/lib/user_menu.ts
+++ b/front/lib/user_menu.ts
@@ -4,12 +4,19 @@ import { isString } from "@app/types/shared/utils/general";
 export const USER_MENU_MODAL_QUERY_PARAM = "modal";
 export const USER_MENU_GOTO_QUERY_PARAM = "goto";
 
-export type UserMenuModal = "personal-usage" | "personal-automations";
+export type UserMenuModal =
+  | "personal-usage"
+  | "personal-automations"
+  | "personal-settings"
+  | "personal-tools";
 
 export function isUserMenuModal(value: unknown): value is UserMenuModal {
   return (
     isString(value) &&
-    (value === "personal-usage" || value === "personal-automations")
+    (value === "personal-usage" ||
+      value === "personal-automations" ||
+      value === "personal-settings" ||
+      value === "personal-tools")
   );
 }
 
@@ -17,11 +24,7 @@ export function getUserMenuModalRoute(
   workspaceId: string,
   modal: UserMenuModal
 ): string {
-  return getConversationRoute(
-    workspaceId,
-    "new",
-    `${USER_MENU_MODAL_QUERY_PARAM}=${modal}`
-  );
+  return `${getConversationRoute(workspaceId, "new")}#?${USER_MENU_MODAL_QUERY_PARAM}=${modal}`;
 }
 
 export function getUserMenuModalShareRoute(modal: UserMenuModal): string {


### PR DESCRIPTION
## Description

This PR adds hash params for the Personal Settings, Tools, Automations, and Analytics menus with `#?modal=personal-settings`, `personal-tools`, `personal-automations`, or `personal-usage`.

The selected dialog is stored in the hash, follows browser and SPA navigation, and clears its parameter when closed. Existing `?modal=` links migrate to the hash, and `/?goto=` share links support all four dialogs.

## Tests

- Added coverage for deep links, opening and closing, browser/SPA navigation, and legacy links preserving unrelated URL parameters.
- Updated existing link tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
