### PR TITLE
Remove poke workOS fallback outside of dev.

### DIFF
--- a/front-api/middlewares/poke_auth.ts
+++ b/front-api/middlewares/poke_auth.ts
@@ -1,27 +1,18 @@
 import {
   getCloudflareAccessConfig,
   getPokeRolesForUserViaCloudflareAccess,
+  resolveCloudflareAccessToken,
   verifyCloudflareAccessJwt,
 } from "@app/lib/api/poke/cloudflare_access";
 import { Authenticator, isDustInternalEmail } from "@app/lib/auth";
-import { getPokeRolesForUser } from "@app/lib/poke/roles";
+import { ALL_ROLES } from "@app/lib/poke/roles";
 import logger from "@app/logger/logger";
 import { isDevelopment } from "@app/types/shared/env";
 import type { PokeCtx } from "@front-api/middlewares/ctx";
 import { resolveSession } from "@front-api/middlewares/session_resolution";
 import { apiError } from "@front-api/middlewares/utils";
-import type { Context } from "hono";
 import { getCookie } from "hono/cookie";
 import { createMiddleware } from "hono/factory";
-
-function getCloudflareAccessToken(ctx: Context): string | undefined {
-  // Cloudflare recommends validating the assertion header over the cookie.
-  const headerToken = ctx.req.header("cf-access-jwt-assertion");
-  if (headerToken) {
-    return headerToken;
-  }
-  return getCookie(ctx, "CF_Authorization");
-}
 
 /**
  * Authenticates a Poke (super-user) request and stashes an unscoped
@@ -30,7 +21,8 @@ function getCloudflareAccessToken(ctx: Context): string | undefined {
  *
  * Prefers a validated Cloudflare Access JWT (`Cf-Access-Jwt-Assertion` /
  * `CF_Authorization`) so poke operators do not need a provisioned Dust user
- * with `isDustSuperUser` on every deployment. Falls back to the WorkOS
+ * with `isDustSuperUser` on every deployment. Outside development, a missing
+ * Access token is rejected. In development only, falls back to the WorkOS
  * super-user session path when no Access token is present.
  *
  * Super-user privilege is an Authenticator flag set only by poke factories
@@ -38,7 +30,10 @@ function getCloudflareAccessToken(ctx: Context): string | undefined {
  */
 export const pokeAuth = createMiddleware<PokeCtx>(async (ctx, next) => {
   const accessConfig = getCloudflareAccessConfig();
-  const accessToken = getCloudflareAccessToken(ctx);
+  const accessToken = resolveCloudflareAccessToken({
+    headerToken: ctx.req.header("cf-access-jwt-assertion"),
+    cookieToken: getCookie(ctx, "CF_Authorization"),
+  });
 
   if (accessConfig && accessToken) {
     const identity = await verifyCloudflareAccessJwt(accessToken);
@@ -87,49 +82,52 @@ export const pokeAuth = createMiddleware<PokeCtx>(async (ctx, next) => {
     ctx.set("pokeRoles", pokeRoles);
     await next();
     return;
+  } else if (accessConfig && !accessToken) {
+    if (!isDevelopment()) {
+      logger.warn(
+        "[Poke Auth] Request missing Cloudflare Access token; rejececting request"
+      );
+    } else {
+      logger.info(
+        "[Poke Auth] Request missing Cloudflare Access token in development; falling back to WorkOS super-user session"
+      );
+
+      const sessionResult = await resolveSession(ctx);
+      if (sessionResult instanceof Response) {
+        return sessionResult;
+      }
+
+      const user = await Authenticator.userFromSession(sessionResult);
+      // WorkOS fallback still requires a provisioned Dust user
+      if (user) {
+        const auth = await Authenticator.fromDustSuperUser({ user });
+        logger.info(
+          {
+            userId: user.sId,
+            email: user.email,
+          },
+          "[Poke Auth] User logged in Poke via WorkOS in development."
+        );
+
+        ctx.set("auth", auth);
+        ctx.set("pokeRoles", ALL_ROLES);
+        await next();
+        return;
+      } else {
+        logger.warn(
+          "[Poke Auth] WorkOS fallback user not found; rejecting request"
+        );
+      }
+    }
   }
 
-  if (accessConfig && !accessToken && !isDevelopment()) {
-    logger.warn(
-      "[Poke Auth] Request missing Cloudflare Access token; falling back to WorkOS super-user session"
-    );
-  }
-
-  const sessionResult = await resolveSession(ctx);
-  if (sessionResult instanceof Response) {
-    return sessionResult;
-  }
-
-  const user = await Authenticator.userFromSession(sessionResult);
-  // WorkOS fallback still requires a provisioned Dust user with the DB flag.
-  if (!user || !user.isDustSuperUser || !isDustInternalEmail(user.email)) {
-    logger.warn(
-      { userId: user?.sId, email: user?.email },
-      "[Poke Auth] WorkOS fallback user is not a Dust internal email"
-    );
-    return apiError(ctx, {
-      status_code: 401,
-      api_error: {
-        type: "not_authenticated",
-        message: "The user does not have permission",
-      },
-    });
-  }
-
-  const auth = await Authenticator.fromDustSuperUser({ user });
-  const pokeRoles = await getPokeRolesForUser(user.email);
-
-  logger.info(
-    {
-      userId: user.sId,
-      email: user.email,
+  return apiError(ctx, {
+    status_code: 401,
+    api_error: {
+      type: "not_authenticated",
+      message: "The user does not have permission",
     },
-    "[Poke Auth] User logged in Poke via WorkOS fallback"
-  );
-
-  ctx.set("auth", auth);
-  ctx.set("pokeRoles", pokeRoles);
-  await next();
+  });
 });
 
 /**

--- a/front-api/routes/poke/cache/index.test.ts
+++ b/front-api/routes/poke/cache/index.test.ts
@@ -1,6 +1,6 @@
 import { getRedisCacheClient, runOnRedisCache } from "@app/lib/api/redis";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -13,7 +13,7 @@ const lookupUrl = `/api/poke/cache?resourceId=group_permissions_by_workspace&par
 
 describe("Poke cache: group permissions", () => {
   beforeEach(async () => {
-    await createPrivateApiMockRequest({ isSuperUser: true });
+    await createPokeApiMockRequest({ isSuperUser: true });
 
     const redis = await getRedisCacheClient({
       origin: "group_permissions_cache",
@@ -74,7 +74,7 @@ describe("DELETE /api/poke/cache", () => {
   });
 
   it("deletes the new and previous keys", async () => {
-    await createPrivateApiMockRequest({
+    await createPokeApiMockRequest({
       method: "DELETE",
       isSuperUser: true,
     });

--- a/front-api/routes/poke/coupons/index.test.ts
+++ b/front-api/routes/poke/coupons/index.test.ts
@@ -4,7 +4,7 @@ import {
   type pushCouponToOtherCells,
 } from "@app/lib/api/poke/coupons";
 import { CouponFactory } from "@app/tests/utils/CouponFactory";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -56,7 +56,7 @@ describe("POST /api/poke/coupons", { sequential: true }, () => {
   });
 
   it("returns 401 when the user is not a super user", async () => {
-    await createPrivateApiMockRequest({ isSuperUser: false });
+    await createPokeApiMockRequest({ isSuperUser: false });
 
     const response = await postCoupon(VALID_BODY);
 
@@ -65,7 +65,7 @@ describe("POST /api/poke/coupons", { sequential: true }, () => {
 
   it("returns 400 when called from a non-main region (EU)", async () => {
     vi.mocked(canCreateCoupon).mockReturnValue(false);
-    await createPrivateApiMockRequest({ isSuperUser: true });
+    await createPokeApiMockRequest({ isSuperUser: true });
 
     const response = await postCoupon(VALID_BODY);
 
@@ -80,7 +80,7 @@ describe("POST /api/poke/coupons", { sequential: true }, () => {
     vi.mocked(createCoupon).mockResolvedValue(
       new Err({ type: "coupon_already_exists" })
     );
-    await createPrivateApiMockRequest({ isSuperUser: true });
+    await createPokeApiMockRequest({ isSuperUser: true });
 
     const response = await postCoupon(VALID_BODY);
 
@@ -97,7 +97,7 @@ describe("POST /api/poke/coupons", { sequential: true }, () => {
     vi.mocked(createCoupon).mockResolvedValue(
       new Ok({ toJSON: () => ({ ...mockCouponJSON, code: "NEWCODE" }) } as any)
     );
-    await createPrivateApiMockRequest({ isSuperUser: true });
+    await createPokeApiMockRequest({ isSuperUser: true });
 
     const response = await postCoupon({ ...VALID_BODY, code: "NEWCODE" });
 
@@ -113,7 +113,7 @@ describe("POST /api/poke/coupons", { sequential: true }, () => {
 
   it("returns 500 when sync to other region fails", async () => {
     vi.mocked(createCoupon).mockResolvedValue(new Err({ type: "sync_failed" }));
-    await createPrivateApiMockRequest({ isSuperUser: true });
+    await createPokeApiMockRequest({ isSuperUser: true });
 
     const response = await postCoupon({ ...VALID_BODY, code: "FAILCODE" });
 

--- a/front-api/routes/poke/degraded_models.test.ts
+++ b/front-api/routes/poke/degraded_models.test.ts
@@ -1,6 +1,6 @@
 import { listDegradableEndpoints } from "@app/lib/api/poke/degraded_models";
 import { ModelDegradationResource } from "@app/lib/resources/model_degradation_resource";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -51,7 +51,7 @@ async function getDegradedEndpoints() {
 
 describe("GET /api/poke/degraded_models", () => {
   it("returns the degradable catalog with nothing degraded", async () => {
-    await createPrivateApiMockRequest({ isSuperUser: true });
+    await createPokeApiMockRequest({ isSuperUser: true });
 
     const response = await honoApp.request("/api/poke/degraded_models");
 
@@ -71,7 +71,7 @@ describe("GET /api/poke/degraded_models", () => {
   });
 
   it("returns 401 when the user is not a super user", async () => {
-    await createPrivateApiMockRequest({ isSuperUser: false });
+    await createPokeApiMockRequest({ isSuperUser: false });
 
     const response = await honoApp.request("/api/poke/degraded_models");
 
@@ -81,7 +81,7 @@ describe("GET /api/poke/degraded_models", () => {
 
 describe("POST /api/poke/degraded_models", () => {
   it("degrades and restores only the endpoints it names", async () => {
-    await createPrivateApiMockRequest({ isSuperUser: true });
+    await createPokeApiMockRequest({ isSuperUser: true });
 
     expect(
       (await postEndpoints([{ ...endpointAt(0), degraded: true }])).status
@@ -103,7 +103,7 @@ describe("POST /api/poke/degraded_models", () => {
   });
 
   it("is a no-op when an endpoint is already in the requested state", async () => {
-    await createPrivateApiMockRequest({ isSuperUser: true });
+    await createPokeApiMockRequest({ isSuperUser: true });
 
     expect(
       (
@@ -125,7 +125,7 @@ describe("POST /api/poke/degraded_models", () => {
   });
 
   it("settles on the last requested state when an endpoint is named twice", async () => {
-    await createPrivateApiMockRequest({ isSuperUser: true });
+    await createPokeApiMockRequest({ isSuperUser: true });
 
     const response = await postEndpoints([
       { ...endpointAt(0), degraded: true },
@@ -137,7 +137,7 @@ describe("POST /api/poke/degraded_models", () => {
   });
 
   it("returns 400 for an endpoint that is not in the catalog", async () => {
-    await createPrivateApiMockRequest({ isSuperUser: true });
+    await createPokeApiMockRequest({ isSuperUser: true });
 
     const response = await postEndpoints([
       { ...endpointAt(0), host: "not-a-host", degraded: true },
@@ -150,7 +150,7 @@ describe("POST /api/poke/degraded_models", () => {
   });
 
   it("returns 401 when the user is not a super user", async () => {
-    await createPrivateApiMockRequest({ isSuperUser: false });
+    await createPokeApiMockRequest({ isSuperUser: false });
 
     const response = await postEndpoints([
       { ...endpointAt(0), degraded: true },

--- a/front-api/routes/poke/feature-flags/index.test.ts
+++ b/front-api/routes/poke/feature-flags/index.test.ts
@@ -1,6 +1,6 @@
 import { Authenticator } from "@app/lib/auth";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { WHITELISTABLE_FEATURES } from "@app/types/shared/feature_flags";
 import type { WorkspaceType } from "@app/types/user";
@@ -29,7 +29,7 @@ function listWorkspacesForFlag(flagName: string) {
 
 describe("GET /api/poke/feature-flags", () => {
   it("returns 401 when the user is not a super user", async () => {
-    await createPrivateApiMockRequest({ isSuperUser: false });
+    await createPokeApiMockRequest({ isSuperUser: false });
 
     const response = await listFeatureFlags();
 
@@ -37,7 +37,7 @@ describe("GET /api/poke/feature-flags", () => {
   });
 
   it("counts the workspaces each flag is enabled on", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     const otherWorkspace = await WorkspaceFactory.basic();
@@ -67,7 +67,7 @@ describe("GET /api/poke/feature-flags", () => {
   });
 
   it("reports every configured flag, with its stage and description", async () => {
-    await createPrivateApiMockRequest({ isSuperUser: true });
+    await createPokeApiMockRequest({ isSuperUser: true });
 
     const response = await listFeatureFlags();
 
@@ -84,7 +84,7 @@ describe("GET /api/poke/feature-flags", () => {
   });
 
   it("surfaces flag rows whose name is no longer configured", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     await enableLegacyFlagOn(workspace);
@@ -108,7 +108,7 @@ describe("GET /api/poke/feature-flags", () => {
 
 describe("GET /api/poke/feature-flags/:flagName", () => {
   it("returns 401 when the user is not a super user", async () => {
-    await createPrivateApiMockRequest({ isSuperUser: false });
+    await createPokeApiMockRequest({ isSuperUser: false });
 
     const response = await listWorkspacesForFlag(FLAG_A);
 
@@ -116,7 +116,7 @@ describe("GET /api/poke/feature-flags/:flagName", () => {
   });
 
   it("lists the workspaces the flag is enabled on", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     const otherWorkspace = await WorkspaceFactory.basic();
@@ -151,7 +151,7 @@ describe("GET /api/poke/feature-flags/:flagName", () => {
   });
 
   it("returns an empty list for a configured flag no workspace has", async () => {
-    await createPrivateApiMockRequest({ isSuperUser: true });
+    await createPokeApiMockRequest({ isSuperUser: true });
 
     const response = await listWorkspacesForFlag(FLAG_A);
 
@@ -162,7 +162,7 @@ describe("GET /api/poke/feature-flags/:flagName", () => {
   });
 
   it("returns 404 for a name that is neither configured nor in the database", async () => {
-    await createPrivateApiMockRequest({ isSuperUser: true });
+    await createPokeApiMockRequest({ isSuperUser: true });
 
     const response = await listWorkspacesForFlag("not_a_flag_at_all");
 
@@ -170,7 +170,7 @@ describe("GET /api/poke/feature-flags/:flagName", () => {
   });
 
   it("serves a legacy flag name that still has rows", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     await enableLegacyFlagOn(workspace);

--- a/front-api/routes/poke/metronome/packages.test.ts
+++ b/front-api/routes/poke/metronome/packages.test.ts
@@ -1,5 +1,5 @@
 import { listMetronomePackages } from "@app/lib/metronome/client";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -38,7 +38,7 @@ describe("GET /api/poke/metronome/packages", () => {
       ])
     );
 
-    await createPrivateApiMockRequest({
+    await createPokeApiMockRequest({
       method: "GET",
       isSuperUser: true,
     });
@@ -62,7 +62,7 @@ describe("GET /api/poke/metronome/packages", () => {
   });
 
   it("returns 401 when the user is not a super user", async () => {
-    await createPrivateApiMockRequest({
+    await createPokeApiMockRequest({
       method: "GET",
       isSuperUser: false,
     });
@@ -83,7 +83,7 @@ describe("GET /api/poke/metronome/packages", () => {
       new Err(new Error("Metronome unavailable"))
     );
 
-    await createPrivateApiMockRequest({
+    await createPokeApiMockRequest({
       method: "GET",
       isSuperUser: true,
     });

--- a/front-api/routes/poke/search.test.ts
+++ b/front-api/routes/poke/search.test.ts
@@ -1,7 +1,7 @@
 import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspace_verification_attempt_resource";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { faker } from "@faker-js/faker";
@@ -16,7 +16,7 @@ function searchRequest(query: string) {
 
 describe("GET /api/poke/search - phone number", () => {
   it("returns workspace when searching by phone number in E.164 format", async () => {
-    const { auth } = await createPrivateApiMockRequest({
+    const { auth } = await createPokeApiMockRequest({
       isSuperUser: true,
       role: "admin",
     });
@@ -44,7 +44,7 @@ describe("GET /api/poke/search - phone number", () => {
   });
 
   it("returns workspace when searching by phone number without +", async () => {
-    const { auth } = await createPrivateApiMockRequest({
+    const { auth } = await createPokeApiMockRequest({
       isSuperUser: true,
       role: "admin",
     });
@@ -73,7 +73,7 @@ describe("GET /api/poke/search - phone number", () => {
   });
 
   it("returns no results for unverified phone numbers", async () => {
-    const { auth } = await createPrivateApiMockRequest({
+    const { auth } = await createPokeApiMockRequest({
       isSuperUser: true,
       role: "admin",
     });
@@ -100,7 +100,7 @@ describe("GET /api/poke/search - phone number", () => {
   });
 
   it("returns both workspace and phone trial when digits match both", async () => {
-    const { workspace, auth } = await createPrivateApiMockRequest({
+    const { workspace, auth } = await createPokeApiMockRequest({
       isSuperUser: true,
       role: "admin",
     });
@@ -133,7 +133,7 @@ describe("GET /api/poke/search - phone number", () => {
   });
 
   it("returns no results for random non-phone strings", async () => {
-    await createPrivateApiMockRequest({ isSuperUser: true });
+    await createPokeApiMockRequest({ isSuperUser: true });
 
     const response = await searchRequest("hello world");
 
@@ -145,7 +145,7 @@ describe("GET /api/poke/search - phone number", () => {
 
 describe("GET /api/poke/search - data source", () => {
   it("returns the data source when searching by dustAPIProjectId", async () => {
-    const { workspace, globalSpace } = await createPrivateApiMockRequest({
+    const { workspace, globalSpace } = await createPokeApiMockRequest({
       isSuperUser: true,
       role: "admin",
     });
@@ -175,7 +175,7 @@ describe("GET /api/poke/search - data source", () => {
   });
 
   it("returns no data source for an unknown dustAPIProjectId", async () => {
-    await createPrivateApiMockRequest({ isSuperUser: true });
+    await createPokeApiMockRequest({ isSuperUser: true });
 
     const response = await searchRequest(faker.string.numeric(9));
 
@@ -187,7 +187,7 @@ describe("GET /api/poke/search - data source", () => {
 
 describe("GET /api/poke/search - resource sId", () => {
   it("returns the data source view when searching by its sId", async () => {
-    await createPrivateApiMockRequest({ isSuperUser: true, role: "admin" });
+    await createPokeApiMockRequest({ isSuperUser: true, role: "admin" });
 
     // The resource lives in a different workspace than the poke session's:
     // the search must re-scope on the workspace embedded in the sId.
@@ -209,7 +209,7 @@ describe("GET /api/poke/search - resource sId", () => {
   });
 
   it("returns the data source when searching by its sId", async () => {
-    await createPrivateApiMockRequest({ isSuperUser: true, role: "admin" });
+    await createPokeApiMockRequest({ isSuperUser: true, role: "admin" });
 
     const workspace = await WorkspaceFactory.basic();
     await GroupFactory.defaults(workspace);
@@ -229,7 +229,7 @@ describe("GET /api/poke/search - resource sId", () => {
   });
 
   it("returns the space when searching by its sId", async () => {
-    await createPrivateApiMockRequest({ isSuperUser: true, role: "admin" });
+    await createPokeApiMockRequest({ isSuperUser: true, role: "admin" });
 
     const workspace = await WorkspaceFactory.basic();
     await GroupFactory.defaults(workspace);
@@ -250,7 +250,7 @@ describe("GET /api/poke/search - resource sId", () => {
   });
 
   it("returns the group when searching by its sId", async () => {
-    await createPrivateApiMockRequest({ isSuperUser: true, role: "admin" });
+    await createPokeApiMockRequest({ isSuperUser: true, role: "admin" });
 
     const workspace = await WorkspaceFactory.basic();
     await GroupFactory.defaults(workspace);

--- a/front-api/routes/poke/stripe/customers/currency.test.ts
+++ b/front-api/routes/poke/stripe/customers/currency.test.ts
@@ -1,5 +1,5 @@
 import { getStripeCustomer } from "@app/lib/plans/stripe";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { honoApp } from "@front-api/app";
 import type Stripe from "stripe";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -33,7 +33,7 @@ describe("POST /api/poke/stripe/customers/currency", () => {
       address: { country: "FR" },
     } as unknown as Stripe.Customer);
 
-    await createPrivateApiMockRequest({
+    await createPokeApiMockRequest({
       method: "POST",
       isSuperUser: true,
     });
@@ -45,7 +45,7 @@ describe("POST /api/poke/stripe/customers/currency", () => {
   });
 
   it("returns 401 when the user is not a super user", async () => {
-    await createPrivateApiMockRequest({
+    await createPokeApiMockRequest({
       method: "POST",
       isSuperUser: false,
     });
@@ -62,7 +62,7 @@ describe("POST /api/poke/stripe/customers/currency", () => {
   });
 
   it("returns 400 when stripeCustomerId is missing", async () => {
-    await createPrivateApiMockRequest({
+    await createPokeApiMockRequest({
       method: "POST",
       isSuperUser: true,
     });
@@ -78,7 +78,7 @@ describe("POST /api/poke/stripe/customers/currency", () => {
   it("returns 404 when the Stripe customer does not exist", async () => {
     vi.mocked(getStripeCustomer).mockResolvedValue(null);
 
-    await createPrivateApiMockRequest({
+    await createPokeApiMockRequest({
       method: "POST",
       isSuperUser: true,
     });

--- a/front-api/routes/poke/templates/pull.test.ts
+++ b/front-api/routes/poke/templates/pull.test.ts
@@ -1,5 +1,5 @@
 import { config } from "@app/lib/api/regions/config";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -57,7 +57,7 @@ describe("POST /api/poke/templates/pull", { sequential: true }, () => {
   });
 
   it("returns 401 when the user is not a super user", async () => {
-    await createPrivateApiMockRequest({ isSuperUser: false });
+    await createPokeApiMockRequest({ isSuperUser: false });
 
     const response = await pullTemplates();
 
@@ -72,7 +72,7 @@ describe("POST /api/poke/templates/pull", { sequential: true }, () => {
 
   it("returns 400 when called with the sync disabled", async () => {
     vi.mocked(config.getDustRegionSyncEnabled).mockReturnValue(false);
-    await createPrivateApiMockRequest({ isSuperUser: true });
+    await createPokeApiMockRequest({ isSuperUser: true });
 
     const response = await pullTemplates();
 
@@ -96,7 +96,7 @@ describe("POST /api/poke/templates/pull", { sequential: true }, () => {
       });
     });
 
-    await createPrivateApiMockRequest({ isSuperUser: true });
+    await createPokeApiMockRequest({ isSuperUser: true });
 
     const response = await pullTemplates();
 
@@ -149,7 +149,7 @@ describe("POST /api/poke/templates/pull", { sequential: true }, () => {
         });
       });
 
-    await createPrivateApiMockRequest({ isSuperUser: true });
+    await createPokeApiMockRequest({ isSuperUser: true });
 
     const response = await pullTemplates();
 
@@ -200,7 +200,7 @@ describe("POST /api/poke/templates/pull", { sequential: true }, () => {
         });
       });
 
-    await createPrivateApiMockRequest({ isSuperUser: true });
+    await createPokeApiMockRequest({ isSuperUser: true });
 
     const response = await pullTemplates();
 

--- a/front-api/routes/poke/workspaces/[wId]/assistants/[aId]/suggestions.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/assistants/[aId]/suggestions.test.ts
@@ -1,7 +1,7 @@
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentSuggestionFactory } from "@app/tests/utils/AgentSuggestionFactory";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
@@ -27,7 +27,7 @@ function deleteSuggestion(
 
 describe("GET /api/poke/workspaces/:wId/assistants/:aId/suggestions", () => {
   it("returns 401 for non super users", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       method: "GET",
       isSuperUser: false,
       role: "admin",
@@ -39,7 +39,7 @@ describe("GET /api/poke/workspaces/:wId/assistants/:aId/suggestions", () => {
   });
 
   it("returns suggestions for a given agent", async () => {
-    const { workspace, auth } = await createPrivateApiMockRequest({
+    const { workspace, auth } = await createPokeApiMockRequest({
       method: "GET",
       isSuperUser: true,
       role: "admin",
@@ -59,7 +59,7 @@ describe("GET /api/poke/workspaces/:wId/assistants/:aId/suggestions", () => {
 
 describe("DELETE /api/poke/workspaces/:wId/assistants/:aId/suggestions", () => {
   it("returns 400 when sId query param is missing", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       method: "DELETE",
       isSuperUser: true,
       role: "admin",
@@ -73,7 +73,7 @@ describe("DELETE /api/poke/workspaces/:wId/assistants/:aId/suggestions", () => {
   });
 
   it("returns 404 when suggestion does not exist", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       method: "DELETE",
       isSuperUser: true,
       role: "admin",
@@ -89,7 +89,7 @@ describe("DELETE /api/poke/workspaces/:wId/assistants/:aId/suggestions", () => {
   });
 
   it("deletes the suggestion and returns 204", async () => {
-    const { workspace, auth } = await createPrivateApiMockRequest({
+    const { workspace, auth } = await createPokeApiMockRequest({
       method: "DELETE",
       isSuperUser: true,
       role: "admin",

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/config.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/config.test.ts
@@ -1,12 +1,12 @@
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
 async function setup() {
-  const { workspace, auth } = await createPrivateApiMockRequest({
+  const { workspace, auth } = await createPokeApiMockRequest({
     isSuperUser: true,
     role: "admin",
   });

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/consumption.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/consumption.test.ts
@@ -3,14 +3,14 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
 const BILLED_CREDITS = 7;
 
 async function setupConversation() {
-  const { auth, user, workspace } = await createPrivateApiMockRequest({
+  const { auth, user, workspace } = await createPokeApiMockRequest({
     isSuperUser: true,
     role: "user",
   });

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/messages/[mId]/consumption.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/messages/[mId]/consumption.test.ts
@@ -4,7 +4,7 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { RunFactory } from "@app/tests/utils/RunFactory";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
@@ -12,7 +12,7 @@ import { describe, expect, it } from "vitest";
 const BILLED_CREDITS = 10;
 
 async function setupMessage() {
-  const { auth, user, workspace } = await createPrivateApiMockRequest({
+  const { auth, user, workspace } = await createPokeApiMockRequest({
     isSuperUser: true,
     role: "user",
   });

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/wakeups.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/wakeups.test.ts
@@ -1,14 +1,14 @@
 import * as wakeUpClient from "@app/temporal/triggers/wakeup_client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { WakeUpFactory } from "@app/tests/utils/WakeUpFactory";
 import { Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 async function setup() {
-  const { workspace, auth } = await createPrivateApiMockRequest({
+  const { workspace, auth } = await createPokeApiMockRequest({
     isSuperUser: true,
     role: "admin",
   });

--- a/front-api/routes/poke/workspaces/[wId]/conversations/index.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/index.test.ts
@@ -1,6 +1,6 @@
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
@@ -16,7 +16,7 @@ function sIds(conversations: { sId: string }[]): string[] {
 
 describe("GET /api/poke/workspaces/:wId/conversations", () => {
   it("pages the agent conversations by offset, newest first", async () => {
-    const { auth, workspace } = await createPrivateApiMockRequest({
+    const { auth, workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
       role: "admin",
     });
@@ -72,7 +72,7 @@ describe("GET /api/poke/workspaces/:wId/conversations", () => {
   });
 
   it("returns an empty page past the end", async () => {
-    const { auth, workspace } = await createPrivateApiMockRequest({
+    const { auth, workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
       role: "admin",
     });
@@ -93,7 +93,7 @@ describe("GET /api/poke/workspaces/:wId/conversations", () => {
   });
 
   it("orders the agent conversations by the requested column", async () => {
-    const { auth, workspace } = await createPrivateApiMockRequest({
+    const { auth, workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
       role: "admin",
     });
@@ -133,7 +133,7 @@ describe("GET /api/poke/workspaces/:wId/conversations", () => {
   });
 
   it("rejects an unknown order column", async () => {
-    const { auth, workspace } = await createPrivateApiMockRequest({
+    const { auth, workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
       role: "admin",
     });
@@ -148,7 +148,7 @@ describe("GET /api/poke/workspaces/:wId/conversations", () => {
   });
 
   it("restricts the agent conversations to the created-at window", async () => {
-    const { auth, workspace } = await createPrivateApiMockRequest({
+    const { auth, workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
       role: "admin",
     });
@@ -199,7 +199,7 @@ describe("GET /api/poke/workspaces/:wId/conversations", () => {
   });
 
   it("pages within the created-at window", async () => {
-    const { auth, workspace } = await createPrivateApiMockRequest({
+    const { auth, workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
       role: "admin",
     });
@@ -239,7 +239,7 @@ describe("GET /api/poke/workspaces/:wId/conversations", () => {
   });
 
   it("rejects a malformed date bound", async () => {
-    const { auth, workspace } = await createPrivateApiMockRequest({
+    const { auth, workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
       role: "admin",
     });
@@ -254,7 +254,7 @@ describe("GET /api/poke/workspaces/:wId/conversations", () => {
   });
 
   it("defaults the paging and ordering when none is provided", async () => {
-    const { auth, workspace } = await createPrivateApiMockRequest({
+    const { auth, workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
       role: "admin",
     });
@@ -276,7 +276,7 @@ describe("GET /api/poke/workspaces/:wId/conversations", () => {
   });
 
   it("rejects a request with no agent, trigger or reinforced skill", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
       role: "admin",
     });

--- a/front-api/routes/poke/workspaces/[wId]/credits/members-usage.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/members-usage.test.ts
@@ -1,5 +1,5 @@
 import * as membersUsage from "@app/lib/api/credits/members_usage";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { makeMemberUsage } from "@app/tests/utils/MemberUsageFactory";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -29,7 +29,7 @@ beforeEach(() => {
 
 describe("GET /api/poke/workspaces/[wId]/credits/members-usage", () => {
   it("returns members usage including the off-pace target, with alert links requested", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
       role: "admin",
     });

--- a/front-api/routes/poke/workspaces/[wId]/frames/[frameId]/functions/index.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/frames/[frameId]/functions/index.test.ts
@@ -1,6 +1,6 @@
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { makeTestFrameFunction } from "@app/tests/utils/FrameFunctionFactory";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { frameV2ContentType } from "@app/types/files";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
@@ -53,7 +53,7 @@ describe("GET /api/poke/workspaces/:wId/frames/:frameId/functions", () => {
 
   it("404s for a Frame in another workspace", async () => {
     const { frame } = await makeTestFrameFunction({ isSuperUser: true });
-    const { workspace: otherWorkspace } = await createPrivateApiMockRequest({
+    const { workspace: otherWorkspace } = await createPokeApiMockRequest({
       isSuperUser: true,
       role: "admin",
     });

--- a/front-api/routes/poke/workspaces/[wId]/frames/index.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/frames/index.test.ts
@@ -160,7 +160,7 @@ describe("GET /api/poke/workspaces/:wId/frames", () => {
   });
 
   it("does not leak frames from another workspace", async () => {
-    // Order matters: each makeTestFrameFunction call re-mocks the WorkOS session, so the target
+    // Order matters: each makeTestFrameFunction call re-mocks poke CF Access, so the target
     // workspace must be created last for the request to authenticate as its own super user.
     await makeTestFrameFunction({ isSuperUser: true });
     const { workspace, frame } = await makeTestFrameFunction({

--- a/front-api/routes/poke/workspaces/[wId]/groups/index.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/groups/index.test.ts
@@ -1,13 +1,13 @@
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
 async function createGroupWithMember() {
-  const { workspace, auth, user } = await createPrivateApiMockRequest({
+  const { workspace, auth, user } = await createPokeApiMockRequest({
     isSuperUser: true,
     role: "admin",
   });

--- a/front-api/routes/poke/workspaces/[wId]/invitations/[iId]/index.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/invitations/[iId]/index.test.ts
@@ -1,6 +1,6 @@
 import { Authenticator } from "@app/lib/auth";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { MembershipInvitationFactory } from "@app/tests/utils/MembershipInvitationFactory";
 import { honoApp } from "@front-api/app";
 import sgMail from "@sendgrid/mail";
@@ -26,7 +26,7 @@ beforeEach(() => {
 
 describe("PATCH /api/poke/workspaces/:wId/invitations/:iId", () => {
   it("revokes the old invitation and creates a new one with a fresh createdAt", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       method: "PATCH",
       isSuperUser: true,
       role: "admin",

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/conversations.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/conversations.test.ts
@@ -1,6 +1,6 @@
 import { Authenticator } from "@app/lib/auth";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
@@ -15,7 +15,7 @@ describe("GET /api/poke/workspaces/:wId/projects/:projectId/conversations", () =
       auth: initialAuth,
       user,
       workspace,
-    } = await createPrivateApiMockRequest({
+    } = await createPokeApiMockRequest({
       isSuperUser: true,
       role: "admin",
     });

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/pod-databases.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/pod-databases.test.ts
@@ -1,6 +1,6 @@
 import { listDatabasesOnSandbox } from "@app/lib/api/sandbox_functions/dsbx_db";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
@@ -16,7 +16,7 @@ vi.mock(import("@app/lib/api/sandbox_functions/dsbx_db"), async (orig) => {
 });
 
 async function setup() {
-  const { workspace } = await createPrivateApiMockRequest({
+  const { workspace } = await createPokeApiMockRequest({
     isSuperUser: true,
     role: "admin",
   });

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/suggestions.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/suggestions.test.ts
@@ -1,5 +1,5 @@
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SkillSuggestionFactory } from "@app/tests/utils/SkillSuggestionFactory";
 import { honoApp } from "@front-api/app";
@@ -27,7 +27,7 @@ function deleteSuggestion(
 
 describe("GET /api/poke/workspaces/:wId/skills/:sId/suggestions", () => {
   it("returns 401 for non super users", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       method: "GET",
       isSuperUser: false,
       role: "admin",
@@ -39,7 +39,7 @@ describe("GET /api/poke/workspaces/:wId/skills/:sId/suggestions", () => {
   });
 
   it("returns suggestions for a given skill", async () => {
-    const { workspace, auth } = await createPrivateApiMockRequest({
+    const { workspace, auth } = await createPokeApiMockRequest({
       method: "GET",
       isSuperUser: true,
       role: "admin",
@@ -57,7 +57,7 @@ describe("GET /api/poke/workspaces/:wId/skills/:sId/suggestions", () => {
   });
 
   it("returns empty array when skill has no suggestions", async () => {
-    const { workspace, auth } = await createPrivateApiMockRequest({
+    const { workspace, auth } = await createPokeApiMockRequest({
       method: "GET",
       isSuperUser: true,
       role: "admin",
@@ -75,7 +75,7 @@ describe("GET /api/poke/workspaces/:wId/skills/:sId/suggestions", () => {
 
 describe("DELETE /api/poke/workspaces/:wId/skills/:sId/suggestions", () => {
   it("returns 400 when suggestionSId query param is missing", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       method: "DELETE",
       isSuperUser: true,
       role: "admin",
@@ -89,7 +89,7 @@ describe("DELETE /api/poke/workspaces/:wId/skills/:sId/suggestions", () => {
   });
 
   it("returns 404 when suggestion does not exist", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       method: "DELETE",
       isSuperUser: true,
       role: "admin",
@@ -105,7 +105,7 @@ describe("DELETE /api/poke/workspaces/:wId/skills/:sId/suggestions", () => {
   });
 
   it("deletes the suggestion and returns 204", async () => {
-    const { workspace, auth } = await createPrivateApiMockRequest({
+    const { workspace, auth } = await createPokeApiMockRequest({
       method: "DELETE",
       isSuperUser: true,
       role: "admin",

--- a/front-api/routes/poke/workspaces/[wId]/skills/suggestions.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/suggestions.test.ts
@@ -2,13 +2,13 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { serializeSkillTag } from "@app/lib/skills/format";
 import { serializeToolTag } from "@app/lib/tools/format";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
 describe("POST /api/poke/workspaces/:wId/skills/suggestions", () => {
   it("stores inline tool and skill references", async () => {
-    const { auth, workspace } = await createPrivateApiMockRequest({
+    const { auth, workspace } = await createPokeApiMockRequest({
       method: "POST",
       isSuperUser: true,
       role: "admin",

--- a/front-api/routes/poke/workspaces/[wId]/slack-workflows.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/slack-workflows.test.ts
@@ -13,7 +13,7 @@ vi.mock("@app/lib/api/audit/workos_audit", async () => {
 
 import { emitAuditLogEvent } from "@app/lib/api/audit/workos_audit";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { Err, Ok } from "@app/types/shared/result";
@@ -40,7 +40,7 @@ async function setupTest({
 }: {
   isSuperUser?: boolean;
 } = {}) {
-  const setup = await createPrivateApiMockRequest({
+  const setup = await createPokeApiMockRequest({
     isSuperUser,
     role: "admin",
   });

--- a/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.test.ts
@@ -1,4 +1,4 @@
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { honoApp } from "@front-api/app";
@@ -10,7 +10,7 @@ function detailsUrl(workspaceId: string, spaceId: string) {
 
 describe("GET /api/poke/workspaces/:wId/spaces/:spaceId/details", () => {
   it("returns the sandbox provider id and status when the pod owns one", async () => {
-    const { workspace, auth } = await createPrivateApiMockRequest({
+    const { workspace, auth } = await createPokeApiMockRequest({
       isSuperUser: true,
       role: "admin",
     });
@@ -29,7 +29,7 @@ describe("GET /api/poke/workspaces/:wId/spaces/:spaceId/details", () => {
   });
 
   it("returns a null sandbox when the pod owns none", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
       role: "admin",
     });
@@ -44,7 +44,7 @@ describe("GET /api/poke/workspaces/:wId/spaces/:spaceId/details", () => {
   });
 
   it("returns a null sandbox for a regular space", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
       role: "admin",
     });

--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
@@ -26,7 +26,7 @@ import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usag
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
 import { honoApp } from "@front-api/app";
@@ -315,7 +315,7 @@ beforeEach(() => {
 describe("POST /api/poke/workspaces/[wId]/switch_contract — Enterprise", () => {
   it("provisions a future-scheduled contract and leaves the DB subscription for contract.start", async () => {
     await ensureEnterprisePlan();
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
@@ -342,7 +342,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Enterprise", () =>
 
   it("starts immediately when startingAt is omitted", async () => {
     await ensureEnterprisePlan();
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
@@ -365,7 +365,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Enterprise", () =>
 
   it("accepts a startingAt in the past (backdated) and schedules at the next hour boundary", async () => {
     await ensureEnterprisePlan();
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
@@ -392,7 +392,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Enterprise", () =>
       address: { country: "FR" },
     } as unknown as Stripe.Customer);
 
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
@@ -409,7 +409,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Enterprise", () =>
 
 describe("POST /api/poke/workspaces/[wId]/switch_contract — Pro / Business", () => {
   it("provisions a Pro contract at the current hour and leaves the DB subscription for contract.start", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
@@ -434,7 +434,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Pro / Business", (
   });
 
   it("provisions a Business contract at the current hour", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
@@ -452,7 +452,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Pro / Business", (
   });
 
   it("accepts startingAt and schedules at the next hour boundary", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
@@ -472,7 +472,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Pro / Business", (
   });
 
   it("provisions the first Pro contract when the workspace has no current Metronome contract", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     // No Stripe sub + no Metronome contract: with Metronome billing enabled
@@ -491,7 +491,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Pro / Business", (
   });
 
   it("stages a created_backend_only subscription for contract.start to activate", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
@@ -517,7 +517,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Pro / Business", (
   });
 
   it("supersedes a prior pending subscription on a second schedule", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
@@ -564,7 +564,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Pro / Business", (
 
 describe("POST /api/poke/workspaces/[wId]/switch_contract — guards", () => {
   it("rejects when plan tier doesn't match package tier", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
@@ -581,7 +581,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — guards", () => {
   });
 
   it("rejects when target plan tier does not match the package tier (pro pkg, free plan)", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
@@ -598,7 +598,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — guards", () => {
 
   it("schedules the Stripe subscription to cancel at the swap moment when the workspace is Stripe-billed", async () => {
     const STRIPE_SUB_ID = "sub_stripe_xxx";
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID, {
@@ -617,7 +617,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — guards", () => {
   });
 
   it("does not call scheduleSubscriptionCancellation when the workspace has no Stripe subscription", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
@@ -632,7 +632,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — guards", () => {
 describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
   it("persists usageCapCredits and syncs the Metronome alert when switching to enterprise with PAYG enabled", async () => {
     await ensureEnterprisePlan();
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
@@ -653,7 +653,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
   });
 
   it("persists usageCapCredits when switching to business with PAYG enabled", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
@@ -674,7 +674,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
   });
 
   it("rejects PAYG on a pro contract", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
@@ -692,7 +692,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
 
   it("accepts paygEnabled without a usage cap (no alert)", async () => {
     await ensureEnterprisePlan();
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
@@ -714,7 +714,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
   });
 
   it("preserves usageCapCredits when paygEnabled is toggled off", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
@@ -744,7 +744,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
 
 describe("POST /api/poke/workspaces/[wId]/switch_contract — no Stripe customer", () => {
   it("provisions a contract with no Stripe billing config when stripeCustomerId is blank", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
@@ -765,7 +765,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — no Stripe customer
   });
 
   it("accepts a package in any currency when stripeCustomerId is blank", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPokeApiMockRequest({
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);

--- a/front-api/routes/poke/workspaces/index.test.ts
+++ b/front-api/routes/poke/workspaces/index.test.ts
@@ -1,6 +1,6 @@
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { WorkspaceType } from "@app/types/user";
 import { honoApp } from "@front-api/app";
@@ -36,7 +36,7 @@ function fetchWorkspaces(params: Record<string, string>) {
 describe("GET /api/poke/workspaces — workspace name search", () => {
   it("matches by prefix", async () => {
     const workspace = await createNamedWorkspace("Zorbix Industries");
-    await createPrivateApiMockRequest({ isSuperUser: true, workspace });
+    await createPokeApiMockRequest({ isSuperUser: true, workspace });
 
     const response = await searchWorkspaces("Zorbix", "20");
 
@@ -49,7 +49,7 @@ describe("GET /api/poke/workspaces — workspace name search", () => {
 
   it("matches by a word in the middle of the name", async () => {
     const workspace = await createNamedWorkspace("Zorbix Industries");
-    await createPrivateApiMockRequest({ isSuperUser: true, workspace });
+    await createPokeApiMockRequest({ isSuperUser: true, workspace });
 
     const response = await searchWorkspaces("Industries", "20");
 
@@ -62,7 +62,7 @@ describe("GET /api/poke/workspaces — workspace name search", () => {
 
   it("matches case-insensitively", async () => {
     const workspace = await createNamedWorkspace("Zorbix Industries");
-    await createPrivateApiMockRequest({ isSuperUser: true, workspace });
+    await createPokeApiMockRequest({ isSuperUser: true, workspace });
 
     const response = await searchWorkspaces("industries", "20");
 
@@ -79,7 +79,7 @@ describe("GET /api/poke/workspaces — plan type filter", () => {
     const workspace = await createNamedWorkspace("Quibble Pro Corp", () =>
       WorkspaceFactory.basic()
     );
-    await createPrivateApiMockRequest({ isSuperUser: true, workspace });
+    await createPokeApiMockRequest({ isSuperUser: true, workspace });
 
     const response = await fetchWorkspaces({
       search: encodeURIComponent("Quibble Pro Corp"),
@@ -98,7 +98,7 @@ describe("GET /api/poke/workspaces — plan type filter", () => {
     const workspace = await createNamedWorkspace("Quibble Pro Corp Two", () =>
       WorkspaceFactory.basic()
     );
-    await createPrivateApiMockRequest({ isSuperUser: true, workspace });
+    await createPokeApiMockRequest({ isSuperUser: true, workspace });
 
     const response = await fetchWorkspaces({
       search: encodeURIComponent("Quibble Pro Corp Two"),
@@ -118,7 +118,7 @@ describe("GET /api/poke/workspaces — plan type filter", () => {
       "Quibble Enterprise Corp",
       () => WorkspaceFactory.enterprise()
     );
-    await createPrivateApiMockRequest({ isSuperUser: true, workspace });
+    await createPokeApiMockRequest({ isSuperUser: true, workspace });
 
     const response = await fetchWorkspaces({
       search: encodeURIComponent("Quibble Enterprise Corp"),
@@ -138,7 +138,7 @@ describe("GET /api/poke/workspaces — plan type filter", () => {
       "Quibble Enterprise Corp Two",
       () => WorkspaceFactory.enterprise()
     );
-    await createPrivateApiMockRequest({ isSuperUser: true, workspace });
+    await createPokeApiMockRequest({ isSuperUser: true, workspace });
 
     const response = await fetchWorkspaces({
       search: encodeURIComponent("Quibble Enterprise Corp Two"),
@@ -158,7 +158,7 @@ describe("GET /api/poke/workspaces — plan type filter", () => {
       WorkspaceFactory.basic()
     );
     await SubscriptionResource.endActiveSubscription(workspace);
-    await createPrivateApiMockRequest({ isSuperUser: true, workspace });
+    await createPokeApiMockRequest({ isSuperUser: true, workspace });
 
     const response = await fetchWorkspaces({
       search: encodeURIComponent("Quibble No Sub Corp"),
@@ -179,7 +179,7 @@ describe("GET /api/poke/workspaces — plan type filter", () => {
       () => WorkspaceFactory.basic()
     );
     await SubscriptionResource.endActiveSubscription(workspace);
-    await createPrivateApiMockRequest({ isSuperUser: true, workspace });
+    await createPokeApiMockRequest({ isSuperUser: true, workspace });
 
     const response = await fetchWorkspaces({
       search: encodeURIComponent("Quibble No Sub Corp Two"),
@@ -195,7 +195,7 @@ describe("GET /api/poke/workspaces — plan type filter", () => {
   });
 
   it("rejects an unknown planType value", async () => {
-    await createPrivateApiMockRequest({ isSuperUser: true });
+    await createPokeApiMockRequest({ isSuperUser: true });
 
     const response = await fetchWorkspaces({ planType: "not_a_real_bucket" });
 
@@ -210,7 +210,7 @@ describe("GET /api/poke/workspaces — pagination", () => {
     const alpha = await createNamedWorkspace("Nimbus Page Test Alpha");
     const beta = await createNamedWorkspace("Nimbus Page Test Beta");
     const gamma = await createNamedWorkspace("Nimbus Page Test Gamma");
-    await createPrivateApiMockRequest({ isSuperUser: true, workspace: alpha });
+    await createPokeApiMockRequest({ isSuperUser: true, workspace: alpha });
 
     const firstPageResponse = await fetchWorkspaces({
       search: encodeURIComponent("Nimbus Page Test"),
@@ -239,7 +239,7 @@ describe("GET /api/poke/workspaces — pagination", () => {
   });
 
   it("rejects a non-numeric offset value", async () => {
-    await createPrivateApiMockRequest({ isSuperUser: true });
+    await createPokeApiMockRequest({ isSuperUser: true });
 
     const response = await fetchWorkspaces({ offset: "not_a_number" });
 

--- a/front/lib/api/poke/cloudflare_access.test.ts
+++ b/front/lib/api/poke/cloudflare_access.test.ts
@@ -29,6 +29,7 @@ vi.mock("@app/logger/logger", () => ({
 import {
   clearCloudflareAccessJwksCacheForTests,
   getCloudflareAccessConfig,
+  resolveCloudflareAccessToken,
   verifyCloudflareAccessJwt,
 } from "./cloudflare_access";
 
@@ -44,6 +45,29 @@ describe("cloudflare_access", () => {
         teamDomain: TEAM_DOMAIN,
         aud: AUD,
       });
+    });
+  });
+
+  describe("resolveCloudflareAccessToken", () => {
+    it("prefers the assertion header over the cookie", () => {
+      expect(
+        resolveCloudflareAccessToken({
+          headerToken: "header-token",
+          cookieToken: "cookie-token",
+        })
+      ).toBe("header-token");
+    });
+
+    it("falls back to the cookie when the header is absent", () => {
+      expect(
+        resolveCloudflareAccessToken({
+          cookieToken: "cookie-token",
+        })
+      ).toBe("cookie-token");
+    });
+
+    it("returns undefined when neither is present", () => {
+      expect(resolveCloudflareAccessToken({})).toBeUndefined();
     });
   });
 

--- a/front/lib/api/poke/cloudflare_access.ts
+++ b/front/lib/api/poke/cloudflare_access.ts
@@ -45,6 +45,27 @@ export function getCloudflareAccessConfig(): CloudflareAccessConfig | null {
   return { teamDomain: normalizeTeamDomain(teamDomain), aud };
 }
 
+/**
+ * Prefer the `Cf-Access-Jwt-Assertion` header (what Cloudflare injects at the
+ * edge). Fall back to the `CF_Authorization` cookie for browser same-origin
+ * requests where the header may not be forwarded.
+ *
+ * Extracted so tests can mock token presence without attaching headers to every
+ * `honoApp.request` call (same idea as mocking WorkOS session resolution).
+ */
+export function resolveCloudflareAccessToken({
+  headerToken,
+  cookieToken,
+}: {
+  headerToken?: string;
+  cookieToken?: string;
+}): string | undefined {
+  if (headerToken) {
+    return headerToken;
+  }
+  return cookieToken;
+}
+
 function getJwks(issuer: string) {
   if (cachedJwks && cachedJwksIssuer === issuer) {
     return cachedJwks;

--- a/front/lib/poke/roles.ts
+++ b/front/lib/poke/roles.ts
@@ -1,7 +1,3 @@
-import { getPokeUserConfigBucket } from "@app/lib/file_storage";
-import logger from "@app/logger/logger";
-import { isDevelopment } from "@app/types/shared/env";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { z } from "zod";
 
 const PokeRoleSchema = z.enum([
@@ -14,17 +10,7 @@ const PokeRoleSchema = z.enum([
 
 export type PokeRole = z.infer<typeof PokeRoleSchema>;
 
-const RolesConfigSchema = z.record(z.string().email(), z.array(PokeRoleSchema));
-
-type RolesConfig = z.infer<typeof RolesConfigSchema>;
-
-const POKE_ROLES_FILE = "poke-roles.json";
-const CACHE_TTL_MS = 5 * 60 * 1000;
-
-let cachedRoles: RolesConfig | null = null;
-let cacheExpiresAtMs = 0;
-
-const ALL_ROLES: PokeRole[] = PokeRoleSchema.options;
+export const ALL_ROLES: PokeRole[] = PokeRoleSchema.options;
 
 /**
  * IdP group names that grant each poke role. Keying by `PokeRole` forces a new
@@ -67,42 +53,6 @@ export function mapAccessGroupNamesToPokeRoles(
   }
 
   return ALL_ROLES.filter((role) => granted.has(role));
-}
-
-async function loadRoles(): Promise<RolesConfig> {
-  if (cachedRoles && Date.now() < cacheExpiresAtMs) {
-    return cachedRoles;
-  }
-
-  try {
-    const content = await getPokeUserConfigBucket({
-      useServiceAccount: false,
-    }).fetchFileContent(POKE_ROLES_FILE);
-    const parsed: unknown = JSON.parse(content);
-    const result = RolesConfigSchema.safeParse(parsed);
-
-    if (!result.success) {
-      throw new Error(`Invalid poke roles config: ${result.error.message}`);
-    }
-
-    cachedRoles = result.data;
-    cacheExpiresAtMs = Date.now() + CACHE_TTL_MS;
-    return cachedRoles;
-  } catch (err) {
-    logger.error(
-      { err: normalizeError(err) },
-      "Failed to load poke roles from GCS"
-    );
-    return cachedRoles ?? {};
-  }
-}
-
-export async function getPokeRolesForUser(email: string): Promise<PokeRole[]> {
-  if (isDevelopment()) {
-    return ALL_ROLES;
-  }
-  const roles = await loadRoles();
-  return roles[email] ?? [];
 }
 
 export function hasPokeRole(

--- a/front/tests/utils/FrameFunctionFactory.ts
+++ b/front/tests/utils/FrameFunctionFactory.ts
@@ -3,6 +3,7 @@ import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_res
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createPokeApiMockRequest } from "@app/tests/utils/generic_poke_api_tests";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { frameV2ContentType } from "@app/types/files";
@@ -20,7 +21,12 @@ export async function makeTestFrameFunction({
   isSuperUser?: boolean;
   shareScope?: "emails_only" | "workspace_and_emails";
 } = {}) {
-  const { workspace, auth: adminAuth } = await createPrivateApiMockRequest({
+  // Poke frame routes authenticate via Cloudflare Access; non-poke callers keep
+  // the WorkOS private-api mock.
+  const createMockRequest = isSuperUser
+    ? createPokeApiMockRequest
+    : createPrivateApiMockRequest;
+  const { workspace, auth: adminAuth } = await createMockRequest({
     isSuperUser,
     role: "admin",
   });
@@ -75,10 +81,10 @@ export async function makeTestFrameFunction({
   if (!sandboxFunction) {
     throw new Error("Expected the Frame function to exist.");
   }
-  // Re-mocks the WorkOS session (the last `createPrivateApiMockRequest` call wins for request
-  // authentication), so `isSuperUser` must be threaded here too or a poke request made right
-  // after `makeTestFrameFunction` would authenticate as this non-super "user" auth instead.
-  const { auth } = await createPrivateApiMockRequest({
+  // Re-mocks request auth (the last mock-request call wins), so `isSuperUser`
+  // must be threaded here too or a poke request made right after
+  // `makeTestFrameFunction` would authenticate as this non-super "user" auth.
+  const { auth } = await createMockRequest({
     isSuperUser,
     role: "user",
     workspace,

--- a/front/tests/utils/generic_poke_api_tests.ts
+++ b/front/tests/utils/generic_poke_api_tests.ts
@@ -1,0 +1,90 @@
+import { ALL_ROLES } from "@app/lib/poke/roles";
+import type { TestWorkspacePlan } from "@app/tests/utils/WorkspaceFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
+import type { WorkspaceType } from "@app/types/user";
+import type { RequestMethod } from "node-mocks-http";
+import { vi } from "vitest";
+
+import { createPrivateApiMockRequest } from "./generic_private_api_tests";
+
+const TEST_CF_ACCESS_TOKEN = "test-cf-access-jwt";
+const TEST_CF_ACCESS_CONFIG = {
+  teamDomain: "https://dust.cloudflareaccess.com",
+  aud: "test-aud",
+};
+
+// Poke auth prefers Cloudflare Access. Mock token resolution / JWT verify /
+// role lookup the same way private-api tests mock WorkOS session resolution, so
+// callers keep using bare `honoApp.request(...)` without attaching headers.
+vi.mock(
+  import("../../lib/api/poke/cloudflare_access"),
+  async (importOriginal) => {
+    const mod = await importOriginal();
+    return {
+      ...mod,
+      getCloudflareAccessConfig: vi.fn(),
+      resolveCloudflareAccessToken: vi.fn(),
+      verifyCloudflareAccessJwt: vi.fn(),
+      getPokeRolesForUserViaCloudflareAccess: vi.fn(),
+    };
+  }
+);
+
+import {
+  getCloudflareAccessConfig,
+  getPokeRolesForUserViaCloudflareAccess,
+  resolveCloudflareAccessToken,
+  verifyCloudflareAccessJwt,
+} from "../../lib/api/poke/cloudflare_access";
+
+/**
+ * Sets up workspace fixtures and mocks Cloudflare Access for poke route tests.
+ *
+ * When `isSuperUser` is true, pokeAuth accepts requests as a Dust internal
+ * Access identity with all poke roles. When false, Access token resolution
+ * returns nothing so pokeAuth rejects with 401 (matching production behavior
+ * outside development when CF Access is configured).
+ */
+export const createPokeApiMockRequest = async ({
+  method = "GET",
+  role = "user",
+  isSuperUser = false,
+  plan = "basic",
+  workspace: existingWorkspace,
+}: {
+  method?: RequestMethod;
+  role?: MembershipRoleType;
+  isSuperUser?: boolean;
+  plan?: TestWorkspacePlan;
+  workspace?: WorkspaceType;
+} = {}) => {
+  const result = await createPrivateApiMockRequest({
+    method,
+    role,
+    isSuperUser,
+    plan,
+    workspace: existingWorkspace,
+  });
+
+  vi.mocked(getCloudflareAccessConfig).mockReturnValue(TEST_CF_ACCESS_CONFIG);
+
+  if (isSuperUser) {
+    vi.mocked(resolveCloudflareAccessToken).mockReturnValue(
+      TEST_CF_ACCESS_TOKEN
+    );
+    vi.mocked(verifyCloudflareAccessJwt).mockResolvedValue({
+      email: result.user.email,
+      name: result.user.fullName(),
+      sub: "test-cf-access-sub",
+    });
+    vi.mocked(getPokeRolesForUserViaCloudflareAccess).mockResolvedValue(
+      ALL_ROLES
+    );
+  } else {
+    vi.mocked(resolveCloudflareAccessToken).mockReturnValue(undefined);
+    vi.mocked(verifyCloudflareAccessJwt).mockResolvedValue(null);
+    vi.mocked(getPokeRolesForUserViaCloudflareAccess).mockResolvedValue([]);
+  }
+
+  return result;
+};


### PR DESCRIPTION
## Description

Restrict Poke's WorkOS session fallback to development environments. Production requests without a Cloudflare Access token now return `401`; development fallback sessions use `ALL_ROLES` and continue through `Authenticator.fromDustSuperUser`. Remove the GCS-backed per-user role lookup, cache, and related error handling from `front/lib/poke/roles.ts`.

## Tests

No automated tests were added or updated. Validate the middleware manually in development and confirm missing-token requests are rejected outside development.

## Risk

Medium security impact: production requests that previously fell back to WorkOS now fail closed. Rollback is straightforward by reverting the middleware and role-loader changes.

## Deploy Plan

Deploy `front` and `front-api`. Verify Cloudflare Access authentication in production and WorkOS fallback behavior in development after deployment.