### PR TITLE
feat(front): offer a free leading period on seat commitments

### DIFF
--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -155,6 +155,67 @@ const DEFAULT_PERIODS_FOR_FREQUENCY: Record<string, number | undefined> = {
   one_time: undefined,
 };
 
+// A small number input + unit dropdown (years / months / weeks), reused for the
+// contract duration and the promotional offer period.
+function PeriodField({
+  value,
+  unit,
+  onValueChange,
+  onUnitChange,
+  portalContainer,
+  min = 1,
+}: {
+  value: number;
+  unit: ContractDurationUnit;
+  onValueChange: (value: number) => void;
+  onUnitChange: (unit: ContractDurationUnit) => void;
+  portalContainer: HTMLElement | undefined;
+  min?: number;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        type="number"
+        min={min}
+        value={value}
+        onChange={(e) => onValueChange(Number(e.target.value))}
+        className="h-7 w-14 rounded-md border border-border bg-background px-1.5 text-xs"
+      />
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="xs"
+            isSelect
+            label={
+              unit === "years"
+                ? "Years"
+                : unit === "months"
+                  ? "Months"
+                  : "Weeks"
+            }
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent mountPortalContainer={portalContainer}>
+          <DropdownMenuItem
+            label="Years"
+            onClick={() => onUnitChange("years")}
+          />
+          <DropdownMenuItem
+            label="Months"
+            onClick={() => onUnitChange("months")}
+          />
+          <DropdownMenuItem
+            label="Weeks"
+            onClick={() => onUnitChange("weeks")}
+          />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
 interface SwitchContractDialogProps {
   owner: WorkspaceType;
   stripeCustomerId: string | null;
@@ -1141,52 +1202,13 @@ export default function SwitchContractDialog({
                                 Set duration
                               </span>
                               {durationMode && (
-                                <>
-                                  <input
-                                    type="number"
-                                    min={1}
-                                    value={durationValue}
-                                    onChange={(e) =>
-                                      setDurationValue(Number(e.target.value))
-                                    }
-                                    className="h-7 w-14 rounded-md border border-border bg-background px-1.5 text-xs"
-                                  />
-                                  <DropdownMenu>
-                                    <DropdownMenuTrigger asChild>
-                                      <Button
-                                        type="button"
-                                        variant="outline"
-                                        size="xs"
-                                        isSelect
-                                        label={
-                                          durationUnit === "years"
-                                            ? "Years"
-                                            : durationUnit === "months"
-                                              ? "Months"
-                                              : "Weeks"
-                                        }
-                                      />
-                                    </DropdownMenuTrigger>
-                                    <DropdownMenuContent
-                                      mountPortalContainer={portalContainer}
-                                    >
-                                      <DropdownMenuItem
-                                        label="Years"
-                                        onClick={() => setDurationUnit("years")}
-                                      />
-                                      <DropdownMenuItem
-                                        label="Months"
-                                        onClick={() =>
-                                          setDurationUnit("months")
-                                        }
-                                      />
-                                      <DropdownMenuItem
-                                        label="Weeks"
-                                        onClick={() => setDurationUnit("weeks")}
-                                      />
-                                    </DropdownMenuContent>
-                                  </DropdownMenu>
-                                </>
+                                <PeriodField
+                                  value={durationValue}
+                                  unit={durationUnit}
+                                  onValueChange={setDurationValue}
+                                  onUnitChange={setDurationUnit}
+                                  portalContainer={portalContainer}
+                                />
                               )}
                             </div>
                           </div>
@@ -1748,50 +1770,14 @@ export default function SwitchContractDialog({
                         <Label className="text-sm font-medium">
                           Offer free period
                         </Label>
-                        <div className="flex items-center gap-2">
-                          <input
-                            type="number"
-                            min={0}
-                            value={offerValue}
-                            onChange={(e) =>
-                              setOfferValue(Math.max(0, Number(e.target.value)))
-                            }
-                            className="h-7 w-14 rounded-md border border-border bg-background px-1.5 text-xs"
-                          />
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <Button
-                                type="button"
-                                variant="outline"
-                                size="xs"
-                                isSelect
-                                label={
-                                  offerUnit === "years"
-                                    ? "Years"
-                                    : offerUnit === "months"
-                                      ? "Months"
-                                      : "Weeks"
-                                }
-                              />
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent
-                              mountPortalContainer={portalContainer}
-                            >
-                              <DropdownMenuItem
-                                label="Years"
-                                onClick={() => setOfferUnit("years")}
-                              />
-                              <DropdownMenuItem
-                                label="Months"
-                                onClick={() => setOfferUnit("months")}
-                              />
-                              <DropdownMenuItem
-                                label="Weeks"
-                                onClick={() => setOfferUnit("weeks")}
-                              />
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                        </div>
+                        <PeriodField
+                          value={offerValue}
+                          unit={offerUnit}
+                          onValueChange={(v) => setOfferValue(Math.max(0, v))}
+                          onUnitChange={setOfferUnit}
+                          portalContainer={portalContainer}
+                          min={0}
+                        />
                         <div className="col-span-2 text-xs text-muted-foreground">
                           Reduces every seat commitment's earliest bill(s) by
                           the prorated value of this leading period, so the

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -337,8 +337,6 @@ export default function SwitchContractDialog({
   useEffect(() => {
     if (!open) {
       creditConfigAppliedRef.current = false;
-      setOfferValue(0);
-      setOfferUnit("weeks");
       return;
     }
     if (!existingCreditConfig || creditConfigAppliedRef.current) {
@@ -948,7 +946,17 @@ export default function SwitchContractDialog({
   );
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        // Reset the promotional offer when the dialog closes.
+        if (!next) {
+          setOfferValue(0);
+          setOfferUnit("weeks");
+        }
+      }}
+    >
       <DialogTrigger asChild>
         <Button variant="outline" label="🔁 Switch contract" />
       </DialogTrigger>

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -171,6 +171,10 @@ export default function SwitchContractDialog({
   const [durationValue, setDurationValue] = useState(1);
   const [durationUnit, setDurationUnit] =
     useState<ContractDurationUnit>("years");
+  // Promotional free period offered at the start of the contract (0 = none),
+  // applied globally to every seat commitment's earliest bills.
+  const [offerValue, setOfferValue] = useState(0);
+  const [offerUnit, setOfferUnit] = useState<ContractDurationUnit>("weeks");
   const [portalContainer, setPortalContainer] = useState<
     HTMLElement | undefined
   >(undefined);
@@ -272,6 +276,8 @@ export default function SwitchContractDialog({
   useEffect(() => {
     if (!open) {
       creditConfigAppliedRef.current = false;
+      setOfferValue(0);
+      setOfferUnit("weeks");
       return;
     }
     if (!existingCreditConfig || creditConfigAppliedRef.current) {
@@ -749,6 +755,10 @@ export default function SwitchContractDialog({
       if (values.recurringFreeCredit !== undefined) {
         cleaned.recurringFreeCredit = values.recurringFreeCredit;
       }
+      // Promotional free period: only sent when a positive duration is entered.
+      if (offerValue > 0) {
+        cleaned.offerFreePeriod = { value: offerValue, unit: offerUnit };
+      }
       // Resolve the start moment. "immediately" leaves `startingAt` unset so
       // the server swaps at the current hour.
       if (values.startMode === "retroactive_first_of_month") {
@@ -865,7 +875,15 @@ export default function SwitchContractDialog({
       };
       void submit();
     },
-    [form, owner.sId, router, selectedSeats, retroactiveFirstOfMonthISO]
+    [
+      form,
+      owner.sId,
+      router,
+      selectedSeats,
+      retroactiveFirstOfMonthISO,
+      offerValue,
+      offerUnit,
+    ]
   );
 
   return (
@@ -1723,6 +1741,63 @@ export default function SwitchContractDialog({
                             />
                           </>
                         )}
+                      </div>
+                    </div>
+                    <div className="border-t pt-4">
+                      <div className="grid grid-cols-[200px_1fr] items-center gap-x-4 gap-y-2">
+                        <Label className="text-sm font-medium">
+                          Offer free period
+                        </Label>
+                        <div className="flex items-center gap-2">
+                          <input
+                            type="number"
+                            min={0}
+                            value={offerValue}
+                            onChange={(e) =>
+                              setOfferValue(Math.max(0, Number(e.target.value)))
+                            }
+                            className="h-7 w-14 rounded-md border border-border bg-background px-1.5 text-xs"
+                          />
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="xs"
+                                isSelect
+                                label={
+                                  offerUnit === "years"
+                                    ? "Years"
+                                    : offerUnit === "months"
+                                      ? "Months"
+                                      : "Weeks"
+                                }
+                              />
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent
+                              mountPortalContainer={portalContainer}
+                            >
+                              <DropdownMenuItem
+                                label="Years"
+                                onClick={() => setOfferUnit("years")}
+                              />
+                              <DropdownMenuItem
+                                label="Months"
+                                onClick={() => setOfferUnit("months")}
+                              />
+                              <DropdownMenuItem
+                                label="Weeks"
+                                onClick={() => setOfferUnit("weeks")}
+                              />
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        </div>
+                        <div className="col-span-2 text-xs text-muted-foreground">
+                          Reduces every seat commitment's earliest bill(s) by
+                          the prorated value of this leading period, so the
+                          customer pays nothing for it. Leave at 0 for no offer.
+                          The granted seats are unchanged.
+                        </div>
                       </div>
                     </div>
                   </>

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -783,11 +783,13 @@ async function stepContractEdits({
       // Optional promotional free period: reduce the seat's earliest bills by
       // the prorated value of the leading offered duration (never beyond the
       // contract end). The grant is left untouched — this is a pure discount.
+      // Use the seat's major-unit `rate` (not `rateNative`) so the reduction is
+      // in the same cents basis as `invoiceAmountCents` (commitmentPrice * 100).
       const offerReductionCents = body.offerFreePeriod
         ? Math.round(
             commitmentAmount({
               minSeats: seat.minSeats,
-              ratePerPeriod: rateNative,
+              ratePerPeriod: seat.rate,
               isAnnual: billingFrequency === "ANNUAL",
               start: alignedStart,
               end: new Date(

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -134,6 +134,36 @@ function validatePlanPackageCompat(
   return { ok: true };
 }
 
+// Timestamp of the i-th invoice installment: `i * monthsPerPeriod` months after
+// the contract start, on the start's day for the first installment and the 1st
+// of the month thereafter, keeping the start's time of day. Month overflow is
+// clamped to the last day of the target month.
+function installmentTimestamp(
+  alignedStart: Date,
+  i: number,
+  monthsPerPeriod: number
+): Date {
+  const totalMonths = alignedStart.getUTCMonth() + i * monthsPerPeriod;
+  const targetYear =
+    alignedStart.getUTCFullYear() + Math.floor(totalMonths / 12);
+  const targetMonth = ((totalMonths % 12) + 12) % 12;
+  const lastDayOfMonth = new Date(
+    Date.UTC(targetYear, targetMonth + 1, 0)
+  ).getUTCDate();
+  const day = i === 0 ? Math.min(alignedStart.getUTCDate(), lastDayOfMonth) : 1;
+  return new Date(
+    Date.UTC(
+      targetYear,
+      targetMonth,
+      day,
+      alignedStart.getUTCHours(),
+      alignedStart.getUTCMinutes(),
+      alignedStart.getUTCSeconds(),
+      alignedStart.getUTCMilliseconds()
+    )
+  );
+}
+
 function buildInvoiceScheduleItems({
   invoiceAmountCents,
   resolvedCurrency,
@@ -179,11 +209,12 @@ function buildInvoiceScheduleItems({
           maxInvoicePeriods(alignedStart, commitmentEnd, frequency)
         );
   // Per-installment amounts (cents) and their timestamps, before the reduction.
-  const amountsCents: number[] = [];
-  const timestamps: Date[] = [];
+  const installments: { amountCents: number; timestamp: Date }[] = [];
   if (frequency === "one_time" || !periods || periods <= 1) {
-    amountsCents.push(invoiceAmountCents);
-    timestamps.push(alignedStart);
+    installments.push({
+      amountCents: invoiceAmountCents,
+      timestamp: alignedStart,
+    });
   } else {
     const monthsPerPeriod = PAYMENT_FREQUENCY_MONTHS[frequency];
     // With a known per-period list amount, bill it in full each period (clamped
@@ -209,42 +240,26 @@ function buildInvoiceScheduleItems({
               )
             : Math.round(invoiceAmountCents * (weights[i] / weightSum));
       allocatedCents += amountCents;
-      amountsCents.push(amountCents);
-      const totalMonths = alignedStart.getUTCMonth() + i * monthsPerPeriod;
-      const targetYear =
-        alignedStart.getUTCFullYear() + Math.floor(totalMonths / 12);
-      const targetMonth = ((totalMonths % 12) + 12) % 12;
-      const lastDayOfMonth = new Date(
-        Date.UTC(targetYear, targetMonth + 1, 0)
-      ).getUTCDate();
-      const day =
-        i === 0 ? Math.min(alignedStart.getUTCDate(), lastDayOfMonth) : 1;
-      timestamps.push(
-        new Date(
-          Date.UTC(
-            targetYear,
-            targetMonth,
-            day,
-            alignedStart.getUTCHours(),
-            alignedStart.getUTCMinutes(),
-            alignedStart.getUTCSeconds(),
-            alignedStart.getUTCMilliseconds()
-          )
-        )
-      );
+      installments.push({
+        amountCents,
+        timestamp: installmentTimestamp(alignedStart, i, monthsPerPeriod),
+      });
     }
   }
   // Apply the promotional free-period reduction from the first bill onwards.
   let remainingReduction = reduceFrontCents ?? 0;
-  for (let i = 0; i < amountsCents.length && remainingReduction > 0; i++) {
-    const applied = Math.min(amountsCents[i], remainingReduction);
-    amountsCents[i] -= applied;
+  for (const installment of installments) {
+    if (remainingReduction <= 0) {
+      break;
+    }
+    const applied = Math.min(installment.amountCents, remainingReduction);
+    installment.amountCents -= applied;
     remainingReduction -= applied;
   }
-  return amountsCents.map((cents, i) => ({
-    unitPrice: metronomeAmount(cents, resolvedCurrency),
+  return installments.map((installment) => ({
+    unitPrice: metronomeAmount(installment.amountCents, resolvedCurrency),
     quantity: 1,
-    timestamp: timestamps[i],
+    timestamp: installment.timestamp,
   }));
 }
 

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -35,6 +35,7 @@ import {
   provisionMetronomeContract,
 } from "@app/lib/metronome/contracts";
 import {
+  addDuration,
   commitmentAmount,
   commitmentPeriodEnd,
   invoicePeriodWeights,
@@ -140,6 +141,7 @@ function buildInvoiceScheduleItems({
   commitmentEnd,
   paymentSchedule,
   fullInstallmentCents,
+  reduceFrontCents,
 }: {
   invoiceAmountCents: number;
   resolvedCurrency: SupportedCurrency;
@@ -163,6 +165,10 @@ function buildInvoiceScheduleItems({
   // total split evenly. When omitted (initial credits, scheduled charges, which
   // have no per-period list rate), the total is split by prorated period weight.
   fullInstallmentCents?: number;
+  // Promotional reduction (cents) applied to the installments from the first
+  // bill onwards, each floored at 0 and carrying the leftover to the next — so a
+  // free leading period zeroes the earliest bills. Defaults to 0.
+  reduceFrontCents?: number;
 }): { unitPrice: number; quantity: number; timestamp: Date }[] {
   const { frequency } = paymentSchedule;
   const periods =
@@ -172,69 +178,74 @@ function buildInvoiceScheduleItems({
           paymentSchedule.periods,
           maxInvoicePeriods(alignedStart, commitmentEnd, frequency)
         );
+  // Per-installment amounts (cents) and their timestamps, before the reduction.
+  const amountsCents: number[] = [];
+  const timestamps: Date[] = [];
   if (frequency === "one_time" || !periods || periods <= 1) {
-    return [
-      {
-        unitPrice: metronomeAmount(invoiceAmountCents, resolvedCurrency),
-        quantity: 1,
-        timestamp: alignedStart,
-      },
-    ];
-  }
-  const monthsPerPeriod = PAYMENT_FREQUENCY_MONTHS[frequency];
-  // Amount per installment. With a known per-period list amount, bill it in full
-  // each period (clamped to what's left) and put the remainder on the last, so
-  // full periods invoice at list price. Otherwise distribute the total by the
-  // prorated fraction of each period (whole periods equal, partial last).
-  let allocatedCents = 0;
-  const weights = invoicePeriodWeights(
-    alignedStart,
-    commitmentEnd,
-    frequency,
-    periods
-  );
-  const weightSum = weights.reduce((sum, w) => sum + w, 0);
-  const amountForInstallment = (i: number, weight: number): number => {
-    if (i === periods - 1) {
-      return invoiceAmountCents - allocatedCents;
-    }
-    if (fullInstallmentCents !== undefined) {
-      return Math.min(
-        fullInstallmentCents,
-        invoiceAmountCents - allocatedCents
+    amountsCents.push(invoiceAmountCents);
+    timestamps.push(alignedStart);
+  } else {
+    const monthsPerPeriod = PAYMENT_FREQUENCY_MONTHS[frequency];
+    // With a known per-period list amount, bill it in full each period (clamped
+    // to what's left) and put the remainder on the last, so full periods invoice
+    // at list price. Otherwise distribute the total by the prorated fraction of
+    // each period (whole periods equal, partial last).
+    const weights = invoicePeriodWeights(
+      alignedStart,
+      commitmentEnd,
+      frequency,
+      periods
+    );
+    const weightSum = weights.reduce((sum, w) => sum + w, 0);
+    let allocatedCents = 0;
+    for (let i = 0; i < periods; i++) {
+      const amountCents =
+        i === periods - 1
+          ? invoiceAmountCents - allocatedCents
+          : fullInstallmentCents !== undefined
+            ? Math.min(
+                fullInstallmentCents,
+                invoiceAmountCents - allocatedCents
+              )
+            : Math.round(invoiceAmountCents * (weights[i] / weightSum));
+      allocatedCents += amountCents;
+      amountsCents.push(amountCents);
+      const totalMonths = alignedStart.getUTCMonth() + i * monthsPerPeriod;
+      const targetYear =
+        alignedStart.getUTCFullYear() + Math.floor(totalMonths / 12);
+      const targetMonth = ((totalMonths % 12) + 12) % 12;
+      const lastDayOfMonth = new Date(
+        Date.UTC(targetYear, targetMonth + 1, 0)
+      ).getUTCDate();
+      const day =
+        i === 0 ? Math.min(alignedStart.getUTCDate(), lastDayOfMonth) : 1;
+      timestamps.push(
+        new Date(
+          Date.UTC(
+            targetYear,
+            targetMonth,
+            day,
+            alignedStart.getUTCHours(),
+            alignedStart.getUTCMinutes(),
+            alignedStart.getUTCSeconds(),
+            alignedStart.getUTCMilliseconds()
+          )
+        )
       );
     }
-    return Math.round(invoiceAmountCents * (weight / weightSum));
-  };
-  return weights.map((weight, i) => {
-    const totalMonths = alignedStart.getUTCMonth() + i * monthsPerPeriod;
-    const targetYear =
-      alignedStart.getUTCFullYear() + Math.floor(totalMonths / 12);
-    const targetMonth = ((totalMonths % 12) + 12) % 12;
-    const lastDayOfMonth = new Date(
-      Date.UTC(targetYear, targetMonth + 1, 0)
-    ).getUTCDate();
-    const day =
-      i === 0 ? Math.min(alignedStart.getUTCDate(), lastDayOfMonth) : 1;
-    const ts = new Date(
-      Date.UTC(
-        targetYear,
-        targetMonth,
-        day,
-        alignedStart.getUTCHours(),
-        alignedStart.getUTCMinutes(),
-        alignedStart.getUTCSeconds(),
-        alignedStart.getUTCMilliseconds()
-      )
-    );
-    const amountCents = amountForInstallment(i, weight);
-    allocatedCents += amountCents;
-    return {
-      unitPrice: metronomeAmount(amountCents, resolvedCurrency),
-      quantity: 1,
-      timestamp: ts,
-    };
-  });
+  }
+  // Apply the promotional free-period reduction from the first bill onwards.
+  let remainingReduction = reduceFrontCents ?? 0;
+  for (let i = 0; i < amountsCents.length && remainingReduction > 0; i++) {
+    const applied = Math.min(amountsCents[i], remainingReduction);
+    amountsCents[i] -= applied;
+    remainingReduction -= applied;
+  }
+  return amountsCents.map((cents, i) => ({
+    unitPrice: metronomeAmount(cents, resolvedCurrency),
+    quantity: 1,
+    timestamp: timestamps[i],
+  }));
 }
 
 // ─── Pre-provision helper functions ──────────────────────────────────────────
@@ -769,6 +780,29 @@ async function stepContractEdits({
         seat.paymentSchedule.frequency === "one_time"
           ? 1
           : PAYMENT_FREQUENCY_MONTHS[seat.paymentSchedule.frequency];
+      // Optional promotional free period: reduce the seat's earliest bills by
+      // the prorated value of the leading offered duration (never beyond the
+      // contract end). The grant is left untouched — this is a pure discount.
+      const offerReductionCents = body.offerFreePeriod
+        ? Math.round(
+            commitmentAmount({
+              minSeats: seat.minSeats,
+              ratePerPeriod: rateNative,
+              isAnnual: billingFrequency === "ANNUAL",
+              start: alignedStart,
+              end: new Date(
+                Math.min(
+                  addDuration(
+                    alignedStart,
+                    body.offerFreePeriod.value,
+                    body.offerFreePeriod.unit
+                  ).getTime(),
+                  commitmentEnd.getTime()
+                )
+              ),
+            }) * 100
+          )
+        : 0;
       const seatScheduleItems = buildInvoiceScheduleItems({
         invoiceAmountCents: Math.round(seat.commitmentPrice * 100),
         resolvedCurrency,
@@ -778,6 +812,7 @@ async function stepContractEdits({
         fullInstallmentCents: Math.round(
           seat.minSeats * seatMonthlyRate * paymentMonths * 100
         ),
+        reduceFrontCents: offerReductionCents,
       });
       addCommits.push({
         product_id: getProductSeatSubscriptionCommitId(),

--- a/front/lib/metronome/seat_commitment.test.ts
+++ b/front/lib/metronome/seat_commitment.test.ts
@@ -1,4 +1,5 @@
 import {
+  addDuration,
   commitmentAmount,
   commitmentMonths,
   commitmentPeriodEnd,
@@ -11,6 +12,28 @@ const start = new Date(Date.UTC(2026, 0, 1));
 const oneYear = new Date(Date.UTC(2027, 0, 1));
 // 42 days after start (Jan 1 → Feb 12): ~1.39 calendar months.
 const sixWeeks = new Date(start.getTime() + 42 * 24 * 60 * 60 * 1000);
+
+describe("addDuration", () => {
+  it("adds whole weeks as 7-day steps", () => {
+    expect(addDuration(start, 2, "weeks")).toEqual(
+      new Date(Date.UTC(2026, 0, 15))
+    );
+  });
+
+  it("adds calendar months and years", () => {
+    expect(addDuration(start, 2, "months")).toEqual(
+      new Date(Date.UTC(2026, 2, 1))
+    );
+    expect(addDuration(start, 1, "years")).toEqual(oneYear);
+  });
+
+  it("clamps month overflow to the last day of the target month", () => {
+    // Jan 31 + 1 month → Feb 28 (2026 is not a leap year).
+    expect(addDuration(new Date(Date.UTC(2026, 0, 31)), 1, "months")).toEqual(
+      new Date(Date.UTC(2026, 1, 28))
+    );
+  });
+});
 
 describe("commitmentPeriodEnd", () => {
   it("uses the end date when set", () => {

--- a/front/lib/metronome/seat_commitment.ts
+++ b/front/lib/metronome/seat_commitment.ts
@@ -58,6 +58,22 @@ export function commitmentPeriodEnd(
   return endingAt ?? oneYearAfter(start);
 }
 
+// Add a duration to a UTC moment: whole weeks are 7-day steps; months and years
+// are calendar steps with day-overflow clamped to the last day of the target
+// month (Jan 31 + 1 month → Feb 28/29). Seconds/millis are zeroed.
+export function addDuration(
+  start: Date,
+  value: number,
+  unit: "years" | "months" | "weeks"
+): Date {
+  if (unit === "weeks") {
+    return new Date(start.getTime() + value * 7 * 24 * 60 * 60 * 1000);
+  }
+  const withMonths = addMonthsUtc(start, unit === "years" ? value * 12 : value);
+  withMonths.setUTCSeconds(0, 0);
+  return withMonths;
+}
+
 // Fractional number of calendar months in [start, end) — the prorated invoice
 // basis. Whole-month and whole-year spans come out exact (a one-year contract is
 // exactly 12 months, not ~11.99), with any partial trailing month measured as a

--- a/front/types/poke/switch_contract.ts
+++ b/front/types/poke/switch_contract.ts
@@ -186,6 +186,17 @@ export const SwitchContractBodySchema = z.object({
   autoSeatUpgradeEnabled: z.boolean().default(false),
   topUpEnabled: z.boolean().default(false),
   autoInvoiceFinalizationEnabled: z.boolean().default(true),
+  // Optional promotional free period offered at the start of the contract: the
+  // seat commitment invoices are reduced, from the first bill onwards, by the
+  // prorated value of this leading duration (all seats), so the customer pays
+  // nothing for that period. The credit grant is unaffected. Does not apply to
+  // initial credits or scheduled charges.
+  offerFreePeriod: z
+    .object({
+      value: z.number().int().min(1),
+      unit: z.enum(["years", "months", "weeks"]),
+    })
+    .optional(),
 });
 
 export type SwitchContractBody = z.infer<typeof SwitchContractBodySchema>;


### PR DESCRIPTION
## Description

Adds an optional promotional **"Offer free period"** to the Switch Contract poke modal: the operator picks a leading duration (years / months / weeks, same picker style as the contract duration), and every seat commitment's earliest bill(s) are reduced by the prorated value of that period — so the customer pays nothing for it.

It's a **global** setting that applies to all seats, and it's a **pure discount**: the credit grant (what Metronome charges/offsets) is unchanged, only the invoice is reduced. It does not touch initial credits or scheduled charges.

Based on `main` (the commitment/proration work from #32025 is merged).

- **Schema** — optional `offerFreePeriod { value, unit }` on `SwitchContractBodySchema`.
- **`seat_commitment.ts`** — a shared `addDuration()` helper (weeks = 7-day steps; months/years = calendar steps with day-overflow clamping).
- **`buildInvoiceScheduleItems`** — new `reduceFrontCents` that subtracts from the installments front-to-back, each floored at 0 (a free leading period zeroes the earliest bills and carries the leftover forward).
- **Server** — sizes the per-seat reduction as the prorated commitment value of the offered window (`commitmentAmount` over `[start, start+offer]`, bounded by the contract end).
- **Dialog** — a bottom **"Offer free period"** row: number input + unit dropdown; `0` = no offer.

Example: 10× yearly seat at $240/yr, offer 2 weeks → each seat's first bill is reduced by `240 × 10 × 14/365 ≈ $92.05`.

## Tests

- Added `addDuration` unit tests (weeks/months/years + month-overflow clamp) to `seat_commitment.test.ts` (18 pass).
- `tsgo` and biome pass.
- Manual: with an offer set, the first invoice line(s) drop by the offered value and cascade; grant unchanged; `0` disables it.

## Risk

Low, internal Poke tooling. `offerFreePeriod` is optional and additive (backward compatible); with no offer, invoice generation is unchanged. Pure invoice discount, no grant/entitlement impact. No migration or feature flag. Rollback is a straight revert.

## Deploy Plan

Standard `front` deploy. No migration or ordering constraints.