### PR TITLE
feat(poke): Cloudflare Access identity and -mdm role mapping

### DIFF
--- a/front-api/middlewares/ctx.ts
+++ b/front-api/middlewares/ctx.ts
@@ -1,3 +1,4 @@
+import type { AuthenticatedAccessUser } from "@app/lib/api/poke/cloudflare_access";
 import type { SandboxTokenPayload } from "@app/lib/api/sandbox/access_tokens";
 import type { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -23,11 +24,12 @@ export type WorkspaceAwareCtx = SessionCtx & {
 };
 
 // Poke authenticates via Cloudflare Access JWT (preferred) or a WorkOS
-// super-user session fallback. Only the resulting Authenticator is exposed.
+// super-user session fallback. `accessUser` is set on the Access path only.
 export type PokeCtx = {
   Variables: {
     auth: Authenticator;
     pokeRoles: PokeRole[];
+    accessUser: AuthenticatedAccessUser | null;
   };
 };
 

--- a/front-api/middlewares/poke_auth.ts
+++ b/front-api/middlewares/poke_auth.ts
@@ -1,25 +1,22 @@
-import {
-  getCloudflareAccessConfig,
-  verifyCloudflareAccessJwt,
-} from "@app/lib/api/poke/cloudflare_access";
+import { authenticateCloudflareAccess } from "@app/lib/api/poke/cloudflare_access";
 import { Authenticator, isDustInternalEmail } from "@app/lib/auth";
 import { getPokeRolesForUser } from "@app/lib/poke/roles";
 import logger from "@app/logger/logger";
-import { isDevelopment } from "@app/types/shared/env";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { PokeCtx } from "@front-api/middlewares/ctx";
 import { resolveSession } from "@front-api/middlewares/session_resolution";
 import { apiError } from "@front-api/middlewares/utils";
 import type { Context } from "hono";
-import { getCookie } from "hono/cookie";
 import { createMiddleware } from "hono/factory";
 
-function getCloudflareAccessToken(ctx: Context): string | undefined {
-  // Cloudflare recommends validating the assertion header over the cookie.
-  const headerToken = ctx.req.header("cf-access-jwt-assertion");
-  if (headerToken) {
-    return headerToken;
-  }
-  return getCookie(ctx, "CF_Authorization");
+function notAuthenticated(ctx: Context) {
+  return apiError(ctx, {
+    status_code: 401,
+    api_error: {
+      type: "not_authenticated",
+      message: "The user does not have permission",
+    },
+  });
 }
 
 /**
@@ -27,71 +24,58 @@ function getCloudflareAccessToken(ctx: Context): string | undefined {
  * `Authenticator` on the Hono context. Apply once at the `/api/poke` root;
  * workspace-scoped routes layer `withPokeWorkspace` on top.
  *
- * Prefers a validated Cloudflare Access JWT (`Cf-Access-Jwt-Assertion` /
- * `CF_Authorization`) so poke operators do not need a provisioned Dust user
- * with `isDustSuperUser` on every deployment. Falls back to the WorkOS
- * super-user session path when no Access token is present.
+ * Cloudflare Access is the primary identity source: when it is configured, a
+ * verified `Cf-Access-Jwt-Assertion` header is mandatory and the WorkOS
+ * super-user session path is unreachable. WorkOS remains the only path when
+ * Access is not configured at all.
  *
  * Super-user privilege is an Authenticator flag set only by poke factories
  * (`fromDustSuperUser` / `fromSuperUserSession`), not by the DB column alone.
  */
 export const pokeAuth = createMiddleware<PokeCtx>(async (ctx, next) => {
-  const accessConfig = getCloudflareAccessConfig();
-  const accessToken = getCloudflareAccessToken(ctx);
+  const access = await authenticateCloudflareAccess(ctx.req.raw.headers);
 
-  if (accessConfig && accessToken) {
-    const identity = await verifyCloudflareAccessJwt(accessToken);
-    if (!identity) {
-      return apiError(ctx, {
-        status_code: 401,
-        api_error: {
-          type: "not_authenticated",
-          message: "Invalid Cloudflare Access token.",
-        },
-      });
-    }
-
-    // Note: we should maybe remove this check and fully trust the Cloudflare Access token.
-    // Kept for now to be symmetric with the WorkOS fallback.
-    if (!isDustInternalEmail(identity.email)) {
+  switch (access.kind) {
+    case "rejected":
       logger.warn(
-        {
-          email: identity.email,
-        },
-        "[Poke Auth] Cloudflare Access token user is not a Dust internal email"
+        { reasonCode: access.reasonCode },
+        "[Poke Auth] Cloudflare Access authentication rejected"
       );
-      return apiError(ctx, {
-        status_code: 401,
-        api_error: {
-          type: "not_authenticated",
-          message: "The user does not have permission",
-        },
+      return notAuthenticated(ctx);
+
+    case "authenticated": {
+      const { user } = access;
+
+      // Kept symmetric with the WorkOS fallback: Access policy is the primary
+      // gate, but poke stays restricted to Dust employees.
+      if (!isDustInternalEmail(user.email)) {
+        logger.warn(
+          { email: user.email },
+          "[Poke Auth] Cloudflare Access user is not a Dust internal email"
+        );
+        return notAuthenticated(ctx);
+      }
+
+      const auth = await Authenticator.fromDustSuperUser({
+        pokePrincipal: { email: user.email, name: user.name },
       });
+
+      logger.info(
+        { email: user.email, identity: user.identity.kind },
+        "[Poke Auth] User logged in Poke via Cloudflare Access"
+      );
+
+      ctx.set("auth", auth);
+      ctx.set("pokeRoles", await getPokeRolesForUser(user.email));
+      await next();
+      return;
     }
 
-    const auth = await Authenticator.fromDustSuperUser({
-      pokePrincipal: {
-        email: identity.email,
-        name: identity.name,
-      },
-    });
+    case "disabled":
+      break;
 
-    logger.info(
-      { email: identity.email },
-      "[Poke Auth] User logged in Poke via Cloudflare Access token"
-    );
-
-    const pokeRoles = await getPokeRolesForUser(identity.email);
-    ctx.set("auth", auth);
-    ctx.set("pokeRoles", pokeRoles);
-    await next();
-    return;
-  }
-
-  if (accessConfig && !accessToken && !isDevelopment()) {
-    logger.warn(
-      "[Poke Auth] Request missing Cloudflare Access token; falling back to WorkOS super-user session"
-    );
+    default:
+      assertNever(access);
   }
 
   const sessionResult = await resolveSession(ctx);
@@ -106,13 +90,7 @@ export const pokeAuth = createMiddleware<PokeCtx>(async (ctx, next) => {
       { userId: user?.sId, email: user?.email },
       "[Poke Auth] WorkOS fallback user is not a Dust internal email"
     );
-    return apiError(ctx, {
-      status_code: 401,
-      api_error: {
-        type: "not_authenticated",
-        message: "The user does not have permission",
-      },
-    });
+    return notAuthenticated(ctx);
   }
 
   const auth = await Authenticator.fromDustSuperUser({ user });

--- a/front-api/middlewares/poke_auth.ts
+++ b/front-api/middlewares/poke_auth.ts
@@ -1,6 +1,6 @@
 import { authenticateCloudflareAccess } from "@app/lib/api/poke/cloudflare_access";
 import { Authenticator, isDustInternalEmail } from "@app/lib/auth";
-import { getPokeRolesForUser } from "@app/lib/poke/roles";
+import { getPokeRolesForPrincipal } from "@app/lib/poke/roles";
 import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { PokeCtx } from "@front-api/middlewares/ctx";
@@ -66,7 +66,14 @@ export const pokeAuth = createMiddleware<PokeCtx>(async (ctx, next) => {
       );
 
       ctx.set("auth", auth);
-      ctx.set("pokeRoles", await getPokeRolesForUser(user.email));
+      ctx.set("accessUser", user);
+      ctx.set(
+        "pokeRoles",
+        await getPokeRolesForPrincipal({
+          kind: "cloudflare_access",
+          user,
+        })
+      );
       await next();
       return;
     }
@@ -94,7 +101,10 @@ export const pokeAuth = createMiddleware<PokeCtx>(async (ctx, next) => {
   }
 
   const auth = await Authenticator.fromDustSuperUser({ user });
-  const pokeRoles = await getPokeRolesForUser(user.email);
+  const pokeRoles = await getPokeRolesForPrincipal({
+    kind: "email",
+    email: user.email,
+  });
 
   logger.info(
     {
@@ -105,6 +115,7 @@ export const pokeAuth = createMiddleware<PokeCtx>(async (ctx, next) => {
   );
 
   ctx.set("auth", auth);
+  ctx.set("accessUser", null);
   ctx.set("pokeRoles", pokeRoles);
   await next();
 });

--- a/front-api/middlewares/poke_auth.ts
+++ b/front-api/middlewares/poke_auth.ts
@@ -32,6 +32,24 @@ function notAuthenticated(ctx: Context) {
  * Super-user privilege is an Authenticator flag set only by poke factories
  * (`fromDustSuperUser` / `fromSuperUserSession`), not by the DB column alone.
  */
+/**
+ * @cc [owner:zmarouf,label:security;api] workos-only-when-access-disabled
+ * `pokeAuth` may resolve a WorkOS super-user session only when
+ * `authenticateCloudflareAccess` returns `disabled`. `rejected` and
+ * `authenticated` must never fall through to WorkOS.
+ */
+/**
+ * @cc [owner:zmarouf,label:security;logging] poke-auth-secret-free-observability
+ * `pokeAuth` must never log the Access assertion, the `CF_Authorization` cookie,
+ * raw JWT claims, or jose/get-identity error messages. Rejection logs may include
+ * only `CloudflareAccessDenialCode` (and non-secret identity fields such as email).
+ */
+/**
+ * @cc [owner:zmarouf,label:api;security] poke-auth-generic-client-errors
+ * Access authentication failures returned to the client must use a generic
+ * `not_authenticated` envelope via `apiError` and must never include
+ * `CloudflareAccessDenialCode` or token material in the response body.
+ */
 export const pokeAuth = createMiddleware<PokeCtx>(async (ctx, next) => {
   const access = await authenticateCloudflareAccess(ctx.req.raw.headers);
 

--- a/front-api/routes/poke/auth-context.ts
+++ b/front-api/routes/poke/auth-context.ts
@@ -6,6 +6,12 @@ import type { AuthenticatedAccessUser } from "@app/lib/api/poke/cloudflare_acces
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
+/**
+ * @cc [owner:zmarouf,label:security;api] auth-context-access-user-sanitized
+ * `toAccessUserView` must return only `subject`, `email`, `name`, and
+ * `identity` from an authenticated Access user, and must never include the
+ * assertion, cookie, or raw get-identity payload.
+ */
 function toAccessUserView(
   user: AuthenticatedAccessUser | null
 ): PokeAccessUserView | null {

--- a/front-api/routes/poke/auth-context.ts
+++ b/front-api/routes/poke/auth-context.ts
@@ -1,6 +1,24 @@
-import type { GetPokeNoWorkspaceAuthContextResponseType } from "@app/lib/api/poke/auth_context";
+import type {
+  GetPokeNoWorkspaceAuthContextResponseType,
+  PokeAccessUserView,
+} from "@app/lib/api/poke/auth_context";
+import type { AuthenticatedAccessUser } from "@app/lib/api/poke/cloudflare_access";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
+
+function toAccessUserView(
+  user: AuthenticatedAccessUser | null
+): PokeAccessUserView | null {
+  if (!user) {
+    return null;
+  }
+  return {
+    subject: user.subject,
+    email: user.email,
+    name: user.name,
+    identity: user.identity,
+  };
+}
 
 // Mounted at /api/poke/auth-context. pokeAuth is applied by the parent poke
 // sub-app, so ctx.get("auth") is always available here and the user is a
@@ -17,6 +35,7 @@ app.get(
       user: auth.toPokeUserJSON(),
       isSuperUser: true,
       pokeRoles: ctx.get("pokeRoles"),
+      accessUser: toAccessUserView(ctx.get("accessUser")),
     });
   }
 );

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -114,16 +114,41 @@ const config = {
     return EnvironmentConfig.getEnvVariable("POKE_APP_URL");
   },
   // Cloudflare Access team domain used to validate poke JWTs
-  // (e.g. "https://dust.cloudflareaccess.com"). Optional: when unset, poke
-  // falls back to the WorkOS super-user session path.
+  // (e.g. "https://dust.cloudflareaccess.com"). Optional: defaults to the Dust
+  // team domain once an audience is configured.
   getCloudflareAccessTeamDomain: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable(
       "CLOUDFLARE_ACCESS_TEAM_DOMAIN"
     );
   },
-  // Cloudflare Access application Audience (AUD) tag for poke.
-  getCloudflareAccessAud: (): string | undefined => {
-    return EnvironmentConfig.getOptionalEnvVariable("CLOUDFLARE_ACCESS_AUD");
+  // Cloudflare Access application Audience (AUD) tag for poke. Configuring it
+  // is what turns Cloudflare Access on for `/api/poke`.
+  getCloudflareAccessAudience: (): string | undefined => {
+    return (
+      EnvironmentConfig.getOptionalEnvVariable("CLOUDFLARE_ACCESS_AUDIENCE") ??
+      EnvironmentConfig.getOptionalEnvVariable("CLOUDFLARE_ACCESS_AUD")
+    );
+  },
+  // HTTPS override for the Cloudflare Access JWKS endpoint. Defaults to
+  // <team domain>/cdn-cgi/access/certs.
+  getCloudflareAccessCertsUrl: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable(
+      "CLOUDFLARE_ACCESS_CERTS_URL"
+    );
+  },
+  // HTTPS override for the Cloudflare Access get-identity endpoint. Defaults to
+  // <team domain>/cdn-cgi/access/get-identity.
+  getCloudflareAccessIdentityUrl: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable(
+      "CLOUDFLARE_ACCESS_IDENTITY_URL"
+    );
+  },
+  // Whether a cross-checked get-identity response is mandatory. Fail closed:
+  // only the exact string "false" makes it optional.
+  getCloudflareAccessIdentityRequired: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable(
+      "CLOUDFLARE_ACCESS_IDENTITY_REQUIRED"
+    );
   },
   // For the WorkOS callback, which must reach the API. Allows overriding the
   // redirect base URL separately from NEXT_PUBLIC_DUST_API_URL.

--- a/front/lib/api/poke/auth_context.ts
+++ b/front/lib/api/poke/auth_context.ts
@@ -1,14 +1,24 @@
 // Contract types for the poke auth-context endpoints, used by the poke
 // auth-context API routes (front-api/routes/poke/...).
+import type { AccessIdentityEvidence } from "@app/lib/api/poke/cloudflare_access";
 import type { PokeRole } from "@app/lib/poke/roles";
 import type { WorkspacePermissions } from "@app/types/group_permissions";
 import type { SubscriptionType } from "@app/types/plan";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 
+/** Sanitized Access identity for poke clients. Never includes JWT or cookie. */
+export type PokeAccessUserView = {
+  subject: string;
+  email: string;
+  name: string | null;
+  identity: AccessIdentityEvidence;
+};
+
 export type GetPokeNoWorkspaceAuthContextResponseType = {
   user: UserType;
   isSuperUser: true;
   pokeRoles: PokeRole[];
+  accessUser: PokeAccessUserView | null;
 };
 
 export type GetPokeWorkspaceAuthContextResponseType = {

--- a/front/lib/api/poke/cloudflare_access.test.ts
+++ b/front/lib/api/poke/cloudflare_access.test.ts
@@ -1,108 +1,731 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const TEAM_DOMAIN = "https://dust.cloudflareaccess.com";
-const AUD = "test-aud-tag";
+const AUDIENCE = "test-aud-tag";
+const CERTS_URL = `${TEAM_DOMAIN}/cdn-cgi/access/certs`;
+const IDENTITY_URL = `${TEAM_DOMAIN}/cdn-cgi/access/get-identity`;
 
-const jwtVerifyMock = vi.hoisted(() => vi.fn());
-const createRemoteJWKSetMock = vi.hoisted(() => vi.fn(() => "mock-jwks"));
+const ASSERTION = "assertion.jwt.value";
+const IDENTITY_COOKIE = "cf-authorization-cookie-value";
+const SUBJECT = "9f45d0f0-0000-4000-8000-000000000000";
+
+const mocks = vi.hoisted(() => ({
+  jwtVerify: vi.fn(),
+  createRemoteJWKSet: vi.fn(() => "mock-jwks"),
+  trustedFetch: vi.fn(),
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  config: {
+    getCloudflareAccessTeamDomain: vi.fn(),
+    getCloudflareAccessAudience: vi.fn(),
+    getCloudflareAccessCertsUrl: vi.fn(),
+    getCloudflareAccessIdentityUrl: vi.fn(),
+    getCloudflareAccessIdentityRequired: vi.fn(),
+  },
+}));
 
 vi.mock("jose", () => ({
-  jwtVerify: jwtVerifyMock,
-  createRemoteJWKSet: createRemoteJWKSetMock,
+  jwtVerify: mocks.jwtVerify,
+  createRemoteJWKSet: mocks.createRemoteJWKSet,
 }));
 
-vi.mock("@app/lib/api/config", () => ({
-  default: {
-    getCloudflareAccessTeamDomain: () => TEAM_DOMAIN,
-    getCloudflareAccessAud: () => AUD,
-  },
+vi.mock("@app/lib/api/config", () => ({ default: mocks.config }));
+
+vi.mock("@app/lib/egress/server", () => ({
+  trustedFetch: mocks.trustedFetch,
 }));
 
-vi.mock("@app/logger/logger", () => ({
-  default: {
-    warn: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-  },
-}));
+vi.mock("@app/logger/logger", () => ({ default: mocks.logger }));
 
 import {
+  authenticateCloudflareAccess,
   clearCloudflareAccessJwksCacheForTests,
-  getCloudflareAccessConfig,
-  verifyCloudflareAccessJwt,
 } from "./cloudflare_access";
 
-describe("cloudflare_access", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    clearCloudflareAccessJwksCacheForTests();
+function headers(values: Record<string, string> = {}): Headers {
+  return new Headers({
+    "Cf-Access-Jwt-Assertion": ASSERTION,
+    Cookie: `CF_Authorization=${IDENTITY_COOKIE}`,
+    ...values,
+  });
+}
+
+function verifiedAssertion(
+  payload: Record<string, unknown> = {},
+  protectedHeader: Record<string, unknown> = {}
+) {
+  return {
+    payload: {
+      sub: SUBJECT,
+      email: "Operator@dust.tt",
+      name: " Operator ",
+      exp: 2_000_000_000,
+      nbf: 1_000_000_000,
+      ...payload,
+    },
+    protectedHeader: { alg: "RS256", kid: "key-1", ...protectedHeader },
+  };
+}
+
+function identityResponse(
+  body: unknown,
+  { status = 200 }: { status?: number } = {}
+) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    json: async () => body,
+  };
+}
+
+function unknownKeyError() {
+  return Object.assign(
+    new Error("no applicable key found in the JSON Web Key Set"),
+    {
+      code: "ERR_JWKS_NO_MATCHING_KEY",
+    }
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearCloudflareAccessJwksCacheForTests();
+
+  mocks.config.getCloudflareAccessTeamDomain.mockReturnValue(TEAM_DOMAIN);
+  mocks.config.getCloudflareAccessAudience.mockReturnValue(AUDIENCE);
+  mocks.config.getCloudflareAccessCertsUrl.mockReturnValue(undefined);
+  mocks.config.getCloudflareAccessIdentityUrl.mockReturnValue(undefined);
+  mocks.config.getCloudflareAccessIdentityRequired.mockReturnValue(undefined);
+
+  mocks.jwtVerify.mockResolvedValue(verifiedAssertion());
+  mocks.trustedFetch.mockResolvedValue(
+    identityResponse({
+      user_uuid: SUBJECT,
+      email: "operator@dust.tt",
+      groups: [{ id: "g1", name: "engineering-mdm" }],
+    })
+  );
+});
+
+describe("configuration", () => {
+  it("is disabled when no Access setting is configured", async () => {
+    mocks.config.getCloudflareAccessTeamDomain.mockReturnValue(undefined);
+    mocks.config.getCloudflareAccessAudience.mockReturnValue(undefined);
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "disabled",
+    });
+    expect(mocks.jwtVerify).not.toHaveBeenCalled();
   });
 
-  describe("getCloudflareAccessConfig", () => {
-    it("returns normalized team domain and aud", () => {
-      expect(getCloudflareAccessConfig()).toEqual({
-        teamDomain: TEAM_DOMAIN,
-        aud: AUD,
-      });
+  it("rejects a partial configuration instead of falling back to WorkOS", async () => {
+    mocks.config.getCloudflareAccessAudience.mockReturnValue(undefined);
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "partial_configuration",
     });
   });
 
-  describe("verifyCloudflareAccessJwt", () => {
-    it("returns identity when JWT verifies", async () => {
-      jwtVerifyMock.mockResolvedValue({
-        payload: {
-          email: "Seb@dust.tt",
-          name: "Seb",
-          sub: "cf-sub-1",
+  it("defaults the team domain when only an audience is configured", async () => {
+    mocks.config.getCloudflareAccessTeamDomain.mockReturnValue(undefined);
+
+    const result = await authenticateCloudflareAccess(headers());
+
+    expect(result.kind).toBe("authenticated");
+    expect(mocks.createRemoteJWKSet).toHaveBeenCalledWith(
+      new URL("https://teamdust.cloudflareaccess.com/cdn-cgi/access/certs"),
+      expect.any(Object)
+    );
+  });
+
+  it("rejects a non-HTTPS certs URL override", async () => {
+    mocks.config.getCloudflareAccessCertsUrl.mockReturnValue(
+      "http://dust.cloudflareaccess.com/cdn-cgi/access/certs"
+    );
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "non_https_certs_url",
+    });
+  });
+
+  it("rejects a non-HTTPS identity URL override", async () => {
+    mocks.config.getCloudflareAccessIdentityUrl.mockReturnValue(
+      "http://dust.cloudflareaccess.com/cdn-cgi/access/get-identity"
+    );
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "non_https_identity_url",
+    });
+  });
+
+  it("rejects a team domain that cannot be an HTTPS origin", async () => {
+    mocks.config.getCloudflareAccessTeamDomain.mockReturnValue("ftp://nope");
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "invalid_team_domain",
+    });
+  });
+
+  it("accepts a bare team domain and derives both endpoints", async () => {
+    mocks.config.getCloudflareAccessTeamDomain.mockReturnValue(
+      "dust.cloudflareaccess.com/"
+    );
+
+    const result = await authenticateCloudflareAccess(headers());
+
+    expect(result.kind).toBe("authenticated");
+    expect(mocks.createRemoteJWKSet).toHaveBeenCalledWith(
+      new URL(CERTS_URL),
+      expect.any(Object)
+    );
+    expect(mocks.trustedFetch).toHaveBeenCalledWith(
+      IDENTITY_URL,
+      expect.any(Object)
+    );
+  });
+});
+
+describe("assertion requirement", () => {
+  it("rejects a missing assertion header", async () => {
+    const withoutAssertion = new Headers({
+      Cookie: `CF_Authorization=${IDENTITY_COOKIE}`,
+    });
+
+    expect(await authenticateCloudflareAccess(withoutAssertion)).toEqual({
+      kind: "rejected",
+      reasonCode: "missing_assertion",
+    });
+  });
+
+  it("rejects a blank assertion header", async () => {
+    expect(
+      await authenticateCloudflareAccess(
+        headers({ "Cf-Access-Jwt-Assertion": "   " })
+      )
+    ).toEqual({ kind: "rejected", reasonCode: "missing_assertion" });
+  });
+
+  it("never accepts the authorization cookie as the assertion", async () => {
+    const cookieOnly = new Headers({
+      Cookie: `CF_Authorization=${IDENTITY_COOKIE}`,
+    });
+
+    expect(await authenticateCloudflareAccess(cookieOnly)).toEqual({
+      kind: "rejected",
+      reasonCode: "missing_assertion",
+    });
+    expect(mocks.jwtVerify).not.toHaveBeenCalled();
+  });
+
+  it("reads the assertion header case-insensitively", async () => {
+    const lowercased = new Headers({
+      "cf-access-jwt-assertion": ASSERTION,
+      Cookie: `CF_Authorization=${IDENTITY_COOKIE}`,
+    });
+
+    const result = await authenticateCloudflareAccess(lowercased);
+
+    expect(result.kind).toBe("authenticated");
+    expect(mocks.jwtVerify).toHaveBeenCalledWith(ASSERTION, "mock-jwks", {
+      algorithms: ["RS256"],
+      issuer: TEAM_DOMAIN,
+      audience: AUDIENCE,
+    });
+  });
+});
+
+describe("assertion verification", () => {
+  it("rejects a malformed assertion", async () => {
+    mocks.jwtVerify.mockRejectedValue(new Error("Invalid Compact JWS"));
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "invalid_assertion",
+    });
+  });
+
+  it("rejects a bad signature", async () => {
+    mocks.jwtVerify.mockRejectedValue(
+      Object.assign(new Error("signature verification failed"), {
+        code: "ERR_JWS_SIGNATURE_VERIFICATION_FAILED",
+      })
+    );
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "invalid_assertion",
+    });
+  });
+
+  it("rejects a wrong issuer", async () => {
+    mocks.jwtVerify.mockRejectedValue(
+      Object.assign(new Error('unexpected "iss" claim value'), {
+        code: "ERR_JWT_CLAIM_VALIDATION_FAILED",
+      })
+    );
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "invalid_assertion",
+    });
+  });
+
+  it("rejects a wrong audience", async () => {
+    mocks.jwtVerify.mockRejectedValue(
+      Object.assign(new Error('unexpected "aud" claim value'), {
+        code: "ERR_JWT_CLAIM_VALIDATION_FAILED",
+      })
+    );
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "invalid_assertion",
+    });
+  });
+
+  it("rejects an expired assertion", async () => {
+    mocks.jwtVerify.mockRejectedValue(
+      Object.assign(new Error('"exp" claim timestamp check failed'), {
+        code: "ERR_JWT_EXPIRED",
+      })
+    );
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "invalid_assertion",
+    });
+  });
+
+  it("rejects a missing exp claim", async () => {
+    mocks.jwtVerify.mockResolvedValue(verifiedAssertion({ exp: undefined }));
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "missing_claims",
+    });
+  });
+
+  it("rejects a missing nbf claim", async () => {
+    mocks.jwtVerify.mockResolvedValue(verifiedAssertion({ nbf: undefined }));
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "missing_claims",
+    });
+  });
+
+  it("rejects a missing email claim", async () => {
+    mocks.jwtVerify.mockResolvedValue(verifiedAssertion({ email: undefined }));
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "missing_claims",
+    });
+  });
+
+  it("rejects a missing sub claim", async () => {
+    mocks.jwtVerify.mockResolvedValue(verifiedAssertion({ sub: "" }));
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "missing_claims",
+    });
+  });
+
+  it("rejects a header without kid", async () => {
+    mocks.jwtVerify.mockResolvedValue(
+      verifiedAssertion({}, { kid: undefined })
+    );
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "missing_kid",
+    });
+  });
+
+  it("rejects an algorithm other than RS256", async () => {
+    mocks.jwtVerify.mockResolvedValue(verifiedAssertion({}, { alg: "HS256" }));
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "unsupported_algorithm",
+    });
+  });
+
+  it("refreshes the key set once and retries on an unknown kid", async () => {
+    mocks.jwtVerify
+      .mockRejectedValueOnce(unknownKeyError())
+      .mockResolvedValueOnce(verifiedAssertion());
+
+    const result = await authenticateCloudflareAccess(headers());
+
+    expect(result.kind).toBe("authenticated");
+    expect(mocks.jwtVerify).toHaveBeenCalledTimes(2);
+    expect(mocks.createRemoteJWKSet).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects when the kid is still unknown after one refresh", async () => {
+    mocks.jwtVerify.mockRejectedValue(unknownKeyError());
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "unknown_kid",
+    });
+    expect(mocks.jwtVerify).toHaveBeenCalledTimes(2);
+    expect(mocks.createRemoteJWKSet).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not refresh the key set on a signature failure", async () => {
+    mocks.jwtVerify.mockRejectedValue(new Error("signature mismatch"));
+
+    await authenticateCloudflareAccess(headers());
+
+    expect(mocks.jwtVerify).toHaveBeenCalledTimes(1);
+    expect(mocks.createRemoteJWKSet).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses the cached key set across calls", async () => {
+    await authenticateCloudflareAccess(headers());
+    await authenticateCloudflareAccess(headers());
+
+    expect(mocks.createRemoteJWKSet).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("get-identity", () => {
+  it("forwards only the authorization cookie", async () => {
+    await authenticateCloudflareAccess(
+      headers({
+        Cookie: `other=leak; CF_Authorization=${IDENTITY_COOKIE}; another=leak`,
+        "X-Custom": "leak",
+      })
+    );
+
+    expect(mocks.trustedFetch).toHaveBeenCalledWith(IDENTITY_URL, {
+      method: "GET",
+      headers: { Cookie: `CF_Authorization=${IDENTITY_COOKIE}` },
+      redirect: "manual",
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("attaches cross-checked group names", async () => {
+    mocks.trustedFetch.mockResolvedValue(
+      identityResponse({
+        user_uuid: SUBJECT,
+        email: "operator@dust.tt",
+        groups: [
+          { id: "g1", name: " Engineering-MDM " },
+          { id: "g2", name: "support-mdm@teamdust.example" },
+          { id: "g3", name: "engineering-mdm" },
+          { id: "g4", name: "unrelated-group" },
+        ],
+      })
+    );
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "authenticated",
+      user: {
+        subject: SUBJECT,
+        email: "operator@dust.tt",
+        name: "Operator",
+        identity: {
+          kind: "cross_checked",
+          groupNames: [
+            "engineering-mdm",
+            "support-mdm@teamdust.example",
+            "unrelated-group",
+          ],
         },
-      });
+      },
+    });
+  });
 
-      const identity = await verifyCloudflareAccessJwt("valid.jwt.token");
+  it("treats an absent groups field as an empty cross-checked set", async () => {
+    mocks.trustedFetch.mockResolvedValue(
+      identityResponse({ user_uuid: SUBJECT, email: "operator@dust.tt" })
+    );
 
-      expect(identity).toEqual({
-        email: "seb@dust.tt",
-        name: "Seb",
-        sub: "cf-sub-1",
-      });
-      expect(createRemoteJWKSetMock).toHaveBeenCalledWith(
-        new URL(`${TEAM_DOMAIN}/cdn-cgi/access/certs`)
-      );
-      expect(jwtVerifyMock).toHaveBeenCalledWith(
-        "valid.jwt.token",
-        "mock-jwks",
-        {
-          issuer: TEAM_DOMAIN,
-          audience: AUD,
-        }
-      );
+    const result = await authenticateCloudflareAccess(headers());
+
+    expect(result).toEqual({
+      kind: "authenticated",
+      user: expect.objectContaining({
+        identity: { kind: "cross_checked", groupNames: [] },
+      }),
+    });
+  });
+
+  it("never lets identity fields override the verified principal", async () => {
+    mocks.trustedFetch.mockResolvedValue(
+      identityResponse({
+        user_uuid: SUBJECT,
+        email: "OPERATOR@dust.tt",
+        name: "Spoofed Admin",
+        sub: "spoofed-subject",
+        groups: [{ name: "engineering-mdm" }],
+      })
+    );
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "authenticated",
+      user: {
+        subject: SUBJECT,
+        email: "operator@dust.tt",
+        name: "Operator",
+        identity: { kind: "cross_checked", groupNames: ["engineering-mdm"] },
+      },
+    });
+  });
+
+  it("rejects a transport failure", async () => {
+    mocks.trustedFetch.mockRejectedValue(new Error("timed out"));
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "identity_unavailable",
+    });
+  });
+
+  it("rejects a redirect", async () => {
+    mocks.trustedFetch.mockResolvedValue(
+      identityResponse(null, { status: 302 })
+    );
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "identity_redirect",
+    });
+  });
+
+  it("rejects a non-2xx response", async () => {
+    mocks.trustedFetch.mockResolvedValue(
+      identityResponse(null, { status: 403 })
+    );
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "identity_non_success",
+    });
+  });
+
+  it("rejects a body that is not JSON", async () => {
+    mocks.trustedFetch.mockResolvedValue({
+      status: 200,
+      ok: true,
+      json: async () => {
+        throw new Error("Unexpected token < in JSON");
+      },
     });
 
-    it("returns null when email claim is missing", async () => {
-      jwtVerifyMock.mockResolvedValue({
-        payload: { sub: "cf-sub-1" },
-      });
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "invalid_identity_payload",
+    });
+  });
 
