### PR TITLE
[poke] Show global multi-cell views for Feature Flags, Kill, Production Checks, and Agent Feedback

### DIFF
--- a/front/components/poke/pages/FeatureFlagDetailPage.tsx
+++ b/front/components/poke/pages/FeatureFlagDetailPage.tsx
@@ -2,11 +2,14 @@ import { FeatureFlagStageChip } from "@app/components/poke/features/stage_chip";
 import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import { RunPluginDialog } from "@app/components/poke/plugins/RunPluginDialog";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
-import { usePokeFeatureFlagWorkspaces } from "@app/hooks/usePokeFeatureFlagWorkspaces";
-import type { PokeFeatureFlagWorkspace } from "@app/lib/api/poke/feature_flags";
+import type { PokeFeatureFlagWorkspaceWithCell } from "@app/hooks/usePokeFeatureFlagWorkspaces";
+import { usePokeFeatureFlagWorkspacesAllCells } from "@app/hooks/usePokeFeatureFlagWorkspaces";
+import { useCellContext } from "@app/lib/auth/CellContext";
 import { useRequiredPathParam } from "@app/lib/platform";
+import { getCellChipColor, getCellDisplay } from "@app/lib/poke/cells";
 import { usePokePageMetadata } from "@app/poke/swr/currentPage";
 import { usePokeListPluginForResourceType } from "@app/poke/swr/plugins";
