### PR TITLE
Add link to analytics breakdown from customer usage page

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -1113,7 +1113,20 @@ export function UsagePage() {
             />
           ) : (
             <div className="flex items-center justify-between">
-              <Page.Header title="Usage" />
+              <Page.Header
+                title={
+                  <div className="flex w-full items-center gap-4">
+                    <Page.H variant="h3">Usage</Page.H>
+                    <Button
+                      label="Breakdown in analytics"
+                      iconRight={LinkExternal01}
+                      size="xs"
+                      variant="highlight-ghost"
+                      href={`/w/${owner.sId}/analytics/consumption`}
+                    />
+                  </div>
+                }
+              />
               {!isNewUsagePage &&
                 isCreditPriced &&
                 usageSettings.topUpEnabled &&


### PR DESCRIPTION
## Description

Adds a "Breakdown in analytics" button next to the Usage page title, linking to the workspace's analytics/consumption page.

## Tests

## Risk

Low pure front addition

## Deploy Plan

- Deploy front
