### PR TITLE
[front,connectors] Exclude originating Slack thread from retrieval

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1269,6 +1269,12 @@ async function answerMessage(
       email: slackChatBotMessage.slackEmail,
       profilePictureUrl: slackChatBotMessage.slackAvatar || null,
       origin,
+      // Keep retrieval from self-matching on the very thread that triggered this run: the current
+      // Slack thread is indexed (question text included) as a document tagged `threadId:<ts>`, and
+      // its content is already provided to the conversation as a content fragment.
+      excludedRetrievalTags: slackChatBotMessage.threadTs
+        ? [`threadId:${slackChatBotMessage.threadTs}`]
+        : undefined,
     },
     skipToolsValidation,
   };

--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -13070,6 +13070,13 @@
             "items": {
               "type": "string"
             }
+          },
+          "excludedRetrievalTags": {
+            "type": "array",
+            "description": "Data source tags to exclude from retrieval for this run, as opaque `key:value` strings.",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },
@@ -14492,6 +14499,13 @@
           },
           "selectedSpaceIds": {
             "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "excludedRetrievalTags": {
+            "type": "array",
+            "description": "Data source tags to exclude from retrieval for this run, as opaque `key:value` strings.",
             "items": {
               "type": "string"
             }

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -1486,6 +1486,11 @@
  *           type: array
  *           items:
  *             type: string
+ *         excludedRetrievalTags:
+ *           type: array
+ *           description: Data source tags to exclude from retrieval for this run, as opaque `key:value` strings.
+ *           items:
+ *             type: string
  *     PrivateReaction:
  *       type: object
  *       description: A reaction on a message.

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -216,6 +216,7 @@ app.post(
     const messageContext: UserMessageContext = {
       clientSideMCPServerIds: context.clientSideMCPServerIds ?? [],
       email: context.email?.toLowerCase() ?? null,
+      excludedRetrievalTags: context.excludedRetrievalTags ?? null,
       fullName: context.fullName ?? null,
       origin,
       profilePictureUrl: context.profilePictureUrl ?? null,

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
@@ -418,6 +418,7 @@ app.post(
       const messageContext: UserMessageContext = {
         clientSideMCPServerIds: message.context.clientSideMCPServerIds ?? [],
         email: message.context.email?.toLowerCase() ?? null,
+        excludedRetrievalTags: message.context.excludedRetrievalTags ?? null,
         fullName: message.context.fullName ?? null,
         origin,
         profilePictureUrl: message.context.profilePictureUrl ?? null,

--- a/front-api/routes/v1/w/[wId]/swagger_schemas.ts
+++ b/front-api/routes/v1/w/[wId]/swagger_schemas.ts
@@ -127,6 +127,11 @@
  *           type: array
  *           items:
  *             type: string
+ *         excludedRetrievalTags:
+ *           type: array
+ *           description: Data source tags to exclude from retrieval for this run, as opaque `key:value` strings.
+ *           items:
+ *             type: string
  *         agenticMessageData:
  *           type: object
  *           properties:

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
@@ -59,6 +59,14 @@ export async function search(
     ? runContext.stepContext
     : { retrievalTopK: AGENT_LESS_DEFAULT_RETRIEVAL_TOP_K, citationsOffset: 0 };
 
+  // See the `excluded-retrieval-tags-honored` contract on `searchFunction`: the originating run may
+  // ask us to keep certain tags out of retrieval (e.g. the Slack bot excludes the thread that
+  // triggered the run). Applied to every data source; these tags only exist on documents that carry
+  // them, so excluding them elsewhere is a no-op.
+  const excludedRetrievalTags = isAgentLoopRunContext(runContext)
+    ? (runContext.userMessage.context.excludedRetrievalTags ?? [])
+    : [];
+
   const agentDataSourceConfigurationsResult =
     await getAgentDataSourceConfigurations(auth, dataSources);
 
@@ -103,6 +111,7 @@ export async function search(
       const finalTagsNot = [
         ...(args.filter.tags?.not ?? []),
         ...(tagsNot ?? []),
+        ...excludedRetrievalTags,
       ];
 
       return {

--- a/front/lib/api/actions/servers/search/tools/index.ts
+++ b/front/lib/api/actions/servers/search/tools/index.ts
@@ -36,6 +36,12 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
 
+/**
+ * @cc [owner:tdraier,label:product] excluded-retrieval-tags-honored
+ * Retrieval honors the originating run's declared scope: exclusions carried on
+ * `userMessage.context.excludedRetrievalTags` are always applied to the effective filter. A run
+ * must never surface documents it asked to exclude.
+ */
 export async function searchFunction(
   auth: Authenticator,
   {
@@ -67,6 +73,14 @@ export async function searchFunction(
   )
     ? toolContext.runContext.stepContext
     : { retrievalTopK: AGENT_LESS_DEFAULT_RETRIEVAL_TOP_K, citationsOffset: 0 };
+
+  // Tags the originating run asked us to keep out of retrieval (e.g. the Slack bot excludes the
+  // very thread that triggered the run so it does not self-match on the question text). Applied
+  // to every data source: these tags only exist on documents that carry them, so excluding them
+  // elsewhere is a no-op.
+  const excludedRetrievalTags = isAgentLoopRunContext(toolContext?.runContext)
+    ? (toolContext.runContext.userMessage.context.excludedRetrievalTags ?? [])
+    : [];
 
   // Get the core search args for each data source, fail if any of them are invalid.
   const coreSearchArgsResults = await getCoreSearchArgs(auth, dataSources);
@@ -118,6 +132,7 @@ export async function searchFunction(
       const finalTagsNot = [
         ...(args.filter.tags?.not ?? []),
         ...(tagsNot ?? []),
+        ...excludedRetrievalTags,
       ];
 
       return {

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -242,6 +242,7 @@ export async function createUserMessage(
         : null,
       userContextApiKeyId: context.apiKeyId ?? null,
       userContextAuthMethod: context.authMethod ?? null,
+      userContextExcludedRetrievalTags: context.excludedRetrievalTags ?? null,
       agenticMessageType,
       agenticOriginMessageId,
       requestedModelId: requestedModel?.modelId ?? null,

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -236,6 +236,7 @@ function renderUserMessage(
       clientSideMCPServerIds: userMessage.clientSideMCPServerIds,
       lastTriggerRunAt:
         userMessage.userContextLastTriggerRunAt?.getTime() ?? null,
+      excludedRetrievalTags: userMessage.userContextExcludedRetrievalTags,
     },
     agenticMessageData:
       userMessage.agenticMessageType && userMessage.agenticOriginMessageId

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -313,6 +313,7 @@ export class UserMessageModel extends WorkspaceAwareModel<UserMessageModel> {
   declare userContextLastTriggerRunAt: Date | null;
   declare userContextApiKeyId: ForeignKey<KeyModel["id"]> | null;
   declare userContextAuthMethod: string | null;
+  declare userContextExcludedRetrievalTags: string[] | null;
 
   declare userId: ForeignKey<UserModel["id"]> | null;
   // Denormalized from messages for conversation-scoped fetches (plain column, no FK — the value
@@ -390,6 +391,11 @@ UserMessageModel.init(
     userContextAuthMethod: {
       type: DataTypes.STRING(50),
       allowNull: true,
+    },
+    userContextExcludedRetrievalTags: {
+      type: DataTypes.ARRAY(DataTypes.STRING),
+      allowNull: true,
+      defaultValue: null,
     },
     agenticMessageType: {
       type: DataTypes.STRING(16),

--- a/front/migrations/pre-deploy/20260907175148_add_excluded_retrieval_tags_to_user_messages.sql
+++ b/front/migrations/pre-deploy/20260907175148_add_excluded_retrieval_tags_to_user_messages.sql
@@ -1,0 +1,11 @@
+/*
+Generic per-message retrieval-scope hint: data source tags to exclude from retrieval for the run,
+stored as opaque "key:value" strings. Downstream code does not interpret their meaning; the Slack
+bot uses it to set "threadId:<ts>" so a run does not self-match on the very thread that triggered it.
+*/
+
+/* Nullable, default NULL: old code ignores the column, new code treats NULL as "no exclusions". */
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."user_messages"
+  ADD COLUMN "userContextExcludedRetrievalTags" character varying(255)[] DEFAULT NULL;

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -166,6 +166,7 @@ export type UserMessageContext = {
   selectedSpaceIds?: string[];
   apiKeyId?: number | null;
   authMethod?: string | null;
+  excludedRetrievalTags?: string[] | null;
 };
 
 export type AgenticMessageData = {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1248,6 +1248,7 @@ const UserMessageContextSchema = z.object({
   clientSideMCPServerIds: z.array(z.string()).optional().nullable(),
   selectedMCPServerViewIds: z.array(z.string()).optional().nullable(),
   lastTriggerRunAt: z.number().optional().nullable(),
+  excludedRetrievalTags: z.array(z.string()).optional().nullable(),
 });
 
 const AgenticMessageDataSchema = z.object({


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/10294

Asked from inside a Slack thread to find an *earlier* thread, the bot returned a link to the **current** thread. The active Slack thread is indexed into the data source with the user's question text verbatim (as a document tagged `threadId:<ts>`), so it self-matches on its own query and gets served back as the answer. Its content is already provided to the conversation as a content fragment, so retrieving the indexed copy only ever hurts.

This adds a generic, channel-agnostic retrieval-scope hint on the user message context: **`excludedRetrievalTags`** — opaque `key:value` tag strings a run asks retrieval to skip (merged into each data source's `filter.tags.not`). The conversation/message models stay entirely Slack-agnostic; the **only** component that knows the Slack→tag mapping is the connectors Slack bot, which sets `excludedRetrievalTags: ["threadId:<threadTs>"]`.

- `sdks/js` + `front` `UserMessageContext`: new optional `excludedRetrievalTags`.
- `front-api`: forwarded on post-message and create-conversation; swagger schemas updated.
- `front`: persisted via new nullable column `userContextExcludedRetrievalTags` on `user_messages` (pre-deploy migration), read back into the message context.
- `front`: both query-based search tools (`search` and `data_sources_file_system/search`) exclude the tags. New `@cc` contract `excluded-retrieval-tags-honored` documents the invariant for future retrieval tools.
- `connectors`: Slack bot stamps the originating thread's tag.

## Tests

- `tsgo --noEmit` clean on front, front-api, connectors; SDK build passes.
- `messages.test.ts` + `conversation/messages.test.ts` — 40/40 pass, exercising the new column's persist→readback roundtrip.
- Biome clean on all changed files.

## Risk

Low. The field is optional everywhere and defaults to no exclusions, so non-Slack runs are unaffected. The exclusion is applied post-`checkConflictingTags` at `finalTagsNot`, and the tags only exist on documents that carry them, so excluding them on other data sources is a no-op. Safe to roll back (additive nullable column, expand-only).

## Deploy Plan

1. Run the pre-deploy migration `20260907175148_add_excluded_retrieval_tags_to_user_messages.sql` (adds nullable column) **before** deploying code.
2. Deploy front / front-api / connectors (rebuilt `@dust-tt/client` is bundled via the workspace file dependency). Field is optional in all directions, so relative deploy order does not matter.