### PR TITLE
Show and edit the workspace default limit in EditMemberSpendLimitModal

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -9,6 +9,7 @@ import {
   seatTypeDisplayName,
 } from "@app/components/workspace/billing/seatTypeUtils";
 import { ChangeSeatModal } from "@app/components/workspace/ChangeSeatModal";
+import type { DefaultUserSpendLimitState } from "@app/components/workspace/EditMemberSpendLimitModal";
 import { EditMemberSpendLimitModal } from "@app/components/workspace/EditMemberSpendLimitModal";
 import { EditSpendLimitModal } from "@app/components/workspace/EditSpendLimitModal";
 import { GroupModelTierPickerDropdown } from "@app/components/workspace/GroupModelTierPickerDropdown";
@@ -313,11 +314,17 @@ export function UsagePage() {
     useState<MemberUsageType | null>(null);
   const [spendLimitRecapMember, setSpendLimitRecapMember] =
     useState<MemberUsageType | null>(null);
-  const { defaultUserSpendLimit, isDefaultUserSpendLimitLoading } =
+  const { defaultUserSpendLimit, isDefaultUserSpendLimitError } =
     useDefaultUserSpendLimit({
       workspaceId: owner.sId,
       disabled: spendLimitRecapMember === null,
     });
+  const defaultUserSpendLimitState: DefaultUserSpendLimitState =
+    defaultUserSpendLimit
+      ? { status: "ready", awuCredits: defaultUserSpendLimit.awuCredits }
+      : isDefaultUserSpendLimitError
+        ? { status: "error" }
+        : { status: "loading" };
   const [
     totalAllowedUsagePendingMemberIds,
     setTotalAllowedUsagePendingMemberIds,
@@ -1453,8 +1460,7 @@ export function UsagePage() {
           groups={groups}
           readOnly={!isManager(owner)}
           canEditDefaultLimit={isWorkspaceAdmin}
-          defaultUserSpendLimitAwuCredits={defaultUserSpendLimit?.awuCredits}
-          isDefaultUserSpendLimitLoading={isDefaultUserSpendLimitLoading}
+          defaultUserSpendLimit={defaultUserSpendLimitState}
         />
 
         <BulkEditSpendLimitModal

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -77,7 +77,10 @@ import {
   useResolveUpgradeRequest,
   useUpgradeRequests,
 } from "@app/lib/swr/upgrade_requests";
-import { useUsageSettings } from "@app/lib/swr/usage_settings";
+import {
+  useDefaultUserSpendLimit,
+  useUsageSettings,
+} from "@app/lib/swr/usage_settings";
 import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
 import type {
@@ -310,6 +313,11 @@ export function UsagePage() {
     useState<MemberUsageType | null>(null);
   const [spendLimitRecapMember, setSpendLimitRecapMember] =
     useState<MemberUsageType | null>(null);
+  const { defaultUserSpendLimit, isDefaultUserSpendLimitLoading } =
+    useDefaultUserSpendLimit({
+      workspaceId: owner.sId,
+      disabled: spendLimitRecapMember === null,
+    });
   const [
     totalAllowedUsagePendingMemberIds,
     setTotalAllowedUsagePendingMemberIds,
@@ -1444,6 +1452,8 @@ export function UsagePage() {
           owner={owner}
           groups={groups}
           readOnly={!isManager(owner)}
+          defaultUserSpendLimitAwuCredits={defaultUserSpendLimit?.awuCredits}
+          isDefaultUserSpendLimitLoading={isDefaultUserSpendLimitLoading}
         />
 
         <BulkEditSpendLimitModal

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -97,6 +97,7 @@ import {
 import {
   isCreditPricedPlan,
   isSubscriptionCancellationScheduled,
+  isSubscriptionMetronomeBilled,
 } from "@app/types/plan";
 import { isAdmin, isManager } from "@app/types/user";
 import {
@@ -314,17 +315,23 @@ export function UsagePage() {
     useState<MemberUsageType | null>(null);
   const [spendLimitRecapMember, setSpendLimitRecapMember] =
     useState<MemberUsageType | null>(null);
+  const hasMetronomeContract = isSubscriptionMetronomeBilled(subscription);
   const { defaultUserSpendLimit, isDefaultUserSpendLimitError } =
     useDefaultUserSpendLimit({
       workspaceId: owner.sId,
-      disabled: spendLimitRecapMember === null,
+      disabled: spendLimitRecapMember === null || !hasMetronomeContract,
     });
+  // Same availability rule as the workspace read endpoint and poke's
+  // PoolUsagePage: the default pool limit only exists for Metronome-billed
+  // workspaces.
   const defaultUserSpendLimitState: DefaultUserSpendLimitState =
-    defaultUserSpendLimit
-      ? { status: "ready", awuCredits: defaultUserSpendLimit.awuCredits }
-      : isDefaultUserSpendLimitError
-        ? { status: "error" }
-        : { status: "loading" };
+    !hasMetronomeContract
+      ? { status: "unavailable" }
+      : defaultUserSpendLimit
+        ? { status: "ready", awuCredits: defaultUserSpendLimit.awuCredits }
+        : isDefaultUserSpendLimitError
+          ? { status: "error" }
+          : { status: "loading" };
   const [
     totalAllowedUsagePendingMemberIds,
     setTotalAllowedUsagePendingMemberIds,

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -1452,6 +1452,7 @@ export function UsagePage() {
           owner={owner}
           groups={groups}
           readOnly={!isManager(owner)}
+          canEditDefaultLimit={isWorkspaceAdmin}
           defaultUserSpendLimitAwuCredits={defaultUserSpendLimit?.awuCredits}
           isDefaultUserSpendLimitLoading={isDefaultUserSpendLimitLoading}
         />

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -19,7 +19,6 @@ import { DEFAULT_MAX_MODEL_TIER } from "@app/lib/model_tiers/tier_order";
 import {
   usePokeAwuPoolCurrentCycle,
   usePokeAwuPoolCycleHistory,
-  usePokeDefaultUserSpendLimit,
   usePokeMembersUsage,
   usePokeSeatPlan,
 } from "@app/poke/swr/credits";
@@ -130,13 +129,6 @@ export function PoolUsagePage() {
     useState<MemberUsageType | null>(null);
   const [spendLimitRecapMember, setSpendLimitRecapMember] =
     useState<MemberUsageType | null>(null);
-  const {
-    defaultUserSpendLimit: pokeDefaultUserSpendLimit,
-    isDefaultUserSpendLimitLoading: isPokeDefaultUserSpendLimitLoading,
-  } = usePokeDefaultUserSpendLimit({
-    owner,
-    disabled: !spendLimitRecapMember,
-  });
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: DEFAULT_PAGE_SIZE,
@@ -172,6 +164,15 @@ export function PoolUsagePage() {
 
   const { data: workspaceInfo } = usePokeWorkspaceInfo({ owner });
   const activeSubscription = workspaceInfo?.activeSubscription;
+  // Same availability rule as the workspace read endpoint: the default pool
+  // limit only exists for Metronome-only billed workspaces. The value itself
+  // is already part of workspace-info, so no dedicated fetch is needed.
+  const isMetronomeOnlyBilled =
+    !!activeSubscription?.metronomeContractId &&
+    !activeSubscription.stripeSubscriptionId;
+  const defaultUserSpendLimitAwuCredits = isMetronomeOnlyBilled
+    ? (workspaceInfo?.creditUsageConfig?.defaultPoolCapAwuCredits ?? 0)
+    : undefined;
   const hasMetronomeContract =
     !!activeSubscription && isSubscriptionMetronomeBilled(activeSubscription);
   const isLegacyPremiumMessagePlan =
@@ -461,8 +462,8 @@ export function PoolUsagePage() {
         owner={owner}
         groups={groups}
         readOnly
-        defaultUserSpendLimitAwuCredits={pokeDefaultUserSpendLimit?.awuCredits}
-        isDefaultUserSpendLimitLoading={isPokeDefaultUserSpendLimitLoading}
+        defaultUserSpendLimitAwuCredits={defaultUserSpendLimitAwuCredits}
+        isDefaultUserSpendLimitLoading={!workspaceInfo}
         onClose={() => setSpendLimitRecapMember(null)}
       />
     </main>

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -4,6 +4,7 @@ import {
   SEAT_TYPE_ICONS,
   seatTypeDisplayName,
 } from "@app/components/workspace/billing/seatTypeUtils";
+import type { DefaultUserSpendLimitState } from "@app/components/workspace/EditMemberSpendLimitModal";
 import { EditMemberSpendLimitModal } from "@app/components/workspace/EditMemberSpendLimitModal";
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
 import { getSeatIconColorClass } from "@app/components/workspace/seat_styles";
@@ -162,19 +163,23 @@ export function PoolUsagePage() {
     setPagination((prev) => ({ ...prev, pageIndex: 0 }));
   }, []);
 
-  const { data: workspaceInfo } = usePokeWorkspaceInfo({ owner });
+  const { data: workspaceInfo, isError: isWorkspaceInfoError } =
+    usePokeWorkspaceInfo({ owner });
   const activeSubscription = workspaceInfo?.activeSubscription;
+  const hasMetronomeContract =
+    !!activeSubscription && isSubscriptionMetronomeBilled(activeSubscription);
   // Same availability rule as the workspace read endpoint: the default pool
   // limit only exists for Metronome-only billed workspaces. The value itself
   // is already part of workspace-info, so no dedicated fetch is needed.
-  const isMetronomeOnlyBilled =
-    !!activeSubscription?.metronomeContractId &&
-    !activeSubscription.stripeSubscriptionId;
-  const defaultUserSpendLimitAwuCredits = isMetronomeOnlyBilled
-    ? (workspaceInfo?.creditUsageConfig?.defaultPoolCapAwuCredits ?? 0)
-    : undefined;
-  const hasMetronomeContract =
-    !!activeSubscription && isSubscriptionMetronomeBilled(activeSubscription);
+  const defaultUserSpendLimit: DefaultUserSpendLimitState = !workspaceInfo
+    ? { status: isWorkspaceInfoError ? "error" : "loading" }
+    : hasMetronomeContract
+      ? {
+          status: "ready",
+          awuCredits:
+            workspaceInfo.creditUsageConfig?.defaultPoolCapAwuCredits ?? 0,
+        }
+      : { status: "unavailable" };
   const isLegacyPremiumMessagePlan =
     !!activeSubscription && !isCreditPricedPlan(activeSubscription.plan);
   const isLegacyWithoutPoolOrMetronome =
@@ -462,8 +467,7 @@ export function PoolUsagePage() {
         owner={owner}
         groups={groups}
         readOnly
-        defaultUserSpendLimitAwuCredits={defaultUserSpendLimitAwuCredits}
-        isDefaultUserSpendLimitLoading={!workspaceInfo}
+        defaultUserSpendLimit={defaultUserSpendLimit}
         onClose={() => setSpendLimitRecapMember(null)}
       />
     </main>

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -19,6 +19,7 @@ import { DEFAULT_MAX_MODEL_TIER } from "@app/lib/model_tiers/tier_order";
 import {
   usePokeAwuPoolCurrentCycle,
   usePokeAwuPoolCycleHistory,
+  usePokeDefaultUserSpendLimit,
   usePokeMembersUsage,
   usePokeSeatPlan,
 } from "@app/poke/swr/credits";
@@ -129,6 +130,13 @@ export function PoolUsagePage() {
     useState<MemberUsageType | null>(null);
   const [spendLimitRecapMember, setSpendLimitRecapMember] =
     useState<MemberUsageType | null>(null);
+  const {
+    defaultUserSpendLimit: pokeDefaultUserSpendLimit,
+    isDefaultUserSpendLimitLoading: isPokeDefaultUserSpendLimitLoading,
+  } = usePokeDefaultUserSpendLimit({
+    owner,
+    disabled: !spendLimitRecapMember,
+  });
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: DEFAULT_PAGE_SIZE,
@@ -453,6 +461,8 @@ export function PoolUsagePage() {
         owner={owner}
         groups={groups}
         readOnly
+        defaultUserSpendLimitAwuCredits={pokeDefaultUserSpendLimit?.awuCredits}
+        isDefaultUserSpendLimitLoading={isPokeDefaultUserSpendLimitLoading}
         onClose={() => setSpendLimitRecapMember(null)}
       />
     </main>

--- a/front/components/workspace/CreditLimitInput.tsx
+++ b/front/components/workspace/CreditLimitInput.tsx
@@ -1,4 +1,4 @@
-import { Chip, Input, Page } from "@dust-tt/sparkle";
+import { Chip, Input, Page, Tooltip } from "@dust-tt/sparkle";
 
 interface CreditLimitNumberInputProps {
   value: string;
@@ -40,6 +40,8 @@ interface CreditLimitInputProps {
   label: string;
   value: string;
   readOnly: boolean;
+  // Shown on hover when the field is read-only, to say why it is locked.
+  readOnlyTooltip?: string;
   isHighest: boolean;
   validationMessage: string | null;
   onChange: (cleaned: string) => void;
@@ -49,22 +51,35 @@ export function CreditLimitInput({
   label,
   value,
   readOnly,
+  readOnlyTooltip,
   isHighest,
   validationMessage,
   onChange,
 }: CreditLimitInputProps) {
+  const input = (
+    <CreditLimitNumberInput
+      value={value}
+      readOnly={readOnly}
+      validationMessage={validationMessage}
+      onChange={onChange}
+    />
+  );
   return (
     <Page.Vertical gap="xs" align="stretch">
       <div className="flex items-center gap-2">
         <span className="text-sm font-medium text-foreground">{label}</span>
         {isHighest && <Chip size="mini" color="highlight" label="Highest" />}
       </div>
-      <CreditLimitNumberInput
-        value={value}
-        readOnly={readOnly}
-        validationMessage={validationMessage}
-        onChange={onChange}
-      />
+      {readOnly && readOnlyTooltip ? (
+        <Tooltip
+          tooltipTriggerAsChild
+          label={readOnlyTooltip}
+          // Disabled inputs swallow hover events, so the trigger is a wrapper.
+          trigger={<div>{input}</div>}
+        />
+      ) : (
+        input
+      )}
     </Page.Vertical>
   );
 }

--- a/front/components/workspace/EditMemberSpendLimitModal.test.tsx
+++ b/front/components/workspace/EditMemberSpendLimitModal.test.tsx
@@ -35,10 +35,22 @@ function makeMember(
   });
 }
 
-function queryDefaultLimitInput(): HTMLElement | null {
-  const label = screen.queryByText("Workspace default limit");
+function queryLimitInput(labelText: string): HTMLElement | null {
+  const label = screen.queryByText(labelText);
   const container = label?.closest("div")?.parentElement;
   return container?.querySelector("input") ?? null;
+}
+
+function queryDefaultLimitInput(): HTMLElement | null {
+  return queryLimitInput("Workspace default limit");
+}
+
+function getPersonalLimitInput(): HTMLElement {
+  const input = queryLimitInput("Personal limit");
+  if (!input) {
+    throw new Error("Personal limit input not found");
+  }
+  return input;
 }
 
 function getDefaultLimitInput(): HTMLElement {
@@ -59,6 +71,7 @@ describe("EditMemberSpendLimitModal", () => {
         owner={owner}
         groups={groups}
         readOnly={false}
+        canEditDefaultLimit
         defaultUserSpendLimitAwuCredits={500}
         isDefaultUserSpendLimitLoading={false}
       />
@@ -66,6 +79,62 @@ describe("EditMemberSpendLimitModal", () => {
 
     expect(getDefaultLimitInput()).not.toBeDisabled();
     expect(getDefaultLimitInput()).toHaveValue("500");
+  });
+
+  it("locks the workspace default limit for managers while leaving the personal limit editable", () => {
+    render(
+      <EditMemberSpendLimitModal
+        isOpen
+        onClose={vi.fn()}
+        member={makeMember("default")}
+        owner={owner}
+        groups={groups}
+        readOnly={false}
+        canEditDefaultLimit={false}
+        defaultUserSpendLimitAwuCredits={500}
+        isDefaultUserSpendLimitLoading={false}
+      />
+    );
+
+    expect(getDefaultLimitInput()).toBeDisabled();
+    expect(getDefaultLimitInput()).toHaveValue("500");
+    expect(getPersonalLimitInput()).not.toBeDisabled();
+  });
+
+  it("does not block a manager's save while the workspace default is still loading", () => {
+    render(
+      <EditMemberSpendLimitModal
+        isOpen
+        onClose={vi.fn()}
+        member={makeMember("default")}
+        owner={owner}
+        groups={groups}
+        readOnly={false}
+        canEditDefaultLimit={false}
+        defaultUserSpendLimitAwuCredits={undefined}
+        isDefaultUserSpendLimitLoading
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Validate" })).not.toBeDisabled();
+  });
+
+  it("blocks an admin's save while the workspace default is still loading", () => {
+    render(
+      <EditMemberSpendLimitModal
+        isOpen
+        onClose={vi.fn()}
+        member={makeMember("default")}
+        owner={owner}
+        groups={groups}
+        readOnly={false}
+        canEditDefaultLimit
+        defaultUserSpendLimitAwuCredits={undefined}
+        isDefaultUserSpendLimitLoading
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Validate" })).toBeDisabled();
   });
 
   it("shows the caller-supplied default limit but disables editing for read-only viewers", () => {

--- a/front/components/workspace/EditMemberSpendLimitModal.test.tsx
+++ b/front/components/workspace/EditMemberSpendLimitModal.test.tsx
@@ -1,7 +1,8 @@
 import { makeMemberUsage } from "@app/tests/utils/MemberUsageFactory";
 import type { GroupType } from "@app/types/groups";
+import type { MembershipSeatType } from "@app/types/memberships";
 import type { LightWorkspaceType } from "@app/types/user";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { EditMemberSpendLimitModal } from "./EditMemberSpendLimitModal";
@@ -24,7 +25,8 @@ const owner = { sId: "wId_1" } as LightWorkspaceType;
 const groups: GroupType[] = [];
 
 function makeMember(
-  spendLimitSource: "default" | "override" | "group" | "none"
+  spendLimitSource: "default" | "override" | "group" | "none",
+  seatType: MembershipSeatType = "max"
 ) {
   return makeMemberUsage({
     sId: "user_1",
@@ -32,6 +34,7 @@ function makeMember(
     memberUsageLimit: 1000,
     spendLimitAwuCredits: 1000,
     spendLimitSource,
+    seatType,
   });
 }
 
@@ -72,8 +75,7 @@ describe("EditMemberSpendLimitModal", () => {
         groups={groups}
         readOnly={false}
         canEditDefaultLimit
-        defaultUserSpendLimitAwuCredits={500}
-        isDefaultUserSpendLimitLoading={false}
+        defaultUserSpendLimit={{ status: "ready", awuCredits: 500 }}
       />
     );
 
@@ -91,8 +93,7 @@ describe("EditMemberSpendLimitModal", () => {
         groups={groups}
         readOnly={false}
         canEditDefaultLimit={false}
-        defaultUserSpendLimitAwuCredits={500}
-        isDefaultUserSpendLimitLoading={false}
+        defaultUserSpendLimit={{ status: "ready", awuCredits: 500 }}
       />
     );
 
@@ -111,8 +112,7 @@ describe("EditMemberSpendLimitModal", () => {
         groups={groups}
         readOnly={false}
         canEditDefaultLimit={false}
-        defaultUserSpendLimitAwuCredits={undefined}
-        isDefaultUserSpendLimitLoading
+        defaultUserSpendLimit={{ status: "loading" }}
       />
     );
 
@@ -129,8 +129,7 @@ describe("EditMemberSpendLimitModal", () => {
         groups={groups}
         readOnly={false}
         canEditDefaultLimit
-        defaultUserSpendLimitAwuCredits={undefined}
-        isDefaultUserSpendLimitLoading
+        defaultUserSpendLimit={{ status: "loading" }}
       />
     );
 
@@ -146,8 +145,7 @@ describe("EditMemberSpendLimitModal", () => {
         owner={owner}
         groups={groups}
         readOnly
-        defaultUserSpendLimitAwuCredits={750}
-        isDefaultUserSpendLimitLoading={false}
+        defaultUserSpendLimit={{ status: "ready", awuCredits: 750 }}
       />
     );
 
@@ -164,13 +162,103 @@ describe("EditMemberSpendLimitModal", () => {
         owner={owner}
         groups={groups}
         readOnly
-        defaultUserSpendLimitAwuCredits={undefined}
-        isDefaultUserSpendLimitLoading
+        defaultUserSpendLimit={{ status: "loading" }}
       />
     );
 
     expect(getDefaultLimitInput()).toHaveValue("");
     expect(getDefaultLimitInput()).toHaveAttribute("placeholder", "--");
+  });
+
+  it("keeps a value typed in another field when the workspace default finishes loading", () => {
+    const { rerender } = render(
+      <EditMemberSpendLimitModal
+        isOpen
+        onClose={vi.fn()}
+        member={makeMember("default")}
+        owner={owner}
+        groups={groups}
+        readOnly={false}
+        canEditDefaultLimit={false}
+        defaultUserSpendLimit={{ status: "loading" }}
+      />
+    );
+    fireEvent.change(getPersonalLimitInput(), { target: { value: "2000" } });
+
+    rerender(
+      <EditMemberSpendLimitModal
+        isOpen
+        onClose={vi.fn()}
+        member={makeMember("default")}
+        owner={owner}
+        groups={groups}
+        readOnly={false}
+        canEditDefaultLimit={false}
+        defaultUserSpendLimit={{ status: "ready", awuCredits: 500 }}
+      />
+    );
+
+    expect(getPersonalLimitInput()).toHaveValue("2,000");
+    expect(getDefaultLimitInput()).toHaveValue("500");
+  });
+
+  it("locks only the workspace default field and shows a message when its fetch failed", () => {
+    render(
+      <EditMemberSpendLimitModal
+        isOpen
+        onClose={vi.fn()}
+        member={makeMember("default")}
+        owner={owner}
+        groups={groups}
+        readOnly={false}
+        canEditDefaultLimit
+        defaultUserSpendLimit={{ status: "error" }}
+      />
+    );
+
+    expect(getDefaultLimitInput()).toBeDisabled();
+    expect(
+      screen.getByText("The workspace default limit could not be loaded.")
+    ).toBeInTheDocument();
+    expect(getPersonalLimitInput()).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: "Validate" })).not.toBeDisabled();
+  });
+
+  it("hides the workspace default limit when the workspace has none", () => {
+    render(
+      <EditMemberSpendLimitModal
+        isOpen
+        onClose={vi.fn()}
+        member={makeMember("default")}
+        owner={owner}
+        groups={groups}
+        readOnly
+        defaultUserSpendLimit={{ status: "unavailable" }}
+      />
+    );
+
+    expect(queryDefaultLimitInput()).toBeNull();
+  });
+
+  it.each([
+    "free",
+    "none",
+  ] as const)("hides the workspace default limit for %s seats even when their source is default", (seatType) => {
+    render(
+      <EditMemberSpendLimitModal
+        isOpen
+        onClose={vi.fn()}
+        member={makeMember("default", seatType)}
+        owner={owner}
+        groups={groups}
+        readOnly={false}
+        canEditDefaultLimit
+        defaultUserSpendLimit={{ status: "ready", awuCredits: 500 }}
+      />
+    );
+
+    expect(queryDefaultLimitInput()).toBeNull();
+    expect(screen.getByRole("button", { name: "Validate" })).not.toBeDisabled();
   });
 
   it.each([
@@ -186,8 +274,7 @@ describe("EditMemberSpendLimitModal", () => {
         owner={owner}
         groups={groups}
         readOnly={false}
-        defaultUserSpendLimitAwuCredits={500}
-        isDefaultUserSpendLimitLoading={false}
+        defaultUserSpendLimit={{ status: "ready", awuCredits: 500 }}
       />
     );
 

--- a/front/components/workspace/EditMemberSpendLimitModal.test.tsx
+++ b/front/components/workspace/EditMemberSpendLimitModal.test.tsx
@@ -1,0 +1,127 @@
+import { makeMemberUsage } from "@app/tests/utils/MemberUsageFactory";
+import type { GroupType } from "@app/types/groups";
+import type { LightWorkspaceType } from "@app/types/user";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { EditMemberSpendLimitModal } from "./EditMemberSpendLimitModal";
+
+vi.mock("@app/lib/swr/usage_settings", () => ({
+  useUpdateDefaultUserSpendLimit: () => ({
+    doUpdateDefaultUserSpendLimit: vi.fn(),
+  }),
+}));
+
+vi.mock("@app/lib/swr/memberships", () => ({
+  useUpdateUserSpendLimit: () => ({ doUpdateSpendLimit: vi.fn() }),
+}));
+
+vi.mock("@app/lib/swr/groups", () => ({
+  useUpdateGroupSpendLimit: () => ({ doUpdateGroupSpendLimit: vi.fn() }),
+}));
+
+const owner = { sId: "wId_1" } as LightWorkspaceType;
+const groups: GroupType[] = [];
+
+function makeMember(
+  spendLimitSource: "default" | "override" | "group" | "none"
+) {
+  return makeMemberUsage({
+    sId: "user_1",
+    name: "Ada Lovelace",
+    memberUsageLimit: 1000,
+    spendLimitAwuCredits: 1000,
+    spendLimitSource,
+  });
+}
+
+function queryDefaultLimitInput(): HTMLElement | null {
+  const label = screen.queryByText("Workspace default limit");
+  const container = label?.closest("div")?.parentElement;
+  return container?.querySelector("input") ?? null;
+}
+
+function getDefaultLimitInput(): HTMLElement {
+  const input = queryDefaultLimitInput();
+  if (!input) {
+    throw new Error("Workspace default limit input not found");
+  }
+  return input;
+}
+
+describe("EditMemberSpendLimitModal", () => {
+  it("lets admins edit the workspace default limit when it's the member's applicable source", () => {
+    render(
+      <EditMemberSpendLimitModal
+        isOpen
+        onClose={vi.fn()}
+        member={makeMember("default")}
+        owner={owner}
+        groups={groups}
+        readOnly={false}
+        defaultUserSpendLimitAwuCredits={500}
+        isDefaultUserSpendLimitLoading={false}
+      />
+    );
+
+    expect(getDefaultLimitInput()).not.toBeDisabled();
+    expect(getDefaultLimitInput()).toHaveValue("500");
+  });
+
+  it("shows the caller-supplied default limit but disables editing for read-only viewers", () => {
+    render(
+      <EditMemberSpendLimitModal
+        isOpen
+        onClose={vi.fn()}
+        member={makeMember("default")}
+        owner={owner}
+        groups={groups}
+        readOnly
+        defaultUserSpendLimitAwuCredits={750}
+        isDefaultUserSpendLimitLoading={false}
+      />
+    );
+
+    expect(getDefaultLimitInput()).toBeDisabled();
+    expect(getDefaultLimitInput()).toHaveValue("750");
+  });
+
+  it("shows a placeholder instead of a real value while the caller's fetch hasn't resolved yet", () => {
+    render(
+      <EditMemberSpendLimitModal
+        isOpen
+        onClose={vi.fn()}
+        member={makeMember("default")}
+        owner={owner}
+        groups={groups}
+        readOnly
+        defaultUserSpendLimitAwuCredits={undefined}
+        isDefaultUserSpendLimitLoading
+      />
+    );
+
+    expect(getDefaultLimitInput()).toHaveValue("");
+    expect(getDefaultLimitInput()).toHaveAttribute("placeholder", "--");
+  });
+
+  it.each([
+    "override",
+    "group",
+    "none",
+  ] as const)("hides the workspace default limit when the member's applicable source is %s", (spendLimitSource) => {
+    render(
+      <EditMemberSpendLimitModal
+        isOpen
+        onClose={vi.fn()}
+        member={makeMember(spendLimitSource)}
+        owner={owner}
+        groups={groups}
+        readOnly={false}
+        defaultUserSpendLimitAwuCredits={500}
+        isDefaultUserSpendLimitLoading={false}
+      />
+    );
+
+    expect(queryDefaultLimitInput()).toBeNull();
+  });
+});

--- a/front/components/workspace/EditMemberSpendLimitModal.test.tsx
+++ b/front/components/workspace/EditMemberSpendLimitModal.test.tsx
@@ -1,7 +1,7 @@
+import { LightWorkspaceFactory } from "@app/tests/utils/LightWorkspaceFactory";
 import { makeMemberUsage } from "@app/tests/utils/MemberUsageFactory";
 import type { GroupType } from "@app/types/groups";
 import type { MembershipSeatType } from "@app/types/memberships";
-import type { LightWorkspaceType } from "@app/types/user";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -21,7 +21,7 @@ vi.mock("@app/lib/swr/groups", () => ({
   useUpdateGroupSpendLimit: () => ({ doUpdateGroupSpendLimit: vi.fn() }),
 }));
 
-const owner = { sId: "wId_1" } as LightWorkspaceType;
+const owner = LightWorkspaceFactory.build({ sId: "wId_1" });
 const groups: GroupType[] = [];
 
 function makeMember(

--- a/front/components/workspace/EditMemberSpendLimitModal.tsx
+++ b/front/components/workspace/EditMemberSpendLimitModal.tsx
@@ -13,6 +13,7 @@ import { useUpdateUserSpendLimit } from "@app/lib/swr/memberships";
 import { useUpdateDefaultUserSpendLimit } from "@app/lib/swr/usage_settings";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { GroupType } from "@app/types/groups";
+import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Avatar,
@@ -30,6 +31,17 @@ import { useEffect, useMemo, useRef, useState } from "react";
 // TODO(spend-limit-modal-rollout): remove `EditSpendLimitModal`
 // once the usage page has fully rolled onto this
 // component, so there's a single spend-limit editing implementation again.
+// The bulk edit modal stays: it covers a different flow.
+
+// Fetched by the caller since the customer-facing app and poke reach the
+// value through different routes. "unavailable" means the workspace has no
+// default pool limit at all, so the field is not shown.
+export type DefaultUserSpendLimitState =
+  | { status: "loading" }
+  | { status: "error" }
+  | { status: "unavailable" }
+  | { status: "ready"; awuCredits: number };
+
 interface EditMemberSpendLimitModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -40,11 +52,7 @@ interface EditMemberSpendLimitModalProps {
   // The workspace default applies to every member, so editing it is reserved
   // to admins even where managers may edit personal and group limits.
   canEditDefaultLimit?: boolean;
-  // Fetched by the caller, same as `member`/`groups`: the customer-facing app
-  // and poke reach this value through different routes (workspace-role-gated
-  // vs. poke's superuser-scoped route), so the modal itself never fetches it.
-  defaultUserSpendLimitAwuCredits: number | undefined;
-  isDefaultUserSpendLimitLoading: boolean;
+  defaultUserSpendLimit: DefaultUserSpendLimitState;
 }
 
 interface MemberSpendLimitFormProps {
@@ -53,10 +61,7 @@ interface MemberSpendLimitFormProps {
   groups: GroupType[];
   readOnly: boolean;
   canEditDefaultLimit: boolean;
-  // Undefined while the workspace default is still being fetched: the field
-  // then shows a "--" placeholder rather than a real 0, and saving is
-  // blocked until it resolves (see `isDefaultLimitPending` below).
-  defaultLimitAwuCredits: number | undefined;
+  defaultUserSpendLimit: DefaultUserSpendLimitState;
   onClose: () => void;
 }
 
@@ -66,7 +71,7 @@ function MemberSpendLimitForm({
   groups,
   readOnly,
   canEditDefaultLimit,
-  defaultLimitAwuCredits,
+  defaultUserSpendLimit,
   onClose,
 }: MemberSpendLimitFormProps) {
   const { doUpdateSpendLimit } = useUpdateUserSpendLimit({
@@ -78,19 +83,40 @@ function MemberSpendLimitForm({
   const { doUpdateDefaultUserSpendLimit } = useUpdateDefaultUserSpendLimit({
     workspaceId: owner.sId,
   });
-  const isDefaultHighest = member?.spendLimitSource === "default";
+  // The "default" source also labels free and none seats, whose cap is the
+  // seat allowance (or 0) rather than the workspace pool default. Only
+  // pool-bearing seats are actually capped by the workspace default.
+  const isDefaultHighest =
+    member?.spendLimitSource === "default" &&
+    normalizeToPoolLimitSeatType(member.seatType) !== null;
+  const showDefaultLimit =
+    isDefaultHighest && defaultUserSpendLimit.status !== "unavailable";
   const canChangeDefaultLimit =
-    isDefaultHighest && canEditDefaultLimit && !readOnly;
+    showDefaultLimit && canEditDefaultLimit && !readOnly;
+  const isDefaultLimitLoaded = defaultUserSpendLimit.status === "ready";
+  const loadedDefaultLimitAwuCredits = isDefaultLimitLoaded
+    ? defaultUserSpendLimit.awuCredits
+    : undefined;
   // While the workspace default is still loading, block saving instead of
   // treating the unresolved value as unchanged (which would let an admin
   // silently commit whatever ends up in the input once it finally arrives).
-  // Viewers who cannot edit it are not held back by its loading state.
+  // Viewers who cannot edit it are not held back by its loading state, and a
+  // failed fetch only locks this field rather than the whole form.
   const isDefaultLimitPending =
-    canChangeDefaultLimit && defaultLimitAwuCredits === undefined;
+    canChangeDefaultLimit && defaultUserSpendLimit.status === "loading";
+  const canSubmitDefaultLimit = canChangeDefaultLimit && isDefaultLimitLoaded;
 
-  const [defaultLimitInput, setDefaultLimitInput] = useState<string>(() =>
-    defaultLimitAwuCredits !== undefined ? String(defaultLimitAwuCredits) : ""
+  // The draft stays null until the user types, so the loaded value can show
+  // up once fetched without remounting the form (which would drop whatever
+  // was typed in the other fields meanwhile).
+  const [defaultLimitDraft, setDefaultLimitDraft] = useState<string | null>(
+    null
   );
+  const defaultLimitInput =
+    defaultLimitDraft ??
+    (loadedDefaultLimitAwuCredits !== undefined
+      ? String(loadedDefaultLimitAwuCredits)
+      : "");
   const [defaultLimitValidationMessage, setDefaultLimitValidationMessage] =
     useState<string | null>(null);
 
@@ -161,9 +187,10 @@ function MemberSpendLimitForm({
       )
     );
 
-    // Only validated when this viewer may change it, so a locked field can
-    // never block saving the other limits.
-    const defaultLimitResult = canChangeDefaultLimit
+    // Only validated when this viewer may change it and the current value is
+    // known, so a locked or unloaded field can never block saving the other
+    // limits.
+    const defaultLimitResult = canSubmitDefaultLimit
       ? parseDefaultLimitInput(defaultLimitInput)
       : null;
     setDefaultLimitValidationMessage(
@@ -189,7 +216,7 @@ function MemberSpendLimitForm({
     );
     const newDefaultLimit =
       defaultLimitResult?.ok &&
-      defaultLimitResult.awuCredits !== defaultLimitAwuCredits
+      defaultLimitResult.awuCredits !== loadedDefaultLimitAwuCredits
         ? defaultLimitResult.awuCredits
         : null;
 
@@ -272,7 +299,7 @@ function MemberSpendLimitForm({
       </DialogHeader>
       <DialogContainer>
         <div className="flex flex-col gap-5">
-          {isDefaultHighest && (
+          {showDefaultLimit && (
             // Only relevant when the workspace default is actually what
             // caps this member: no personal override, and no group they're
             // in carries its own cap. Otherwise editing it here wouldn't
@@ -280,16 +307,20 @@ function MemberSpendLimitForm({
             <CreditLimitInput
               label="Workspace default limit"
               value={defaultLimitInput}
-              readOnly={!canChangeDefaultLimit}
+              readOnly={!canSubmitDefaultLimit}
               readOnlyTooltip={
                 !readOnly && !canEditDefaultLimit
                   ? "Only workspace admins can edit the workspace default limit."
                   : undefined
               }
               isHighest={false}
-              validationMessage={defaultLimitValidationMessage}
+              validationMessage={
+                defaultUserSpendLimit.status === "error"
+                  ? "The workspace default limit could not be loaded."
+                  : defaultLimitValidationMessage
+              }
               onChange={(cleaned) => {
-                setDefaultLimitInput(cleaned);
+                setDefaultLimitDraft(cleaned);
                 setDefaultLimitValidationMessage(null);
               }}
             />
@@ -349,8 +380,7 @@ export function EditMemberSpendLimitModal({
   groups,
   readOnly = false,
   canEditDefaultLimit = false,
-  defaultUserSpendLimitAwuCredits,
-  isDefaultUserSpendLimitLoading,
+  defaultUserSpendLimit,
 }: EditMemberSpendLimitModalProps) {
   const lastMemberRef = useRef<MemberUsageType | null>(null);
   useEffect(() => {
@@ -369,16 +399,15 @@ export function EditMemberSpendLimitModal({
       <DialogContent size="md" className="font-sans">
         <MemberSpendLimitForm
           // Remounts with fresh draft state on every open, whenever the
-          // targeted member changes, once the member's groups resolve, or
-          // once the workspace default limit finishes loading, instead of
-          // syncing state from props.
-          key={`${displayedMember?.sId ?? "none"}:${isOpen}:${memberGroupsResolved}:${isDefaultUserSpendLimitLoading}`}
+          // targeted member changes, or once the member's groups resolve,
+          // instead of syncing state from props.
+          key={`${displayedMember?.sId ?? "none"}:${isOpen}:${memberGroupsResolved}`}
           member={displayedMember}
           owner={owner}
           groups={groups}
           readOnly={readOnly}
           canEditDefaultLimit={canEditDefaultLimit}
-          defaultLimitAwuCredits={defaultUserSpendLimitAwuCredits}
+          defaultUserSpendLimit={defaultUserSpendLimit}
           onClose={onClose}
         />
       </DialogContent>

--- a/front/components/workspace/EditMemberSpendLimitModal.tsx
+++ b/front/components/workspace/EditMemberSpendLimitModal.tsx
@@ -37,6 +37,9 @@ interface EditMemberSpendLimitModalProps {
   owner: LightWorkspaceType;
   groups: GroupType[];
   readOnly?: boolean;
+  // The workspace default applies to every member, so editing it is reserved
+  // to admins even where managers may edit personal and group limits.
+  canEditDefaultLimit?: boolean;
   // Fetched by the caller, same as `member`/`groups`: the customer-facing app
   // and poke reach this value through different routes (workspace-role-gated
   // vs. poke's superuser-scoped route), so the modal itself never fetches it.
@@ -49,6 +52,7 @@ interface MemberSpendLimitFormProps {
   owner: LightWorkspaceType;
   groups: GroupType[];
   readOnly: boolean;
+  canEditDefaultLimit: boolean;
   // Undefined while the workspace default is still being fetched: the field
   // then shows a "--" placeholder rather than a real 0, and saving is
   // blocked until it resolves (see `isDefaultLimitPending` below).
@@ -61,6 +65,7 @@ function MemberSpendLimitForm({
   owner,
   groups,
   readOnly,
+  canEditDefaultLimit,
   defaultLimitAwuCredits,
   onClose,
 }: MemberSpendLimitFormProps) {
@@ -74,11 +79,14 @@ function MemberSpendLimitForm({
     workspaceId: owner.sId,
   });
   const isDefaultHighest = member?.spendLimitSource === "default";
+  const canChangeDefaultLimit =
+    isDefaultHighest && canEditDefaultLimit && !readOnly;
   // While the workspace default is still loading, block saving instead of
   // treating the unresolved value as unchanged (which would let an admin
   // silently commit whatever ends up in the input once it finally arrives).
+  // Viewers who cannot edit it are not held back by its loading state.
   const isDefaultLimitPending =
-    isDefaultHighest && defaultLimitAwuCredits === undefined;
+    canChangeDefaultLimit && defaultLimitAwuCredits === undefined;
 
   const [defaultLimitInput, setDefaultLimitInput] = useState<string>(() =>
     defaultLimitAwuCredits !== undefined ? String(defaultLimitAwuCredits) : ""
@@ -153,14 +161,20 @@ function MemberSpendLimitForm({
       )
     );
 
-    const defaultLimitResult = parseDefaultLimitInput(defaultLimitInput);
+    // Only validated when this viewer may change it, so a locked field can
+    // never block saving the other limits.
+    const defaultLimitResult = canChangeDefaultLimit
+      ? parseDefaultLimitInput(defaultLimitInput)
+      : null;
     setDefaultLimitValidationMessage(
-      defaultLimitResult.ok ? null : defaultLimitResult.message
+      defaultLimitResult && !defaultLimitResult.ok
+        ? defaultLimitResult.message
+        : null
     );
 
     if (
       !personalResult.ok ||
-      !defaultLimitResult.ok ||
+      (defaultLimitResult && !defaultLimitResult.ok) ||
       groupResults.some(({ result }) => !result.ok)
     ) {
       return;
@@ -173,10 +187,17 @@ function MemberSpendLimitForm({
         ? [{ row, awuCredits: result.awuCredits }]
         : []
     );
-    const defaultLimitChanged =
-      defaultLimitResult.awuCredits !== defaultLimitAwuCredits;
+    const newDefaultLimit =
+      defaultLimitResult?.ok &&
+      defaultLimitResult.awuCredits !== defaultLimitAwuCredits
+        ? defaultLimitResult.awuCredits
+        : null;
 
-    if (!personalChanged && !defaultLimitChanged && groupChanges.length === 0) {
+    if (
+      !personalChanged &&
+      newDefaultLimit === null &&
+      groupChanges.length === 0
+    ) {
       onClose();
       return;
     }
@@ -184,10 +205,8 @@ function MemberSpendLimitForm({
     setIsSaving(true);
     try {
       const tasks: Array<() => Promise<unknown>> = [];
-      if (defaultLimitChanged) {
-        tasks.push(() =>
-          doUpdateDefaultUserSpendLimit(defaultLimitResult.awuCredits)
-        );
+      if (newDefaultLimit !== null) {
+        tasks.push(() => doUpdateDefaultUserSpendLimit(newDefaultLimit));
       }
       if (personalChanged) {
         const limit = toSpendLimit(personalResult.awuCredits);
@@ -261,10 +280,14 @@ function MemberSpendLimitForm({
             <CreditLimitInput
               label="Workspace default limit"
               value={defaultLimitInput}
-              readOnly={readOnly}
+              readOnly={!canChangeDefaultLimit}
+              readOnlyTooltip={
+                !readOnly && !canEditDefaultLimit
+                  ? "Only workspace admins can edit the workspace default limit."
+                  : undefined
+              }
               isHighest={false}
               validationMessage={defaultLimitValidationMessage}
-              placeholder="--"
               onChange={(cleaned) => {
                 setDefaultLimitInput(cleaned);
                 setDefaultLimitValidationMessage(null);
@@ -325,6 +348,7 @@ export function EditMemberSpendLimitModal({
   owner,
   groups,
   readOnly = false,
+  canEditDefaultLimit = false,
   defaultUserSpendLimitAwuCredits,
   isDefaultUserSpendLimitLoading,
 }: EditMemberSpendLimitModalProps) {
@@ -353,6 +377,7 @@ export function EditMemberSpendLimitModal({
           owner={owner}
           groups={groups}
           readOnly={readOnly}
+          canEditDefaultLimit={canEditDefaultLimit}
           defaultLimitAwuCredits={defaultUserSpendLimitAwuCredits}
           onClose={onClose}
         />

--- a/front/components/workspace/EditMemberSpendLimitModal.tsx
+++ b/front/components/workspace/EditMemberSpendLimitModal.tsx
@@ -13,7 +13,10 @@ import { useUpdateUserSpendLimit } from "@app/lib/swr/memberships";
 import { useUpdateDefaultUserSpendLimit } from "@app/lib/swr/usage_settings";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { GroupType } from "@app/types/groups";
-import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
+import {
+  isMembershipSeatType,
+  normalizeToPoolLimitSeatType,
+} from "@app/types/memberships";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Avatar,
@@ -85,9 +88,13 @@ function MemberSpendLimitForm({
   });
   // The "default" source also labels free and none seats, whose cap is the
   // seat allowance (or 0) rather than the workspace pool default. Only
-  // pool-bearing seats are actually capped by the workspace default.
+  // pool-bearing seats are actually capped by the workspace default. The
+  // server may have introduced a seat type the client hasn't refreshed to
+  // know about yet, so unrecognized values are treated as non-pool rather
+  // than passed to the exhaustive normalizer.
   const isDefaultHighest =
     member?.spendLimitSource === "default" &&
+    isMembershipSeatType(member.seatType) &&
     normalizeToPoolLimitSeatType(member.seatType) !== null;
   const showDefaultLimit =
     isDefaultHighest && defaultUserSpendLimit.status !== "unavailable";

--- a/front/components/workspace/EditMemberSpendLimitModal.tsx
+++ b/front/components/workspace/EditMemberSpendLimitModal.tsx
@@ -3,12 +3,14 @@ import { MemberGroupLimitTable } from "@app/components/workspace/MemberGroupLimi
 import {
   groupRowsForMember,
   parseCreditsInput,
+  parseDefaultLimitInput,
   toSpendLimit,
 } from "@app/components/workspace/member_spend_limit_helpers";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { formatCredits } from "@app/lib/client/credits";
 import { useUpdateGroupSpendLimit } from "@app/lib/swr/groups";
 import { useUpdateUserSpendLimit } from "@app/lib/swr/memberships";
+import { useUpdateDefaultUserSpendLimit } from "@app/lib/swr/usage_settings";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { GroupType } from "@app/types/groups";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -25,8 +27,8 @@ import {
 } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-// TODO(spend-limit-modal-rollout): remove `EditSpendLimitModal` and
-// `BulkEditSpendLimitModal` once the usage page has fully rolled onto this
+// TODO(spend-limit-modal-rollout): remove `EditSpendLimitModal`
+// once the usage page has fully rolled onto this
 // component, so there's a single spend-limit editing implementation again.
 interface EditMemberSpendLimitModalProps {
   isOpen: boolean;
@@ -35,6 +37,11 @@ interface EditMemberSpendLimitModalProps {
   owner: LightWorkspaceType;
   groups: GroupType[];
   readOnly?: boolean;
+  // Fetched by the caller, same as `member`/`groups`: the customer-facing app
+  // and poke reach this value through different routes (workspace-role-gated
+  // vs. poke's superuser-scoped route), so the modal itself never fetches it.
+  defaultUserSpendLimitAwuCredits: number | undefined;
+  isDefaultUserSpendLimitLoading: boolean;
 }
 
 interface MemberSpendLimitFormProps {
@@ -42,6 +49,10 @@ interface MemberSpendLimitFormProps {
   owner: LightWorkspaceType;
   groups: GroupType[];
   readOnly: boolean;
+  // Undefined while the workspace default is still being fetched: the field
+  // then shows a "--" placeholder rather than a real 0, and saving is
+  // blocked until it resolves (see `isDefaultLimitPending` below).
+  defaultLimitAwuCredits: number | undefined;
   onClose: () => void;
 }
 
@@ -50,6 +61,7 @@ function MemberSpendLimitForm({
   owner,
   groups,
   readOnly,
+  defaultLimitAwuCredits,
   onClose,
 }: MemberSpendLimitFormProps) {
   const { doUpdateSpendLimit } = useUpdateUserSpendLimit({
@@ -58,6 +70,21 @@ function MemberSpendLimitForm({
   const { doUpdateGroupSpendLimit } = useUpdateGroupSpendLimit({
     workspaceId: owner.sId,
   });
+  const { doUpdateDefaultUserSpendLimit } = useUpdateDefaultUserSpendLimit({
+    workspaceId: owner.sId,
+  });
+  const isDefaultHighest = member?.spendLimitSource === "default";
+  // While the workspace default is still loading, block saving instead of
+  // treating the unresolved value as unchanged (which would let an admin
+  // silently commit whatever ends up in the input once it finally arrives).
+  const isDefaultLimitPending =
+    isDefaultHighest && defaultLimitAwuCredits === undefined;
+
+  const [defaultLimitInput, setDefaultLimitInput] = useState<string>(() =>
+    defaultLimitAwuCredits !== undefined ? String(defaultLimitAwuCredits) : ""
+  );
+  const [defaultLimitValidationMessage, setDefaultLimitValidationMessage] =
+    useState<string | null>(null);
 
   const seatAllowanceAwuCredits = member?.memberUsageLimit ?? 0;
   const effectiveLimitAwuCredits = member?.spendLimitAwuCredits ?? 0;
@@ -106,7 +133,7 @@ function MemberSpendLimitForm({
   }
 
   async function handleValidate() {
-    if (!member) {
+    if (!member || isDefaultLimitPending) {
       return;
     }
 
@@ -126,7 +153,16 @@ function MemberSpendLimitForm({
       )
     );
 
-    if (!personalResult.ok || groupResults.some(({ result }) => !result.ok)) {
+    const defaultLimitResult = parseDefaultLimitInput(defaultLimitInput);
+    setDefaultLimitValidationMessage(
+      defaultLimitResult.ok ? null : defaultLimitResult.message
+    );
+
+    if (
+      !personalResult.ok ||
+      !defaultLimitResult.ok ||
+      groupResults.some(({ result }) => !result.ok)
+    ) {
       return;
     }
 
@@ -137,8 +173,10 @@ function MemberSpendLimitForm({
         ? [{ row, awuCredits: result.awuCredits }]
         : []
     );
+    const defaultLimitChanged =
+      defaultLimitResult.awuCredits !== defaultLimitAwuCredits;
 
-    if (!personalChanged && groupChanges.length === 0) {
+    if (!personalChanged && !defaultLimitChanged && groupChanges.length === 0) {
       onClose();
       return;
     }
@@ -146,6 +184,11 @@ function MemberSpendLimitForm({
     setIsSaving(true);
     try {
       const tasks: Array<() => Promise<unknown>> = [];
+      if (defaultLimitChanged) {
+        tasks.push(() =>
+          doUpdateDefaultUserSpendLimit(defaultLimitResult.awuCredits)
+        );
+      }
       if (personalChanged) {
         const limit = toSpendLimit(personalResult.awuCredits);
         tasks.push(() =>
@@ -210,6 +253,25 @@ function MemberSpendLimitForm({
       </DialogHeader>
       <DialogContainer>
         <div className="flex flex-col gap-5">
+          {isDefaultHighest && (
+            // Only relevant when the workspace default is actually what
+            // caps this member: no personal override, and no group they're
+            // in carries its own cap. Otherwise editing it here wouldn't
+            // change this member's effective limit.
+            <CreditLimitInput
+              label="Workspace default limit"
+              value={defaultLimitInput}
+              readOnly={readOnly}
+              isHighest={false}
+              validationMessage={defaultLimitValidationMessage}
+              placeholder="--"
+              onChange={(cleaned) => {
+                setDefaultLimitInput(cleaned);
+                setDefaultLimitValidationMessage(null);
+              }}
+            />
+          )}
+
           <CreditLimitInput
             label="Personal limit"
             value={personalLimitInput}
@@ -247,7 +309,7 @@ function MemberSpendLimitForm({
         rightButtonProps={{
           label: "Validate",
           variant: "highlight",
-          disabled: isSaving || readOnly,
+          disabled: isSaving || readOnly || isDefaultLimitPending,
           isLoading: isSaving,
           onClick: handleValidate,
         }}
@@ -263,6 +325,8 @@ export function EditMemberSpendLimitModal({
   owner,
   groups,
   readOnly = false,
+  defaultUserSpendLimitAwuCredits,
+  isDefaultUserSpendLimitLoading,
 }: EditMemberSpendLimitModalProps) {
   const lastMemberRef = useRef<MemberUsageType | null>(null);
   useEffect(() => {
@@ -281,13 +345,15 @@ export function EditMemberSpendLimitModal({
       <DialogContent size="md" className="font-sans">
         <MemberSpendLimitForm
           // Remounts with fresh draft state on every open, whenever the
-          // targeted member changes, or once the member's groups resolve,
-          // instead of syncing state from props.
-          key={`${displayedMember?.sId ?? "none"}:${isOpen}:${memberGroupsResolved}`}
+          // targeted member changes, once the member's groups resolve, or
+          // once the workspace default limit finishes loading, instead of
+          // syncing state from props.
+          key={`${displayedMember?.sId ?? "none"}:${isOpen}:${memberGroupsResolved}:${isDefaultUserSpendLimitLoading}`}
           member={displayedMember}
           owner={owner}
           groups={groups}
           readOnly={readOnly}
+          defaultLimitAwuCredits={defaultUserSpendLimitAwuCredits}
           onClose={onClose}
         />
       </DialogContent>


### PR DESCRIPTION
## Description

Stack 4/4, on #32151.
- When the workspace default is the member's applicable limit, the modal shows a "Workspace default limit" field. Only for pool-bearing seats: the "default" source also labels free and none seats, whose cap is the seat allowance (or 0), not the workspace default.
- Admins edit it. Managers see it locked with a tooltip explaining only admins can change it, while personal and group limits stay editable for them. Poke stays read-only.
- Value is fetched by the caller (usage page or poke) and passed in as a single state: loading, error, unavailable, or ready. Saving is blocked while it loads only for viewers who can edit it, so a manager is never held back by that field. A failed fetch locks only that field with a message, the other limits can still be saved. Poke passes "unavailable" for workspaces without a default pool limit (not Metronome-only billed), which hides the field.
- The form no longer remounts when the default finishes loading, so values typed in the other fields meanwhile are kept.

## Tests

`EditMemberSpendLimitModal.test.tsx` (14 tests): admin editable, manager locked with personal limit still editable, read-only viewer, loading placeholder, loading blocks admin save but not manager save, typed value survives loading→ready, error locks only the default field, hidden when unavailable, hidden for free/none seats, hidden when a personal or group cap applies. Manual: edit the default as admin, row updates; locked with tooltip as manager.

## Risk

Low, additive and edit scoped to admins.

## Deploy Plan

Deploy front.
