### PR TITLE
[front] fix: monthly credit reset date on annually-billed seats

### DIFF
--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -2320,9 +2320,9 @@ async function reconcileSeatBasedSegment({
 export type SeatData = {
   awuAllocation: number;
   billingFrequency: BillingFrequency | null;
-  // ISO timestamp of the next credit reset. Null when no current billing period
-  // is available. Equals billing_periods.current.ending_before since credits
-  // are now anchored to the contract start date (same as the billing period).
+  // ISO timestamp of the next per-seat AWU credit renewal (recurs MONTHLY even
+  // on annually-billed seats — see `getNextSeatCreditRenewalDate`). Null when
+  // the seat carries no recurring credit or no recurrence anchor is available.
   nextCreditResetAt: string | null;
 };
 
@@ -2402,8 +2402,17 @@ export async function buildSeatDataByUserId({
       const assignedSeatIds = seatStateResult.value.assignedSeatIds;
 
       const freq = sub.subscription_rate.billing_frequency;
+      // Per-seat AWU credits recur MONTHLY even on annually-billed seats, so the
+      // reset date must follow the credit's recurrence grid — not the billing
+      // period's `ending_before`, which on an annual seat points up to a year
+      // out (see `getNextSeatCreditRenewalDate`).
       const nextCreditResetAt =
-        sub.billing_periods?.current?.ending_before ?? null;
+        getNextSeatCreditRenewalDate({
+          contract,
+          seatType,
+          productSeatTypes,
+          now: new Date(),
+        })?.toISOString() ?? null;
       return new Ok({
         seatIds: assignedSeatIds,
         awuAllocation,


### PR DESCRIPTION
## Description

On Pro/Enterprise seats billed **annually**, the Personal Usage Card's "Resets on [date]" showed a date up to 12 months out, making customers believe their credit allowance (e.g. 8,000 credits) only refreshes once a year. In reality per-seat AWU credits recur **monthly** regardless of billing cadence.

Root cause: `buildSeatDataByUserId` (`front/lib/metronome/seats.ts`) set `nextCreditResetAt` from the subscription's `billing_periods.current.ending_before` — which is the annual billing period end on an annual seat.

Fix: reuse the existing canonical `getNextSeatCreditRenewalDate`, which steps the credit's monthly recurrence grid forward independent of billing frequency (already used for the same reasoning in deferred seat-change logic). Also corrected the now-stale doc comment on `SeatData.nextCreditResetAt`.

Fixes dust-tt/tasks#10330

## Tests

- `npx tsgo --noEmit` — clean.
- `lib/metronome/seats.test.ts` — 66/66 pass. The fix delegates entirely to `getNextSeatCreditRenewalDate`, which already has dedicated coverage; monthly seats are unaffected (their credit grid coincides with the billing period).

## Risk

Low. Display-only change on an existing field; no schema, API, or write-path changes. Falls back to `null` (no date shown) when no recurrence anchor is resolvable, same graceful-degradation behavior as before.

## Deploy Plan

Standard front deploy. No migration, flag, or config changes.