### PR TITLE
Add: move port forwarding back to the devcontainer setup.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,24 +7,18 @@
   "workspaceFolder": "/workspace",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
   "remoteUser": "root",
+  "forwardPorts": [
+    3000,
+    3010,
+    3011,
+    3001,
+    3007,
+    6333,
+    7233,
+    8233
+  ],
   "runArgs": [
     "--init",
-    "-p",
-    "3000:3000",
-    "-p",
-    "3010:3010",
-    "-p",
-    "3011:3011",
-    "-p",
-    "3001:3001",
-    "-p",
-    "3007:3007",
-    "-p",
-    "6333:6333",
-    "-p",
-    "7233:7233",
-    "-p",
-    "8233:8233"
   ],
   "otherPortsAttributes": {
     "onAutoForward": "ignore"


### PR DESCRIPTION
## Description

I moved local service port mappings from Docker `runArgs` `-p` flags to `forwardPorts` in `.devcontainer/devcontainer.json`. Dev Container clients can now manage forwarding for the application, database, Temporal, and related local services without changing container startup arguments.

## Tests

Not run; this is a configuration-only change. I reviewed the JSON structure and port list.

## Risk

Low. The change only affects local development port exposure; production services are untouched. Reverting the commit restores the previous mappings.

## Deploy Plan

No deployment required. Rebuild or reopen the Dev Container to apply the updated forwarding configuration.