### PR TITLE
feat(front): prorate prepaid seat commitments to the contract period

### DIFF
--- a/front/components/poke/shadcn/ui/form/fields.tsx
+++ b/front/components/poke/shadcn/ui/form/fields.tsx
@@ -119,6 +119,8 @@ interface InputFieldProps<T extends FieldValues> {
   placeholder?: string;
   /** Native `min` attribute, useful for `number` and `datetime-local`. */
   min?: string;
+  /** Native `max` attribute, useful for `number` and `datetime-local`. */
+  max?: string;
   /** Native `step` attribute, useful for `number` and `datetime-local`. */
   step?: number | string;
   readOnly?: boolean;
@@ -135,6 +137,7 @@ export function InputField<T extends FieldValues>({
   type,
   placeholder,
   min,
+  max,
   step,
   readOnly,
   disabled,
@@ -156,6 +159,7 @@ export function InputField<T extends FieldValues>({
               placeholder={placeholder ?? name}
               type={type}
               min={min}
+              max={max}
               step={step}
               {...field}
               value={field.value ?? ""}

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -167,6 +167,7 @@ export default function SwitchContractDialog({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
+  const [durationMode, setDurationMode] = useState(false);
   const [durationValue, setDurationValue] = useState(1);
   const [durationUnit, setDurationUnit] =
     useState<ContractDurationUnit>("years");
@@ -501,21 +502,21 @@ export default function SwitchContractDialog({
     };
   }, [commitmentStartDate, commitmentEndDate]);
 
-  // Compute `endingAt` from the contract start plus the chosen duration, so the
-  // operator can express the term as years/months/weeks instead of picking a
-  // date. Requires a resolved start.
-  const applyDuration = useCallback(() => {
-    if (!commitmentStartDate || !(durationValue > 0)) {
+  // While "Set duration" is on, the end date is derived from the (floored) start
+  // plus the chosen duration and kept in sync as the start, value, or unit
+  // change — the end-date field is read-only in this mode. Anchored to the
+  // floored start hour so the end lands on a whole hour.
+  useEffect(() => {
+    if (!durationMode || !commitmentStartDate || !(durationValue > 0)) {
       return;
     }
-    // Anchor to the floored start hour so the end lands on a whole hour.
     const end = addContractDuration(
       floorToHourUTC(commitmentStartDate),
       durationValue,
       durationUnit
     );
     form.setValue("endingAt", toDatetimeLocalUTC(end));
-  }, [commitmentStartDate, durationValue, durationUnit, form]);
+  }, [durationMode, commitmentStartDate, durationValue, durationUnit, form]);
 
   const startModeOptions = useMemo(
     () => [
@@ -1104,6 +1105,7 @@ export default function SwitchContractDialog({
                                 type="datetime-local"
                                 step={3600}
                                 placeholder="open-ended"
+                                disabled={durationMode}
                                 transformValue={snapDatetimeLocalToHour}
                               />
                               {endingAtLocalLabel && (
@@ -1113,58 +1115,61 @@ export default function SwitchContractDialog({
                               )}
                             </div>
                             <div className="mt-2 flex items-center gap-2">
-                              <input
-                                type="number"
-                                min={1}
-                                value={durationValue}
-                                onChange={(e) =>
-                                  setDurationValue(Number(e.target.value))
-                                }
-                                className="h-7 w-14 rounded-md border border-border bg-background px-1.5 text-xs"
+                              <SliderToggle
+                                selected={durationMode}
+                                onClick={() => setDurationMode((v) => !v)}
                               />
-                              <DropdownMenu>
-                                <DropdownMenuTrigger asChild>
-                                  <Button
-                                    type="button"
-                                    variant="outline"
-                                    size="xs"
-                                    isSelect
-                                    label={
-                                      durationUnit === "years"
-                                        ? "Years"
-                                        : durationUnit === "months"
-                                          ? "Months"
-                                          : "Weeks"
+                              <span className="text-xs text-muted-foreground">
+                                Set duration
+                              </span>
+                              {durationMode && (
+                                <>
+                                  <input
+                                    type="number"
+                                    min={1}
+                                    value={durationValue}
+                                    onChange={(e) =>
+                                      setDurationValue(Number(e.target.value))
                                     }
+                                    className="h-7 w-14 rounded-md border border-border bg-background px-1.5 text-xs"
                                   />
-                                </DropdownMenuTrigger>
-                                <DropdownMenuContent
-                                  mountPortalContainer={portalContainer}
-                                >
-                                  <DropdownMenuItem
-                                    label="Years"
-                                    onClick={() => setDurationUnit("years")}
-                                  />
-                                  <DropdownMenuItem
-                                    label="Months"
-                                    onClick={() => setDurationUnit("months")}
-                                  />
-                                  <DropdownMenuItem
-                                    label="Weeks"
-                                    onClick={() => setDurationUnit("weeks")}
-                                  />
-                                </DropdownMenuContent>
-                              </DropdownMenu>
-                              <Button
-                                type="button"
-                                variant="outline"
-                                size="xs"
-                                label="Set duration"
-                                disabled={
-                                  !commitmentStartDate || !(durationValue > 0)
-                                }
-                                onClick={applyDuration}
-                              />
+                                  <DropdownMenu>
+                                    <DropdownMenuTrigger asChild>
+                                      <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="xs"
+                                        isSelect
+                                        label={
+                                          durationUnit === "years"
+                                            ? "Years"
+                                            : durationUnit === "months"
+                                              ? "Months"
+                                              : "Weeks"
+                                        }
+                                      />
+                                    </DropdownMenuTrigger>
+                                    <DropdownMenuContent
+                                      mountPortalContainer={portalContainer}
+                                    >
+                                      <DropdownMenuItem
+                                        label="Years"
+                                        onClick={() => setDurationUnit("years")}
+                                      />
+                                      <DropdownMenuItem
+                                        label="Months"
+                                        onClick={() =>
+                                          setDurationUnit("months")
+                                        }
+                                      />
+                                      <DropdownMenuItem
+                                        label="Weeks"
+                                        onClick={() => setDurationUnit("weeks")}
+                                      />
+                                    </DropdownMenuContent>
+                                  </DropdownMenu>
+                                </>
+                              )}
                             </div>
                           </div>
                           {commitmentPeriodInfo && (

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -5,6 +5,12 @@ import {
 } from "@app/components/poke/shadcn/ui/form/fields";
 import { clientFetch } from "@app/lib/egress/client";
 import { amountCents } from "@app/lib/metronome/amounts";
+import {
+  commitmentAmount,
+  commitmentMonths,
+  commitmentPeriodEnd,
+  maxInvoicePeriods,
+} from "@app/lib/metronome/seat_commitment";
 import { isPaygEligibleTier } from "@app/lib/metronome/types";
 import {
   CREDIT_PRICED_BUSINESS_PLAN_CODE,
@@ -36,6 +42,10 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   Label,
   SliderToggle,
   Spinner,
@@ -85,6 +95,56 @@ function snapDatetimeLocalToHour(value: string): string {
   return value;
 }
 
+type ContractDurationUnit = "years" | "months" | "weeks";
+
+// Add a contract duration to a start moment (UTC), clamping month/year day
+// overflow to the last day of the target month (Jan 31 + 1 month → Feb 28/29).
+function addContractDuration(
+  start: Date,
+  value: number,
+  unit: ContractDurationUnit
+): Date {
+  if (unit === "weeks") {
+    return new Date(start.getTime() + value * 7 * 24 * 60 * 60 * 1000);
+  }
+  const monthsToAdd = unit === "years" ? value * 12 : value;
+  const targetMonthIndex = start.getUTCMonth() + monthsToAdd;
+  const targetYear = start.getUTCFullYear() + Math.floor(targetMonthIndex / 12);
+  const targetMonth = ((targetMonthIndex % 12) + 12) % 12;
+  const lastDay = new Date(
+    Date.UTC(targetYear, targetMonth + 1, 0)
+  ).getUTCDate();
+  return new Date(
+    Date.UTC(
+      targetYear,
+      targetMonth,
+      Math.min(start.getUTCDate(), lastDay),
+      start.getUTCHours(),
+      start.getUTCMinutes(),
+      0,
+      0
+    )
+  );
+}
+
+// Floor a moment to the start of its UTC hour. Contracts always start and end
+// on whole hours, so the duration math anchors to the floored start hour.
+function floorToHourUTC(d: Date): Date {
+  const floored = new Date(d);
+  floored.setUTCMinutes(0, 0, 0);
+  return floored;
+}
+
+// Format a Date to the `YYYY-MM-DDTHH:mm` shape the datetime-local field uses,
+// interpreted in UTC.
+function toDatetimeLocalUTC(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}` +
+    `T${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}`
+  );
+}
+
 const isLegacyPackageName = (name: string) => /\blegacy\b/i.test(name);
 
 const DEFAULT_PERIODS_FOR_FREQUENCY: Record<string, number | undefined> = {
@@ -107,6 +167,9 @@ export default function SwitchContractDialog({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
+  const [durationValue, setDurationValue] = useState(1);
+  const [durationUnit, setDurationUnit] =
+    useState<ContractDurationUnit>("years");
   const [portalContainer, setPortalContainer] = useState<
     HTMLElement | undefined
   >(undefined);
@@ -396,6 +459,64 @@ export default function SwitchContractDialog({
       };
     }, []);
 
+  // Resolve the contract start moment the same way `onSubmit` does, so the
+  // commitment-period info and the per-seat default commitment prices reflect
+  // what will actually be provisioned.
+  const commitmentStartDate = useMemo(() => {
+    if (startMode === "retroactive_first_of_month") {
+      return new Date(retroactiveFirstOfMonthISO);
+    }
+    if (startMode === "immediately") {
+      // "Immediately" swaps at a whole hour; floor now so the displayed period,
+      // prorated defaults, and computed end date all sit on hour boundaries.
+      return floorToHourUTC(new Date());
+    }
+    if (startMode === "select" && startingAt) {
+      const d = new Date(startingAt + ":00Z");
+      return isNaN(d.getTime()) ? null : d;
+    }
+    return null;
+  }, [startMode, startingAt, retroactiveFirstOfMonthISO]);
+
+  const commitmentEndDate = useMemo(() => {
+    if (!endingAt) {
+      return undefined;
+    }
+    const d = new Date(endingAt + ":00Z");
+    return isNaN(d.getTime()) ? undefined : d;
+  }, [endingAt]);
+
+  // The commitment period drives the default seat commitment prices: it runs
+  // from the contract start to its end date, or one year when open-ended.
+  const commitmentPeriodInfo = useMemo(() => {
+    if (!commitmentStartDate) {
+      return null;
+    }
+    const end = commitmentPeriodEnd(commitmentStartDate, commitmentEndDate);
+    return {
+      start: commitmentStartDate,
+      end,
+      months: commitmentMonths(commitmentStartDate, end),
+      openEnded: commitmentEndDate === undefined,
+    };
+  }, [commitmentStartDate, commitmentEndDate]);
+
+  // Compute `endingAt` from the contract start plus the chosen duration, so the
+  // operator can express the term as years/months/weeks instead of picking a
+  // date. Requires a resolved start.
+  const applyDuration = useCallback(() => {
+    if (!commitmentStartDate || !(durationValue > 0)) {
+      return;
+    }
+    // Anchor to the floored start hour so the end lands on a whole hour.
+    const end = addContractDuration(
+      floorToHourUTC(commitmentStartDate),
+      durationValue,
+      durationUnit
+    );
+    form.setValue("endingAt", toDatetimeLocalUTC(end));
+  }, [commitmentStartDate, durationValue, durationUnit, form]);
+
   const startModeOptions = useMemo(
     () => [
       { value: "immediately", display: "Start immediately" },
@@ -474,6 +595,45 @@ export default function SwitchContractDialog({
     }
   }, [promoteNoneSeatsTo, enterableSeatTypes, form]);
 
+  // Canonical default installment count for a payment frequency, capped so no
+  // installment lands at or past the commitment period end (a 3rd monthly
+  // invoice on a six-week contract would never be raised). Reads the start/end
+  // from the live form values so it tracks whatever the operator has entered.
+  const cappedDefaultPeriods = useCallback(
+    (
+      freq: "one_time" | "monthly" | "quarterly" | "semi_annually" | "annually",
+      values: {
+        startMode?: string;
+        startingAt?: string;
+        endingAt?: string;
+      }
+    ): number | undefined => {
+      const base = DEFAULT_PERIODS_FOR_FREQUENCY[freq];
+      if (base === undefined || freq === "one_time") {
+        return base;
+      }
+      const start =
+        values.startMode === "retroactive_first_of_month"
+          ? new Date(retroactiveFirstOfMonthISO)
+          : values.startMode === "immediately"
+            ? new Date()
+            : values.startMode === "select" && values.startingAt
+              ? new Date(values.startingAt + ":00Z")
+              : null;
+      if (!start || isNaN(start.getTime())) {
+        return base;
+      }
+      const end = values.endingAt
+        ? new Date(values.endingAt + ":00Z")
+        : undefined;
+      return Math.min(
+        base,
+        maxInvoicePeriods(start, commitmentPeriodEnd(start, end), freq)
+      );
+    },
+    [retroactiveFirstOfMonthISO]
+  );
+
   // When any payment frequency field changes, pre-fill its sibling periods
   // field with the canonical default. Uses form.watch(callback) — the only
   // reliable way to know exactly which field changed (via the `name` argument).
@@ -485,7 +645,7 @@ export default function SwitchContractDialog({
           : "one_time";
         form.setValue(
           "initialCredits.paymentSchedule.periods",
-          DEFAULT_PERIODS_FOR_FREQUENCY[freq]
+          cappedDefaultPeriods(freq, value)
         );
       }
       if (name === "scheduledCharge.paymentSchedule.frequency") {
@@ -494,7 +654,7 @@ export default function SwitchContractDialog({
           : "one_time";
         form.setValue(
           "scheduledCharge.paymentSchedule.periods",
-          DEFAULT_PERIODS_FOR_FREQUENCY[freq]
+          cappedDefaultPeriods(freq, value)
         );
       }
       if (
@@ -506,7 +666,7 @@ export default function SwitchContractDialog({
           value.seats?.[seatType]?.paymentSchedule?.frequency ?? "one_time";
         form.setValue(
           `seats.${seatType}.paymentSchedule.periods`,
-          DEFAULT_PERIODS_FOR_FREQUENCY[freq]
+          cappedDefaultPeriods(freq, value)
         );
       }
       // A commitment can't be invoiced at a $0 rate — clear a stale commitment
@@ -520,7 +680,7 @@ export default function SwitchContractDialog({
       }
     });
     return unsubscribe;
-  }, [form]);
+  }, [form, cappedDefaultPeriods]);
 
   const onSubmit = useCallback(
     (values: SwitchContractFormValues) => {
@@ -600,6 +760,18 @@ export default function SwitchContractDialog({
         // datetime-local has no timezone — append Z to interpret as UTC.
         cleaned.endingAt = new Date(values.endingAt + ":00Z").toISOString();
       }
+      // Resolve the commitment window (mirrors the display memos) so the default
+      // seat commitment price is prorated to the contract, not a fixed year.
+      const commitStart =
+        values.startMode === "retroactive_first_of_month"
+          ? new Date(retroactiveFirstOfMonthISO)
+          : values.startMode === "select" && values.startingAt
+            ? new Date(values.startingAt + ":00Z")
+            : floorToHourUTC(new Date());
+      const commitEnd = values.endingAt
+        ? new Date(values.endingAt + ":00Z")
+        : undefined;
+      const commitPeriodEnd = commitmentPeriodEnd(commitStart, commitEnd);
       // Seats: every seat the package knows about, each carrying its `selected`
       // state, so the server can entitle checked seats and disable unchecked
       // ones the package would otherwise sell. Entitled-by-default seats are
@@ -617,8 +789,8 @@ export default function SwitchContractDialog({
             ? entry.maxSeats
             : undefined;
         const rate = Number.isFinite(entry?.rate) ? (entry?.rate ?? 0) : 0;
-        // If the operator left commitment price blank, default to minSeats * rate
-        // (the list value of the committed seats).
+        // If the operator left commitment price blank, default to the
+        // commitment period prorated in months (see `commitmentInvoiceAmount`).
         const explicitPrice =
           typeof entry?.commitmentPrice === "number" &&
           Number.isFinite(entry.commitmentPrice) &&
@@ -627,7 +799,17 @@ export default function SwitchContractDialog({
             : null;
         const commitmentPrice =
           explicitPrice ??
-          (minSeats > 0 && rate > 0 ? minSeats * rate : undefined);
+          (minSeats > 0 && rate > 0
+            ? Math.round(
+                commitmentAmount({
+                  minSeats,
+                  ratePerPeriod: rate,
+                  isAnnual: seatType.endsWith("_yearly"),
+                  start: commitStart,
+                  end: commitPeriodEnd,
+                }) * 100
+              ) / 100
+            : undefined);
         // Periods-when-not-one-time is enforced by `paymentScheduleSchema`'s
         // own refine, so it's guaranteed present here whenever needed.
         const paymentSchedule = entry?.paymentSchedule ?? {
@@ -914,21 +1096,91 @@ export default function SwitchContractDialog({
                             </span>
                           </Label>
                           <div className="relative">
-                            <InputField
-                              control={form.control}
-                              name="endingAt"
-                              hideLabel
-                              type="datetime-local"
-                              step={3600}
-                              placeholder="open-ended"
-                              transformValue={snapDatetimeLocalToHour}
-                            />
-                            {endingAtLocalLabel && (
-                              <p className="mt-1 text-xs text-muted-foreground absolute top-2 right-2">
-                                Local: {endingAtLocalLabel}
-                              </p>
-                            )}
+                            <div className="relative">
+                              <InputField
+                                control={form.control}
+                                name="endingAt"
+                                hideLabel
+                                type="datetime-local"
+                                step={3600}
+                                placeholder="open-ended"
+                                transformValue={snapDatetimeLocalToHour}
+                              />
+                              {endingAtLocalLabel && (
+                                <p className="mt-1 text-xs text-muted-foreground absolute top-2 right-2">
+                                  Local: {endingAtLocalLabel}
+                                </p>
+                              )}
+                            </div>
+                            <div className="mt-2 flex items-center gap-2">
+                              <input
+                                type="number"
+                                min={1}
+                                value={durationValue}
+                                onChange={(e) =>
+                                  setDurationValue(Number(e.target.value))
+                                }
+                                className="h-7 w-14 rounded-md border border-border bg-background px-1.5 text-xs"
+                              />
+                              <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                  <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="xs"
+                                    isSelect
+                                    label={
+                                      durationUnit === "years"
+                                        ? "Years"
+                                        : durationUnit === "months"
+                                          ? "Months"
+                                          : "Weeks"
+                                    }
+                                  />
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent
+                                  mountPortalContainer={portalContainer}
+                                >
+                                  <DropdownMenuItem
+                                    label="Years"
+                                    onClick={() => setDurationUnit("years")}
+                                  />
+                                  <DropdownMenuItem
+                                    label="Months"
+                                    onClick={() => setDurationUnit("months")}
+                                  />
+                                  <DropdownMenuItem
+                                    label="Weeks"
+                                    onClick={() => setDurationUnit("weeks")}
+                                  />
+                                </DropdownMenuContent>
+                              </DropdownMenu>
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="xs"
+                                label="Set duration"
+                                disabled={
+                                  !commitmentStartDate || !(durationValue > 0)
+                                }
+                                onClick={applyDuration}
+                              />
+                            </div>
                           </div>
+                          {commitmentPeriodInfo && (
+                            <>
+                              <Label className="text-sm">
+                                Commitment period
+                              </Label>
+                              <div className="text-sm text-muted-foreground">
+                                {commitmentPeriodInfo.openEnded
+                                  ? "1 year (open-ended contract)"
+                                  : `${commitmentPeriodInfo.months.toFixed(1)} months (contract start → end)`}
+                                . Drives the default seat commitment prices
+                                below.
+                              </div>
+                            </>
+                          )}
                         </>
                       )}
                     </div>
@@ -1083,9 +1335,28 @@ export default function SwitchContractDialog({
                           const rate = watchedSeats?.[seatType]?.rate ?? 0;
                           const isAnnualSeat = seatType.endsWith("_yearly");
                           const defaultCommitment =
-                            minSeats > 0 && rate > 0 ? minSeats * rate : null;
+                            commitmentPeriodInfo && minSeats > 0 && rate > 0
+                              ? Math.round(
+                                  commitmentAmount({
+                                    minSeats,
+                                    ratePerPeriod: rate,
+                                    isAnnual: isAnnualSeat,
+                                    start: commitmentPeriodInfo.start,
+                                    end: commitmentPeriodInfo.end,
+                                  }) * 100
+                                ) / 100
+                              : null;
                           const monthlyRate =
                             isAnnualSeat && rate > 0 ? rate / 12 : null;
+                          const maxPeriods =
+                            commitmentPeriodInfo &&
+                            seatPaymentFrequency !== "one_time"
+                              ? maxInvoicePeriods(
+                                  commitmentPeriodInfo.start,
+                                  commitmentPeriodInfo.end,
+                                  seatPaymentFrequency
+                                )
+                              : undefined;
                           return (
                             <div
                               key={seatType}
@@ -1193,6 +1464,12 @@ export default function SwitchContractDialog({
                                     name={`seats.${seatType}.paymentSchedule.periods`}
                                     hideLabel
                                     type="number"
+                                    min="1"
+                                    max={
+                                      maxPeriods !== undefined
+                                        ? String(maxPeriods)
+                                        : undefined
+                                    }
                                     placeholder="e.g., 4"
                                   />
                                 )}

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -35,6 +35,13 @@ import {
   provisionMetronomeContract,
 } from "@app/lib/metronome/contracts";
 import {
+  commitmentAmount,
+  commitmentPeriodEnd,
+  invoicePeriodWeights,
+  maxInvoicePeriods,
+  PAYMENT_FREQUENCY_MONTHS,
+} from "@app/lib/metronome/seat_commitment";
+import {
   remapMembershipSeatTypesForContract,
   syncSeatCount,
 } from "@app/lib/metronome/seats";
@@ -126,83 +133,21 @@ function validatePlanPackageCompat(
   return { ok: true };
 }
 
-/**
- * First-period seat commitment bounds.
- *
- * - `contract_start_date` anchor: billing periods run from the contract start,
- *   so the first period is always full. Returns fraction=1 and periodEnd one
- *   period after `startingAt`.
- * - `first_billing_period` anchor: billing periods align to calendar month
- *   boundaries (1st → 1st). The first period is a partial stub from contract
- *   start to the next 1st-of-month. Returns the remaining fraction and the
- *   next 1st-of-month as periodEnd.
- */
-function firstPeriodCommitment(
-  startingAt: Date,
-  frequency: "MONTHLY" | "ANNUAL",
-  billingAnchor: "contract_start_date" | "first_billing_period"
-): { fraction: number; periodEnd: Date } {
-  const year = startingAt.getUTCFullYear();
-  const month = startingAt.getUTCMonth();
-  if (billingAnchor === "contract_start_date") {
-    const hh = startingAt.getUTCHours();
-    const mm = startingAt.getUTCMinutes();
-    const ss = startingAt.getUTCSeconds();
-
-    // Clamp day to the last day of the target month to avoid overflow:
-    // e.g. Jan 31 + 1 month must land on Feb 28/29, not Mar 3.
-    const clampToMonth = (y: number, m: number, d: number): number =>
-      Math.min(d, new Date(Date.UTC(y, m + 1, 0)).getUTCDate());
-
-    const [ty, tm] =
-      frequency === "ANNUAL" ? [year + 1, month] : [year, month + 1];
-    const periodEnd = new Date(
-      Date.UTC(
-        ty,
-        tm,
-        clampToMonth(ty, tm, startingAt.getUTCDate()),
-        hh,
-        mm,
-        ss
-      )
-    );
-    return { fraction: 1, periodEnd };
-  }
-
-  // first_billing_period: prorate from contract start to next 1st-of-month.
-  const HOUR_MS = 60 * 60 * 1000;
-  const periodStartMs = Date.UTC(year, month, 1);
-  const periodEndMs =
-    frequency === "ANNUAL"
-      ? Date.UTC(year + 1, month, 1)
-      : Date.UTC(year, month + 1, 1);
-  const totalHours = Math.round((periodEndMs - periodStartMs) / HOUR_MS);
-  const remainingHours = Math.round(
-    (periodEndMs - startingAt.getTime()) / HOUR_MS
-  );
-  const fraction = Math.max(0, Math.min(1, remainingHours / totalHours));
-  return { fraction, periodEnd: new Date(periodEndMs) };
-}
-
-const MONTHS_PER_PAYMENT_FREQUENCY: Record<
-  "monthly" | "quarterly" | "semi_annually" | "annually",
-  number
-> = {
-  monthly: 1,
-  quarterly: 3,
-  semi_annually: 6,
-  annually: 12,
-};
-
 function buildInvoiceScheduleItems({
   invoiceAmountCents,
   resolvedCurrency,
   alignedStart,
+  commitmentEnd,
   paymentSchedule,
+  fullInstallmentCents,
 }: {
   invoiceAmountCents: number;
   resolvedCurrency: SupportedCurrency;
   alignedStart: Date;
+  // End of the commitment period. Installments are clamped so none is ever
+  // scheduled at or past it (a 3rd monthly invoice on a 6-week contract would
+  // never be raised).
+  commitmentEnd: Date;
   paymentSchedule: {
     frequency:
       | "one_time"
@@ -212,8 +157,21 @@ function buildInvoiceScheduleItems({
       | "annually";
     periods?: number;
   };
+  // List amount (cents) of one full payment period. When set, each installment
+  // bills this full amount and the last takes the remainder — a full month of a
+  // yearly seat is its nominal monthly rate (annual / 12), not the prorated
+  // total split evenly. When omitted (initial credits, scheduled charges, which
+  // have no per-period list rate), the total is split by prorated period weight.
+  fullInstallmentCents?: number;
 }): { unitPrice: number; quantity: number; timestamp: Date }[] {
-  const { frequency, periods } = paymentSchedule;
+  const { frequency } = paymentSchedule;
+  const periods =
+    frequency === "one_time" || !paymentSchedule.periods
+      ? paymentSchedule.periods
+      : Math.min(
+          paymentSchedule.periods,
+          maxInvoicePeriods(alignedStart, commitmentEnd, frequency)
+        );
   if (frequency === "one_time" || !periods || periods <= 1) {
     return [
       {
@@ -223,10 +181,32 @@ function buildInvoiceScheduleItems({
       },
     ];
   }
-  const monthsPerPeriod = MONTHS_PER_PAYMENT_FREQUENCY[frequency];
-  const perPeriodCents = Math.floor(invoiceAmountCents / periods);
-  const remainderCents = invoiceAmountCents - perPeriodCents * periods;
-  return Array.from({ length: periods }, (_, i) => {
+  const monthsPerPeriod = PAYMENT_FREQUENCY_MONTHS[frequency];
+  // Amount per installment. With a known per-period list amount, bill it in full
+  // each period (clamped to what's left) and put the remainder on the last, so
+  // full periods invoice at list price. Otherwise distribute the total by the
+  // prorated fraction of each period (whole periods equal, partial last).
+  let allocatedCents = 0;
+  const weights = invoicePeriodWeights(
+    alignedStart,
+    commitmentEnd,
+    frequency,
+    periods
+  );
+  const weightSum = weights.reduce((sum, w) => sum + w, 0);
+  const amountForInstallment = (i: number, weight: number): number => {
+    if (i === periods - 1) {
+      return invoiceAmountCents - allocatedCents;
+    }
+    if (fullInstallmentCents !== undefined) {
+      return Math.min(
+        fullInstallmentCents,
+        invoiceAmountCents - allocatedCents
+      );
+    }
+    return Math.round(invoiceAmountCents * (weight / weightSum));
+  };
+  return weights.map((weight, i) => {
     const totalMonths = alignedStart.getUTCMonth() + i * monthsPerPeriod;
     const targetYear =
       alignedStart.getUTCFullYear() + Math.floor(totalMonths / 12);
@@ -247,8 +227,8 @@ function buildInvoiceScheduleItems({
         alignedStart.getUTCMilliseconds()
       )
     );
-    const amountCents =
-      i === 0 ? perPeriodCents + remainderCents : perPeriodCents;
+    const amountCents = amountForInstallment(i, weight);
+    allocatedCents += amountCents;
     return {
       unitPrice: metronomeAmount(amountCents, resolvedCurrency),
       quantity: 1,
@@ -627,6 +607,7 @@ async function stepContractEdits({
   metronomeCustomerId,
   metronomeContractId,
   alignedStart,
+  endingAtDate,
   resolvedCurrency,
   pkg,
   pkgSeatByType,
@@ -640,6 +621,11 @@ async function stepContractEdits({
   const addScheduledCharges: NonNullable<
     ContractEditParams["add_scheduled_charges"]
   > = [];
+
+  // The commitment period bounds every prepaid commit and invoice schedule on
+  // this contract: it runs to the contract end, or one year out when the
+  // contract is open-ended.
+  const commitmentEnd = commitmentPeriodEnd(alignedStart, endingAtDate);
 
   // Optional recurring free AWU credit pool, granted directly on this
   // contract (not baked into the package) — e.g. the Partner Demo shared
@@ -673,6 +659,7 @@ async function stepContractEdits({
       invoiceAmountCents,
       resolvedCurrency,
       alignedStart,
+      commitmentEnd,
       paymentSchedule: body.initialCredits.paymentSchedule,
     });
     const initialCreditsEndingBefore = floorToHourISO(
@@ -717,6 +704,7 @@ async function stepContractEdits({
       invoiceAmountCents: chargeAmountCents,
       resolvedCurrency,
       alignedStart,
+      commitmentEnd,
       paymentSchedule: body.scheduledCharge.paymentSchedule,
     });
     addScheduledCharges.push({
@@ -757,18 +745,39 @@ async function stepContractEdits({
       pkgSeat
     ) {
       const fiatCreditTypeId = CURRENCY_TO_CREDIT_TYPE_ID[resolvedCurrency];
-      const { fraction, periodEnd } = firstPeriodCommitment(
-        alignedStart,
-        billingFrequency,
-        pkg.billingAnchor
-      );
+      // The grant covers the seat subscription charges over the commitment
+      // period, matching Metronome's per-hour proration (see `commitmentAmount`)
+      // so it fully offsets them. The customer is invoiced `commitmentPrice`,
+      // which the dialog defaults to this same amount.
       const accessAmountNative =
-        Math.round(seat.minSeats * rateNative * fraction * 100) / 100;
+        Math.round(
+          commitmentAmount({
+            minSeats: seat.minSeats,
+            ratePerPeriod: rateNative,
+            isAnnual: billingFrequency === "ANNUAL",
+            start: alignedStart,
+            end: commitmentEnd,
+          }) * 100
+        ) / 100;
+      // A full payment period bills the committed seats at their list rate for
+      // that period: the seat's monthly rate (annual / 12 for a yearly seat)
+      // times the months per payment period. The last installment takes the
+      // prorated remainder.
+      const seatMonthlyRate =
+        billingFrequency === "ANNUAL" ? seat.rate / 12 : seat.rate;
+      const paymentMonths =
+        seat.paymentSchedule.frequency === "one_time"
+          ? 1
+          : PAYMENT_FREQUENCY_MONTHS[seat.paymentSchedule.frequency];
       const seatScheduleItems = buildInvoiceScheduleItems({
         invoiceAmountCents: Math.round(seat.commitmentPrice * 100),
         resolvedCurrency,
         alignedStart,
+        commitmentEnd,
         paymentSchedule: seat.paymentSchedule,
+        fullInstallmentCents: Math.round(
+          seat.minSeats * seatMonthlyRate * paymentMonths * 100
+        ),
       });
       addCommits.push({
         product_id: getProductSeatSubscriptionCommitId(),
@@ -782,7 +791,7 @@ async function stepContractEdits({
             {
               amount: accessAmountNative,
               starting_at: floorToHourISO(alignedStart),
-              ending_before: floorToHourISO(periodEnd),
+              ending_before: floorToHourISO(commitmentEnd),
             },
           ],
         },

--- a/front/lib/metronome/seat_commitment.test.ts
+++ b/front/lib/metronome/seat_commitment.test.ts
@@ -1,0 +1,149 @@
+import {
+  commitmentAmount,
+  commitmentMonths,
+  commitmentPeriodEnd,
+  invoicePeriodWeights,
+  maxInvoicePeriods,
+} from "@app/lib/metronome/seat_commitment";
+import { describe, expect, it } from "vitest";
+
+const start = new Date(Date.UTC(2026, 0, 1));
+const oneYear = new Date(Date.UTC(2027, 0, 1));
+// 42 days after start (Jan 1 → Feb 12): ~1.39 calendar months.
+const sixWeeks = new Date(start.getTime() + 42 * 24 * 60 * 60 * 1000);
+
+describe("commitmentPeriodEnd", () => {
+  it("uses the end date when set", () => {
+    expect(commitmentPeriodEnd(start, oneYear)).toEqual(oneYear);
+  });
+
+  it("defaults to one year out when open-ended", () => {
+    expect(commitmentPeriodEnd(start, undefined)).toEqual(oneYear);
+  });
+});
+
+describe("commitmentMonths", () => {
+  it("is exactly 12 for a one-year span", () => {
+    expect(commitmentMonths(start, oneYear)).toBe(12);
+  });
+
+  it("is exactly 1 for a one-month span", () => {
+    expect(commitmentMonths(start, new Date(Date.UTC(2026, 1, 1)))).toBe(1);
+  });
+
+  it("measures the partial trailing month as a calendar fraction", () => {
+    // 1 whole month (Jan 1 → Feb 1) + 11/28 of February.
+    expect(commitmentMonths(start, sixWeeks)).toBeCloseTo(1 + 11 / 28, 5);
+  });
+
+  it("is zero when the end is at or before the start", () => {
+    expect(commitmentMonths(start, start)).toBe(0);
+  });
+});
+
+describe("maxInvoicePeriods", () => {
+  it("caps a six-week contract at 2 monthly installments", () => {
+    expect(maxInvoicePeriods(start, sixWeeks, "monthly")).toBe(2);
+  });
+
+  it("caps a six-week contract at a single quarterly/annual installment", () => {
+    expect(maxInvoicePeriods(start, sixWeeks, "quarterly")).toBe(1);
+    expect(maxInvoicePeriods(start, sixWeeks, "annually")).toBe(1);
+  });
+
+  it("allows a full year of monthly/quarterly installments over a year", () => {
+    expect(maxInvoicePeriods(start, oneYear, "monthly")).toBe(12);
+    expect(maxInvoicePeriods(start, oneYear, "quarterly")).toBe(4);
+    expect(maxInvoicePeriods(start, oneYear, "semi_annually")).toBe(2);
+    expect(maxInvoicePeriods(start, oneYear, "annually")).toBe(1);
+  });
+});
+
+describe("invoicePeriodWeights", () => {
+  it("weighs a full first month at 1 and a partial second month at its fraction", () => {
+    const [first, second] = invoicePeriodWeights(start, sixWeeks, "monthly", 2);
+    expect(first).toBe(1);
+    // Jan 1 → Feb 12: second month covers 11 of February's 28 days.
+    expect(second).toBeCloseTo(11 / 28, 5);
+  });
+
+  it("weighs every installment 1 when all periods are whole", () => {
+    expect(invoicePeriodWeights(start, oneYear, "quarterly", 4)).toEqual([
+      1, 1, 1, 1,
+    ]);
+  });
+});
+
+describe("commitmentAmount", () => {
+  // Real case (Sep 7 2026 21:00 → Oct 19 2026 21:00), all on the hour, so the
+  // per-hour proration is exact. A $240/yr seat prorates over the contract's
+  // year (365 days); a $20/mo seat prorates over each calendar month.
+  const contractStart = new Date(Date.UTC(2026, 8, 7, 21));
+  const contractEnd = new Date(Date.UTC(2026, 9, 19, 21));
+
+  it("prorates a yearly seat over the year, matching Metronome", () => {
+    expect(
+      commitmentAmount({
+        minSeats: 1,
+        ratePerPeriod: 240,
+        isAnnual: true,
+        start: contractStart,
+        end: contractEnd,
+      })
+    ).toBeCloseTo(27.616438, 6);
+  });
+
+  it("prorates a monthly seat over each month (full first month + partial)", () => {
+    // 1 full month (Sep 7 → Oct 7) + 12/31 of Oct → 20 * (1 + 12/31).
+    expect(
+      commitmentAmount({
+        minSeats: 1,
+        ratePerPeriod: 20,
+        isAnnual: false,
+        start: contractStart,
+        end: contractEnd,
+      })
+    ).toBeCloseTo(20 * (1 + 12 / 31), 6);
+  });
+
+  it("is a full period rate when the commitment spans exactly one period", () => {
+    // Yearly seat over exactly one year, and monthly seat over exactly a year
+    // (12 full months) — no proration.
+    expect(
+      commitmentAmount({
+        minSeats: 30,
+        ratePerPeriod: 528,
+        isAnnual: true,
+        start,
+        end: oneYear,
+      })
+    ).toBe(30 * 528);
+    expect(
+      commitmentAmount({
+        minSeats: 30,
+        ratePerPeriod: 44,
+        isAnnual: false,
+        start,
+        end: oneYear,
+      })
+    ).toBeCloseTo(30 * 44 * 12, 6);
+  });
+
+  it("scales linearly with the seat count", () => {
+    const one = commitmentAmount({
+      minSeats: 1,
+      ratePerPeriod: 240,
+      isAnnual: true,
+      start: contractStart,
+      end: contractEnd,
+    });
+    const thirty = commitmentAmount({
+      minSeats: 30,
+      ratePerPeriod: 240,
+      isAnnual: true,
+      start: contractStart,
+      end: contractEnd,
+    });
+    expect(thirty).toBeCloseTo(one * 30, 6);
+  });
+});

--- a/front/lib/metronome/seat_commitment.ts
+++ b/front/lib/metronome/seat_commitment.ts
@@ -1,0 +1,192 @@
+import { oneYearAfter } from "@app/lib/metronome/constants";
+
+// Prepaid seat-commitment math, shared verbatim by the SwitchContractDialog SPA
+// form (which prefills the default commitment price and shows the commitment
+// period) and the server (`lib/api/poke/switch_contract.ts`, which sizes the
+// contract credit grant) so the two never drift.
+//
+// A prepaid seat commitment covers a fixed "commitment period": the window the
+// committed seats are billed for. It runs from the contract start to its end
+// date, or one year when the contract is open-ended.
+//
+// Metronome prorates each seat subscription charge per hour over its own billing
+// period: a yearly seat's charge is prorated over the contract's year, a monthly
+// seat's over each calendar month. `commitmentAmount` reproduces that exactly.
+// The credit grant is sized to the same prorated total (so it fully covers the
+// charges), and the invoice defaults to it too — the operator may then invoice
+// less (a discount), never more than needed to cover the grant.
+//
+// `ratePerPeriod` is the seat's native billing-period rate (the monthly rate for
+// a monthly seat, the yearly rate for a yearly seat), in any consistent unit;
+// each helper returns a value in that same unit, so callers may pass either
+// major currency units (the form) or Metronome fiat units (the server).
+
+const HOUR_MS = 60 * 60 * 1000;
+
+// Add `months` calendar months in UTC, clamping the day to the last day of the
+// target month to avoid overflow (Jan 31 + 1 month lands on Feb 28/29, not Mar
+// 3), matching Metronome's contract-start-anchored period math.
+function addMonthsUtc(date: Date, months: number): Date {
+  const targetMonthIndex = date.getUTCMonth() + months;
+  const targetYear = date.getUTCFullYear() + Math.floor(targetMonthIndex / 12);
+  const targetMonth = ((targetMonthIndex % 12) + 12) % 12;
+  const lastDay = new Date(
+    Date.UTC(targetYear, targetMonth + 1, 0)
+  ).getUTCDate();
+  return new Date(
+    Date.UTC(
+      targetYear,
+      targetMonth,
+      Math.min(date.getUTCDate(), lastDay),
+      date.getUTCHours(),
+      date.getUTCMinutes(),
+      date.getUTCSeconds(),
+      date.getUTCMilliseconds()
+    )
+  );
+}
+
+/**
+ * @cc [owner:tdraier,label:product] commitment-period-end
+ * The commitment period ends at `endingAt` when set, otherwise exactly one year
+ * after `start`.
+ */
+export function commitmentPeriodEnd(
+  start: Date,
+  endingAt: Date | undefined
+): Date {
+  return endingAt ?? oneYearAfter(start);
+}
+
+// Fractional number of calendar months in [start, end) — the prorated invoice
+// basis. Whole-month and whole-year spans come out exact (a one-year contract is
+// exactly 12 months, not ~11.99), with any partial trailing month measured as a
+// fraction of that calendar month's length.
+export function commitmentMonths(start: Date, end: Date): number {
+  if (end.getTime() <= start.getTime()) {
+    return 0;
+  }
+  let wholeMonths = 0;
+  while (addMonthsUtc(start, wholeMonths + 1).getTime() <= end.getTime()) {
+    wholeMonths++;
+  }
+  const lastWholeMs = addMonthsUtc(start, wholeMonths).getTime();
+  const nextWholeMs = addMonthsUtc(start, wholeMonths + 1).getTime();
+  const fraction = (end.getTime() - lastWholeMs) / (nextWholeMs - lastWholeMs);
+  return wholeMonths + fraction;
+}
+
+// Number of months in one period of each invoice payment frequency.
+export const PAYMENT_FREQUENCY_MONTHS: Record<
+  "monthly" | "quarterly" | "semi_annually" | "annually",
+  number
+> = {
+  monthly: 1,
+  quarterly: 3,
+  semi_annually: 6,
+  annually: 12,
+};
+
+// Count of period starts (start, start + periodMonths, ...) strictly before end.
+// Always at least 1.
+function periodsWithin(start: Date, end: Date, periodMonths: number): number {
+  let count = 0;
+  // Bounded well above any realistic commitment (100 years of monthly periods).
+  for (let k = 0; k < 1200; k++) {
+    if (addMonthsUtc(start, k * periodMonths).getTime() < end.getTime()) {
+      count++;
+    } else {
+      break;
+    }
+  }
+  return Math.max(1, count);
+}
+
+/**
+ * @cc [owner:tdraier,label:product] invoice-periods-bounded-by-commitment
+ * The maximum number of invoice installments of `frequency` is the count of its
+ * period starts that fall within the commitment period `[start, end)` (at least
+ * 1), so no installment is ever scheduled at or past the contract end.
+ */
+export function maxInvoicePeriods(
+  start: Date,
+  end: Date,
+  frequency: "monthly" | "quarterly" | "semi_annually" | "annually"
+): number {
+  return periodsWithin(start, end, PAYMENT_FREQUENCY_MONTHS[frequency]);
+}
+
+/**
+ * @cc [owner:tdraier,label:product] invoice-period-weights-full-then-remainder
+ * Returns one weight per installment (`periods` of `frequency`): the fraction of
+ * each period's whole hours that fall within `[start, end)`. Whole periods weigh
+ * 1 and only a partial trailing period weighs less, so distributing an amount by
+ * these weights bills a full period each installment and the remainder on the
+ * last.
+ */
+export function invoicePeriodWeights(
+  start: Date,
+  end: Date,
+  frequency: "monthly" | "quarterly" | "semi_annually" | "annually",
+  periods: number
+): number[] {
+  const periodMonths = PAYMENT_FREQUENCY_MONTHS[frequency];
+  const weights: number[] = [];
+  for (let i = 0; i < periods; i++) {
+    const periodStart = addMonthsUtc(start, i * periodMonths);
+    const periodEnd = addMonthsUtc(start, (i + 1) * periodMonths);
+    const overlapEndMs = Math.min(periodEnd.getTime(), end.getTime());
+    const periodHours = Math.round(
+      (periodEnd.getTime() - periodStart.getTime()) / HOUR_MS
+    );
+    const overlapHours = Math.max(
+      0,
+      Math.round((overlapEndMs - periodStart.getTime()) / HOUR_MS)
+    );
+    weights.push(overlapHours / periodHours);
+  }
+  return weights;
+}
+
+/**
+ * @cc [owner:tdraier,label:product] commitment-amount-hourly-prorated
+ * The commitment amount equals `minSeats` times, for each seat billing period
+ * (one year for a yearly seat, one calendar month for a monthly seat) that
+ * starts within `[start, end)`, `ratePerPeriod` scaled by the fraction of that
+ * period's whole hours that fall before `end` — reproducing Metronome's
+ * per-hour subscription proration. It sizes the credit grant and is the default
+ * invoice amount.
+ */
+export function commitmentAmount({
+  minSeats,
+  ratePerPeriod,
+  isAnnual,
+  start,
+  end,
+}: {
+  minSeats: number;
+  ratePerPeriod: number;
+  isAnnual: boolean;
+  start: Date;
+  end: Date;
+}): number {
+  const periodMonths = isAnnual ? 12 : 1;
+  let total = 0;
+  // Bounded well above any realistic commitment (100 years of monthly periods).
+  for (let k = 0; k < 1200; k++) {
+    const periodStart = addMonthsUtc(start, k * periodMonths);
+    if (periodStart.getTime() >= end.getTime()) {
+      break;
+    }
+    const periodEnd = addMonthsUtc(start, (k + 1) * periodMonths);
+    const overlapEndMs = Math.min(periodEnd.getTime(), end.getTime());
+    const periodHours = Math.round(
+      (periodEnd.getTime() - periodStart.getTime()) / HOUR_MS
+    );
+    const overlapHours = Math.round(
+      (overlapEndMs - periodStart.getTime()) / HOUR_MS
+    );
+    total += ratePerPeriod * (overlapHours / periodHours);
+  }
+  return minSeats * total;
+}

--- a/front/types/poke/switch_contract.ts
+++ b/front/types/poke/switch_contract.ts
@@ -11,7 +11,11 @@ export const paymentScheduleSchema = z
     frequency: z
       .enum(["one_time", "monthly", "quarterly", "semi_annually", "annually"])
       .default("one_time"),
-    periods: z.number().int().min(2).max(60).optional(),
+    // Number of invoice installments. May be 1 (a single upfront invoice) when
+    // the commitment period is too short to fit more than one period of the
+    // chosen frequency — e.g. a quarterly schedule on a six-week contract. The
+    // server clamps larger values down to what fits (see `maxInvoicePeriods`).
+    periods: z.number().int().min(1).max(60).optional(),
   })
   .refine(
     (s) => s.frequency === "one_time" || s.periods !== undefined,
@@ -57,8 +61,10 @@ const recurringFreeCreditSchema = z
 // `workspace_seat_limits`. `rate` is the per-seat rate in the currency's MAJOR
 // units (dollars / euros); the server converts it to Metronome's fiat unit via
 // `metronomeAmount`. When `commitmentPrice` is set (also in major units), a
-// contract prepaid commit is created granting `minSeats * rate` of contract
-// credit, invoiced at `commitmentPrice`.
+// contract prepaid commit is created granting enough contract credit to cover
+// the seat subscription charges over the commitment period, matching Metronome's
+// per-hour proration (see `commitmentAmount`), and invoiced at `commitmentPrice`
+// — which the dialog defaults to that same prorated amount.
 const seatEntrySchema = z
   .object({
     // Whether the seat is entitled on the new contract. `true` (the default,


### PR DESCRIPTION
## Description

Prepaid seat commitments in the Switch Contract poke modal previously always assumed a **one-year** commitment, ignoring the contract end date. On a short contract this over- or under-billed (e.g. a yearly seat over 6 weeks billed a full year). This PR makes the commitment follow the actual contract timeframe and match Metronome's proration.

New shared `front/lib/metronome/seat_commitment.ts` (pure, unit-tested, `@cc`-annotated):
- **Commitment period** = contract start → end date, or one year when open-ended.
- **Prorated amount** (`commitmentAmount`) reproduces Metronome's **per-hour** subscription proration: a yearly seat prorates over its year, a monthly seat over each calendar month. Sizes both the credit grant and the default invoice price so the grant exactly covers what Metronome charges.
- **Invoice installments** bill a full nominal period at list rate (e.g. a yearly seat's month = `annual/12`) and put the prorated remainder on the last installment; installments are capped so none is scheduled at/past the contract end (`maxInvoicePeriods`).

Modal (`SwitchContractDialog.tsx`):
- Read-only **"Commitment period"** info line.
- **"Set duration"** control (years / months / weeks) that computes the end date from the floored start hour.
- Default commitment price now reflects the prorated amount.

Also adds a `max` passthrough to the poke `InputField`.

<img width="827" height="168" alt="Screenshot 2026-09-08 at 10 28 45" src="https://github.com/user-attachments/assets/38cbb0b2-2687-4492-bac3-a3b3507f1981" />



<img width="760" height="200" alt="Screenshot 2026-09-08 at 10 29 01" src="https://github.com/user-attachments/assets/47bd36af-b0c3-40e3-8834-a3fbb0289aea" />


## Tests

- New `front/lib/metronome/seat_commitment.test.ts` (15 tests) covering the commitment period, per-hour proration (incl. the real Sep 9 → Oct 21 case: `$240/yr` seat → `$27.616438`), installment period caps, and period weights.
- Verified end-to-end in the poke modal against Metronome: yearly seat, 10 seats, 6-week contract, monthly invoicing → invoice 1 `$200.00` (full month) + invoice 2 `$76.16` (remainder).
- `tsgo`, biome, and `cc-check` pass.

## Risk

Low, scoped to the internal poke Switch Contract flow (no public API or customer-facing surface). Billing math is unit-tested and matches Metronome's proration. The operator can still override the commitment price and payment schedule. No schema/DB migration. Rollback is a straight revert.

## Deploy Plan

Standard `front` deploy. No migration, feature flag, or ordering constraints.