### PR TITLE
Add: get poke roles via cloudflare

### DIFF
--- a/front-api/middlewares/poke_auth.ts
+++ b/front-api/middlewares/poke_auth.ts
@@ -1,5 +1,6 @@
 import {
   getCloudflareAccessConfig,
+  getPokeRolesForUserViaCloudflareAccess,
   verifyCloudflareAccessJwt,
 } from "@app/lib/api/poke/cloudflare_access";
 import { Authenticator, isDustInternalEmail } from "@app/lib/auth";
@@ -81,7 +82,7 @@ export const pokeAuth = createMiddleware<PokeCtx>(async (ctx, next) => {
       "[Poke Auth] User logged in Poke via Cloudflare Access token"
     );
 
-    const pokeRoles = await getPokeRolesForUser(identity.email);
+    const pokeRoles = await getPokeRolesForUserViaCloudflareAccess(accessToken);
     ctx.set("auth", auth);
     ctx.set("pokeRoles", pokeRoles);
     await next();

--- a/front/lib/api/poke/cloudflare_access.ts
+++ b/front/lib/api/poke/cloudflare_access.ts
@@ -1,7 +1,11 @@
 import config from "@app/lib/api/config";
+import { trustedFetch } from "@app/lib/egress/server";
+import type { PokeRole } from "@app/lib/poke/roles";
+import { mapAccessGroupNamesToPokeRoles } from "@app/lib/poke/roles";
 import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { createRemoteJWKSet, jwtVerify } from "jose";
+import { z } from "zod";
 
 export type CloudflareAccessIdentity = {
   email: string;
@@ -9,6 +13,15 @@ export type CloudflareAccessIdentity = {
   sub: string;
 };
 
+const CloudFlareIdentityResponseSchema = z.object({
+  groups: z.array(
+    z.object({
+      id: z.string(),
+      email: z.string(),
+      name: z.string(),
+    })
+  ),
+});
 type CloudflareAccessConfig = {
   teamDomain: string;
   aud: string;
@@ -91,6 +104,38 @@ export async function verifyCloudflareAccessJwt(
       "[poke] Cloudflare Access JWT verification failed"
     );
     return null;
+  }
+}
+
+export async function getPokeRolesForUserViaCloudflareAccess(
+  accessToken: string
+): Promise<PokeRole[]> {
+  const accessConfig = getCloudflareAccessConfig();
+  if (!accessConfig) {
+    return [];
+  }
+  const response = await trustedFetch(
+    `${accessConfig.teamDomain}/cdn-cgi/access/get-identity`,
+    {
+      headers: {
+        cookie: `CF_Authorization=${accessToken}`,
+      },
+    }
+  );
+
+  if (response.ok) {
+    const data = await response.json();
+    const parsedData = CloudFlareIdentityResponseSchema.parse(data);
+
+    return mapAccessGroupNamesToPokeRoles(
+      parsedData.groups.map((group) => group.name)
+    );
+  } else {
+    logger.error("cloudflare access get-identity request failed", {
+      status: response.status,
+      statusText: response.statusText,
+    });
+    return [];
   }
 }
 

--- a/front/lib/poke/roles.ts
+++ b/front/lib/poke/roles.ts
@@ -26,6 +26,49 @@ let cacheExpiresAtMs = 0;
 
 const ALL_ROLES: PokeRole[] = PokeRoleSchema.options;
 
+/**
+ * IdP group names that grant each poke role. Keying by `PokeRole` forces a new
+ * role to declare its groups instead of silently granting nothing.
+ */
+const ACCESS_GROUPS_BY_ROLE: Record<PokeRole, readonly string[]> = {
+  admin: ["admin-mdm"],
+  billing: ["billing-mdm"],
+  engineering: ["engineering-mdm"],
+  support: ["support-mdm"],
+  talent: ["talent-mdm"],
+};
+
+const ROLE_BY_ACCESS_GROUP = new Map<string, PokeRole>(
+  ALL_ROLES.flatMap((role) =>
+    ACCESS_GROUPS_BY_ROLE[role].map(
+      (group) => [group.toLowerCase(), role] as const
+    )
+  )
+);
+
+export function mapAccessGroupNamesToPokeRoles(
+  groupNames: readonly string[]
+): PokeRole[] {
+  const granted = new Set<PokeRole>();
+
+  for (const groupName of groupNames) {
+    const normalized = groupName.trim().toLowerCase();
+    const at = normalized.indexOf("@");
+    const localPart =
+      at === -1 ? normalized : normalized.slice(0, at).trimEnd();
+    if (at !== -1 && !/^[^@\s]+$/.test(normalized.slice(at + 1))) {
+      continue;
+    }
+
+    const role = ROLE_BY_ACCESS_GROUP.get(localPart);
+    if (role) {
+      granted.add(role);
+    }
+  }
+
+  return ALL_ROLES.filter((role) => granted.has(role));
+}
+
 async function loadRoles(): Promise<RolesConfig> {
   if (cachedRoles && Date.now() < cacheExpiresAtMs) {
     return cachedRoles;


### PR DESCRIPTION
## Description

Poke authentication now derives Cloudflare Access users’ roles from the groups returned by `/cdn-cgi/access/get-identity` instead of the GCS email-to-role configuration. The explicit `admin-mdm`, `billing-mdm`, `engineering-mdm`, `support-mdm`, and `talent-mdm` mappings normalize group names and ignore unknown or malformed groups; the WorkOS fallback keeps the existing configuration path.

## Tests

No automated tests were added or run in this change but tested manually with a real access token.

## Risk

Medium risk: incorrect Cloudflare group mappings could grant or deny Poke capabilities. Unknown groups are ignored, the mapping is explicit, and the WorkOS fallback is unchanged. Rollback is safe by reverting the deployment.

## Deploy Plan

Deploy `front` and `front-api`. No database migrations or infrastructure changes are required.