### PR TITLE
[viz] Fix "URI malformed" when an emoji straddles an editable-span context window

### DIFF
--- a/viz/app/lib/transformEditableText.test.ts
+++ b/viz/app/lib/transformEditableText.test.ts
@@ -69,6 +69,18 @@ function Foo() {
     expect(transformEditableText(code)).toBe(code);
   });
 
+  it("does not throw when an emoji straddles a context window boundary", () => {
+    // The ctxBefore/ctxAfter windows are cut at a fixed count of UTF-16 code units; an emoji
+    // sitting on the cut used to leave a lone surrogate, which encodeURIComponent rejects with
+    // `URIError: URI malformed`.
+    for (let padding = 0; padding <= 90; padding++) {
+      const before = `const App = () => <div>{"\u{1F389}${"x".repeat(padding)}"}<span>Hello</span></div>;`;
+      const after = `const App = () => <div><span>Hello</span>{"${"x".repeat(padding)}\u{1F389}"}</div>;`;
+      expect(() => transformEditableText(before)).not.toThrow();
+      expect(() => transformEditableText(after)).not.toThrow();
+    }
+  });
+
   it("wraps text in multiple sibling elements", () => {
     const code = `
 function Foo() {

--- a/viz/app/lib/transformEditableText.ts
+++ b/viz/app/lib/transformEditableText.ts
@@ -19,6 +19,44 @@ export interface EditableSpanMeta {
 // even when the same visible text appears multiple times in the file (e.g. repeated table labels).
 const CONTEXT_CHARS = 60;
 
+const HIGH_SURROGATE_FIRST = 0xd800;
+const HIGH_SURROGATE_LAST = 0xdbff;
+const LOW_SURROGATE_FIRST = 0xdc00;
+const LOW_SURROGATE_LAST = 0xdfff;
+
+function isHighSurrogate(charCode: number): boolean {
+  return charCode >= HIGH_SURROGATE_FIRST && charCode <= HIGH_SURROGATE_LAST;
+}
+
+function isLowSurrogate(charCode: number): boolean {
+  return charCode >= LOW_SURROGATE_FIRST && charCode <= LOW_SURROGATE_LAST;
+}
+
+// The context windows are cut at a fixed count of UTF-16 code units, which lands mid-surrogate-pair
+// whenever an astral character (an emoji) straddles the cut. encodeURIComponent throws
+// `URIError: URI malformed` on a lone surrogate, so shrink the window to the nearest code point
+// boundary. One code unit of context is irrelevant to the uniqueness of the match.
+function contextStart(code: string, pos: number): number {
+  const start = Math.max(0, pos - CONTEXT_CHARS);
+  const splitsPair =
+    start > 0 &&
+    isHighSurrogate(code.charCodeAt(start - 1)) &&
+    isLowSurrogate(code.charCodeAt(start));
+
+  return splitsPair ? start + 1 : start;
+}
+
+function contextEnd(code: string, pos: number): number {
+  const end = Math.min(code.length, pos + CONTEXT_CHARS);
+  const splitsPair =
+    end > 0 &&
+    end < code.length &&
+    isHighSurrogate(code.charCodeAt(end - 1)) &&
+    isLowSurrogate(code.charCodeAt(end));
+
+  return splitsPair ? end - 1 : end;
+}
+
 // Prefix on data-file-id attributes so extractFileRefs skips them (avoids deadlocking the cache).
 export const EDITABLE_FILE_ID_PREFIX = "edit:";
 
@@ -40,8 +78,8 @@ function collectJsxTextNodes(code: string): JSXTextReplacement[] {
         start: pos,
         end,
         rawText: code.slice(pos, end),
-        ctxBefore: code.slice(Math.max(0, pos - CONTEXT_CHARS), pos),
-        ctxAfter: code.slice(end, Math.min(code.length, end + CONTEXT_CHARS)),
+        ctxBefore: code.slice(contextStart(code, pos), pos),
+        ctxAfter: code.slice(end, contextEnd(code, end)),
       });
     }
     ts.forEachChild(node, visit);


### PR DESCRIPTION
### Symptom

A Frame in the conversation side panel failed to render with the parent's error card: *"The visualization failed due to an error in the generated code — URI malformed"*. The React stack pointed at `<VisualizationWrapper>`, which is a red herring: `if (errored) throw errored` re-throws an error captured earlier, so the component stack says nothing about the origin.

### Root cause

`transformEditableText` wraps each JSX text node in an editable span and stores 60 characters of surrounding source on it (`data-ctx-before` / `data-ctx-after`), so an inline edit can be matched back to a unique location in the file even when the same visible text appears several times.

Those windows were cut with `code.slice()` at fixed **UTF-16 code-unit** offsets. When an astral character (an emoji) straddles the cut, the window begins or ends on half a surrogate pair, and `encodeURIComponent` rejects a lone surrogate with `URIError: URI malformed`.

The failing Frame had a single emoji:

```
12:30–13:30 · weekly team lunch 🥗</div><Pill tone="emerald">Accepted
```

In the raw source that emoji sits 29 code units before the next JSX text node, so the `pos - 60` cut lands clear of it. But viz executes the **bundled** Frame, where the sandbox build has injected a `data-source="<relPath>:<line>:<col>"` attribute onto every JSX element — exactly 32 characters here. That pushes `Accepted` to `i + 61`, putting the cut at `i + 1`: the emoji's low surrogate, alone.

Sweeping an inserted shift at that point in the real file confirms it:

```
pre-fix:   failing shifts: [32]
with fix:  failing shifts: []
```

The throw sits outside the `try` that wraps `collectJsxTextNodes`, so it propagated to `loadCode`'s catch and took down the whole Frame rather than just degrading inline editing.

### Fix

Snap both cuts to the nearest code point boundary before slicing. One code unit of context is irrelevant to the uniqueness of the match, and the contexts are consumed verbatim (`ctxBefore + rawText + ctxAfter` in `EditableFrame`), so nothing downstream cares.

### Testing

Added a regression test that sweeps an emoji across every offset either side of the boundary, in both the leading and trailing context window. On `main` it fails with `expected [Function] to not throw an error but 'URIError: URI malformed' was thrown`; with the fix all 8 tests in the file pass. Also verified by hand against the Frame that triggered this.

### Follow-up worth considering

Not addressed here: a failure in the span-wrapping step replaces the entire Frame with an error card, even though inline editing is a progressive enhancement. This removes the known trigger, but the asymmetry remains if another encoding hazard turns up.

