### PR TITLE
Fix Unblock action never showing on the customer usage page

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -1113,7 +1113,20 @@ export function UsagePage() {
             />
           ) : (
             <div className="flex items-center justify-between">
-              <Page.Header title="Usage" />
+              <Page.Header
+                title={
+                  <div className="flex w-full items-center gap-4">
+                    <Page.H variant="h3">Usage</Page.H>
+                    <Button
+                      label="Breakdown in analytics"
+                      iconRight={LinkExternal01}
+                      size="xs"
+                      variant="highlight-ghost"
+                      href={`/w/${owner.sId}/analytics/consumption`}
+                    />
+                  </div>
+                }
+              />
               {!isNewUsagePage &&
                 isCreditPriced &&
                 usageSettings.topUpEnabled &&

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -188,7 +188,7 @@ export type MemberUsageType = {
   // "capped" (counter ≥ cap), "near_limit" (≥ 80%), or "ok". The counter is the
   // lifetime one for free seats and the per-cycle one otherwise, compared to the
   // free-seat allowance / effective cycle cap. Null when no cap applies, or not
-  // requested (poke's `includeAlertLinks`) and the rate-cap flag is off.
+  // requested.
   rateLimiterState: RateLimiterState | null;
   // Flag-aware "blocked by the per-user spend cap" verdict — the signal the
   // Unblock action (poke and the customer usage page) keys off. With the
@@ -2176,15 +2176,6 @@ async function resolveMembersUsagePageUsers({
   });
 }
 
-/**
- * @cc [owner:avervaet,label:product] spend-cap-verdict-independent-of-alert-links
- * `isSpendCapped`, `rateLimiterState`, `seatUsageTarget`, and `overallUsageTarget` on each
- * returned member must be computed whenever `enforce_user_spend_limit_rate_cap` is enabled for
- * the workspace, regardless of `includeAlertLinks`. `MembersUsageTable`'s off-pace/Unblock
- * column is shared between poke (which passes `includeAlertLinks: true`) and the customer usage
- * page (which never does), so gating this verdict on `includeAlertLinks` alone silently breaks
- * it on the customer usage page.
- */
 export async function getMembersUsage({
   auth,
   paginationParams,
@@ -2193,11 +2184,6 @@ export async function getMembersUsage({
 }: {
   auth: Authenticator;
   paginationParams: MembersUsagePaginationInput;
-  // Metronome-backed alert links/near-limit/consumption figures used for poke
-  // debugging — extra Metronome calls, so it stays off on the customer usage
-  // page. Independent of the rate-limiter-backed `isSpendCapped`/off-pace
-  // verdict, which is also computed here whenever the rate-cap flag is on,
-  // regardless of this flag.
   includeAlertLinks?: boolean;
   // Live per-seat balance read (an extra Metronome call). Poke-only — the
   // customer usage page doesn't surface it, so it stays off there.
@@ -2385,13 +2371,11 @@ export async function getMembersUsage({
       )
     : new Map<string, boolean>();
 
-  // Bulk-fetch the Redis fixed-window spend-cap counter per user, to display
-  // beside the Elasticsearch-derived usage (poke) and to back the `isSpendCapped`
-  // / off-pace verdict consumed by both poke and the customer usage page's
-  // Unblock action. Free seats are enforced on a never-rolling *lifetime*
-  // counter (their lifetime credit allowance); everyone else on the
-  // per-contract-cycle counter. The cycle also backs the per-member seat-usage
-  // pace below, so resolve it regardless.
+  // Bulk-fetch the Redis fixed-window spend-cap counter per user (poke-only), to
+  // display beside the Elasticsearch-derived usage. Free seats are enforced on a
+  // never-rolling *lifetime* counter (their lifetime credit allowance); everyone
+  // else on the per-contract-cycle counter. The cycle also backs the per-member
+  // seat-usage pace below, so resolve it regardless.
   const rateLimiterSpendByUserId = new Map<string, number>();
   let billingCycle: BillingCycle | null = null;
   if (includeAlertLinks || spendCapEnabled) {

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -187,21 +187,23 @@ export type MemberUsageType = {
   // The rate-limiter's view of the user's spend cap (independent of the flag):
   // "capped" (counter ≥ cap), "near_limit" (≥ 80%), or "ok". The counter is the
   // lifetime one for free seats and the per-cycle one otherwise, compared to the
-  // free-seat allowance / effective cycle cap. Null when no cap applies or not
-  // requested. Poke-only.
+  // free-seat allowance / effective cycle cap. Null when no cap applies, or not
+  // requested (poke's `includeAlertLinks`) and the rate-cap flag is off.
   rateLimiterState: RateLimiterState | null;
-  // Flag-aware "blocked by the per-user spend cap" verdict — the signal the poke
-  // Unblock action keys off. With the rate-cap flag on, from the rate-limiter
-  // counter (`rateLimiterState`); with it off, from the persisted Metronome
-  // credit state. Mirrors the enforcement switch in
-  // lib/api/credits/access_control.ts, so it never disagrees with what actually
-  // blocks. The single-member / synthetic construction paths (which don't read
-  // the rate-limiter) fall back to the persisted credit state.
+  // Flag-aware "blocked by the per-user spend cap" verdict — the signal the
+  // Unblock action (poke and the customer usage page) keys off. With the
+  // rate-cap flag on, from the rate-limiter counter (`rateLimiterState`); with
+  // it off, from the persisted Metronome credit state. Mirrors the enforcement
+  // switch in lib/api/credits/access_control.ts, so it never disagrees with
+  // what actually blocks. The single-member / synthetic construction paths
+  // (which don't read the rate-limiter) fall back to the persisted credit
+  // state.
   isSpendCapped: boolean;
   // Classifies seat-allowance consumption against how far the billing cycle
   // has elapsed: "elevated"/"critical" mean the member is burning through
-  // their seat allowance faster than a linear pace would predict. Poke-only
-  // (null otherwise, or when the billing cycle can't be resolved).
+  // their seat allowance faster than a linear pace would predict. Null when
+  // not requested (poke's `includeAlertLinks`) and the rate-cap flag is off,
+  // or when the billing cycle can't be resolved.
   seatUsageTarget: CreditUsageTarget | null;
   // Same pace classification as `seatUsageTarget`, but against the member's
   // total effective spend limit (seat allowance + pool/overage).
@@ -2174,6 +2176,15 @@ async function resolveMembersUsagePageUsers({
   });
 }
 
+/**
+ * @cc [owner:avervaet,label:product] spend-cap-verdict-independent-of-alert-links
+ * `isSpendCapped`, `rateLimiterState`, `seatUsageTarget`, and `overallUsageTarget` on each
+ * returned member must be computed whenever `enforce_user_spend_limit_rate_cap` is enabled for
+ * the workspace, regardless of `includeAlertLinks`. `MembersUsageTable`'s off-pace/Unblock
+ * column is shared between poke (which passes `includeAlertLinks: true`) and the customer usage
+ * page (which never does), so gating this verdict on `includeAlertLinks` alone silently breaks
+ * it on the customer usage page.
+ */
 export async function getMembersUsage({
   auth,
   paginationParams,
@@ -2182,6 +2193,11 @@ export async function getMembersUsage({
 }: {
   auth: Authenticator;
   paginationParams: MembersUsagePaginationInput;
+  // Metronome-backed alert links/near-limit/consumption figures used for poke
+  // debugging — extra Metronome calls, so it stays off on the customer usage
+  // page. Independent of the rate-limiter-backed `isSpendCapped`/off-pace
+  // verdict, which is also computed here whenever the rate-cap flag is on,
+  // regardless of this flag.
   includeAlertLinks?: boolean;
   // Live per-seat balance read (an extra Metronome call). Poke-only — the
   // customer usage page doesn't surface it, so it stays off there.
@@ -2369,14 +2385,16 @@ export async function getMembersUsage({
       )
     : new Map<string, boolean>();
 
-  // Bulk-fetch the Redis fixed-window spend-cap counter per user (poke-only), to
-  // display beside the Elasticsearch-derived usage. Free seats are enforced on a
-  // never-rolling *lifetime* counter (their lifetime credit allowance); everyone
-  // else on the per-contract-cycle counter. The cycle also backs the per-member
-  // seat-usage pace below, so resolve it regardless.
+  // Bulk-fetch the Redis fixed-window spend-cap counter per user, to display
+  // beside the Elasticsearch-derived usage (poke) and to back the `isSpendCapped`
+  // / off-pace verdict consumed by both poke and the customer usage page's
+  // Unblock action. Free seats are enforced on a never-rolling *lifetime*
+  // counter (their lifetime credit allowance); everyone else on the
+  // per-contract-cycle counter. The cycle also backs the per-member seat-usage
+  // pace below, so resolve it regardless.
   const rateLimiterSpendByUserId = new Map<string, number>();
   let billingCycle: BillingCycle | null = null;
-  if (includeAlertLinks) {
+  if (includeAlertLinks || spendCapEnabled) {
     const periodResult = await getCachedMetronomeCurrentBillingPeriod(
       workspace.sId
     );
@@ -2617,26 +2635,29 @@ export async function getMembersUsage({
         ? (freeCreditAlertIds?.get(metronomeUserId) ?? null)
         : null;
 
-    const rateLimiterSpendAwuCredits = includeAlertLinks
-      ? (rateLimiterSpendByUserId.get(userId) ?? 0)
-      : null;
+    const rateLimiterSpendAwuCredits =
+      includeAlertLinks || spendCapEnabled
+        ? (rateLimiterSpendByUserId.get(userId) ?? 0)
+        : null;
     // Poke-only near-limit for the Metronome "Credit state" column, from the
     // Metronome near-limit flag.
     const nearLimit =
       includeAlertLinks && (nearLimitByUserId.get(userId) ?? false);
 
-    // Poke-only rate-limiter verdict (independent of the flag): the counter vs
-    // the threshold the seat is capped against — the free-seat lifetime
-    // allowance for free seats, the effective per-cycle cap otherwise.
+    // Rate-limiter verdict (independent of the flag): the counter vs the
+    // threshold the seat is capped against — the free-seat lifetime allowance
+    // for free seats, the effective per-cycle cap otherwise.
     // `rateLimiterSpendAwuCredits` already holds the matching counter (lifetime
-    // for free seats, per-cycle otherwise). Null when no cap applies.
+    // for free seats, per-cycle otherwise). Null when no cap applies. Backs
+    // `isSpendCapped` for both poke and the customer usage page's Unblock
+    // action.
     const rateCapThresholdAwuCredits =
       membership.seatType === "free"
         ? freeStartingBalanceAwu
         : effectiveSpendLimitAwuCredits;
     let rateLimiterState: RateLimiterState | null = null;
     if (
-      includeAlertLinks &&
+      (includeAlertLinks || spendCapEnabled) &&
       rateCapThresholdAwuCredits !== null &&
       rateCapThresholdAwuCredits > 0
     ) {


### PR DESCRIPTION
## Description

`getMembersUsage` only computed the `isSpendCapped`/`rateLimiterState` off-pace verdict when `includeAlertLinks` was true, which only poke ever passes. So the Unblock action on the new usage page was structurally impossible on the customer usage page. It's now gated on `includeAlertLinks || spendCapEnabled` instead.

## Tests

## Risk

Low risk: the change only widens when an existing verdict is computed and leaves poke's behavior untouched. Rollback is a plain revert.

## Deploy Plan

Deploy front