### PR TITLE
feat: hide microUsd in consumption export

### DIFF
--- a/front/lib/api/analytics/consumption/export_lines.ts
+++ b/front/lib/api/analytics/consumption/export_lines.ts
@@ -56,7 +56,6 @@ type ConsumptionLineExportRow = {
   creditsReasoning: number;
   creditsDirect: number;
   totalCredits: number;
-  costMicroUsd: number;
   usageType: string;
   status: string;
   stepIndex: number;
@@ -101,7 +100,6 @@ const CONSUMPTION_LINE_EXPORT_HEADERS: (keyof ConsumptionLineExportRow)[] = [
   "creditsReasoning",
   "creditsDirect",
   "totalCredits",
-  "costMicroUsd",
   "usageType",
   "status",
   "stepIndex",
@@ -255,7 +253,6 @@ async function buildConsumptionLineExportRows(
         microCreditsToCredits(gross.direct ?? 0)
       ),
       totalCredits: roundToTwoDecimals(microCreditsToCredits(doc.credit_micro)),
-      costMicroUsd: doc.micro_usd ?? 0,
       usageType: doc.usage_type,
       status: doc.status,
       stepIndex: doc.step_index,


### PR DESCRIPTION
## Description

field added in #31934 that we have no reason to expose in export at this point. removing it from the export.

## Tests

downloaded export locally

## Risk

Low

## Deploy Plan

Front