+import type { CellType } from "@app/types/cell";
 import type { PluginResourceTarget } from "@app/types/poke/plugins";
 import {
   isWhitelistableFeature,
@@ -15,6 +18,7 @@ import {
 import { dateToHumanReadable } from "@app/types/shared/utils/date_utils";
 import {
   Button,
+  Chip,
   Dialog,
   DialogContent,
   DialogHeader,
@@ -95,24 +99,46 @@ function WorkspaceTogglePluginDialog({
 }
 
 interface MakeColumnsParams {
-  onToggleFlags: (workspaceId: string) => void;
+  onToggleFlags: (workspaceId: string, cell: CellType) => void;
+  onSwitchCell: (cell: CellType) => void;
 }
 
 function makeColumns({
   onToggleFlags,
-}: MakeColumnsParams): ColumnDef<PokeFeatureFlagWorkspace>[] {
+  onSwitchCell,
+}: MakeColumnsParams): ColumnDef<PokeFeatureFlagWorkspaceWithCell>[] {
   return [
+    {
+      id: "cell",
+      accessorKey: "cell",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Cell" />
+      ),
+      filterFn: (row, id, value) => value.includes(row.getValue(id)),
+      cell: ({ row }) => (
+        <Chip
+          size="mini"
+          color={getCellChipColor(row.original.region)}
+          label={getCellDisplay({
+            name: row.original.cell,
+            region: row.original.region,
+          })}
+        />
+      ),
+    },
     {
       accessorKey: "workspaceName",
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Workspace" />
       ),
       cell: ({ row }) => (
-        <LinkWrapper href={`/poke/${row.original.workspaceId}`}>
-          <span className="text-highlight-600 hover:underline">
-            {row.original.workspaceName}
-          </span>
-        </LinkWrapper>
+        <div onClick={() => onSwitchCell(row.original.cell)}>
+          <LinkWrapper href={`/poke/${row.original.workspaceId}`}>
+            <span className="text-highlight-600 hover:underline">
+              {row.original.workspaceName}
+            </span>
+          </LinkWrapper>
+        </div>
       ),
     },
     {
@@ -157,7 +183,9 @@ function makeColumns({
           icon={Pencil01}
           label="Toggle flags"
           tooltip="Open this workspace's Toggle Feature Flag plugin"
-          onClick={() => onToggleFlags(row.original.workspaceId)}
+          onClick={() =>
+            onToggleFlags(row.original.workspaceId, row.original.cell)
+          }
         />
       ),
     },
@@ -169,14 +197,10 @@ export function FeatureFlagDetailPage() {
 
   usePokePageMetadata({ name: flagName });
 
-  const {
-    workspaces,
-    totalCount,
-    globalRolloutPercentage,
-    isLoading,
-    isError,
-    mutate,
-  } = usePokeFeatureFlagWorkspaces({ flagName });
+  const { cells, cellInfo, setCellInfo } = useCellContext();
+
+  const { workspaces, cellRollouts, totalCount, isLoading, isError, mutate } =
+    usePokeFeatureFlagWorkspacesAllCells({ flagName });
 
   // Description and stage are static config, so they need no round trip. A flag name that is not
   // in the config is a legacy row still present in the database.
@@ -188,9 +212,22 @@ export function FeatureFlagDetailPage() {
     string | null
   >(null);
 
+  const switchToCell = useCallback(
+    (cell: CellType) => {
+      const targetCell = cells.find((c) => c.name === cell);
+      if (targetCell && targetCell.name !== cellInfo.name) {
+        setCellInfo(targetCell);
+      }
+    },
+    [cells, cellInfo, setCellInfo]
+  );
+
   const onToggleFlags = useCallback(
-    (workspaceId: string) => setWorkspaceBeingEdited(workspaceId),
-    []
+    (workspaceId: string, cell: CellType) => {
+      switchToCell(cell);
+      setWorkspaceBeingEdited(workspaceId);
+    },
+    [switchToCell]
   );
 
   const handlePluginDialogClose = useCallback(() => {
@@ -199,8 +236,17 @@ export function FeatureFlagDetailPage() {
   }, [mutate]);
 
   const columns = useMemo(
-    () => makeColumns({ onToggleFlags }),
-    [onToggleFlags]
+    () => makeColumns({ onToggleFlags, onSwitchCell: switchToCell }),
+    [onToggleFlags, switchToCell]
+  );
+
+  const cellFacetOptions = useMemo(
+    () =>
+      cells.map((cell) => ({
+        label: getCellDisplay(cell),
+        value: cell.name,
+      })),
+    [cells]
   );
 
   return (
@@ -211,19 +257,35 @@ export function FeatureFlagDetailPage() {
             ← All feature flags
           </span>
         </LinkWrapper>
-        <div className="mt-2 flex items-center gap-3">
+        <div className="mt-2 flex flex-wrap items-center gap-3">
           <h1 className="font-mono text-2xl font-bold">{flagName}</h1>
           <FeatureFlagStageChip flagName={flagName} />
-          {globalRolloutPercentage !== null && (
-            <span className="text-sm text-muted-foreground">
-              global rollout: {globalRolloutPercentage}%
-            </span>
-          )}
         </div>
         <p className="mt-1 text-sm text-muted-foreground">
           {flagConfig?.description ??
             "No longer declared in WHITELISTABLE_FEATURES_CONFIG."}
         </p>
+        {cellRollouts.length > 0 && (
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <span className="text-sm text-muted-foreground">
+              Global rollout:
+            </span>
+            {cellRollouts.map((rollout) => {
+              const pctLabel =
+                rollout.globalRolloutPercentage === null
+                  ? "—"
+                  : `${rollout.globalRolloutPercentage}%`;
+              return (
+                <Chip
+                  key={rollout.cell}
+                  size="xs"
+                  color={getCellChipColor(rollout.region)}
+                  label={`${getCellDisplay({ name: rollout.cell, region: rollout.region })}: ${pctLabel} (${rollout.totalCount})`}
+                />
+              );
+            })}
+          </div>
+        )}
       </div>
 
       {isError ? (
@@ -234,14 +296,21 @@ export function FeatureFlagDetailPage() {
         <>
           <p className="mb-2 text-sm text-muted-foreground">
             {workspaces.length === totalCount
-              ? `${totalCount} workspace(s)`
-              : `Showing the ${workspaces.length} most recently enabled of ${totalCount} workspaces.`}
+              ? `${totalCount} workspace(s) across all cells`
+              : `Showing the ${workspaces.length} most recently enabled of ${totalCount} workspaces across all cells.`}
           </p>
           <PokeDataTable
             columns={columns}
             data={workspaces}
             isLoading={isLoading}
             pageSize={50}
+            facets={[
+              {
+                columnId: "cell",
+                title: "Cell",
+                options: cellFacetOptions,
+              },
+            ]}
           />
         </>
       )}

--- a/front/components/poke/pages/FeatureFlagsPage.tsx
+++ b/front/components/poke/pages/FeatureFlagsPage.tsx
@@ -2,10 +2,13 @@ import { FeatureFlagStageChip } from "@app/components/poke/features/stage_chip";
 import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import { RunPluginDialog } from "@app/components/poke/plugins/RunPluginDialog";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
-import { usePokeFeatureFlagUsage } from "@app/hooks/usePokeFeatureFlagUsage";
-import type { PokeFeatureFlagUsage } from "@app/lib/api/poke/feature_flags";
+import type { PokeFeatureFlagUsageAllCells } from "@app/hooks/usePokeFeatureFlagUsage";
+import { usePokeFeatureFlagUsageAllCells } from "@app/hooks/usePokeFeatureFlagUsage";
+import { useCellContext } from "@app/lib/auth/CellContext";
+import { getCellChipColor, getCellDisplay } from "@app/lib/poke/cells";
 import { usePokePageMetadata } from "@app/poke/swr/currentPage";
 import { usePokeListPluginForResourceType } from "@app/poke/swr/plugins";
+import type { CellType } from "@app/types/cell";
 import type { PluginResourceTarget } from "@app/types/poke/plugins";
 import {
   FEATURE_FLAG_STAGE_LABELS,
@@ -13,7 +16,7 @@ import {
   isWhitelistableFeature,
   WHITELISTABLE_FEATURES_CONFIG,
 } from "@app/types/shared/feature_flags";
-import { Button, LinkWrapper, Pencil01, Trash01 } from "@dust-tt/sparkle";
+import { Button, Chip, LinkWrapper, Pencil01, Trash01 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useCallback, useMemo, useState } from "react";
 
@@ -29,18 +32,19 @@ const GLOBAL_PLUGIN_TARGET: PluginResourceTarget = { resourceType: "global" };
 interface PendingPluginAction {
   pluginId: string;
   flagName: string;
+  cell: CellType;
 }
 
 interface MakeColumnsParams {
   // Both are `null` when the current user cannot run the corresponding plugin.
-  onDeleteLegacyRows: ((flagName: string) => void) | null;
-  onEditGlobalRollout: ((flagName: string) => void) | null;
+  onDeleteLegacyRows: ((flagName: string, cell: CellType) => void) | null;
+  onEditGlobalRollout: ((flagName: string, cell: CellType) => void) | null;
 }
 
 function makeColumns({
   onDeleteLegacyRows,
   onEditGlobalRollout,
-}: MakeColumnsParams): ColumnDef<PokeFeatureFlagUsage>[] {
+}: MakeColumnsParams): ColumnDef<PokeFeatureFlagUsageAllCells>[] {
   return [
     {
       accessorKey: "name",
@@ -91,51 +95,101 @@ function makeColumns({
       },
     },
     {
-      accessorKey: "workspaceCount",
+      accessorKey: "totalWorkspaceCount",
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Workspaces" />
       ),
       cell: ({ row }) => {
-        const { workspaceCount } = row.original;
+        const { byCell, totalWorkspaceCount } = row.original;
         return (
-          <span
-            className={
-              workspaceCount === 0
-                ? "text-muted-foreground"
-                : "font-medium text-foreground"
-            }
-          >
-            {workspaceCount}
-          </span>
+          <div className="flex flex-col gap-1">
+            <span
+              className={
+                totalWorkspaceCount === 0
+                  ? "text-muted-foreground"
+                  : "font-medium text-foreground"
+              }
+            >
+              {totalWorkspaceCount} total
+            </span>
+            <div className="flex flex-wrap items-center gap-1">
+              {byCell.map((stat) => (
+                <Chip
+                  key={stat.cell}
+                  size="mini"
+                  color={getCellChipColor(stat.region)}
+                  label={`${getCellDisplay({ name: stat.cell, region: stat.region })}: ${stat.workspaceCount}`}
+                />
+              ))}
+            </div>
+          </div>
         );
       },
     },
     {
-      accessorKey: "globalRolloutPercentage",
+      id: "globalRollout",
+      accessorFn: (flag) =>
+        flag.byCell.reduce(
+          (max, stat) => Math.max(max, stat.globalRolloutPercentage ?? -1),
+          -1
+        ),
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Global rollout" />
       ),
       cell: ({ row }) => {
-        const { globalRolloutPercentage, name, stage } = row.original;
-        const label =
-          globalRolloutPercentage === null
-            ? "—"
-            : `${globalRolloutPercentage}%`;
+        const { byCell, name, stage } = row.original;
 
         // Legacy flags are not in the plugin's list of features, so there is nothing to open.
         if (!onEditGlobalRollout || stage === null) {
-          return <span className="text-muted-foreground">{label}</span>;
+          return (
+            <div className="flex flex-wrap items-center gap-1">
+              {byCell.map((stat) => {
+                const label =
+                  stat.globalRolloutPercentage === null
+                    ? "—"
+                    : `${stat.globalRolloutPercentage}%`;
+                return (
+                  <Chip
+                    key={stat.cell}
+                    size="mini"
+                    color={getCellChipColor(stat.region)}
+                    label={`${getCellDisplay({ name: stat.cell, region: stat.region })}: ${label}`}
+                  />
+                );
+              })}
+            </div>
+          );
         }
 
         return (
-          <Button
-            variant="ghost"
-            size="xs"
-            icon={Pencil01}
-            label={label}
-            tooltip="Set the global rollout percentage"
-            onClick={() => onEditGlobalRollout(name)}
-          />
+          <div className="flex flex-col gap-1">
+            {byCell.map((stat) => {
+              const label =
+                stat.globalRolloutPercentage === null
+                  ? "—"
+                  : `${stat.globalRolloutPercentage}%`;
+              return (
+                <div key={stat.cell} className="flex items-center gap-1">
+                  <Chip
+                    size="mini"
+                    color={getCellChipColor(stat.region)}
+                    label={getCellDisplay({
+                      name: stat.cell,
+                      region: stat.region,
+                    })}
+                  />
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    icon={Pencil01}
+                    label={label}
+                    tooltip="Set the global rollout percentage"
+                    onClick={() => onEditGlobalRollout(name, stat.cell)}
+                  />
+                </div>
+              );
+            })}
+          </div>
         );
       },
     },
@@ -155,7 +209,7 @@ function makeColumns({
       header: "",
       enableSorting: false,
       cell: ({ row }) => {
-        const { name, stage } = row.original;
+        const { name, stage, byCell } = row.original;
 
         // Only leftover rows are deleted wholesale; a flag that still exists is turned off per
         // workspace, or globally, through the toggle plugins.
@@ -163,15 +217,34 @@ function makeColumns({
           return null;
         }
 
+        const deletable = byCell.filter((stat) => stat.workspaceCount > 0);
+        if (deletable.length === 0) {
+          return null;
+        }
+
         return (
-          <Button
-            variant="warning"
-            size="xs"
-            icon={Trash01}
-            label="Delete rows"
-            tooltip="Delete every row for this retired flag"
-            onClick={() => onDeleteLegacyRows(name)}
-          />
+          <div className="flex flex-col gap-1">
+            {deletable.map((stat) => (
+              <div key={stat.cell} className="flex items-center gap-1">
+                <Chip
+                  size="mini"
+                  color={getCellChipColor(stat.region)}
+                  label={getCellDisplay({
+                    name: stat.cell,
+                    region: stat.region,
+                  })}
+                />
+                <Button
+                  variant="warning"
+                  size="xs"
+                  icon={Trash01}
+                  label="Delete rows"
+                  tooltip="Delete every row for this retired flag"
+                  onClick={() => onDeleteLegacyRows(name, stat.cell)}
+                />
+              </div>
+            ))}
+          </div>
         );
       },
     },
@@ -181,7 +254,8 @@ function makeColumns({
 export function FeatureFlagsPage() {
   usePokePageMetadata({ name: "Feature Flags" });
 
-  const { featureFlags, isLoading, mutate } = usePokeFeatureFlagUsage();
+  const { cells, cellInfo, setCellInfo } = useCellContext();
+  const { featureFlags, isLoading, mutate } = usePokeFeatureFlagUsageAllCells();
 
   const { plugins } = usePokeListPluginForResourceType({
     pluginResourceTarget: GLOBAL_PLUGIN_TARGET,
@@ -196,19 +270,38 @@ export function FeatureFlagsPage() {
   const [pendingAction, setPendingAction] =
     useState<PendingPluginAction | null>(null);
 
+  const switchToCell = useCallback(
+    (cell: CellType) => {
+      const targetCell = cells.find((c) => c.name === cell);
+      if (targetCell && targetCell.name !== cellInfo.name) {
+        setCellInfo(targetCell);
+      }
+    },
+    [cells, cellInfo, setCellInfo]
+  );
+
   const onEditGlobalRollout = useCallback(
-    (flagName: string) =>
+    (flagName: string, cell: CellType) => {
+      switchToCell(cell);
       setPendingAction({
         pluginId: TOGGLE_GLOBAL_ROLLOUT_PLUGIN_ID,
         flagName,
-      }),
-    []
+        cell,
+      });
+    },
+    [switchToCell]
   );
 
   const onDeleteLegacyRows = useCallback(
-    (flagName: string) =>
-      setPendingAction({ pluginId: DELETE_LEGACY_FLAG_PLUGIN_ID, flagName }),
-    []
+    (flagName: string, cell: CellType) => {
+      switchToCell(cell);
+      setPendingAction({
+        pluginId: DELETE_LEGACY_FLAG_PLUGIN_ID,
+        flagName,
+        cell,
+      });
+    },
+    [switchToCell]
   );
 
   const handlePluginDialogClose = useCallback(() => {
@@ -229,9 +322,12 @@ export function FeatureFlagsPage() {
     ? plugins.find((plugin) => plugin.id === pendingAction.pluginId)
     : undefined;
 
-  // The table starts unsorted, so the most-used flags come first by default.
+  // Most-used flags across all cells come first by default.
   const sortedFeatureFlags = useMemo(
-    () => [...featureFlags].sort((a, b) => b.workspaceCount - a.workspaceCount),
+    () =>
+      [...featureFlags].sort(
+        (a, b) => b.totalWorkspaceCount - a.totalWorkspaceCount
+      ),
     [featureFlags]
   );
 
@@ -240,8 +336,8 @@ export function FeatureFlagsPage() {
       <div className="mb-6">
         <h1 className="text-2xl font-bold">Feature Flags</h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          Every feature flag in this region, with the number of workspaces it is
-          enabled on. Click a flag to see those workspaces.
+          Every feature flag across all cells, with the number of workspaces it
+          is enabled on. Click a flag to see those workspaces.
         </p>
       </div>
 

--- a/front/components/poke/pages/GlobalAgentFeedbacksPage.tsx
+++ b/front/components/poke/pages/GlobalAgentFeedbacksPage.tsx
@@ -1,8 +1,18 @@
 import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
-import { usePokeGlobalAgentFeedbacks } from "@app/hooks/usePokeGlobalAgentFeedbacks";
-import type { GlobalAgentFeedbackItem } from "@app/lib/api/poke/global_agent_feedbacks";
+import type {
+  CellCursors,
+  GlobalAgentFeedbackItemWithCell,
+} from "@app/hooks/usePokeGlobalAgentFeedbacks";
+import {
+  nextExhaustedCells,
+  nextFeedbackCursors,
+  usePokeGlobalAgentFeedbacksAllCells,
+} from "@app/hooks/usePokeGlobalAgentFeedbacks";
+import { useCellContext } from "@app/lib/auth/CellContext";
+import { getCellChipColor, getCellDisplay } from "@app/lib/poke/cells";
 import { usePokePageMetadata } from "@app/poke/swr/currentPage";
+import type { CellType } from "@app/types/cell";
 import {
   Button,
   CheckboxWithText,
@@ -11,10 +21,34 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
-function makeColumns(): ColumnDef<GlobalAgentFeedbackItem>[] {
+interface MakeColumnsParams {
+  onSwitchCell: (cell: CellType) => void;
+}
+
+function makeColumns({
+  onSwitchCell,
+}: MakeColumnsParams): ColumnDef<GlobalAgentFeedbackItemWithCell>[] {
   return [
+    {
+      id: "cell",
+      accessorKey: "cell",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Cell" />
+      ),
+      filterFn: (row, id, value) => value.includes(row.getValue(id)),
+      cell: ({ row }) => (
+        <Chip
+          size="mini"
+          color={getCellChipColor(row.original.region)}
+          label={getCellDisplay({
+            name: row.original.cell,
+            region: row.original.region,
+          })}
+        />
+      ),
+    },
     {
       accessorKey: "createdAt",
       header: ({ column }) => (
@@ -78,11 +112,13 @@ function makeColumns(): ColumnDef<GlobalAgentFeedbackItem>[] {
       cell: ({ row }) => {
         const feedback = row.original;
         return (
-          <LinkWrapper href={`/poke/${feedback.workspaceId}`}>
-            <span className="text-highlight-600 hover:underline">
-              {feedback.workspaceName}
-            </span>
-          </LinkWrapper>
+          <div onClick={() => onSwitchCell(feedback.cell)}>
+            <LinkWrapper href={`/poke/${feedback.workspaceId}`}>
+              <span className="text-highlight-600 hover:underline">
+                {feedback.workspaceName}
+              </span>
+            </LinkWrapper>
+          </div>
         );
       },
     },
@@ -106,11 +142,13 @@ function makeColumns(): ColumnDef<GlobalAgentFeedbackItem>[] {
           feedback.workspaceId !== "unknown"
         ) {
           return (
-            <LinkWrapper
-              href={`/poke/${feedback.workspaceId}/conversation/${feedback.conversationId}`}
-            >
-              <span className="text-highlight-600 hover:underline">View</span>
-            </LinkWrapper>
+            <div onClick={() => onSwitchCell(feedback.cell)}>
+              <LinkWrapper
+                href={`/poke/${feedback.workspaceId}/conversation/${feedback.conversationId}`}
+              >
+                <span className="text-highlight-600 hover:underline">View</span>
+              </LinkWrapper>
+            </div>
           );
         }
         return <span className="text-gray-400">-</span>;
@@ -122,32 +160,70 @@ function makeColumns(): ColumnDef<GlobalAgentFeedbackItem>[] {
 export function GlobalAgentFeedbacksPage() {
   usePokePageMetadata({ name: "Global Agent Feedbacks" });
 
+  const { cells, cellInfo, setCellInfo } = useCellContext();
+
   const [includeEmpty, setIncludeEmpty] = useState(false);
-  const [pages, setPages] = useState<number[]>([]);
+  const [cursors, setCursors] = useState<CellCursors>({});
+  const [exhaustedCells, setExhaustedCells] = useState<Set<CellType>>(
+    () => new Set()
+  );
+  const [cursorHistory, setCursorHistory] = useState<CellCursors[]>([]);
+  const [exhaustedHistory, setExhaustedHistory] = useState<Set<CellType>[]>([]);
 
-  const currentLastId = pages.length > 0 ? pages[pages.length - 1] : null;
+  const { feedbacks, hasMore, hasMoreByCell, isLoading } =
+    usePokeGlobalAgentFeedbacksAllCells({
+      includeEmpty,
+      cursors,
+      exhaustedCells,
+    });
 
-  const { feedbacks, hasMore, isLoading } = usePokeGlobalAgentFeedbacks({
-    includeEmpty,
-    lastId: currentLastId,
-  });
+  const switchToCell = useCallback(
+    (cell: CellType) => {
+      const targetCell = cells.find((c) => c.name === cell);
+      if (targetCell && targetCell.name !== cellInfo.name) {
+        setCellInfo(targetCell);
+      }
+    },
+    [cells, cellInfo, setCellInfo]
+  );
 
-  const columns = useMemo(() => makeColumns(), []);
+  const columns = useMemo(
+    () => makeColumns({ onSwitchCell: switchToCell }),
+    [switchToCell]
+  );
+
+  const cellFacetOptions = useMemo(
+    () =>
+      cells.map((cell) => ({
+        label: getCellDisplay(cell),
+        value: cell.name,
+      })),
+    [cells]
+  );
 
   const handleNextPage = () => {
-    if (feedbacks.length > 0) {
-      const lastFeedback = feedbacks[feedbacks.length - 1];
-      setPages((prev) => [...prev, lastFeedback.id]);
-    }
+    setCursorHistory((prev) => [...prev, cursors]);
+    setExhaustedHistory((prev) => [...prev, exhaustedCells]);
+    setCursors(nextFeedbackCursors(feedbacks, cursors, hasMoreByCell));
+    setExhaustedCells(nextExhaustedCells(exhaustedCells, hasMoreByCell));
   };
 
   const handlePrevPage = () => {
-    setPages((prev) => prev.slice(0, -1));
+    const prevCursors = cursorHistory[cursorHistory.length - 1] ?? {};
+    const prevExhausted =
+      exhaustedHistory[exhaustedHistory.length - 1] ?? new Set<CellType>();
+    setCursorHistory((prev) => prev.slice(0, -1));
+    setExhaustedHistory((prev) => prev.slice(0, -1));
+    setCursors(prevCursors);
+    setExhaustedCells(prevExhausted);
   };
 
   const handleIncludeEmptyChange = () => {
     setIncludeEmpty((prev) => !prev);
-    setPages([]);
+    setCursors({});
+    setExhaustedCells(new Set());
+    setCursorHistory([]);
+    setExhaustedHistory([]);
   };
 
   return (
@@ -158,7 +234,7 @@ export function GlobalAgentFeedbacksPage() {
             Global Agent Feedback
           </h1>
           <p className="mt-1 text-sm text-primary-600">
-            User feedback on global agents across all workspaces.
+            User feedback on global agents across all workspaces and cells.
           </p>
         </div>
 
@@ -176,7 +252,18 @@ export function GlobalAgentFeedbacksPage() {
           </div>
         ) : (
           <>
-            <PokeDataTable columns={columns} data={feedbacks} pageSize={25} />
+            <PokeDataTable
+              columns={columns}
+              data={feedbacks}
+              pageSize={25}
+              facets={[
+                {
+                  columnId: "cell",
+                  title: "Cell",
+                  options: cellFacetOptions,
+                },
+              ]}
+            />
 
             <div className="mt-4 flex items-center justify-between">
               <Button
@@ -184,10 +271,10 @@ export function GlobalAgentFeedbacksPage() {
                 size="sm"
                 label="Previous batch"
                 onClick={handlePrevPage}
-                disabled={pages.length === 0}
+                disabled={cursorHistory.length === 0}
               />
               <span className="text-sm text-primary-500">
-                Batch {pages.length + 1}
+                Batch {cursorHistory.length + 1}
                 {hasMore ? " (more available)" : " (last)"}
               </span>
               <Button

--- a/front/components/poke/pages/KillPage.tsx
+++ b/front/components/poke/pages/KillPage.tsx
@@ -1,16 +1,19 @@
 import { DegradedModelsDialog } from "@app/components/poke/DegradedModelsDialog";
 import { cn } from "@app/components/poke/shadcn/lib/utils";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { useCellContext } from "@app/lib/auth/CellContext";
 import { clientFetch } from "@app/lib/egress/client";
+import { getCellChipColor, getCellDisplay } from "@app/lib/poke/cells";
 import type { KillSwitchType } from "@app/lib/poke/types";
 import { isLegacyKillSwitchType, KILL_SWITCH_TYPES } from "@app/lib/poke/types";
 import { usePokePageMetadata } from "@app/poke/swr/currentPage";
 import { usePokeDegradedModels } from "@app/poke/swr/degraded_models";
-import { usePokeKillSwitches } from "@app/poke/swr/kill";
+import { usePokeKillSwitchesAllCells } from "@app/poke/swr/kill";
 import {
   usePokeSandboxKillImages,
   useRequestSandboxKill,
 } from "@app/poke/swr/sandbox_kill";
+import type { CellType } from "@app/types/cell";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import {
   AlertCircle,
@@ -109,6 +112,11 @@ const PANEL_SECTION_CLASSES = cn(
 
 type SandboxKillRequestKey = string;
 
+interface UpdatingKillSwitch {
+  type: KillSwitchType;
+  cell: CellType;
+}
+
 function sandboxKillKey(
   baseImage: string,
   version?: string
@@ -119,12 +127,12 @@ function sandboxKillKey(
 export function KillPage() {
   usePokePageMetadata({ name: "Kill Switches" });
 
-  const { killSwitches, isKillSwitchesLoading, mutateKillSwitches } =
-    usePokeKillSwitches();
+  const { cellInfo } = useCellContext();
+  const { killSwitchesByCell, isKillSwitchesLoading, mutateKillSwitches } =
+    usePokeKillSwitchesAllCells();
   const [updatingKillSwitch, setUpdatingKillSwitch] =
-    useState<KillSwitchType | null>(null);
+    useState<UpdatingKillSwitch | null>(null);
   const sendNotification = useSendNotification();
-  const enabledKillSwitches = new Set(killSwitches);
   const { endpoints, mutateDegradedModels } = usePokeDegradedModels();
   const degradedEndpoints = endpoints.filter((endpoint) => endpoint.degraded);
 
@@ -135,6 +143,8 @@ export function KillPage() {
 
   async function updateKillSwitch(
     killSwitch: KillSwitchType,
+    cell: CellType,
+    cellUrl: string,
     enabled: boolean
   ): Promise<void> {
     if (updatingKillSwitch) {
@@ -144,16 +154,16 @@ export function KillPage() {
     if (
       enabled &&
       !window.confirm(
-        `Enable "${KILL_SWITCH_DEFINITIONS[killSwitch].title}" kill switch?`
+        `Enable "${KILL_SWITCH_DEFINITIONS[killSwitch].title}" kill switch on ${cell}?`
       )
     ) {
       return;
     }
 
-    setUpdatingKillSwitch(killSwitch);
+    setUpdatingKillSwitch({ type: killSwitch, cell });
 
     try {
-      const res = await clientFetch("/api/poke/kill", {
+      const res = await clientFetch(`${cellUrl}/api/poke/kill`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -179,7 +189,7 @@ export function KillPage() {
         title: "Kill switch updated",
         description: `${KILL_SWITCH_DEFINITIONS[killSwitch].title} ${
           enabled ? "enabled" : "disabled"
-        }.`,
+        } on ${cell}.`,
         type: "success",
       });
     } catch (error) {
@@ -222,7 +232,7 @@ export function KillPage() {
           <span>Kill switches</span>
         </h2>
         <p className={PANEL_DESCRIPTION_CLASSES}>
-          Control critical system functionality.
+          Control critical system functionality across all cells.
         </p>
 
         {isKillSwitchesLoading ? (
@@ -239,8 +249,6 @@ export function KillPage() {
                 icon: Icon,
               } = KILL_SWITCH_DEFINITIONS[type];
 
-              const isEnabled = enabledKillSwitches.has(type);
-              const isUpdating = updatingKillSwitch === type;
               const isLegacy = isLegacyKillSwitchType(type);
 
               return (
@@ -277,16 +285,50 @@ export function KillPage() {
                     )}
                   </div>
 
-                  <div className="flex h-7 w-10 items-center justify-center">
-                    {isUpdating ? (
-                      <Spinner size="xs" />
-                    ) : (
-                      <SliderToggle
-                        disabled={updatingKillSwitch !== null}
-                        onClick={() => void updateKillSwitch(type, !isEnabled)}
-                        selected={isEnabled}
-                      />
-                    )}
+                  <div className="flex flex-col items-end gap-2">
+                    {killSwitchesByCell.map((cellEntry) => {
+                      const enabledKillSwitches = new Set(
+                        cellEntry.killSwitches
+                      );
+                      const isEnabled = enabledKillSwitches.has(type);
+                      const isUpdating =
+                        updatingKillSwitch?.type === type &&
+                        updatingKillSwitch.cell === cellEntry.cell;
+
+                      return (
+                        <div
+                          key={cellEntry.cell}
+                          className="flex items-center gap-2"
+                        >
+                          <Chip
+                            size="mini"
+                            color={getCellChipColor(cellEntry.region)}
+                            label={getCellDisplay({
+                              name: cellEntry.cell,
+                              region: cellEntry.region,
+                            })}
+                          />
+                          <div className="flex h-7 w-10 items-center justify-center">
+                            {isUpdating ? (
+                              <Spinner size="xs" />
+                            ) : (
+                              <SliderToggle
+                                disabled={updatingKillSwitch !== null}
+                                onClick={() =>
+                                  void updateKillSwitch(
+                                    type,
+                                    cellEntry.cell,
+                                    cellEntry.url,
+                                    !isEnabled
+                                  )
+                                }
+                                selected={isEnabled}
+                              />
+                            )}
+                          </div>
+                        </div>
+                      );
+                    })}
                   </div>
                 </div>
               );
@@ -299,14 +341,20 @@ export function KillPage() {
               )}
             >
               <div className="space-y-1">
-                <h3 className="flex items-center gap-3 text-sm font-medium text-foreground">
+                <h3 className="flex flex-wrap items-center gap-3 text-sm font-medium text-foreground">
                   <Cube01 className="h-4 w-4 text-foreground" />
                   <span>Degraded Models</span>
+                  <Chip
+                    size="mini"
+                    color={getCellChipColor(cellInfo.region)}
+                    label={getCellDisplay(cellInfo)}
+                  />
                 </h3>
 
                 <p className="text-sm leading-6 text-muted-foreground">
                   Flag the model endpoints hit by a provider incident, one
-                  switch per model and host.
+                  switch per model and host. Scoped to the currently selected
+                  cell.
                   {degradedEndpoints.length > 0 &&
                     ` Currently degraded: ${degradedEndpoints
                       .map(
@@ -339,11 +387,16 @@ export function KillPage() {
         <h2 className={PANEL_HEADING_CLASSES}>
           <Trash01 className={PANEL_ICON_CLASSES} />
           <span>Sandbox Kill Requester</span>
+          <Chip
+            size="xs"
+            color={getCellChipColor(cellInfo.region)}
+            label={getCellDisplay(cellInfo)}
+          />
         </h2>
         <p className={PANEL_DESCRIPTION_CLASSES}>
-          Mark running sandboxes for immediate reaping. The reaper or the next
-          bash invocation will destroy them and recreate fresh ones from the
-          current image.
+          Mark running sandboxes for immediate reaping on the currently selected
+          cell. The reaper or the next bash invocation will destroy them and
+          recreate fresh ones from the current image.
         </p>
 
         {isImagesLoading ? (

--- a/front/components/poke/pages/ProductionChecksPage.tsx
+++ b/front/components/poke/pages/ProductionChecksPage.tsx
@@ -1,11 +1,14 @@
 import { cn } from "@app/components/poke/shadcn/lib/utils";
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { ProductionChecksForCell } from "@app/hooks/usePokeProductionChecks";
 import {
-  usePokeCheckHistory,
-  usePokeProductionChecks,
-  useRunProductionCheck,
+  usePokeCheckHistoryForCell,
+  usePokeProductionChecksAllCells,
+  useRunProductionCheckForCell,
 } from "@app/hooks/usePokeProductionChecks";
+import { getCellChipColor, getCellDisplay } from "@app/lib/poke/cells";
 import { usePokePageMetadata } from "@app/poke/swr/currentPage";
+import type { CellType } from "@app/types/cell";
 import type {
   ActionLink,
   CheckFailurePayload,
@@ -25,6 +28,10 @@ import {
   LinkWrapper,
   Play,
   Spinner,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
 } from "@dust-tt/sparkle";
 import type React from "react";
 import type { ComponentProps } from "react";
@@ -334,10 +341,15 @@ function HistoryRunRow({ run, checkName }: HistoryRunRowProps) {
 
 interface PastRunsSectionProps {
   checkName: string;
+  cellUrl: string;
 }
 
-function PastRunsSection({ checkName }: PastRunsSectionProps) {
-  const { runs, isCheckHistoryLoading } = usePokeCheckHistory(checkName, true);
+function PastRunsSection({ checkName, cellUrl }: PastRunsSectionProps) {
+  const { runs, isCheckHistoryLoading } = usePokeCheckHistoryForCell(
+    cellUrl,
+    checkName,
+    true
+  );
 
   if (isCheckHistoryLoading) {
     return (
@@ -366,12 +378,14 @@ function PastRunsSection({ checkName }: PastRunsSectionProps) {
 
 interface ProductionCheckCardProps {
   check: CheckSummary;
+  cellUrl: string;
   onRun: () => void;
   isRunning: boolean;
 }
 
 function ProductionCheckCard({
   check,
+  cellUrl,
   onRun,
   isRunning,
 }: ProductionCheckCardProps) {
@@ -450,7 +464,7 @@ function ProductionCheckCard({
       <div>
         <h4 className="mb-2 text-sm font-medium text-primary-700">Past Runs</h4>
         <div className="rounded-md bg-background p-3">
-          <PastRunsSection checkName={check.name} />
+          <PastRunsSection checkName={check.name} cellUrl={cellUrl} />
         </div>
       </div>
     </div>
@@ -473,14 +487,67 @@ function ProductionCheckCard({
   );
 }
 
+function CellChecksGrid({
+  cellEntry,
+  runCheck,
+  isCheckRunning,
+}: {
+  cellEntry: ProductionChecksForCell;
+  runCheck: (
+    cellUrl: string,
+    cell: CellType,
+    checkName: string
+  ) => Promise<void>;
+  isCheckRunning: (cell: CellType, checkName: string) => boolean;
+}) {
+  if (cellEntry.isError) {
+    return (
+      <p className="text-sm text-warning-600">
+        Could not load production checks for{" "}
+        {getCellDisplay({ name: cellEntry.cell, region: cellEntry.region })}.
+      </p>
+    );
+  }
+
+  if (cellEntry.checks.length === 0) {
+    return (
+      <p className="text-sm text-primary-500">No production checks found.</p>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 items-start gap-4 lg:grid-cols-2">
+      {cellEntry.checks.map((check) => (
+        <ProductionCheckCard
+          key={check.name}
+          check={check}
+          cellUrl={cellEntry.url}
+          onRun={() => void runCheck(cellEntry.url, cellEntry.cell, check.name)}
+          isRunning={isCheckRunning(cellEntry.cell, check.name)}
+        />
+      ))}
+    </div>
+  );
+}
+
 export function ProductionChecksPage() {
   usePokePageMetadata({ name: "Production Checks" });
 
-  const { checks, isProductionChecksLoading, mutateProductionChecks } =
-    usePokeProductionChecks();
-  const { runCheck, isCheckRunning } = useRunProductionCheck();
+  const { checksByCell, isProductionChecksLoading, mutateProductionChecks } =
+    usePokeProductionChecksAllCells();
+  const { runCheck, isCheckRunning } = useRunProductionCheckForCell(
+    mutateProductionChecks
+  );
 
-  const alertCount = checks.filter((c) => c.status === "alert").length;
+  const totalAlertCount = useMemo(
+    () => checksByCell.reduce((sum, entry) => sum + entry.alertCount, 0),
+    [checksByCell]
+  );
+
+  const defaultTab = useMemo(() => {
+    const withAlerts = checksByCell.find((entry) => entry.alertCount > 0);
+    return withAlerts?.cell ?? checksByCell[0]?.cell ?? "";
+  }, [checksByCell]);
 
   return (
     <main className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
@@ -492,10 +559,34 @@ export function ProductionChecksPage() {
             </h1>
             {!isProductionChecksLoading && (
               <p className="mt-1 text-sm text-primary-600">
-                {alertCount > 0
-                  ? `${alertCount} check${pluralize(alertCount)} need${conjugate(alertCount)} attention`
-                  : "All checks passing"}
+                {totalAlertCount > 0
+                  ? `${totalAlertCount} check${pluralize(totalAlertCount)} need${conjugate(totalAlertCount)} attention across all cells`
+                  : "All checks passing across all cells"}
               </p>
+            )}
+            {!isProductionChecksLoading && checksByCell.length > 0 && (
+              <div className="mt-3 flex flex-wrap gap-2">
+                {checksByCell.map((entry) => (
+                  <Chip
+                    key={entry.cell}
+                    size="xs"
+                    color={
+                      entry.isError
+                        ? "warning"
+                        : entry.alertCount > 0
+                          ? "warning"
+                          : getCellChipColor(entry.region)
+                    }
+                    label={`${getCellDisplay({ name: entry.cell, region: entry.region })}: ${
+                      entry.isError
+                        ? "error"
+                        : entry.alertCount > 0
+                          ? `${entry.alertCount} alert${pluralize(entry.alertCount)}`
+                          : "ok"
+                    }`}
+                  />
+                ))}
+              </div>
             )}
           </div>
           <Button
@@ -510,17 +601,31 @@ export function ProductionChecksPage() {
           <div className="flex justify-center py-12">
             <Spinner />
           </div>
+        ) : checksByCell.length === 0 ? (
+          <p className="text-sm text-primary-500">No cells available.</p>
         ) : (
-          <div className="grid grid-cols-1 items-start gap-4 lg:grid-cols-2">
-            {checks.map((check) => (
-              <ProductionCheckCard
-                key={check.name}
-                check={check}
-                onRun={() => runCheck(check.name)}
-                isRunning={isCheckRunning(check.name)}
-              />
+          <Tabs defaultValue={defaultTab} key={defaultTab}>
+            <TabsList className="mb-4">
+              {checksByCell.map((entry) => (
+                <TabsTrigger
+                  key={entry.cell}
+                  value={entry.cell}
+                  label={`${getCellDisplay({ name: entry.cell, region: entry.region })}${
+                    entry.alertCount > 0 ? ` (${entry.alertCount})` : ""
+                  }`}
+                />
+              ))}
+            </TabsList>
+            {checksByCell.map((entry) => (
+              <TabsContent key={entry.cell} value={entry.cell}>
+                <CellChecksGrid
+                  cellEntry={entry}
+                  runCheck={runCheck}
+                  isCheckRunning={isCheckRunning}
+                />
+              </TabsContent>
             ))}
-          </div>
+          </Tabs>
         )}
       </div>
     </main>

--- a/front/hooks/usePokeFeatureFlagUsage.ts
+++ b/front/hooks/usePokeFeatureFlagUsage.ts
@@ -1,21 +1,132 @@
-import type { GetPokeFeatureFlagsResponseBody } from "@app/lib/api/poke/feature_flags";
-import { emptyArray, useFetcher } from "@app/lib/swr/swr";
-import type { Fetcher } from "swr";
-import useSWR from "swr";
+import type {
+  GetPokeFeatureFlagsResponseBody,
+  PokeFeatureFlagUsage,
+} from "@app/lib/api/poke/feature_flags";
+import { useCellContext } from "@app/lib/auth/CellContext";
+import { emptyArray } from "@app/lib/swr/swr";
+import { fetchPokeFromAllCells } from "@app/poke/swr/cells";
+import type { CellType } from "@app/types/cell";
+import type { RegionType } from "@app/types/region";
+import type { FeatureFlagStage } from "@app/types/shared/feature_flags";
+import { useCallback, useEffect, useState } from "react";
 
-export function usePokeFeatureFlagUsage() {
-  const { fetcher } = useFetcher();
-  const featureFlagsFetcher: Fetcher<GetPokeFeatureFlagsResponseBody> = fetcher;
+export interface PokeFeatureFlagCellStats {
+  cell: CellType;
+  region: RegionType;
+  workspaceCount: number;
+  globalRolloutPercentage: number | null;
+}
 
-  const { data, error, mutate } = useSWR(
-    "/api/poke/feature-flags",
-    featureFlagsFetcher
-  );
+export interface PokeFeatureFlagUsageAllCells {
+  name: string;
+  description: string | null;
+  stage: FeatureFlagStage | null;
+  byCell: PokeFeatureFlagCellStats[];
+  totalWorkspaceCount: number;
+}
+
+function mergeFeatureFlagUsage(
+  results: {
+    cell: CellType;
+    region: RegionType;
+    featureFlags: PokeFeatureFlagUsage[];
+  }[]
+): PokeFeatureFlagUsageAllCells[] {
+  const byName = new Map<string, PokeFeatureFlagUsageAllCells>();
+
+  for (const { cell, region, featureFlags } of results) {
+    for (const flag of featureFlags) {
+      const existing = byName.get(flag.name);
+      const cellStats: PokeFeatureFlagCellStats = {
+        cell,
+        region,
+        workspaceCount: flag.workspaceCount,
+        globalRolloutPercentage: flag.globalRolloutPercentage,
+      };
+
+      if (!existing) {
+        byName.set(flag.name, {
+          name: flag.name,
+          description: flag.description,
+          stage: flag.stage,
+          byCell: [cellStats],
+          totalWorkspaceCount: flag.workspaceCount,
+        });
+        continue;
+      }
+
+      existing.byCell.push(cellStats);
+      existing.totalWorkspaceCount += flag.workspaceCount;
+      // Prefer configured metadata over legacy nulls when cells disagree.
+      if (existing.description === null && flag.description !== null) {
+        existing.description = flag.description;
+      }
+      if (existing.stage === null && flag.stage !== null) {
+        existing.stage = flag.stage;
+      }
+    }
+  }
+
+  return [...byName.values()];
+}
+
+export function usePokeFeatureFlagUsageAllCells() {
+  const { cells } = useCellContext();
+  const [featureFlags, setFeatureFlags] = useState<
+    PokeFeatureFlagUsageAllCells[]
+  >(emptyArray());
+  const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const mutate = useCallback(() => {
+    setRefreshKey((key) => key + 1);
+  }, []);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshKey is an intentional refetch trigger via mutate()
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    setIsError(false);
+
+    const run = async () => {
+      const settled =
+        await fetchPokeFromAllCells<GetPokeFeatureFlagsResponseBody>({
+          cells,
+          path: "/api/poke/feature-flags",
+        });
+
+      const okResults = settled.flatMap((result) =>
+        result.ok
+          ? [
+              {
+                cell: result.cell.name,
+                region: result.cell.region,
+                featureFlags: result.data.featureFlags,
+              },
+            ]
+          : []
+      );
+      const hasErrors = settled.some((result) => !result.ok);
+
+      if (!cancelled) {
+        setFeatureFlags(mergeFeatureFlagUsage(okResults));
+        setIsError(hasErrors);
+        setIsLoading(false);
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [cells, refreshKey]);
 
   return {
-    featureFlags: data?.featureFlags ?? emptyArray(),
+    featureFlags,
     mutate,
-    isLoading: !error && !data,
-    isError: error,
+    isLoading,
+    isError,
   };
 }

--- a/front/hooks/usePokeFeatureFlagWorkspaces.ts
+++ b/front/hooks/usePokeFeatureFlagWorkspaces.ts
@@ -1,28 +1,115 @@
-import type { GetPokeFeatureFlagWorkspacesResponseBody } from "@app/lib/api/poke/feature_flags";
-import { emptyArray, useFetcher } from "@app/lib/swr/swr";
-import type { Fetcher } from "swr";
-import useSWR from "swr";
+import type {
+  GetPokeFeatureFlagWorkspacesResponseBody,
+  PokeFeatureFlagWorkspace,
+} from "@app/lib/api/poke/feature_flags";
+import { useCellContext } from "@app/lib/auth/CellContext";
+import { emptyArray } from "@app/lib/swr/swr";
+import { fetchPokeFromAllCells } from "@app/poke/swr/cells";
+import type { CellType } from "@app/types/cell";
+import type { RegionType } from "@app/types/region";
+import { useCallback, useEffect, useState } from "react";
 
-export function usePokeFeatureFlagWorkspaces({
+export interface PokeFeatureFlagWorkspaceWithCell
+  extends PokeFeatureFlagWorkspace {
+  cell: CellType;
+  region: RegionType;
+}
+
+export interface PokeFeatureFlagCellRollout {
+  cell: CellType;
+  region: RegionType;
+  globalRolloutPercentage: number | null;
+  totalCount: number;
+}
+
+export function usePokeFeatureFlagWorkspacesAllCells({
   flagName,
 }: {
   flagName: string;
 }) {
-  const { fetcher } = useFetcher();
-  const workspacesFetcher: Fetcher<GetPokeFeatureFlagWorkspacesResponseBody> =
-    fetcher;
+  const { cells } = useCellContext();
+  const [workspaces, setWorkspaces] = useState<
+    PokeFeatureFlagWorkspaceWithCell[]
+  >(emptyArray());
+  const [cellRollouts, setCellRollouts] = useState<
+    PokeFeatureFlagCellRollout[]
+  >(emptyArray());
+  const [totalCount, setTotalCount] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
 
-  const { data, error, mutate } = useSWR(
-    `/api/poke/feature-flags/${encodeURIComponent(flagName)}`,
-    workspacesFetcher
-  );
+  const mutate = useCallback(() => {
+    setRefreshKey((key) => key + 1);
+  }, []);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshKey is an intentional refetch trigger via mutate()
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    setIsError(false);
+
+    const run = async () => {
+      const settled =
+        await fetchPokeFromAllCells<GetPokeFeatureFlagWorkspacesResponseBody>({
+          cells,
+          path: `/api/poke/feature-flags/${encodeURIComponent(flagName)}`,
+        });
+
+      const mergedWorkspaces: PokeFeatureFlagWorkspaceWithCell[] = [];
+      const rollouts: PokeFeatureFlagCellRollout[] = [];
+      let combinedTotal = 0;
+      let hasErrors = false;
+
+      for (const result of settled) {
+        if (!result.ok) {
+          hasErrors = true;
+          continue;
+        }
+
+        combinedTotal += result.data.totalCount;
+        rollouts.push({
+          cell: result.cell.name,
+          region: result.cell.region,
+          globalRolloutPercentage: result.data.globalRolloutPercentage,
+          totalCount: result.data.totalCount,
+        });
+        for (const workspace of result.data.workspaces) {
+          mergedWorkspaces.push({
+            ...workspace,
+            cell: result.cell.name,
+            region: result.cell.region,
+          });
+        }
+      }
+
+      mergedWorkspaces.sort(
+        (a, b) =>
+          new Date(b.enabledAt).getTime() - new Date(a.enabledAt).getTime()
+      );
+
+      if (!cancelled) {
+        setWorkspaces(mergedWorkspaces);
+        setCellRollouts(rollouts);
+        setTotalCount(combinedTotal);
+        setIsError(hasErrors);
+        setIsLoading(false);
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [cells, flagName, refreshKey]);
 
   return {
-    workspaces: data?.workspaces ?? emptyArray(),
-    totalCount: data?.totalCount ?? 0,
-    globalRolloutPercentage: data?.globalRolloutPercentage ?? null,
+    workspaces,
+    cellRollouts,
+    totalCount,
     mutate,
-    isLoading: !error && !data,
-    isError: error,
+    isLoading,
+    isError,
   };
 }

--- a/front/hooks/usePokeGlobalAgentFeedbacks.ts
+++ b/front/hooks/usePokeGlobalAgentFeedbacks.ts
@@ -1,35 +1,199 @@
-import type { GetGlobalAgentFeedbacksResponseBody } from "@app/lib/api/poke/global_agent_feedbacks";
-import { emptyArray, useFetcher } from "@app/lib/swr/swr";
-import type { Fetcher } from "swr";
-import useSWR from "swr";
+import type {
+  GetGlobalAgentFeedbacksResponseBody,
+  GlobalAgentFeedbackItem,
+} from "@app/lib/api/poke/global_agent_feedbacks";
+import { useCellContext } from "@app/lib/auth/CellContext";
+import { clientFetch } from "@app/lib/egress/client";
+import { emptyArray } from "@app/lib/swr/swr";
+import { getUniqueCells } from "@app/poke/swr/cells";
+import type { CellType } from "@app/types/cell";
+import type { RegionType } from "@app/types/region";
+import { useEffect, useMemo, useState } from "react";
 
-export function usePokeGlobalAgentFeedbacks({
+export interface GlobalAgentFeedbackItemWithCell
+  extends GlobalAgentFeedbackItem {
+  cell: CellType;
+  region: RegionType;
+}
+
+export type CellCursors = Partial<Record<CellType, number | null>>;
+
+export function usePokeGlobalAgentFeedbacksAllCells({
   includeEmpty,
-  lastId,
+  cursors,
+  exhaustedCells,
 }: {
   includeEmpty: boolean;
-  lastId: number | null;
+  /** Per-cell `lastId` cursors. Missing / null means first page for that cell. */
+  cursors: CellCursors;
+  /** Cells that reported `hasMore: false` on a previous batch — skip refetching them. */
+  exhaustedCells: ReadonlySet<CellType>;
 }) {
-  const { fetcher } = useFetcher();
-  const feedbacksFetcher: Fetcher<GetGlobalAgentFeedbacksResponseBody> =
-    fetcher;
+  const { cells } = useCellContext();
+  const [feedbacks, setFeedbacks] = useState<GlobalAgentFeedbackItemWithCell[]>(
+    emptyArray()
+  );
+  const [hasMoreByCell, setHasMoreByCell] = useState<
+    Partial<Record<CellType, boolean>>
+  >({});
+  const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
 
-  const params = new URLSearchParams();
-  if (includeEmpty) {
-    params.set("includeEmpty", "true");
-  }
-  if (lastId !== null) {
-    params.set("lastId", String(lastId));
-  }
+  // Stabilize object/set dependencies: parent may pass fresh references with the same values.
+  const cursorsKey = useMemo(() => JSON.stringify(cursors), [cursors]);
+  const exhaustedKey = useMemo(
+    () => [...exhaustedCells].sort().join(","),
+    [exhaustedCells]
+  );
 
-  const key = `/api/poke/global-agent-feedbacks?${params.toString()}`;
+  useEffect(() => {
+    const abortController = new AbortController();
+    setIsLoading(true);
+    setIsError(false);
 
-  const { data, error } = useSWR(key, feedbacksFetcher);
+    const parsedCursors = JSON.parse(cursorsKey) as CellCursors;
+    const exhausted = new Set(
+      exhaustedKey === "" ? [] : (exhaustedKey.split(",") as CellType[])
+    );
+
+    const run = async () => {
+      const cellsToFetch = getUniqueCells(cells).filter(
+        (cell) => !exhausted.has(cell.name)
+      );
+
+      if (cellsToFetch.length === 0) {
+        if (!abortController.signal.aborted) {
+          setFeedbacks(emptyArray());
+          setHasMoreByCell({});
+          setIsError(false);
+          setIsLoading(false);
+        }
+        return;
+      }
+
+      const settled = await Promise.allSettled(
+        cellsToFetch.map(async (cell) => {
+          const params = new URLSearchParams();
+          if (includeEmpty) {
+            params.set("includeEmpty", "true");
+          }
+          const lastId = parsedCursors[cell.name];
+          if (lastId != null) {
+            params.set("lastId", String(lastId));
+          }
+          const query = params.toString();
+          const url = `${cell.url}/api/poke/global-agent-feedbacks${
+            query ? `?${query}` : ""
+          }`;
+
+          const response = await clientFetch(url, {
+            credentials: "include",
+            signal: abortController.signal,
+          });
+          if (!response.ok) {
+            throw new Error(`Failed to fetch from ${cell.name}`);
+          }
+
+          const data: GetGlobalAgentFeedbacksResponseBody =
+            await response.json();
+          return {
+            cell,
+            feedbacks: data.feedbacks,
+            hasMore: data.hasMore,
+          };
+        })
+      );
+
+      const merged: GlobalAgentFeedbackItemWithCell[] = [];
+      const nextHasMore: Partial<Record<CellType, boolean>> = {};
+      let hasErrors = false;
+
+      for (const result of settled) {
+        if (result.status !== "fulfilled") {
+          hasErrors = true;
+          continue;
+        }
+        nextHasMore[result.value.cell.name] = result.value.hasMore;
+        for (const feedback of result.value.feedbacks) {
+          merged.push({
+            ...feedback,
+            cell: result.value.cell.name,
+            region: result.value.cell.region,
+          });
+        }
+      }
+
+      merged.sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      );
+
+      if (!abortController.signal.aborted) {
+        setFeedbacks(merged);
+        setHasMoreByCell(nextHasMore);
+        setIsError(hasErrors);
+        setIsLoading(false);
+      }
+    };
+
+    void run();
+
+    return () => {
+      abortController.abort();
+    };
+  }, [cells, cursorsKey, exhaustedKey, includeEmpty]);
+
+  const hasMore = Object.values(hasMoreByCell).some(Boolean);
 
   return {
-    feedbacks: data?.feedbacks ?? emptyArray(),
-    hasMore: data?.hasMore ?? false,
-    isLoading: !error && !data,
-    isError: error,
+    feedbacks,
+    hasMore,
+    hasMoreByCell,
+    isLoading,
+    isError,
   };
+}
+
+/**
+ * Build the next per-cell cursors from the current batch: each cell advances to
+ * the lowest id it contributed (API pages with `id < lastId`).
+ */
+export function nextFeedbackCursors(
+  feedbacks: GlobalAgentFeedbackItemWithCell[],
+  previous: CellCursors,
+  hasMoreByCell: Partial<Record<CellType, boolean>>
+): CellCursors {
+  const next: CellCursors = { ...previous };
+
+  const lastIdByCell = new Map<CellType, number>();
+  for (const feedback of feedbacks) {
+    const current = lastIdByCell.get(feedback.cell);
+    if (current === undefined || feedback.id < current) {
+      lastIdByCell.set(feedback.cell, feedback.id);
+    }
+  }
+
+  for (const [cell, lastId] of lastIdByCell) {
+    if (hasMoreByCell[cell]) {
+      next[cell] = lastId;
+    }
+  }
+
+  return next;
+}
+
+export function nextExhaustedCells(
+  previous: ReadonlySet<CellType>,
+  hasMoreByCell: Partial<Record<CellType, boolean>>
+): Set<CellType> {
+  const next = new Set(previous);
+  for (const [cell, hasMore] of Object.entries(hasMoreByCell) as [
+    CellType,
+    boolean | undefined,
+  ][]) {
+    if (hasMore === false) {
+      next.add(cell);
+    }
+  }
+  return next;
 }

--- a/front/hooks/usePokeProductionChecks.ts
+++ b/front/hooks/usePokeProductionChecks.ts
@@ -1,78 +1,180 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import { useCellContext } from "@app/lib/auth/CellContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher } from "@app/lib/swr/swr";
+import { fetchPokeFromAllCells } from "@app/poke/swr/cells";
 import type {
   GetCheckHistoryResponseBody,
   GetProductionChecksResponseBody,
 } from "@app/types/api/poke/production_checks";
-import { useState } from "react";
+import type { CellType } from "@app/types/cell";
+import type {
+  CheckHistoryRun,
+  CheckSummary,
+} from "@app/types/production_checks";
+import type { RegionType } from "@app/types/region";
+import { useCallback, useEffect, useState } from "react";
 import type { Fetcher } from "swr";
 import useSWR from "swr";
 
 const REFRESH_INTERVAL_MS = 30000;
 const REFETCH_DELAY_MS = 2000;
 
-export function usePokeProductionChecks() {
-  const { fetcher } = useFetcher();
-  const productionChecksFetcher: Fetcher<GetProductionChecksResponseBody> =
-    fetcher;
+export interface ProductionChecksForCell {
+  cell: CellType;
+  region: RegionType;
+  url: string;
+  checks: CheckSummary[];
+  alertCount: number;
+  isError: boolean;
+}
 
-  const { data, error, mutate } = useSWR(
-    "/api/poke/production-checks",
-    productionChecksFetcher,
-    { refreshInterval: REFRESH_INTERVAL_MS }
+export function usePokeProductionChecksAllCells() {
+  const { cells } = useCellContext();
+  const [checksByCell, setChecksByCell] = useState<ProductionChecksForCell[]>(
+    emptyArray()
   );
+  const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const mutateProductionChecks = useCallback(() => {
+    setRefreshKey((key) => key + 1);
+  }, []);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshKey is an intentional refetch trigger via mutateProductionChecks()
+  useEffect(() => {
+    let cancelled = false;
+    let intervalId: ReturnType<typeof setInterval> | undefined;
+
+    const run = async (showLoading: boolean) => {
+      if (showLoading) {
+        setIsLoading(true);
+      }
+
+      const settled =
+        await fetchPokeFromAllCells<GetProductionChecksResponseBody>({
+          cells,
+          path: "/api/poke/production-checks",
+        });
+
+      const byCell: ProductionChecksForCell[] = [];
+      let hasErrors = false;
+
+      for (const result of settled) {
+        if (!result.ok) {
+          hasErrors = true;
+          byCell.push({
+            cell: result.cell.name,
+            region: result.cell.region,
+            url: result.cell.url,
+            checks: [],
+            alertCount: 0,
+            isError: true,
+          });
+          continue;
+        }
+
+        const checks = result.data.checks;
+        byCell.push({
+          cell: result.cell.name,
+          region: result.cell.region,
+          url: result.cell.url,
+          checks,
+          alertCount: checks.filter((check) => check.status === "alert").length,
+          isError: false,
+        });
+      }
+
+      byCell.sort(
+        (a, b) =>
+          cells.findIndex((cell) => cell.name === a.cell) -
+          cells.findIndex((cell) => cell.name === b.cell)
+      );
+
+      if (!cancelled) {
+        setChecksByCell(byCell);
+        setIsError(hasErrors);
+        setIsLoading(false);
+      }
+    };
+
+    void run(true);
+    intervalId = setInterval(() => {
+      void run(false);
+    }, REFRESH_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
+    };
+  }, [cells, refreshKey]);
 
   return {
-    checks: data?.checks ?? emptyArray(),
-    isProductionChecksLoading: !error && !data,
-    isProductionChecksError: error,
-    mutateProductionChecks: mutate,
+    checksByCell,
+    isProductionChecksLoading: isLoading,
+    isProductionChecksError: isError,
+    mutateProductionChecks,
   };
 }
 
-export function usePokeCheckHistory(checkName: string, enabled: boolean) {
+export function usePokeCheckHistoryForCell(
+  cellUrl: string | null,
+  checkName: string,
+  enabled: boolean
+) {
   const { fetcher } = useFetcher();
   const checkHistoryFetcher: Fetcher<GetCheckHistoryResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWR(
-    enabled
-      ? `/api/poke/production-checks/${encodeURIComponent(checkName)}/history`
+    enabled && cellUrl
+      ? `${cellUrl}/api/poke/production-checks/${encodeURIComponent(checkName)}/history`
       : null,
     checkHistoryFetcher
   );
 
   return {
-    runs: data?.runs ?? emptyArray(),
+    runs: (data?.runs ?? emptyArray()) as CheckHistoryRun[],
     isCheckHistoryLoading: enabled && !error && !data,
     isCheckHistoryError: error,
     mutateCheckHistory: mutate,
   };
 }
 
-export function useRunProductionCheck() {
+export function useRunProductionCheckForCell(
+  mutateProductionChecks: () => void
+) {
   const sendNotification = useSendNotification();
-  const { mutateProductionChecks } = usePokeProductionChecks();
   const [runningChecks, setRunningChecks] = useState<Set<string>>(new Set());
 
-  const runCheck = async (checkName: string) => {
-    setRunningChecks((prev) => new Set(prev).add(checkName));
+  const runCheck = async (
+    cellUrl: string,
+    cell: CellType,
+    checkName: string
+  ) => {
+    const runKey = `${cell}:${checkName}`;
+    setRunningChecks((prev) => new Set(prev).add(runKey));
 
     try {
-      const res = await clientFetch("/api/poke/production-checks/run", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ checkName }),
-      });
+      const res = await clientFetch(
+        `${cellUrl}/api/poke/production-checks/run`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ checkName }),
+        }
+      );
 
       if (res.ok) {
         sendNotification({
           title: "Check started",
-          description: `${checkName} has been triggered`,
+          description: `${checkName} has been triggered on ${cell}`,
           type: "success",
         });
         setTimeout(() => {
-          void mutateProductionChecks();
+          mutateProductionChecks();
         }, REFETCH_DELAY_MS);
       } else {
         const errorData = await res.json();
@@ -92,13 +194,14 @@ export function useRunProductionCheck() {
     } finally {
       setRunningChecks((prev) => {
         const next = new Set(prev);
-        next.delete(checkName);
+        next.delete(runKey);
         return next;
       });
     }
   };
 
-  const isCheckRunning = (checkName: string) => runningChecks.has(checkName);
+  const isCheckRunning = (cell: CellType, checkName: string) =>
+    runningChecks.has(`${cell}:${checkName}`);
 
   return {
     runCheck,

--- a/front/poke/swr/cells.ts
+++ b/front/poke/swr/cells.ts
@@ -1,0 +1,62 @@
+import { clientFetch } from "@app/lib/egress/client";
+import type { CellInfo } from "@app/types/cell";
+
+/**
+ * Deduplicate cells by URL. In dev, all cells can point to the same localhost
+ * server, so without this we would fire one identical request per cell.
+ */
+export function getUniqueCells(cells: CellInfo[]): CellInfo[] {
+  const seen = new Set<string>();
+  return cells.filter((cell) => {
+    const url = cell.url;
+    if (seen.has(url)) {
+      return false;
+    }
+    seen.add(url);
+    return true;
+  });
+}
+
+export type CellFetchResult<T> =
+  | { cell: CellInfo; ok: true; data: T }
+  | { cell: CellInfo; ok: false; error: unknown };
+
+/**
+ * Fetch the same poke path from every unique cell in parallel.
+ * Absolute URLs bypass the selected-cell base URL rewrite in `clientFetch`.
+ */
+export async function fetchPokeFromAllCells<T>({
+  cells,
+  path,
+  init,
+}: {
+  cells: CellInfo[];
+  /** Absolute path beginning with `/api/poke/...`, optionally with a query string. */
+  path: string;
+  init?: RequestInit;
+}): Promise<CellFetchResult<T>[]> {
+  const uniqueCells = getUniqueCells(cells);
+
+  const settled = await Promise.allSettled(
+    uniqueCells.map(async (cell): Promise<CellFetchResult<T>> => {
+      const response = await clientFetch(`${cell.url}${path}`, {
+        credentials: "include",
+        ...init,
+      });
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch from ${cell.name}: ${response.status}`
+        );
+      }
+      const data = (await response.json()) as T;
+      return { cell, ok: true, data };
+    })
+  );
+
+  return settled.map((result, index) => {
+    if (result.status === "fulfilled") {
+      return result.value;
+    }
+    return { cell: uniqueCells[index], ok: false, error: result.reason };
+  });
+}

--- a/front/poke/swr/kill.ts
+++ b/front/poke/swr/kill.ts
@@ -1,18 +1,86 @@
 import type { GetKillSwitchesResponseBody } from "@app/lib/api/poke/kill";
-import { emptyArray, useFetcher } from "@app/lib/swr/swr";
-import type { Fetcher } from "swr";
-import useSWR from "swr";
+import { useCellContext } from "@app/lib/auth/CellContext";
+import type { KillSwitchType } from "@app/lib/poke/types";
+import { emptyArray } from "@app/lib/swr/swr";
+import { fetchPokeFromAllCells } from "@app/poke/swr/cells";
+import type { CellType } from "@app/types/cell";
+import type { RegionType } from "@app/types/region";
+import { useCallback, useEffect, useState } from "react";
 
-export function usePokeKillSwitches() {
-  const { fetcher } = useFetcher();
-  const killSwitchesFetcher: Fetcher<GetKillSwitchesResponseBody> = fetcher;
+export interface KillSwitchesForCell {
+  cell: CellType;
+  region: RegionType;
+  url: string;
+  killSwitches: KillSwitchType[];
+}
 
-  const { data, error, mutate } = useSWR("/api/poke/kill", killSwitchesFetcher);
+export function usePokeKillSwitchesAllCells() {
+  const { cells } = useCellContext();
+  const [killSwitchesByCell, setKillSwitchesByCell] = useState<
+    KillSwitchesForCell[]
+  >(emptyArray());
+  const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const mutateKillSwitches = useCallback(() => {
+    setRefreshKey((key) => key + 1);
+  }, []);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshKey is an intentional refetch trigger via mutateKillSwitches()
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    setIsError(false);
+
+    const run = async () => {
+      const settled = await fetchPokeFromAllCells<GetKillSwitchesResponseBody>({
+        cells,
+        path: "/api/poke/kill",
+      });
+
+      const byCell: KillSwitchesForCell[] = [];
+      let hasErrors = false;
+
+      for (const result of settled) {
+        if (!result.ok) {
+          hasErrors = true;
+          continue;
+        }
+        byCell.push({
+          cell: result.cell.name,
+          region: result.cell.region,
+          url: result.cell.url,
+          killSwitches: result.data.killSwitches,
+        });
+      }
+
+      // Keep catalog order so the UI stays stable across refreshes.
+      byCell.sort(
+        (a, b) =>
+          cells.findIndex((cell) => cell.name === a.cell) -
+          cells.findIndex((cell) => cell.name === b.cell)
+      );
+
+      if (!cancelled) {
+        setKillSwitchesByCell(byCell);
+        setIsError(hasErrors);
+        setIsLoading(false);
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [cells, refreshKey]);
 
   return {
-    killSwitches: data?.killSwitches ?? emptyArray(),
-    isKillSwitchesLoading: !error && !data,
-    isKillSwitchesError: error,
-    mutateKillSwitches: mutate,
+    killSwitchesByCell,
+    cells,
+    isKillSwitchesLoading: isLoading,
+    isKillSwitchesError: isError,
+    mutateKillSwitches,
   };
 }

--- a/front/poke/swr/search.ts
+++ b/front/poke/swr/search.ts
@@ -1,6 +1,7 @@
 import { clientFetch } from "@app/lib/egress/client";
 import type { PokePlanTypeFilter } from "@app/lib/plans/plan_codes";
 import { emptyArray } from "@app/lib/swr/swr";
+import { getUniqueCells } from "@app/poke/swr/cells";
 import type { GetPokeSearchItemsResponseBody } from "@app/types/api/poke/search";
 import type {
   GetPokeWorkspacesResponseBody,
@@ -9,21 +10,6 @@ import type {
 import type { CellInfo, CellType } from "@app/types/cell";
 import type { PokeItemBase } from "@app/types/poke";
 import { useEffect, useState } from "react";
-
-// Deduplicate cells by URL. In dev, all cells can point to the same localhost
-// server, so without this we would fire one identical request per cell and
-// list every workspace once per cell.
-function getUniqueCells(cells: CellInfo[]): CellInfo[] {
-  const seen = new Set<string>();
-  return cells.filter((cell) => {
-    const url = cell.url;
-    if (seen.has(url)) {
-      return false;
-    }
-    seen.add(url);
-    return true;
-  });
-}
 
 /**
  * Search across all cells in parallel.


### PR DESCRIPTION
## Description

Poke’s Feature Flags, Kill Switches, Production Checks, and Global Agent Feedback pages now aggregate data across every configured cell instead of the navbar-selected cell. `fetchPokeFromAllCells` and `getUniqueCells` centralize fan-out and cell labeling while preserving cell-specific actions and pagination.

- Feature flag usage and detail views show per-cell counts, rollout percentages, and workspace rows.
- Kill-switch controls render one state per cell and POST mutations to the selected cell’s URL; degraded models and sandbox remain scoped to the active cell.
- Production checks show cross-cell alert summaries with per-cell tabs and history.
- Global Agent Feedback merges results with per-cell cursor pagination.

UI changes are included; attach a screenshot or GIF from Poke.

## Tests

- Ran `npx tsgo --noEmit` for the changed Poke hooks and pages.
- Manually verified the multi-cell views and cell-targeted actions in Poke.

## Risk

Low. This is a frontend-only aggregation change with no API or database changes. Existing single-cell endpoints remain unchanged, writes stay cell-scoped, and partial cell failures surface as partial data or an error state instead of blocking other cells. Rollback is a standard frontend revert.

## Deploy Plan

Deploy `front`. No SQL migration, infrastructure change, or API deploy is required.