### PR TITLE
fix(front): stop cropping Name/Group columns in Usage tables

### DIFF
--- a/front/components/workspace/GroupsUsageTable.tsx
+++ b/front/components/workspace/GroupsUsageTable.tsx
@@ -78,7 +78,7 @@ export function GroupsUsageTable({
             {
               id: "cap",
               header: "Spend limit",
-              meta: { className: "w-64" },
+              meta: { className: "hidden @3xl:table-cell @3xl:w-64" },
               cell: (info: GroupInfo) => (
                 <GroupSpendLimitCell
                   group={info.row.original}
@@ -105,7 +105,7 @@ export function GroupsUsageTable({
                   <ModelTiersInfoButton />
                 </span>
               ),
-              meta: { className: "w-64" },
+              meta: { className: "hidden @2xl:table-cell @2xl:w-64" },
               cell: (info: GroupInfo) => (
                 <GroupModelTierPickerDropdown
                   owner={owner}
@@ -136,12 +136,7 @@ export function GroupsUsageTable({
           member belongs to several groups, the highest limit is used.
         </span>
       )}
-      <DataTable
-        filterColumn="name"
-        data={rows}
-        columns={columns}
-        columnsBreakpoints={{ name: "md" }}
-      />
+      <DataTable filterColumn="name" data={rows} columns={columns} />
     </div>
   );
 }

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -484,6 +484,10 @@ export function AwuUsageBar({
   );
 }
 
+// Name is intentionally the only column without a set width, so it absorbs
+// every bit of leftover space. Secondary columns hide (via the container
+// queries in their meta.className) before Name has to shrink, keeping long
+// names/emails readable.
 const nameColumn = buildMemberNameColumn<RowData>();
 
 const groupsColumn: ColumnDef<RowData, string> = {
@@ -502,7 +506,10 @@ const groupsColumn: ColumnDef<RowData, string> = {
     );
   },
   meta: {
-    className: "w-48",
+    // Least essential: only appears on very wide containers (e.g. the Poke
+    // pool-usage page), never crowding out Name on the sidebar-constrained
+    // customer admin page.
+    className: "hidden @6xl:table-cell @6xl:w-48",
   },
 };
 
@@ -547,7 +554,7 @@ const seatTypeColumn: ColumnDef<RowData, string> = {
     );
   },
   meta: {
-    className: "w-32",
+    className: "hidden @3xl:table-cell @3xl:w-32",
   },
 };
 
@@ -598,7 +605,7 @@ const seatsIconColumn: ColumnDef<RowData, string> = {
     );
   },
   meta: {
-    className: "w-24",
+    className: "hidden @3xl:table-cell @3xl:w-24",
     headerAlign: "center",
   },
 };
@@ -692,7 +699,7 @@ const seatUsageColumn: ColumnDef<RowData, string> = {
     );
   },
   meta: {
-    className: "w-24",
+    className: "hidden @4xl:table-cell @4xl:w-24",
     headerAlign: "center",
   },
 };
@@ -1032,7 +1039,7 @@ const offPaceColumn: ColumnDef<RowData, string> = {
     );
   },
   meta: {
-    className: "w-28",
+    className: "hidden @4xl:table-cell @4xl:w-28",
     headerAlign: "center",
   },
 };
@@ -1076,7 +1083,14 @@ function buildModelTiersColumn(
       );
     },
     meta: {
-      className: "w-48",
+      // On the compact (new usage / Poke) variant the extra seat + off-pace
+      // columns compete for width, so Models tier yields sooner to keep Name
+      // readable; the legacy admin page has fewer columns and can show it at
+      // the container width it caps out at.
+      className:
+        variant === "compact"
+          ? "hidden @6xl:table-cell @6xl:w-48"
+          : "hidden @5xl:table-cell @5xl:w-48",
     },
   };
 }
@@ -1189,16 +1203,6 @@ function buildColumns({
     ...(showSeatAndCredits || showModelTiersColumn ? [actionsColumn] : []),
   ];
 }
-
-// The table is fixed layout and Name is the only column without a set width,
-// so it absorbs every shrink. Drop the secondary columns first as the window
-// narrows, most dispensable at the widest breakpoint.
-const COLUMNS_BREAKPOINTS = {
-  groups: "2xl",
-  modelTiers: "xl",
-  seatType: "xl",
-  consumedFromPoolAwuCredits: "lg",
-} as const;
 
 // "compact" is the Poke Pool Usage page layout: no "Up to " prefix on the
 // Models tier summary, a "Models" header instead of "Models tier". "legacy"
@@ -1515,7 +1519,6 @@ export function MembersUsageTable({
         <DataTable
           data={rows}
           columns={columns}
-          columnsBreakpoints={COLUMNS_BREAKPOINTS}
           pagination={pagination}
           setPagination={setPagination}
           totalRowCount={totalRowCount}

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -144,7 +144,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
 
   /**
    * @cc [owner:philipperolet,label:performance] empty-users-skip-membership-queries
-   * With a workspace, empty users return no memberships without querying. This does not 
+   * With a workspace, empty users return no memberships without querying. This does not
    * apply to undefined/null users.
    */
   static async getActiveMemberships({


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#10335. In **Admin > Usage**, the primary text column was getting cropped:

- **Members tab**: long names/emails were clipped (e.g. on a 1932px monitor the table container still caps at ~1072px, and every secondary column rendered into it, crushing Name to ~230px — or ~0 on the new/compact usage page).
- **Groups tab**: the Group name was cropped to "Gr…" on narrower containers (the fixed Members/Spend limit/Models tier columns left the Group column ~50px).

Root cause: responsive column dropping was keyed to **window width** (`columnsBreakpoints`), but these tables live in a max-width content area whose container is far narrower than the viewport. So columns never dropped and the flexible text column got squeezed.

Fix: switch both tables to **container-query-based** column visibility on each column's `meta.className` (`hidden @Nxl:table-cell`), driven by the `@container/table` context on `DataTable.Root` — the same pattern already used by `AssistantsTable`, `AdminActionsList`, and `APIKeysTable`. Columns now drop by the table's *actual* width, so the primary column always has room to display fully. Also removed the backwards `columnsBreakpoints={{ name: "md" }}` on the Groups table that hid the primary Group column below the md window.

## Tests

Manual, via Playwright against the local app at several widths (measured column widths directly):

- Members tab: Name goes from ~230px (legacy) / ~0px (compact) to **~430–450px** at the 1072px container; secondary columns drop cleanly as the container narrows and Name absorbs the space.
- Groups tab: "group test" now renders fully — Group column **309px** at a 429px container (was 53px, "Gr…"); Models tier drops, Members stays.
- Validated the crowded credit-priced layouts (which the dev workspace can't populate) with a synthetic render using the real compiled CSS at the 1072px cap.
- `tsgo --noEmit` clean; biome clean.

No unit tests exist for these presentational table components.

## Risk

Low. Presentational-only (Tailwind class changes); no logic, data, or API changes. Behavior is easy to eyeball and trivially reversible. Container-query utilities are already used by sibling tables in the codebase.

## Deploy Plan

Standard front deploy. No migrations, flags, or ordering constraints.