### PR TITLE
feat(front): pre-fill templates for the Switch Contract modal

### DIFF
--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -593,6 +593,11 @@ export default function SwitchContractDialog({
         setDurationUnit(template.duration.unit);
         setDurationMode(true);
       }
+      // A promotional free leading period.
+      if (template.offerFreePeriod) {
+        setOfferValue(template.offerFreePeriod.value);
+        setOfferUnit(template.offerFreePeriod.unit);
+      }
     },
     [form]
   );
@@ -614,6 +619,8 @@ export default function SwitchContractDialog({
       setDurationMode(false);
       setDurationValue(1);
       setDurationUnit("years");
+      setOfferValue(0);
+      setOfferUnit("weeks");
       pendingTemplateRef.current = null;
 
       const packageId = resolveTemplatePackageId(template);

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -283,9 +283,8 @@ export default function SwitchContractDialog({
   // The credit-priced usage cap lives on `credit_usage_configuration.usageCapCredits`
   // and is managed via the "Manage Credit Usage Configuration" plugin — operators
   // enter the desired cap (in AWU credits) fresh when switching contracts.
-  const form = useForm<SwitchContractFormValues>({
-    resolver: zodResolver(SwitchContractFormSchema),
-    defaultValues: {
+  const formDefaults: SwitchContractFormValues = useMemo(
+    () => ({
       metronomePackageId: "",
       planCode: "",
       hubspotDealId: "",
@@ -311,7 +310,12 @@ export default function SwitchContractDialog({
       scheduledCharge: undefined,
       recurringFreeCredit: undefined,
       seats: {},
-    },
+    }),
+    [stripeCustomerId]
+  );
+  const form = useForm<SwitchContractFormValues>({
+    resolver: zodResolver(SwitchContractFormSchema),
+    defaultValues: formDefaults,
   });
 
   const watchedStripeCustomerId = form.watch("stripeCustomerId");
@@ -597,17 +601,32 @@ export default function SwitchContractDialog({
     (template: SwitchContractTemplate) => {
       setError(null);
       setAppliedTemplateName(template.name);
+      // Start from a blank form so no field from a previously applied template
+      // lingers. The billing identity (Stripe customer + currency) is preserved
+      // since it identifies the customer, not the contract shape.
+      const current = form.getValues();
+      form.reset({
+        ...formDefaults,
+        stripeCustomerId: current.stripeCustomerId,
+        stripeCollectionMethod: current.stripeCollectionMethod,
+        manualCurrency: current.manualCurrency,
+      });
+      setDurationMode(false);
+      setDurationValue(1);
+      setDurationUnit("years");
+      pendingTemplateRef.current = null;
+
       const packageId = resolveTemplatePackageId(template);
-      if (packageId && packageId !== selectedPackageId) {
-        // Changing the package repopulates seats and resets tier defaults; defer
-        // the rest of the template until that settles.
+      if (packageId) {
+        // Selecting the package repopulates seats and resets tier defaults;
+        // defer the rest of the template until that settles.
         pendingTemplateRef.current = template;
         form.setValue("metronomePackageId", packageId);
       } else {
         applyTemplateFields(template);
       }
     },
-    [resolveTemplatePackageId, selectedPackageId, form, applyTemplateFields]
+    [resolveTemplatePackageId, form, formDefaults, applyTemplateFields]
   );
 
   // Second phase of applying a template: once selecting its package has

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -349,9 +349,9 @@ export default function SwitchContractDialog({
   const creditConfigAppliedRef = useRef(false);
   useEffect(() => {
     if (!open) {
+      // Re-arm the one-shot prefill for the next open; the operator-facing
+      // resets happen in the dialog's onOpenChange handler.
       creditConfigAppliedRef.current = false;
-      pendingTemplateRef.current = null;
-      setAppliedTemplateName(null);
       return;
     }
     if (!existingCreditConfig || creditConfigAppliedRef.current) {
@@ -587,17 +587,6 @@ export default function SwitchContractDialog({
         }
         form.setValue("seats", next);
       }
-      // A duration sets the end date via the "Set duration" toggle.
-      if (template.duration) {
-        setDurationValue(template.duration.value);
-        setDurationUnit(template.duration.unit);
-        setDurationMode(true);
-      }
-      // A promotional free leading period.
-      if (template.offerFreePeriod) {
-        setOfferValue(template.offerFreePeriod.value);
-        setOfferUnit(template.offerFreePeriod.unit);
-      }
     },
     [form]
   );
@@ -616,11 +605,13 @@ export default function SwitchContractDialog({
         stripeCollectionMethod: current.stripeCollectionMethod,
         manualCurrency: current.manualCurrency,
       });
-      setDurationMode(false);
-      setDurationValue(1);
-      setDurationUnit("years");
-      setOfferValue(0);
-      setOfferUnit("weeks");
+      // Duration and offer are local UI state that don't depend on the package,
+      // so set them here in the handler (not from the deferred effect below).
+      setDurationMode(template.duration !== undefined);
+      setDurationValue(template.duration?.value ?? 1);
+      setDurationUnit(template.duration?.unit ?? "years");
+      setOfferValue(template.offerFreePeriod?.value ?? 0);
+      setOfferUnit(template.offerFreePeriod?.unit ?? "weeks");
       pendingTemplateRef.current = null;
 
       const packageId = resolveTemplatePackageId(template);
@@ -1120,10 +1111,12 @@ export default function SwitchContractDialog({
       open={open}
       onOpenChange={(next) => {
         setOpen(next);
-        // Reset the promotional offer when the dialog closes.
+        // Reset the transient selections when the dialog closes.
         if (!next) {
           setOfferValue(0);
           setOfferUnit("weeks");
+          setAppliedTemplateName(null);
+          pendingTemplateRef.current = null;
         }
       }}
     >

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -537,6 +537,9 @@ export default function SwitchContractDialog({
       if (template.usageCapCredits !== undefined) {
         form.setValue("usageCapCredits", template.usageCapCredits);
       }
+      if (template.defaultPoolCapCredits !== undefined) {
+        form.setValue("defaultPoolCapCredits", template.defaultPoolCapCredits);
+      }
       if (template.paygEnabled !== undefined) {
         form.setValue("paygEnabled", template.paygEnabled);
       }

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -19,6 +19,11 @@ import {
   isEnterprisePlanPrefix,
 } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
+import type {
+  ContractDurationUnit,
+  SwitchContractTemplate,
+} from "@app/lib/poke/switch_contract_templates";
+import { SWITCH_CONTRACT_TEMPLATES } from "@app/lib/poke/switch_contract_templates";
 import {
   usePokeMetronomePackages,
   usePokePlans,
@@ -94,8 +99,6 @@ function snapDatetimeLocalToHour(value: string): string {
   }
   return value;
 }
-
-type ContractDurationUnit = "years" | "months" | "weeks";
 
 // Add a contract duration to a start moment (UTC), clamping month/year day
 // overflow to the last day of the target month (Jan 31 + 1 month → Feb 28/29).
@@ -236,6 +239,12 @@ export default function SwitchContractDialog({
   // applied globally to every seat commitment's earliest bills.
   const [offerValue, setOfferValue] = useState(0);
   const [offerUnit, setOfferUnit] = useState<ContractDurationUnit>("weeks");
+  const [appliedTemplateName, setAppliedTemplateName] = useState<string | null>(
+    null
+  );
+  // Template whose non-package fields still need applying once the package it
+  // selects has repopulated the seats (see the apply-template effect below).
+  const pendingTemplateRef = useRef<SwitchContractTemplate | null>(null);
   const [portalContainer, setPortalContainer] = useState<
     HTMLElement | undefined
   >(undefined);
@@ -337,6 +346,8 @@ export default function SwitchContractDialog({
   useEffect(() => {
     if (!open) {
       creditConfigAppliedRef.current = false;
+      pendingTemplateRef.current = null;
+      setAppliedTemplateName(null);
       return;
     }
     if (!existingCreditConfig || creditConfigAppliedRef.current) {
@@ -479,6 +490,136 @@ export default function SwitchContractDialog({
       form.setValue("usageCapCredits", undefined);
     }
   }, [selectedTier, form, defaultStartingAtUTC]);
+
+  // Resolve a template's contract type to a concrete package id in the resolved
+  // currency: same tier and, when given, a case-insensitive name-substring match.
+  const resolveTemplatePackageId = useCallback(
+    (template: SwitchContractTemplate): string | null => {
+      if (!template.package) {
+        return null;
+      }
+      const pattern = template.package.namePattern?.toLowerCase();
+      const match = metronomePackages.find(
+        (p) =>
+          p.tier === template.package?.tier &&
+          p.currency === resolvedCurrency &&
+          (!pattern || p.name.toLowerCase().includes(pattern))
+      );
+      return match?.id ?? null;
+    },
+    [metronomePackages, resolvedCurrency]
+  );
+
+  // Apply every non-package field of a template onto the form. Package selection
+  // is handled separately (it repopulates the seats first), so this runs either
+  // directly (package unchanged / template has none) or from the apply-template
+  // effect once the seats are ready.
+  const applyTemplateFields = useCallback(
+    (template: SwitchContractTemplate) => {
+      if (template.planCode !== undefined) {
+        form.setValue("planCode", template.planCode);
+      }
+      if (template.startMode !== undefined) {
+        form.setValue("startMode", template.startMode);
+      }
+      if (template.startingAt !== undefined) {
+        form.setValue("startingAt", template.startingAt);
+      }
+      if (template.netPaymentTermsDays !== undefined) {
+        form.setValue("netPaymentTermsDays", template.netPaymentTermsDays);
+      }
+      if (template.defaultDiscountPercent !== undefined) {
+        form.setValue(
+          "defaultDiscountPercent",
+          template.defaultDiscountPercent
+        );
+      }
+      if (template.usageCapCredits !== undefined) {
+        form.setValue("usageCapCredits", template.usageCapCredits);
+      }
+      if (template.paygEnabled !== undefined) {
+        form.setValue("paygEnabled", template.paygEnabled);
+      }
+      if (template.autoSeatUpgradeEnabled !== undefined) {
+        form.setValue(
+          "autoSeatUpgradeEnabled",
+          template.autoSeatUpgradeEnabled
+        );
+      }
+      if (template.topUpEnabled !== undefined) {
+        form.setValue("topUpEnabled", template.topUpEnabled);
+      }
+      if (template.autoInvoiceFinalizationEnabled !== undefined) {
+        form.setValue(
+          "autoInvoiceFinalizationEnabled",
+          template.autoInvoiceFinalizationEnabled
+        );
+      }
+      if (template.promoteNoneSeatsTo !== undefined) {
+        form.setValue("promoteNoneSeatsTo", template.promoteNoneSeatsTo);
+      }
+      if (template.initialCredits !== undefined) {
+        form.setValue("initialCredits", template.initialCredits);
+      }
+      if (template.scheduledCharge !== undefined) {
+        form.setValue("scheduledCharge", template.scheduledCharge);
+      }
+      if (template.recurringFreeCredit !== undefined) {
+        form.setValue("recurringFreeCredit", template.recurringFreeCredit);
+      }
+      // Merge seat overrides onto the current package's seats; a seat type the
+      // package does not sell has no entry to merge onto and is skipped.
+      if (template.seats) {
+        const current = form.getValues("seats") ?? {};
+        const next = { ...current };
+        for (const [seatType, override] of Object.entries(template.seats)) {
+          if (!override || !next[seatType]) {
+            continue;
+          }
+          next[seatType] = { ...next[seatType], ...override };
+        }
+        form.setValue("seats", next);
+      }
+      // A duration sets the end date via the "Set duration" toggle.
+      if (template.duration) {
+        setDurationValue(template.duration.value);
+        setDurationUnit(template.duration.unit);
+        setDurationMode(true);
+      }
+    },
+    [form]
+  );
+
+  const applyTemplate = useCallback(
+    (template: SwitchContractTemplate) => {
+      setError(null);
+      setAppliedTemplateName(template.name);
+      const packageId = resolveTemplatePackageId(template);
+      if (packageId && packageId !== selectedPackageId) {
+        // Changing the package repopulates seats and resets tier defaults; defer
+        // the rest of the template until that settles.
+        pendingTemplateRef.current = template;
+        form.setValue("metronomePackageId", packageId);
+      } else {
+        applyTemplateFields(template);
+      }
+    },
+    [resolveTemplatePackageId, selectedPackageId, form, applyTemplateFields]
+  );
+
+  // Second phase of applying a template: once selecting its package has
+  // repopulated the seats and reset the tier defaults, apply the template's own
+  // fields on top. Placed after the seat-reset and tier-default effects so it
+  // wins. No-op unless a template is pending.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: selectedSeats and selectedTier are intentional re-run triggers — this effect must fire once the package's seats/tier have settled, even though it reads neither directly.
+  useEffect(() => {
+    const pending = pendingTemplateRef.current;
+    if (!pending) {
+      return;
+    }
+    pendingTemplateRef.current = null;
+    applyTemplateFields(pending);
+  }, [selectedSeats, selectedTier, applyTemplateFields]);
 
   const startMode = form.watch("startMode");
   const startingAt = form.watch("startingAt");
@@ -1036,6 +1177,45 @@ export default function SwitchContractDialog({
                     credit configuration to show for an unresolved customer. */}
                 {resolvedCurrency && (
                   <>
+                    <div className="grid grid-cols-[200px_1fr] items-center gap-x-4 gap-y-2">
+                      <Label className="text-sm">
+                        Template
+                        <span className="ml-1 text-muted-foreground">
+                          (optional)
+                        </span>
+                      </Label>
+                      <div className="flex items-center gap-2">
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="xs"
+                              isSelect
+                              disabled={isPackagesLoading}
+                              label={
+                                appliedTemplateName ?? "Select a template…"
+                              }
+                            />
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent
+                            mountPortalContainer={portalContainer}
+                          >
+                            {SWITCH_CONTRACT_TEMPLATES.map((template) => (
+                              <DropdownMenuItem
+                                key={template.id}
+                                label={template.name}
+                                description={template.description}
+                                onClick={() => applyTemplate(template)}
+                              />
+                            ))}
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                        <span className="text-xs text-muted-foreground">
+                          Pre-fills the form; every field stays editable.
+                        </span>
+                      </div>
+                    </div>
                     <div className="grid grid-cols-[200px_1fr] items-center gap-x-4 gap-y-2">
                       <Label className="text-sm">
                         HubSpot Deal ID

--- a/front/lib/poke/switch_contract_templates.ts
+++ b/front/lib/poke/switch_contract_templates.ts
@@ -123,4 +123,23 @@ export const SWITCH_CONTRACT_TEMPLATES: SwitchContractTemplate[] = [
       paymentSchedule: { frequency: "one_time" },
     },
   },
+  {
+    id: "enterprise-pilot-2m",
+    name: "Pilot — 2 months",
+    description:
+      "Enterprise pooled, 2-month commitment, workspace seats at the standard rate, 10k initial credits.",
+    package: { tier: "enterprise", namePattern: "pooled" },
+    planCode: CREDIT_PRICED_ENTERPRISE_DEFAULT_PLAN_CODE,
+    startMode: "select",
+    duration: { value: 2, unit: "months" },
+    // No rate override: keep the package's standard workspace-seat rate.
+    seats: {
+      workspace_yearly: { selected: true },
+    },
+    initialCredits: {
+      amountCredits: 10000,
+      invoiceAmount: 0,
+      paymentSchedule: { frequency: "one_time" },
+    },
+  },
 ];

--- a/front/lib/poke/switch_contract_templates.ts
+++ b/front/lib/poke/switch_contract_templates.ts
@@ -1,0 +1,108 @@
+import {
+  CREDIT_PRICED_BUSINESS_PLAN_CODE,
+  CREDIT_PRICED_ENTERPRISE_DEFAULT_PLAN_CODE,
+} from "@app/lib/plans/plan_codes";
+import type { MembershipSeatType } from "@app/types/memberships";
+
+// Hardcoded pre-fill templates for the Switch Contract poke dialog. Selecting a
+// template fills the form with these values; the operator can then edit any
+// field before submitting. Every field is optional — an omitted field keeps the
+// form's current/default value.
+//
+// Packages are referenced by tier (+ optional case-insensitive name substring)
+// rather than by Metronome package id, since ids differ per environment; the
+// dialog resolves the matching package in the resolved currency at apply time.
+// Seats are keyed by seat type and merged onto the selected package's seats, so
+// a seat type the package does not sell is ignored.
+
+type PaymentFrequency =
+  | "one_time"
+  | "monthly"
+  | "quarterly"
+  | "semi_annually"
+  | "annually";
+
+type TemplatePaymentSchedule = {
+  frequency: PaymentFrequency;
+  periods?: number;
+};
+
+export type ContractDurationUnit = "years" | "months" | "weeks";
+
+type TemplateSeat = {
+  selected?: boolean;
+  minSeats?: number;
+  maxSeats?: number;
+  // Per-seat rate in the currency's major units (dollars / euros); the monthly
+  // rate for a monthly seat, the yearly rate for a yearly seat. Omit to keep the
+  // package's default rate.
+  rate?: number;
+  commitmentPrice?: number;
+  paymentSchedule?: TemplatePaymentSchedule;
+};
+
+export type SwitchContractTemplate = {
+  id: string;
+  name: string;
+  description?: string;
+  // Contract type. Resolved to a concrete package at apply time.
+  package?: { tier: "business" | "enterprise"; namePattern?: string };
+  planCode?: string;
+  startMode?: "immediately" | "retroactive_first_of_month" | "select";
+  // datetime-local shape ("YYYY-MM-DDTHH:mm", interpreted as UTC). Only used
+  // when startMode is "select".
+  startingAt?: string;
+  // Sets the contract end date to start + duration (via the "Set duration"
+  // toggle), which also drives the commitment period.
+  duration?: { value: number; unit: ContractDurationUnit };
+  netPaymentTermsDays?: number;
+  defaultDiscountPercent?: number;
+  usageCapCredits?: number;
+  paygEnabled?: boolean;
+  autoSeatUpgradeEnabled?: boolean;
+  topUpEnabled?: boolean;
+  autoInvoiceFinalizationEnabled?: boolean;
+  promoteNoneSeatsTo?: MembershipSeatType;
+  seats?: Partial<Record<MembershipSeatType, TemplateSeat>>;
+  initialCredits?: {
+    amountCredits: number;
+    invoiceAmount: number;
+    paymentSchedule: TemplatePaymentSchedule;
+  };
+  scheduledCharge?: {
+    name?: string;
+    invoiceAmount: number;
+    paymentSchedule: TemplatePaymentSchedule;
+  };
+  recurringFreeCredit?: number;
+};
+
+export const SWITCH_CONTRACT_TEMPLATES: SwitchContractTemplate[] = [
+  {
+    id: "business-annual",
+    name: "Business — annual",
+    description: "Business plan, starts immediately, 1-year commitment.",
+    package: { tier: "business" },
+    planCode: CREDIT_PRICED_BUSINESS_PLAN_CODE,
+    startMode: "immediately",
+    duration: { value: 1, unit: "years" },
+    seats: {
+      pro_yearly: { selected: true, minSeats: 10 },
+    },
+  },
+  {
+    id: "enterprise-annual",
+    name: "Enterprise — annual",
+    description:
+      "Enterprise plan, starts immediately, 1-year commitment, prepaid credits.",
+    package: { tier: "enterprise" },
+    planCode: CREDIT_PRICED_ENTERPRISE_DEFAULT_PLAN_CODE,
+    startMode: "immediately",
+    duration: { value: 1, unit: "years" },
+    initialCredits: {
+      amountCredits: 100000,
+      invoiceAmount: 5000,
+      paymentSchedule: { frequency: "one_time" },
+    },
+  },
+];

--- a/front/lib/poke/switch_contract_templates.ts
+++ b/front/lib/poke/switch_contract_templates.ts
@@ -1,7 +1,4 @@
-import {
-  CREDIT_PRICED_BUSINESS_PLAN_CODE,
-  CREDIT_PRICED_ENTERPRISE_DEFAULT_PLAN_CODE,
-} from "@app/lib/plans/plan_codes";
+import { CREDIT_PRICED_ENTERPRISE_DEFAULT_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import type { MembershipSeatType } from "@app/types/memberships";
 
 // Hardcoded pre-fill templates for the Switch Contract poke dialog. Selecting a
@@ -84,33 +81,6 @@ export type SwitchContractTemplate = {
 };
 
 export const SWITCH_CONTRACT_TEMPLATES: SwitchContractTemplate[] = [
-  {
-    id: "business-annual",
-    name: "Business — annual",
-    description: "Business plan, starts immediately, 1-year commitment.",
-    package: { tier: "business" },
-    planCode: CREDIT_PRICED_BUSINESS_PLAN_CODE,
-    startMode: "select",
-    duration: { value: 1, unit: "years" },
-    seats: {
-      pro_yearly: { selected: true, minSeats: 10 },
-    },
-  },
-  {
-    id: "enterprise-annual",
-    name: "Enterprise — annual",
-    description:
-      "Enterprise plan, starts immediately, 1-year commitment, prepaid credits.",
-    package: { tier: "enterprise" },
-    planCode: CREDIT_PRICED_ENTERPRISE_DEFAULT_PLAN_CODE,
-    startMode: "select",
-    duration: { value: 1, unit: "years" },
-    initialCredits: {
-      amountCredits: 100000,
-      invoiceAmount: 5000,
-      paymentSchedule: { frequency: "one_time" },
-    },
-  },
   {
     id: "enterprise-free-pilot-2w",
     name: "Free pilot — 2 weeks",

--- a/front/lib/poke/switch_contract_templates.ts
+++ b/front/lib/poke/switch_contract_templates.ts
@@ -84,7 +84,7 @@ export const SWITCH_CONTRACT_TEMPLATES: SwitchContractTemplate[] = [
     description: "Business plan, starts immediately, 1-year commitment.",
     package: { tier: "business" },
     planCode: CREDIT_PRICED_BUSINESS_PLAN_CODE,
-    startMode: "immediately",
+    startMode: "select",
     duration: { value: 1, unit: "years" },
     seats: {
       pro_yearly: { selected: true, minSeats: 10 },
@@ -97,11 +97,29 @@ export const SWITCH_CONTRACT_TEMPLATES: SwitchContractTemplate[] = [
       "Enterprise plan, starts immediately, 1-year commitment, prepaid credits.",
     package: { tier: "enterprise" },
     planCode: CREDIT_PRICED_ENTERPRISE_DEFAULT_PLAN_CODE,
-    startMode: "immediately",
+    startMode: "select",
     duration: { value: 1, unit: "years" },
     initialCredits: {
       amountCredits: 100000,
       invoiceAmount: 5000,
+      paymentSchedule: { frequency: "one_time" },
+    },
+  },
+  {
+    id: "enterprise-free-pilot-2w",
+    name: "Free pilot — 2 weeks",
+    description:
+      "Enterprise pooled, 2-week commitment, free workspace seats, 10k free credits.",
+    package: { tier: "enterprise", namePattern: "pooled" },
+    planCode: CREDIT_PRICED_ENTERPRISE_DEFAULT_PLAN_CODE,
+    startMode: "select",
+    duration: { value: 2, unit: "weeks" },
+    seats: {
+      workspace_yearly: { selected: true, rate: 0 },
+    },
+    initialCredits: {
+      amountCredits: 10000,
+      invoiceAmount: 0,
       paymentSchedule: { frequency: "one_time" },
     },
   },

--- a/front/lib/poke/switch_contract_templates.ts
+++ b/front/lib/poke/switch_contract_templates.ts
@@ -77,6 +77,10 @@ export type SwitchContractTemplate = {
     paymentSchedule: TemplatePaymentSchedule;
   };
   recurringFreeCredit?: number;
+  // Promotional free leading period: reduces the seat commitment's earliest
+  // bill(s) by the prorated value of this duration, so the customer pays nothing
+  // for it (the granted seats are unchanged).
+  offerFreePeriod?: { value: number; unit: ContractDurationUnit };
 };
 
 export const SWITCH_CONTRACT_TEMPLATES: SwitchContractTemplate[] = [
@@ -130,12 +134,14 @@ export const SWITCH_CONTRACT_TEMPLATES: SwitchContractTemplate[] = [
     id: "enterprise-pilot-2m",
     name: "Pilot — 2 months",
     description:
-      "Enterprise pooled, 2-month commitment, workspace seats at the standard rate, 10k initial credits.",
+      "Enterprise pooled, 2-month commitment, workspace seats at the standard rate, first 2 weeks free, 10k initial credits.",
     package: { tier: "enterprise", namePattern: "pooled" },
     planCode: CREDIT_PRICED_ENTERPRISE_DEFAULT_PLAN_CODE,
     startMode: "select",
     duration: { value: 2, unit: "months" },
     defaultPoolCapCredits: 10000,
+    // First 2 weeks offered for free.
+    offerFreePeriod: { value: 2, unit: "weeks" },
     // No rate override: keep the package's standard workspace-seat rate.
     seats: {
       workspace_yearly: { selected: true },

--- a/front/lib/poke/switch_contract_templates.ts
+++ b/front/lib/poke/switch_contract_templates.ts
@@ -58,6 +58,8 @@ export type SwitchContractTemplate = {
   netPaymentTermsDays?: number;
   defaultDiscountPercent?: number;
   usageCapCredits?: number;
+  // Default per-user workspace credit pool monthly limit (credits).
+  defaultPoolCapCredits?: number;
   paygEnabled?: boolean;
   autoSeatUpgradeEnabled?: boolean;
   topUpEnabled?: boolean;
@@ -114,6 +116,7 @@ export const SWITCH_CONTRACT_TEMPLATES: SwitchContractTemplate[] = [
     planCode: CREDIT_PRICED_ENTERPRISE_DEFAULT_PLAN_CODE,
     startMode: "select",
     duration: { value: 2, unit: "weeks" },
+    defaultPoolCapCredits: 10000,
     seats: {
       workspace_yearly: { selected: true, rate: 0 },
     },
@@ -132,6 +135,7 @@ export const SWITCH_CONTRACT_TEMPLATES: SwitchContractTemplate[] = [
     planCode: CREDIT_PRICED_ENTERPRISE_DEFAULT_PLAN_CODE,
     startMode: "select",
     duration: { value: 2, unit: "months" },
+    defaultPoolCapCredits: 10000,
     // No rate override: keep the package's standard workspace-seat rate.
     seats: {
       workspace_yearly: { selected: true },


### PR DESCRIPTION
## Description

Adds selectable **templates** that pre-fill the Switch Contract poke modal, so common contract shapes (Business/Enterprise annual, etc.) can be set up in one click. The operator can edit any field afterwards — a template is just a pre-fill.

Stacked on #32025.

- **`front/lib/poke/switch_contract_templates.ts`** — a `SwitchContractTemplate` type and a hardcoded `SWITCH_CONTRACT_TEMPLATES` list. Every field is optional; an omitted field keeps the form default. Templates commonly set: contract type, plan code, start + duration, seat prices, commitment period, and initial credits — but any field can be pre-filled.
  - **Contract type / package** is referenced by **tier (+ optional name substring)**, not by Metronome package id, so a template resolves to the right package per environment.
  - **Seats** are keyed by seat type and merged onto the selected package's seats (a seat type the package doesn't sell is skipped).
- **`SwitchContractDialog.tsx`** — a **"Template"** dropdown at the top. Selecting one resolves + selects the package, then (once the package's seats repopulate and tier defaults reset) applies the template's scalar fields, per-seat overrides, initial credits, and start/duration (via the existing "Set duration" toggle). Reset on dialog close.

Two starter templates are included (Business annual, Enterprise annual); more are added by editing the list.

## Tests

- `tsgo` and biome pass.
- Manual: selecting a template pre-fills the package, plan, start/duration, seats, and initial credits; fields remain editable; switching templates re-applies cleanly; closing the dialog clears the selection.

Follow-up option (not in this PR): DB-managed, ops-editable templates instead of hardcoded — deliberately deferred per discussion; hardcoded is enough for now.

## Risk

Low, internal Poke tooling only. Templates are pure pre-fill data with no server or billing-logic changes (the commitment/proration logic from #32025 is untouched); the operator reviews and can edit everything before submitting. Rollback is a straight revert. No migration or feature flag.

## Deploy Plan

Merge after #32025. Standard `front` deploy, no migration or ordering constraints.