-      expect(await verifyCloudflareAccessJwt("token")).toBeNull();
+  it("rejects a body missing user_uuid", async () => {
+    mocks.trustedFetch.mockResolvedValue(
+      identityResponse({ email: "operator@dust.tt" })
+    );
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "invalid_identity_payload",
+    });
+  });
+
+  it("rejects a body whose groups are the wrong shape", async () => {
+    mocks.trustedFetch.mockResolvedValue(
+      identityResponse({
+        user_uuid: SUBJECT,
+        email: "operator@dust.tt",
+        groups: ["engineering-mdm"],
+      })
+    );
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "invalid_identity_payload",
+    });
+  });
+});
+
+describe("identity cross-check", () => {
+  it("rejects a user_uuid that does not match sub", async () => {
+    mocks.trustedFetch.mockResolvedValue(
+      identityResponse({
+        user_uuid: "another-subject",
+        email: "operator@dust.tt",
+      })
+    );
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "identity_subject_mismatch",
+    });
+  });
+
+  it("rejects an email that does not match the assertion", async () => {
+    mocks.trustedFetch.mockResolvedValue(
+      identityResponse({ user_uuid: SUBJECT, email: "someone@dust.tt" })
+    );
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "identity_email_mismatch",
+    });
+  });
+
+  it("matches emails case-insensitively", async () => {
+    mocks.trustedFetch.mockResolvedValue(
+      identityResponse({ user_uuid: SUBJECT, email: "OPERATOR@DUST.TT" })
+    );
+
+    expect((await authenticateCloudflareAccess(headers())).kind).toBe(
+      "authenticated"
+    );
+  });
+});
+
+describe("CLOUDFLARE_ACCESS_IDENTITY_REQUIRED", () => {
+  it("rejects a missing cookie by default", async () => {
+    const withoutCookie = new Headers({
+      "Cf-Access-Jwt-Assertion": ASSERTION,
     });
 
-    it("returns null when verification throws", async () => {
-      jwtVerifyMock.mockRejectedValue(new Error("signature mismatch"));
+    expect(await authenticateCloudflareAccess(withoutCookie)).toEqual({
+      kind: "rejected",
+      reasonCode: "missing_identity_cookie",
+    });
+    expect(mocks.trustedFetch).not.toHaveBeenCalled();
+  });
 
-      expect(await verifyCloudflareAccessJwt("bad.token")).toBeNull();
+  it("rejects a missing cookie for any value other than false", async () => {
+    mocks.config.getCloudflareAccessIdentityRequired.mockReturnValue("0");
+    const withoutCookie = new Headers({
+      "Cf-Access-Jwt-Assertion": ASSERTION,
     });
 
-    it("reuses the JWKS client across calls", async () => {
-      jwtVerifyMock.mockResolvedValue({
-        payload: {
-          email: "seb@dust.tt",
-          sub: "cf-sub-1",
-        },
-      });
-
-      await verifyCloudflareAccessJwt("token-1");
-      await verifyCloudflareAccessJwt("token-2");
-
-      expect(createRemoteJWKSetMock).toHaveBeenCalledTimes(1);
+    expect(await authenticateCloudflareAccess(withoutCookie)).toEqual({
+      kind: "rejected",
+      reasonCode: "missing_identity_cookie",
     });
+  });
+
+  it("rejects a blank cookie value", async () => {
+    expect(
+      await authenticateCloudflareAccess(
+        headers({ Cookie: "CF_Authorization=" })
+      )
+    ).toEqual({ kind: "rejected", reasonCode: "missing_identity_cookie" });
+  });
+
+  it("rejects a cookie value that could inject into the outbound header", async () => {
+    expect(
+      await authenticateCloudflareAccess(
+        headers({ Cookie: "CF_Authorization=abc\\def" })
+      )
+    ).toEqual({ kind: "rejected", reasonCode: "invalid_identity_cookie" });
+    expect(mocks.trustedFetch).not.toHaveBeenCalled();
+  });
+
+  it("degrades to jwt_only when identity is optional and the cookie is absent", async () => {
+    mocks.config.getCloudflareAccessIdentityRequired.mockReturnValue("false");
+    const withoutCookie = new Headers({
+      "Cf-Access-Jwt-Assertion": ASSERTION,
+    });
+
+    expect(await authenticateCloudflareAccess(withoutCookie)).toEqual({
+      kind: "authenticated",
+      user: {
+        subject: SUBJECT,
+        email: "operator@dust.tt",
+        name: "Operator",
+        identity: { kind: "jwt_only" },
+      },
+    });
+    expect(mocks.trustedFetch).not.toHaveBeenCalled();
+  });
+
+  it("degrades to jwt_only when identity is optional and get-identity fails", async () => {
+    mocks.config.getCloudflareAccessIdentityRequired.mockReturnValue("false");
+    mocks.trustedFetch.mockResolvedValue(
+      identityResponse(null, { status: 500 })
+    );
+
+    const result = await authenticateCloudflareAccess(headers());
+
+    expect(result).toEqual({
+      kind: "authenticated",
+      user: expect.objectContaining({ identity: { kind: "jwt_only" } }),
+    });
+  });
+
+  it("still rejects a mismatch when identity is optional", async () => {
+    mocks.config.getCloudflareAccessIdentityRequired.mockReturnValue("false");
+    mocks.trustedFetch.mockResolvedValue(
+      identityResponse({
+        user_uuid: "another-subject",
+        email: "operator@dust.tt",
+      })
+    );
+
+    expect(await authenticateCloudflareAccess(headers())).toEqual({
+      kind: "rejected",
+      reasonCode: "identity_subject_mismatch",
+    });
+  });
+
+  it("still rejects a malformed cookie when identity is optional", async () => {
+    mocks.config.getCloudflareAccessIdentityRequired.mockReturnValue("false");
+
+    expect(
+      await authenticateCloudflareAccess(
+        headers({ Cookie: "CF_Authorization=abc def" })
+      )
+    ).toEqual({ kind: "rejected", reasonCode: "invalid_identity_cookie" });
+  });
+});
+
+describe("secret containment", () => {
+  const secrets = [ASSERTION, IDENTITY_COOKIE];
+
+  function assertSecretFree(value: unknown) {
+    const serialized = JSON.stringify(value) ?? "";
+    for (const secret of secrets) {
+      expect(serialized).not.toContain(secret);
+    }
+  }
+
+  it("keeps secrets out of an authenticated result", async () => {
+    assertSecretFree(await authenticateCloudflareAccess(headers()));
+  });
+
+  it("keeps secrets and JOSE messages out of a rejected result", async () => {
+    mocks.jwtVerify.mockRejectedValue(
+      new Error(`signature verification failed for ${ASSERTION}`)
+    );
+
+    const result = await authenticateCloudflareAccess(headers());
+
+    assertSecretFree(result);
+    expect(result).toEqual({
+      kind: "rejected",
+      reasonCode: "invalid_assertion",
+    });
+  });
+
+  it("never logs from the authentication path", async () => {
+    mocks.jwtVerify.mockRejectedValue(new Error(`bad token ${ASSERTION}`));
+
+    await authenticateCloudflareAccess(headers());
+
+    expect(mocks.logger.warn).not.toHaveBeenCalled();
+    expect(mocks.logger.error).not.toHaveBeenCalled();
+    expect(mocks.logger.info).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/poke/cloudflare_access.test.ts
+++ b/front/lib/api/poke/cloudflare_access.test.ts
@@ -308,12 +308,27 @@ describe("assertion verification", () => {
     });
   });
 
-  it("rejects a missing nbf claim", async () => {
+  it("accepts a JWT without an nbf claim", async () => {
     mocks.jwtVerify.mockResolvedValue(verifiedAssertion({ nbf: undefined }));
+    mocks.trustedFetch.mockResolvedValue(
+      identityResponse({
+        user_uuid: SUBJECT,
+        email: "operator@dust.tt",
+        groups: [{ name: "engineering-mdm" }],
+      })
+    );
 
     expect(await authenticateCloudflareAccess(headers())).toEqual({
-      kind: "rejected",
-      reasonCode: "missing_claims",
+      kind: "authenticated",
+      user: {
+        subject: SUBJECT,
+        email: "operator@dust.tt",
+        name: "Operator",
+        identity: {
+          kind: "cross_checked",
+          groupNames: ["engineering-mdm"],
+        },
+      },
     });
   });
 

--- a/front/lib/api/poke/cloudflare_access.ts
+++ b/front/lib/api/poke/cloudflare_access.ts
@@ -222,7 +222,8 @@ function parseVerifiedAssertion({
       sub: z.string().min(1),
       email: z.string().email(),
       exp: z.number(),
-      nbf: z.number(),
+      // jose already enforces nbf when present; keep it optional here.
+      nbf: z.number().optional(),
       name: z.string().nullish(),
     })
     .safeParse(payload);

--- a/front/lib/api/poke/cloudflare_access.ts
+++ b/front/lib/api/poke/cloudflare_access.ts
@@ -1,101 +1,463 @@
 import config from "@app/lib/api/config";
-import logger from "@app/logger/logger";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { trustedFetch } from "@app/lib/egress/server";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { createRemoteJWKSet, jwtVerify } from "jose";
+import { z } from "zod";
 
-export type CloudflareAccessIdentity = {
+const ACCESS_ASSERTION_HEADER = "Cf-Access-Jwt-Assertion";
+const ACCESS_IDENTITY_COOKIE = "CF_Authorization";
+const DEFAULT_TEAM_DOMAIN = "https://teamdust.cloudflareaccess.com";
+
+const JWKS_REQUEST_TIMEOUT_MS = 5_000;
+const JWKS_COOLDOWN_MS = 30_000;
+const IDENTITY_REQUEST_TIMEOUT_MS = 3_000;
+
+/**
+ * Identity evidence backing an authenticated Access principal. The union keeps
+ * `jwt_only` distinguishable from a cross-checked, genuinely empty group set,
+ * so role resolution cannot mistake one for the other.
+ */
+export type AccessIdentityEvidence =
+  | { kind: "cross_checked"; groupNames: readonly string[] }
+  | { kind: "jwt_only" };
+
+export type AuthenticatedAccessUser = {
+  subject: string;
   email: string;
   name: string | null;
-  sub: string;
+  identity: AccessIdentityEvidence;
 };
 
-type CloudflareAccessConfig = {
-  teamDomain: string;
-  aud: string;
+/** Closed, secret-free taxonomy. Safe to log; never returned to a client. */
+export type CloudflareAccessDenialCode =
+  | "partial_configuration"
+  | "invalid_team_domain"
+  | "non_https_certs_url"
+  | "non_https_identity_url"
+  | "missing_assertion"
+  | "invalid_assertion"
+  | "unsupported_algorithm"
+  | "missing_kid"
+  | "unknown_kid"
+  | "missing_claims"
+  | "missing_identity_cookie"
+  | "invalid_identity_cookie"
+  | "identity_unavailable"
+  | "identity_redirect"
+  | "identity_non_success"
+  | "invalid_identity_payload"
+  | "identity_subject_mismatch"
+  | "identity_email_mismatch";
+
+export type CloudflareAccessAuthentication =
+  // Access is not configured at all. The only result that permits the WorkOS
+  // super-user fallback.
+  | { kind: "disabled" }
+  | { kind: "authenticated"; user: AuthenticatedAccessUser }
+  | { kind: "rejected"; reasonCode: CloudflareAccessDenialCode };
+
+type EnabledCloudflareAccessConfig = {
+  issuer: string;
+  audience: string;
+  certsUrl: URL;
+  identityUrl: URL;
+  identityRequired: boolean;
 };
 
-let cachedJwks: ReturnType<typeof createRemoteJWKSet> | null = null;
-let cachedJwksIssuer: string | null = null;
+type CloudflareAccessConfig =
+  | { kind: "disabled" }
+  | { kind: "invalid"; reasonCode: CloudflareAccessDenialCode }
+  | { kind: "enabled"; value: EnabledCloudflareAccessConfig };
 
-function normalizeTeamDomain(teamDomain: string): string {
-  return teamDomain.startsWith("https://")
-    ? teamDomain.replace(/\/$/, "")
-    : `https://${teamDomain.replace(/\/$/, "")}`;
+type VerifiedAssertion = {
+  subject: string;
+  email: string;
+  name: string | null;
+};
+
+type ParsedAccessIdentity = {
+  userUuid: string;
+  email: string;
+  groupNames: readonly string[];
+};
+
+const AccessIdentityPayloadSchema = z.object({
+  user_uuid: z.string().min(1),
+  email: z.string().email(),
+  groups: z
+    .array(z.object({ name: z.string() }))
+    .nullish()
+    .transform((groups) => groups ?? []),
+});
+
+const jwksByCertsUrl = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
+
+function canonicalEmail(email: string): string {
+  return email.trim().toLowerCase();
 }
 
-export function getCloudflareAccessConfig(): CloudflareAccessConfig | null {
-  const teamDomain = config.getCloudflareAccessTeamDomain();
-  const aud = config.getCloudflareAccessAud();
-  if (!teamDomain || !aud) {
+function parseHttpsUrl(raw: string): URL | null {
+  let url: URL;
+  try {
+    url = new URL(raw.trim());
+  } catch {
     return null;
   }
-  return { teamDomain: normalizeTeamDomain(teamDomain), aud };
+  if (url.protocol !== "https:") {
+    return null;
+  }
+  // Credentials embedded in a URL would be attached to every outbound request.
+  if (url.username.length > 0 || url.password.length > 0) {
+    return null;
+  }
+  return url;
 }
 
-function getJwks(issuer: string) {
-  if (cachedJwks && cachedJwksIssuer === issuer) {
-    return cachedJwks;
+function parseTeamDomain(raw: string): URL | null {
+  const trimmed = raw.trim().replace(/\/+$/, "");
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`;
+  return parseHttpsUrl(withScheme);
+}
+
+function resolveCloudflareAccessConfig(): CloudflareAccessConfig {
+  const audience = config.getCloudflareAccessAudience()?.trim();
+  const teamDomain = config.getCloudflareAccessTeamDomain()?.trim();
+  const certsUrlOverride = config.getCloudflareAccessCertsUrl()?.trim();
+  const identityUrlOverride = config.getCloudflareAccessIdentityUrl()?.trim();
+  const identityRequiredRaw = config
+    .getCloudflareAccessIdentityRequired()
+    ?.trim();
+
+  if (!audience) {
+    const hasDependentSetting = [
+      teamDomain,
+      certsUrlOverride,
+      identityUrlOverride,
+      identityRequiredRaw,
+    ].some((value) => Boolean(value));
+    // Half-configured Access must never degrade into the WorkOS fallback.
+    return hasDependentSetting
+      ? { kind: "invalid", reasonCode: "partial_configuration" }
+      : { kind: "disabled" };
   }
-  cachedJwks = createRemoteJWKSet(new URL(`${issuer}/cdn-cgi/access/certs`));
-  cachedJwksIssuer = issuer;
-  return cachedJwks;
+
+  const teamDomainUrl = parseTeamDomain(teamDomain ?? DEFAULT_TEAM_DOMAIN);
+  if (!teamDomainUrl) {
+    return { kind: "invalid", reasonCode: "invalid_team_domain" };
+  }
+  const issuer = teamDomainUrl.origin;
+
+  const certsUrl = parseHttpsUrl(
+    certsUrlOverride ?? `${issuer}/cdn-cgi/access/certs`
+  );
+  if (!certsUrl) {
+    return { kind: "invalid", reasonCode: "non_https_certs_url" };
+  }
+
+  const identityUrl = parseHttpsUrl(
+    identityUrlOverride ?? `${issuer}/cdn-cgi/access/get-identity`
+  );
+  if (!identityUrl) {
+    return { kind: "invalid", reasonCode: "non_https_identity_url" };
+  }
+
+  return {
+    kind: "enabled",
+    value: {
+      issuer,
+      audience,
+      certsUrl,
+      identityUrl,
+      identityRequired: identityRequiredRaw !== "false",
+    },
+  };
+}
+
+function getJwks(certsUrl: URL): ReturnType<typeof createRemoteJWKSet> {
+  const cached = jwksByCertsUrl.get(certsUrl.href);
+  if (cached) {
+    return cached;
+  }
+  const jwks = createRemoteJWKSet(certsUrl, {
+    timeoutDuration: JWKS_REQUEST_TIMEOUT_MS,
+    cooldownDuration: JWKS_COOLDOWN_MS,
+  });
+  jwksByCertsUrl.set(certsUrl.href, jwks);
+  return jwks;
+}
+
+function isUnknownKeyError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    err.code === "ERR_JWKS_NO_MATCHING_KEY"
+  );
+}
+
+function parseVerifiedAssertion({
+  payload,
+  protectedHeader,
+}: {
+  payload: unknown;
+  protectedHeader: unknown;
+}): Result<VerifiedAssertion, CloudflareAccessDenialCode> {
+  const header = z
+    .object({ alg: z.string(), kid: z.string().min(1) })
+    .safeParse(protectedHeader);
+  if (!header.success) {
+    return new Err("missing_kid");
+  }
+  if (header.data.alg !== "RS256") {
+    return new Err("unsupported_algorithm");
+  }
+
+  // `jwtVerify` owns signature, issuer, audience and temporal validation; this
+  // parse makes the claims we depend on mandatory rather than optional.
+  const claims = z
+    .object({
+      sub: z.string().min(1),
+      email: z.string().email(),
+      exp: z.number(),
+      nbf: z.number(),
+      name: z.string().nullish(),
+    })
+    .safeParse(payload);
+  if (!claims.success) {
+    return new Err("missing_claims");
+  }
+
+  const name = claims.data.name?.trim();
+  return new Ok({
+    subject: claims.data.sub,
+    email: canonicalEmail(claims.data.email),
+    name: name && name.length > 0 ? name : null,
+  });
+}
+
+async function verifyAssertion(
+  assertion: string,
+  accessConfig: EnabledCloudflareAccessConfig
+): Promise<Result<VerifiedAssertion, CloudflareAccessDenialCode>> {
+  const verifyOnce = async () =>
+    jwtVerify(assertion, getJwks(accessConfig.certsUrl), {
+      algorithms: ["RS256"],
+      issuer: accessConfig.issuer,
+      audience: accessConfig.audience,
+    });
+
+  let verified: Awaited<ReturnType<typeof verifyOnce>>;
+  try {
+    verified = await verifyOnce();
+  } catch (err) {
+    if (!isUnknownKeyError(err)) {
+      return new Err("invalid_assertion");
+    }
+    // Cloudflare rotates signing keys without warning. Drop the cached key set
+    // so the retry refetches instead of waiting out jose's cooldown.
+    jwksByCertsUrl.delete(accessConfig.certsUrl.href);
+    try {
+      verified = await verifyOnce();
+    } catch (retryErr) {
+      return new Err(
+        isUnknownKeyError(retryErr) ? "unknown_kid" : "invalid_assertion"
+      );
+    }
+  }
+
+  return parseVerifiedAssertion(verified);
+}
+
+function readAccessIdentityCookie(headers: Headers): string | null {
+  const cookieHeader = headers.get("Cookie");
+  if (!cookieHeader) {
+    return null;
+  }
+  for (const pair of cookieHeader.split(";")) {
+    const separator = pair.indexOf("=");
+    if (separator === -1) {
+      continue;
+    }
+    if (pair.slice(0, separator).trim() !== ACCESS_IDENTITY_COOKIE) {
+      continue;
+    }
+    const value = pair.slice(separator + 1).trim();
+    return value.length > 0 ? value : null;
+  }
+  return null;
+}
+
+// RFC 6265 cookie-octet. Excluding CTLs, whitespace, `"`, `,`, `;` and `\` keeps
+// a client-supplied value from injecting into the outbound Cookie header.
+const COOKIE_OCTETS = /^[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]+$/;
+
+async function fetchAccessIdentity(
+  identityCookie: string,
+  accessConfig: EnabledCloudflareAccessConfig
+): Promise<Result<ParsedAccessIdentity, CloudflareAccessDenialCode>> {
+  let response;
+  try {
+    response = await trustedFetch(accessConfig.identityUrl.href, {
+      method: "GET",
+      headers: { Cookie: `${ACCESS_IDENTITY_COOKIE}=${identityCookie}` },
+      redirect: "manual",
+      signal: AbortSignal.timeout(IDENTITY_REQUEST_TIMEOUT_MS),
+    });
+  } catch {
+    return new Err("identity_unavailable");
+  }
+
+  if (response.status >= 300 && response.status < 400) {
+    return new Err("identity_redirect");
+  }
+  if (!response.ok) {
+    return new Err("identity_non_success");
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    return new Err("invalid_identity_payload");
+  }
+
+  const parsed = AccessIdentityPayloadSchema.safeParse(body);
+  if (!parsed.success) {
+    return new Err("invalid_identity_payload");
+  }
+
+  const groupNames = new Set<string>();
+  for (const group of parsed.data.groups) {
+    const name = group.name.trim().toLowerCase();
+    if (name.length > 0) {
+      groupNames.add(name);
+    }
+  }
+
+  return new Ok({
+    userUuid: parsed.data.user_uuid,
+    email: canonicalEmail(parsed.data.email),
+    groupNames: [...groupNames],
+  });
+}
+
+function crossCheckAccessIdentity(
+  assertion: VerifiedAssertion,
+  identity: ParsedAccessIdentity
+): Result<readonly string[], CloudflareAccessDenialCode> {
+  if (identity.userUuid !== assertion.subject) {
+    return new Err("identity_subject_mismatch");
+  }
+  if (identity.email !== assertion.email) {
+    return new Err("identity_email_mismatch");
+  }
+  return new Ok(identity.groupNames);
+}
+
+function authenticated(
+  assertion: VerifiedAssertion,
+  identity: AccessIdentityEvidence
+): CloudflareAccessAuthentication {
+  return {
+    kind: "authenticated",
+    user: {
+      subject: assertion.subject,
+      email: assertion.email,
+      name: assertion.name,
+      identity,
+    },
+  };
 }
 
 /**
- * Validates a Cloudflare Access application JWT.
- *
- * Prefer the `Cf-Access-Jwt-Assertion` header (what Cloudflare injects at the
- * edge). Fall back to the `CF_Authorization` cookie for browser same-origin
- * requests where the header may not be forwarded.
- *
- * @see https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/validating-json/
+ * @cc [label:security;api] assertion-header-only
+ * When Cloudflare Access is configured, authentication must require a non-empty
+ * `Cf-Access-Jwt-Assertion` header and must never accept `CF_Authorization` as a
+ * substitute for it.
  */
-export async function verifyCloudflareAccessJwt(
-  token: string
-): Promise<CloudflareAccessIdentity | null> {
-  const accessConfig = getCloudflareAccessConfig();
-  if (!accessConfig) {
-    return null;
+/**
+ * @cc [label:security] identity-cookie-isolation
+ * The get-identity request must forward only the `CF_Authorization` cookie and must
+ * never forward the assertion, the incoming `Cookie` header, or any other inbound
+ * header.
+ */
+/**
+ * @cc [label:security] identity-cross-check
+ * A parsed get-identity response must match the assertion's `sub` to `user_uuid`
+ * exactly and its email case-insensitively; either mismatch rejects authentication
+ * regardless of `CLOUDFLARE_ACCESS_IDENTITY_REQUIRED`.
+ */
+/**
+ * @cc [label:security] assertion-owns-principal
+ * `subject`, `email` and `name` on the returned user must come from the verified
+ * assertion; a get-identity response contributes group names only.
+ */
+/**
+ * @cc [label:security;logging] secret-free-result
+ * The returned value must never carry the assertion, the authorization cookie, raw
+ * JWT claims, a raw get-identity payload, or an underlying error; failures are
+ * reported as a `CloudflareAccessDenialCode`.
+ */
+/**
+ * @cc [label:security] partial-configuration-fails-closed
+ * `disabled` must be returned only when no audience and no dependent
+ * `CLOUDFLARE_ACCESS_*` setting is configured; any other configuration defect
+ * rejects.
+ */
+export async function authenticateCloudflareAccess(
+  headers: Headers
+): Promise<CloudflareAccessAuthentication> {
+  const accessConfig = resolveCloudflareAccessConfig();
+  if (accessConfig.kind === "disabled") {
+    return { kind: "disabled" };
+  }
+  if (accessConfig.kind === "invalid") {
+    return { kind: "rejected", reasonCode: accessConfig.reasonCode };
+  }
+  const enabled = accessConfig.value;
+
+  const assertion = headers.get(ACCESS_ASSERTION_HEADER)?.trim();
+  if (!assertion) {
+    return { kind: "rejected", reasonCode: "missing_assertion" };
   }
 
-  try {
-    const { payload } = await jwtVerify(
-      token,
-      getJwks(accessConfig.teamDomain),
-      {
-        issuer: accessConfig.teamDomain,
-        audience: accessConfig.aud,
-      }
-    );
-
-    const email =
-      typeof payload.email === "string" ? payload.email.toLowerCase() : null;
-    const sub = typeof payload.sub === "string" ? payload.sub : null;
-    if (!email || !sub) {
-      logger.warn(
-        { hasEmail: !!email, hasSub: !!sub },
-        "[poke] Cloudflare Access JWT missing email or sub claim"
-      );
-      return null;
-    }
-
-    const name =
-      typeof payload.name === "string" && payload.name.trim().length > 0
-        ? payload.name.trim()
-        : null;
-
-    return { email, name, sub };
-  } catch (err) {
-    logger.warn(
-      { err: normalizeError(err) },
-      "[poke] Cloudflare Access JWT verification failed"
-    );
-    return null;
+  const verified = await verifyAssertion(assertion, enabled);
+  if (verified.isErr()) {
+    return { kind: "rejected", reasonCode: verified.error };
   }
+
+  const identityCookie = readAccessIdentityCookie(headers);
+  if (identityCookie === null) {
+    return enabled.identityRequired
+      ? { kind: "rejected", reasonCode: "missing_identity_cookie" }
+      : authenticated(verified.value, { kind: "jwt_only" });
+  }
+  if (!COOKIE_OCTETS.test(identityCookie)) {
+    return { kind: "rejected", reasonCode: "invalid_identity_cookie" };
+  }
+
+  const identity = await fetchAccessIdentity(identityCookie, enabled);
+  if (identity.isErr()) {
+    return enabled.identityRequired
+      ? { kind: "rejected", reasonCode: identity.error }
+      : authenticated(verified.value, { kind: "jwt_only" });
+  }
+
+  const groupNames = crossCheckAccessIdentity(verified.value, identity.value);
+  if (groupNames.isErr()) {
+    return { kind: "rejected", reasonCode: groupNames.error };
+  }
+
+  return authenticated(verified.value, {
+    kind: "cross_checked",
+    groupNames: groupNames.value,
+  });
 }
 
 /** Test-only helper to clear the cached JWKS between cases. */
 export function clearCloudflareAccessJwksCacheForTests(): void {
-  cachedJwks = null;
-  cachedJwksIssuer = null;
+  jwksByCertsUrl.clear();
 }

--- a/front/lib/api/poke/cloudflare_access.ts
+++ b/front/lib/api/poke/cloudflare_access.ts
@@ -2,6 +2,7 @@ import config from "@app/lib/api/config";
 import { trustedFetch } from "@app/lib/egress/server";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { createRemoteJWKSet, jwtVerify } from "jose";
 import { z } from "zod";
 
@@ -374,49 +375,60 @@ function authenticated(
 }
 
 /**
- * @cc [label:security;api] assertion-header-only
+ * @cc [owner:zmarouf,label:security;api] assertion-header-only
  * When Cloudflare Access is configured, authentication must require a non-empty
  * `Cf-Access-Jwt-Assertion` header and must never accept `CF_Authorization` as a
  * substitute for it.
  */
 /**
- * @cc [label:security] identity-cookie-isolation
+ * @cc [owner:zmarouf,label:security] identity-cookie-isolation
  * The get-identity request must forward only the `CF_Authorization` cookie and must
  * never forward the assertion, the incoming `Cookie` header, or any other inbound
  * header.
  */
 /**
- * @cc [label:security] identity-cross-check
+ * @cc [owner:zmarouf,label:security] identity-cross-check
  * A parsed get-identity response must match the assertion's `sub` to `user_uuid`
  * exactly and its email case-insensitively; either mismatch rejects authentication
  * regardless of `CLOUDFLARE_ACCESS_IDENTITY_REQUIRED`.
  */
 /**
- * @cc [label:security] assertion-owns-principal
+ * @cc [owner:zmarouf,label:security] assertion-owns-principal
  * `subject`, `email` and `name` on the returned user must come from the verified
  * assertion; a get-identity response contributes group names only.
  */
 /**
- * @cc [label:security;logging] secret-free-result
+ * @cc [owner:zmarouf,label:security;logging] secret-free-result
  * The returned value must never carry the assertion, the authorization cookie, raw
  * JWT claims, a raw get-identity payload, or an underlying error; failures are
  * reported as a `CloudflareAccessDenialCode`.
  */
 /**
- * @cc [label:security] partial-configuration-fails-closed
+ * @cc [owner:zmarouf,label:security] partial-configuration-fails-closed
  * `disabled` must be returned only when no audience and no dependent
  * `CLOUDFLARE_ACCESS_*` setting is configured; any other configuration defect
  * rejects.
+ */
+/**
+ * @cc [owner:zmarouf,label:security] identity-required-default
+ * Identity enrichment is required unless `CLOUDFLARE_ACCESS_IDENTITY_REQUIRED` is
+ * exactly `"false"`. When required, a missing cookie or failed get-identity rejects;
+ * when not required, those cases authenticate as `jwt_only`. Identity mismatches
+ * always reject.
  */
 export async function authenticateCloudflareAccess(
   headers: Headers
 ): Promise<CloudflareAccessAuthentication> {
   const accessConfig = resolveCloudflareAccessConfig();
-  if (accessConfig.kind === "disabled") {
-    return { kind: "disabled" };
-  }
-  if (accessConfig.kind === "invalid") {
-    return { kind: "rejected", reasonCode: accessConfig.reasonCode };
+  switch (accessConfig.kind) {
+    case "disabled":
+      return { kind: "disabled" };
+    case "invalid":
+      return { kind: "rejected", reasonCode: accessConfig.reasonCode };
+    case "enabled":
+      break;
+    default:
+      assertNever(accessConfig);
   }
   const enabled = accessConfig.value;
 

--- a/front/lib/poke/roles.test.ts
+++ b/front/lib/poke/roles.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetchFileContent: vi.fn(),
+  isDevelopment: vi.fn(() => false),
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock("@app/lib/file_storage", () => ({
+  getPokeUserConfigBucket: () => ({
+    fetchFileContent: mocks.fetchFileContent,
+  }),
+}));
+
+vi.mock("@app/types/shared/env", () => ({
+  isDevelopment: () => mocks.isDevelopment(),
+}));
+
+vi.mock("@app/logger/logger", () => ({
+  default: mocks.logger,
+}));
+
+import type { AuthenticatedAccessUser } from "@app/lib/api/poke/cloudflare_access";
+import {
+  clearPokeRolesCacheForTests,
+  getPokeRolesForPrincipal,
+  hasPokeRole,
+} from "@app/lib/poke/roles";
+
+function accessUser(
+  overrides: Partial<AuthenticatedAccessUser> & {
+    identity: AuthenticatedAccessUser["identity"];
+  }
+): AuthenticatedAccessUser {
+  return {
+    subject: "sub-1",
+    email: "seb@dust.tt",
+    name: "Seb",
+    ...overrides,
+  };
+}
+
+describe("getPokeRolesForPrincipal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearPokeRolesCacheForTests();
+    mocks.isDevelopment.mockReturnValue(false);
+    mocks.fetchFileContent.mockResolvedValue(
+      JSON.stringify({
+        "seb@dust.tt": ["admin", "billing"],
+        "other@dust.tt": ["support"],
+      })
+    );
+  });
+
+  it("maps bare and email-shaped -mdm groups to poke roles", async () => {
+    const roles = await getPokeRolesForPrincipal({
+      kind: "cloudflare_access",
+      user: accessUser({
+        identity: {
+          kind: "cross_checked",
+          groupNames: [
+            "engineering-mdm",
+            "Billing-MDM@dust.tt",
+            "support-mdm",
+            "unrelated-group",
+            "admin-mdm-extra",
+          ],
+        },
+      }),
+    });
+
+    expect(roles).toEqual(["billing", "engineering", "support"]);
+    expect(mocks.fetchFileContent).not.toHaveBeenCalled();
+  });
+
+  it("grants no roles for an empty cross-checked group list", async () => {
+    const roles = await getPokeRolesForPrincipal({
+      kind: "cloudflare_access",
+      user: accessUser({
+        identity: { kind: "cross_checked", groupNames: [] },
+      }),
+    });
+
+    expect(roles).toEqual([]);
+    expect(mocks.fetchFileContent).not.toHaveBeenCalled();
+  });
+
+  it("falls back to GCS for jwt_only Access principals", async () => {
+    const roles = await getPokeRolesForPrincipal({
+      kind: "cloudflare_access",
+      user: accessUser({
+        identity: { kind: "jwt_only" },
+      }),
+    });
+
+    expect(roles).toEqual(["admin", "billing"]);
+    expect(mocks.fetchFileContent).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to GCS for email principals", async () => {
+    const roles = await getPokeRolesForPrincipal({
+      kind: "email",
+      email: "other@dust.tt",
+    });
+
+    expect(roles).toEqual(["support"]);
+  });
+
+  it("returns all roles in development", async () => {
+    mocks.isDevelopment.mockReturnValue(true);
+
+    const roles = await getPokeRolesForPrincipal({
+      kind: "cloudflare_access",
+      user: accessUser({
+        identity: { kind: "cross_checked", groupNames: [] },
+      }),
+    });
+
+    expect(roles).toEqual([
+      "admin",
+      "billing",
+      "engineering",
+      "support",
+      "talent",
+    ]);
+  });
+});
+
+describe("hasPokeRole", () => {
+  it("returns true when any required role is present", () => {
+    expect(hasPokeRole(["engineering"], ["billing", "engineering"])).toBe(true);
+    expect(hasPokeRole(["support"], ["billing", "engineering"])).toBe(false);
+  });
+});

--- a/front/lib/poke/roles.ts
+++ b/front/lib/poke/roles.ts
@@ -2,6 +2,7 @@ import type { AuthenticatedAccessUser } from "@app/lib/api/poke/cloudflare_acces
 import { getPokeUserConfigBucket } from "@app/lib/file_storage";
 import logger from "@app/logger/logger";
 import { isDevelopment } from "@app/types/shared/env";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { z } from "zod";
 
@@ -87,7 +88,7 @@ async function loadRoles(): Promise<RolesConfig> {
 }
 
 /**
- * @cc [label:product] mdm-group-mapping
+ * @cc [owner:zmarouf,label:product] mdm-group-mapping
  * A group name grants a `PokeRole` only when it equals one of that role's entries in
  * `ACCESS_GROUPS_BY_ROLE`, case-insensitively, either bare or as the local part of an
  * `<group>@<domain>` address.
@@ -100,7 +101,6 @@ function mapAccessGroupNamesToPokeRoles(
   for (const groupName of groupNames) {
     const normalized = groupName.trim().toLowerCase();
     const at = normalized.indexOf("@");
-    // Google groups surface either as a bare name or as a group address.
     const localPart =
       at === -1 ? normalized : normalized.slice(0, at).trimEnd();
     if (at !== -1 && !/^[^@\s]+$/.test(normalized.slice(at + 1))) {
@@ -117,11 +117,17 @@ function mapAccessGroupNamesToPokeRoles(
 }
 
 /**
- * @cc [label:product;security] role-source-selection
+ * @cc [owner:zmarouf,label:product;security] role-source-selection
  * A cross-checked Cloudflare Access principal's groups are the sole role source for
  * that request, so an empty group list grants no roles; a `jwt_only` Access principal
  * and an email principal resolve roles from the GCS config instead. The two sources
  * are never combined.
+ */
+/**
+ * @cc [owner:zmarouf,label:product] development-grants-all-roles
+ * When `isDevelopment()` is true, `getPokeRolesForPrincipal` returns every `PokeRole`
+ * after the caller has already authenticated, and does not consult Access groups or
+ * GCS.
  */
 export async function getPokeRolesForPrincipal(
   principal: PokeRolePrincipal
@@ -130,17 +136,19 @@ export async function getPokeRolesForPrincipal(
     return ALL_ROLES;
   }
 
-  if (
-    principal.kind === "cloudflare_access" &&
-    principal.user.identity.kind === "cross_checked"
-  ) {
-    return mapAccessGroupNamesToPokeRoles(principal.user.identity.groupNames);
+  switch (principal.kind) {
+    case "cloudflare_access":
+      if (principal.user.identity.kind === "cross_checked") {
+        return mapAccessGroupNamesToPokeRoles(
+          principal.user.identity.groupNames
+        );
+      }
+      return (await loadRoles())[principal.user.email] ?? [];
+    case "email":
+      return (await loadRoles())[principal.email] ?? [];
+    default:
+      return assertNever(principal);
   }
-
-  const email =
-    principal.kind === "email" ? principal.email : principal.user.email;
-  const roles = await loadRoles();
-  return roles[email] ?? [];
 }
 
 export function hasPokeRole(

--- a/front/lib/poke/roles.ts
+++ b/front/lib/poke/roles.ts
@@ -1,3 +1,4 @@
+import type { AuthenticatedAccessUser } from "@app/lib/api/poke/cloudflare_access";
 import { getPokeUserConfigBucket } from "@app/lib/file_storage";
 import logger from "@app/logger/logger";
 import { isDevelopment } from "@app/types/shared/env";
@@ -24,7 +25,38 @@ const CACHE_TTL_MS = 5 * 60 * 1000;
 let cachedRoles: RolesConfig | null = null;
 let cacheExpiresAtMs = 0;
 
+/** Test-only helper to clear the GCS roles cache between cases. */
+export function clearPokeRolesCacheForTests(): void {
+  cachedRoles = null;
+  cacheExpiresAtMs = 0;
+}
+
 const ALL_ROLES: PokeRole[] = PokeRoleSchema.options;
+
+/**
+ * IdP group names that grant each poke role. Keying by `PokeRole` forces a new
+ * role to declare its groups instead of silently granting nothing.
+ */
+const ACCESS_GROUPS_BY_ROLE: Record<PokeRole, readonly string[]> = {
+  admin: ["admin-mdm"],
+  billing: ["billing-mdm"],
+  engineering: ["engineering-mdm"],
+  support: ["support-mdm"],
+  talent: ["talent-mdm"],
+};
+
+const ROLE_BY_ACCESS_GROUP = new Map<string, PokeRole>(
+  ALL_ROLES.flatMap((role) =>
+    ACCESS_GROUPS_BY_ROLE[role].map(
+      (group) => [group.toLowerCase(), role] as const
+    )
+  )
+);
+
+/** A poke operator, discriminated by which role source applies to them. */
+export type PokeRolePrincipal =
+  | { kind: "cloudflare_access"; user: AuthenticatedAccessUser }
+  | { kind: "email"; email: string };
 
 async function loadRoles(): Promise<RolesConfig> {
   if (cachedRoles && Date.now() < cacheExpiresAtMs) {
@@ -54,10 +86,59 @@ async function loadRoles(): Promise<RolesConfig> {
   }
 }
 
-export async function getPokeRolesForUser(email: string): Promise<PokeRole[]> {
+/**
+ * @cc [label:product] mdm-group-mapping
+ * A group name grants a `PokeRole` only when it equals one of that role's entries in
+ * `ACCESS_GROUPS_BY_ROLE`, case-insensitively, either bare or as the local part of an
+ * `<group>@<domain>` address.
+ */
+function mapAccessGroupNamesToPokeRoles(
+  groupNames: readonly string[]
+): PokeRole[] {
+  const granted = new Set<PokeRole>();
+
+  for (const groupName of groupNames) {
+    const normalized = groupName.trim().toLowerCase();
+    const at = normalized.indexOf("@");
+    // Google groups surface either as a bare name or as a group address.
+    const localPart =
+      at === -1 ? normalized : normalized.slice(0, at).trimEnd();
+    if (at !== -1 && !/^[^@\s]+$/.test(normalized.slice(at + 1))) {
+      continue;
+    }
+
+    const role = ROLE_BY_ACCESS_GROUP.get(localPart);
+    if (role) {
+      granted.add(role);
+    }
+  }
+
+  return ALL_ROLES.filter((role) => granted.has(role));
+}
+
+/**
+ * @cc [label:product;security] role-source-selection
+ * A cross-checked Cloudflare Access principal's groups are the sole role source for
+ * that request, so an empty group list grants no roles; a `jwt_only` Access principal
+ * and an email principal resolve roles from the GCS config instead. The two sources
+ * are never combined.
+ */
+export async function getPokeRolesForPrincipal(
+  principal: PokeRolePrincipal
+): Promise<PokeRole[]> {
   if (isDevelopment()) {
     return ALL_ROLES;
   }
+
+  if (
+    principal.kind === "cloudflare_access" &&
+    principal.user.identity.kind === "cross_checked"
+  ) {
+    return mapAccessGroupNamesToPokeRoles(principal.user.identity.groupNames);
+  }
+
+  const email =
+    principal.kind === "email" ? principal.email : principal.user.email;
   const roles = await loadRoles();
   return roles[email] ?? [];
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Poke auth now treats Cloudflare Access as the source of truth: verify `Cf-Access-Jwt-Assertion`, call `get-identity` with only the `CF_Authorization` cookie, cross-check the two, and map Google groups `{role}-mdm` (`admin`, `billing`, `engineering`, `support`, `talent`) to poke roles.

Main pieces:
- `authenticateCloudflareAccess(headers)` in `front/lib/api/poke/cloudflare_access.ts` (cookie is never a JWT substitute)
- Config: `CLOUDFLARE_ACCESS_AUDIENCE` (alias `CLOUDFLARE_ACCESS_AUD`), optional CERTS/IDENTITY URLs, `IDENTITY_REQUIRED` (fail-closed unless `"false"`)
- `getPokeRolesForPrincipal` — cross-checked groups replace GCS; `jwt_only` / WorkOS keep the email map
- `GET /api/poke/auth-context` returns sanitized `accessUser` (no JWT/cookie)

No UI changes.

## Tests

Automated:
- `cd front && npm run test -- lib/api/poke/cloudflare_access.test.ts lib/poke/roles.test.ts` → 56 passed
- Lefthook pre-commit (biome, swagger annotations, docs check, ggshield) passed on the roles commit
- Code-contracts pass: `cc-check format` / `cc-check list --no-global` on Access auth, roles, `poke_auth`, and auth-context; backfilled `@cc` contracts and exhaustive switches where coding contracts required them

Manual:
- Not run end-to-end against live Cloudflare Access in this environment (needs a real Access app + AUD + operator login)

## Risk

- When Access is configured, a missing assertion header is a 401. Cookie-as-JWT and WorkOS fallback no longer apply for that deployment. If the API host is not behind Access, poke locks out.
- Empty cross-checked group lists grant no roles (GCS is not used). Removing someone from `*-mdm` takes effect immediately; a misconfigured IdP group list can drop plugins with no error UI.
- `IDENTITY_REQUIRED` defaults on. Set `CLOUDFLARE_ACCESS_IDENTITY_REQUIRED=false` only for a deliberate JWT-only / GCS roles rollout.
- Rollback: unset `CLOUDFLARE_ACCESS_AUDIENCE` / `CLOUDFLARE_ACCESS_AUD` (or revert the PR) to return to WorkOS + GCS email roles.

Main product WorkOS session auth is unchanged.

## Deploy Plan

1. Confirm poke API hostnames sit behind the Access application so `Cf-Access-Jwt-Assertion` is injected.
2. Copy the Application Audience (AUD) Tag from Zero Trust → Access → Applications → Configure → Overview / Additional settings. Set `CLOUDFLARE_ACCESS_AUDIENCE` (or keep `CLOUDFLARE_ACCESS_AUD`). Optionally set team domain / CERTS / IDENTITY URLs.
3. Confirm the Google IdP returns `*-mdm` groups on `get-identity`.
4. Deploy. If groups are not ready yet, temporarily set `CLOUDFLARE_ACCESS_IDENTITY_REQUIRED=false` so jwt_only falls back to GCS roles.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e611ac02-4b21-49e4-b3a2-aa5bd265c3fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e611ac02-4b21-49e4-b3a2-aa5bd265c3fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

