### PR TITLE
admin governance: space access copy and member search spacing

### DIFF
--- a/front/components/members/MemberSelectionTable.tsx
+++ b/front/components/members/MemberSelectionTable.tsx
@@ -183,6 +183,7 @@ export function MemberSelectionTable({
         value={searchText}
         onChange={handleSearchChange}
         placeholder="Search users..."
+        className="mt-2"
       />
       <div className="flex min-h-0 flex-1 flex-col">
         {isLoading ? (

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -32,6 +32,9 @@ import {
 import * as React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+const MEMBERSHIP_SOURCES_DESCRIPTION =
+  "Members are the people picked below, plus everyone in the groups given access to the space.";
+
 interface CreateOrEditSpaceModalProps {
   defaultRestricted?: boolean;
   isAdmin: boolean;
@@ -329,6 +332,7 @@ export function CreateOrEditSpaceModal({
                         Members can read the content of the space and write data
                         into it (upload files, delete documents...).
                       </span>
+                      <span>{MEMBERSHIP_SOURCES_DESCRIPTION}</span>
                     </>
                   }
                   unrestrictedDescription={
@@ -344,6 +348,7 @@ export function CreateOrEditSpaceModal({
                         Members of the space can also write data (upload files,
                         delete documents...).
                       </span>
+                      <span>{MEMBERSHIP_SOURCES_DESCRIPTION}</span>
                     </>
                   }
                 />

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -144,7 +144,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
 
   /**
    * @cc [owner:philipperolet,label:performance] empty-users-skip-membership-queries
-   * With a workspace, empty users return no memberships without querying. This does not 
+   * With a workspace, empty users return no memberships without querying. This does not
    * apply to undefined/null users.
    */
   static async getActiveMemberships({


### PR DESCRIPTION
## Description

Two small imrpovements for the space settings sheet:
 - the member table's search input had no top margin, so it sat tighter under the tabs than the group table's
 - the access description now says where a space's members come from, in both access states.

## Tests

Checked by hand.

## Risk

Low. UI only

## Deploy Plan

- Deploy front
