### PR TITLE
Move top-up button between cards and cycle history, cap history to 3 rows

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -1252,12 +1252,15 @@ export function UsagePage() {
           ) : null}
 
           {isNewUsagePage && isCreditPriced ? (
-            <div className="flex flex-col items-stretch gap-4">
-              <CreditPoolCards owner={owner} disabled={!isCreditPriced} />
-              {usageSettings.topUpEnabled && (
-                <div className="flex justify-end">{topUpButton}</div>
-              )}
-            </div>
+            <CreditPoolCards
+              owner={owner}
+              disabled={!isCreditPriced}
+              topUpButton={
+                usageSettings.topUpEnabled ? (
+                  <div className="flex justify-end">{topUpButton}</div>
+                ) : null
+              }
+            />
           ) : null}
 
           {!isNewUsagePage &&

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -1252,15 +1252,12 @@ export function UsagePage() {
           ) : null}
 
           {isNewUsagePage && isCreditPriced ? (
-            <CreditPoolCards
-              owner={owner}
-              disabled={!isCreditPriced}
-              topUpButton={
-                usageSettings.topUpEnabled ? (
-                  <div className="flex justify-end">{topUpButton}</div>
-                ) : null
-              }
-            />
+            <div className="flex flex-col items-stretch gap-4">
+              <CreditPoolCards owner={owner} disabled={!isCreditPriced} />
+              {usageSettings.topUpEnabled && (
+                <div className="flex justify-end">{topUpButton}</div>
+              )}
+            </div>
           ) : null}
 
           {!isNewUsagePage &&

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -21,7 +21,8 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
-import type { ReactNode } from "react";
+
+const CYCLE_HISTORY_ROW_LIMIT = 3;
 
 export type CreditPoolFetchStatus = "loading" | "error" | "ready";
 
@@ -150,15 +151,13 @@ export function WorkspaceCreditPoolCycleHistoryTable({
   if (cycleBreakdown.length === 0) {
     return null;
   }
-  const rows: CycleHistoryRowData[] = cycleBreakdown
-    .slice(0, 3)
-    .map((cycle) => ({
-      cycle:
-        cycle.cycleStartMs && cycle.cycleEndMs
-          ? `${formatConsumptionDate(cycle.cycleStartMs)} – ${formatConsumptionDate(cycle.cycleEndMs)}`
-          : "Unknown cycle",
-      consumedCredits: formatCredits(Math.round(cycle.consumedCredits)),
-    }));
+  const rows: CycleHistoryRowData[] = cycleBreakdown.map((cycle) => ({
+    cycle:
+      cycle.cycleStartMs && cycle.cycleEndMs
+        ? `${formatConsumptionDate(cycle.cycleStartMs)} – ${formatConsumptionDate(cycle.cycleEndMs)}`
+        : "Unknown cycle",
+    consumedCredits: formatCredits(Math.round(cycle.consumedCredits)),
+  }));
   return (
     <>
       <Page.H variant="h5">Previous cycles</Page.H>
@@ -216,7 +215,6 @@ interface WorkspaceCreditPoolSectionProps {
   currentCycleEndMs: number | null;
   cycleBreakdown: AwuPoolCycleBreakdown[];
   programmaticConsumedCredits: number | null;
-  topUpButton?: ReactNode;
 }
 
 export function WorkspaceCreditPoolSection({
@@ -230,7 +228,6 @@ export function WorkspaceCreditPoolSection({
   currentCycleEndMs,
   cycleBreakdown,
   programmaticConsumedCredits,
-  topUpButton,
 }: WorkspaceCreditPoolSectionProps) {
   if (cardsStatus === "ready" && !isVisible) {
     return null;
@@ -263,7 +260,6 @@ export function WorkspaceCreditPoolSection({
             programmaticConsumedCredits={programmaticConsumedCredits}
             isLoading={false}
           />
-          {topUpButton}
           <WorkspaceCreditPoolHistory
             tableStatus={tableStatus}
             cycleBreakdown={cycleBreakdown}
@@ -280,7 +276,6 @@ interface CreditPoolCardsFromCycleDataProps {
   poolCycleBreakdown: AwuPoolCycleBreakdown[];
   excessCycleBreakdown: AwuPoolCycleBreakdown[];
   tableStatus: CreditPoolFetchStatus;
-  topUpButton?: ReactNode;
 }
 export function CreditPoolCardsFromCycleData({
   awuPoolCurrentCycle,
@@ -288,7 +283,6 @@ export function CreditPoolCardsFromCycleData({
   poolCycleBreakdown,
   excessCycleBreakdown,
   tableStatus,
-  topUpButton,
 }: CreditPoolCardsFromCycleDataProps) {
   const {
     totalRemainingCredits,
@@ -326,7 +320,6 @@ export function CreditPoolCardsFromCycleData({
       currentCycleEndMs={currentCycleEndMs}
       cycleBreakdown={hasPool ? poolCycleBreakdown : excessCycleBreakdown}
       programmaticConsumedCredits={programmaticConsumedCredits}
-      topUpButton={topUpButton}
     />
   );
 }
@@ -334,13 +327,8 @@ export function CreditPoolCardsFromCycleData({
 interface CreditPoolCardsProps {
   owner: LightWorkspaceType;
   disabled: boolean;
-  topUpButton?: ReactNode;
 }
-export function CreditPoolCards({
-  owner,
-  disabled,
-  topUpButton,
-}: CreditPoolCardsProps) {
+export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
   const {
     awuPoolCurrentCycle,
     isAwuPoolCurrentCycleLoading,
@@ -351,7 +339,11 @@ export function CreditPoolCards({
     excessCycleBreakdown,
     isAwuPoolCycleHistoryLoading,
     isAwuPoolCycleHistoryError,
-  } = useAwuPoolCycleHistory({ workspaceId: owner.sId, disabled });
+  } = useAwuPoolCycleHistory({
+    workspaceId: owner.sId,
+    cycleHistoryLimit: CYCLE_HISTORY_ROW_LIMIT,
+    disabled,
+  });
 
   return (
     <CreditPoolCardsFromCycleData
@@ -362,7 +354,6 @@ export function CreditPoolCards({
       )}
       poolCycleBreakdown={poolCycleBreakdown}
       excessCycleBreakdown={excessCycleBreakdown}
-      topUpButton={topUpButton}
       tableStatus={toCreditPoolFetchStatus(
         isAwuPoolCycleHistoryLoading,
         !!isAwuPoolCycleHistoryError

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -21,6 +21,7 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
+import type { ReactNode } from "react";
 
 export type CreditPoolFetchStatus = "loading" | "error" | "ready";
 
@@ -149,13 +150,15 @@ export function WorkspaceCreditPoolCycleHistoryTable({
   if (cycleBreakdown.length === 0) {
     return null;
   }
-  const rows: CycleHistoryRowData[] = cycleBreakdown.map((cycle) => ({
-    cycle:
-      cycle.cycleStartMs && cycle.cycleEndMs
-        ? `${formatConsumptionDate(cycle.cycleStartMs)} – ${formatConsumptionDate(cycle.cycleEndMs)}`
-        : "Unknown cycle",
-    consumedCredits: formatCredits(Math.round(cycle.consumedCredits)),
-  }));
+  const rows: CycleHistoryRowData[] = cycleBreakdown
+    .slice(0, 3)
+    .map((cycle) => ({
+      cycle:
+        cycle.cycleStartMs && cycle.cycleEndMs
+          ? `${formatConsumptionDate(cycle.cycleStartMs)} – ${formatConsumptionDate(cycle.cycleEndMs)}`
+          : "Unknown cycle",
+      consumedCredits: formatCredits(Math.round(cycle.consumedCredits)),
+    }));
   return (
     <>
       <Page.H variant="h5">Previous cycles</Page.H>
@@ -213,6 +216,7 @@ interface WorkspaceCreditPoolSectionProps {
   currentCycleEndMs: number | null;
   cycleBreakdown: AwuPoolCycleBreakdown[];
   programmaticConsumedCredits: number | null;
+  topUpButton?: ReactNode;
 }
 
 export function WorkspaceCreditPoolSection({
@@ -226,6 +230,7 @@ export function WorkspaceCreditPoolSection({
   currentCycleEndMs,
   cycleBreakdown,
   programmaticConsumedCredits,
+  topUpButton,
 }: WorkspaceCreditPoolSectionProps) {
   if (cardsStatus === "ready" && !isVisible) {
     return null;
@@ -258,6 +263,7 @@ export function WorkspaceCreditPoolSection({
             programmaticConsumedCredits={programmaticConsumedCredits}
             isLoading={false}
           />
+          {topUpButton}
           <WorkspaceCreditPoolHistory
             tableStatus={tableStatus}
             cycleBreakdown={cycleBreakdown}
@@ -274,6 +280,7 @@ interface CreditPoolCardsFromCycleDataProps {
   poolCycleBreakdown: AwuPoolCycleBreakdown[];
   excessCycleBreakdown: AwuPoolCycleBreakdown[];
   tableStatus: CreditPoolFetchStatus;
+  topUpButton?: ReactNode;
 }
 export function CreditPoolCardsFromCycleData({
   awuPoolCurrentCycle,
@@ -281,6 +288,7 @@ export function CreditPoolCardsFromCycleData({
   poolCycleBreakdown,
   excessCycleBreakdown,
   tableStatus,
+  topUpButton,
 }: CreditPoolCardsFromCycleDataProps) {
   const {
     totalRemainingCredits,
@@ -318,6 +326,7 @@ export function CreditPoolCardsFromCycleData({
       currentCycleEndMs={currentCycleEndMs}
       cycleBreakdown={hasPool ? poolCycleBreakdown : excessCycleBreakdown}
       programmaticConsumedCredits={programmaticConsumedCredits}
+      topUpButton={topUpButton}
     />
   );
 }
@@ -325,8 +334,13 @@ export function CreditPoolCardsFromCycleData({
 interface CreditPoolCardsProps {
   owner: LightWorkspaceType;
   disabled: boolean;
+  topUpButton?: ReactNode;
 }
-export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
+export function CreditPoolCards({
+  owner,
+  disabled,
+  topUpButton,
+}: CreditPoolCardsProps) {
   const {
     awuPoolCurrentCycle,
     isAwuPoolCurrentCycleLoading,
@@ -348,6 +362,7 @@ export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
       )}
       poolCycleBreakdown={poolCycleBreakdown}
       excessCycleBreakdown={excessCycleBreakdown}
+      topUpButton={topUpButton}
       tableStatus={toCreditPoolFetchStatus(
         isAwuPoolCycleHistoryLoading,
         !!isAwuPoolCycleHistoryError

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -292,16 +292,20 @@ export function useAwuPoolCurrentCycle({
 
 export function useAwuPoolCycleHistory({
   workspaceId,
+  cycleHistoryLimit,
   disabled,
 }: {
   workspaceId: string;
+  cycleHistoryLimit?: number;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
   const awuFetcher: Fetcher<AwuPoolCycleHistoryResponseBody> = fetcher;
 
   const { data, error, isValidating, mutate } = useSWRWithDefaults(
-    `/api/w/${workspaceId}/credits/awu-pool-cycle-history`,
+    `/api/w/${workspaceId}/credits/awu-pool-cycle-history${
+      cycleHistoryLimit ? `?cycleHistoryLimit=${cycleHistoryLimit}` : ""
+    }`,
     awuFetcher,
     { disabled }
   );


### PR DESCRIPTION
## Description

In the new usage page only show up to 3 previous cycle so the table doesn't consume too much space.

## Tests



## Risk

Low

## Deploy Plan

Deploy front
