### PR TITLE
Add sandbox controls to Frame and conversation Poke pages

### DIFF
--- a/front/components/poke/pages/FrameV2Page.tsx
+++ b/front/components/poke/pages/FrameV2Page.tsx
@@ -4,6 +4,7 @@ import { FramePublicationSection } from "@app/components/poke/frames/publication
 import { FrameSharingSection } from "@app/components/poke/frames/sharing";
 import { FrameStorageTable } from "@app/components/poke/frames/storage";
 import { ViewFrameTable } from "@app/components/poke/frames/view";
+import { PluginList } from "@app/components/poke/plugins/PluginList";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { usePokeFrameDetails } from "@app/poke/swr/frames";
 import { LinkWrapper, Spinner } from "@dust-tt/sparkle";
@@ -47,6 +48,13 @@ export function FrameV2Page({ frameId }: FrameV2PageProps) {
       </h3>
 
       <ViewFrameTable details={details} owner={owner} />
+      <PluginList
+        pluginResourceTarget={{
+          resourceId: details.frame.sId,
+          resourceType: "files",
+          workspace: owner,
+        }}
+      />
       <FrameSharingSection
         sharing={details.sharing}
         sharingGrants={details.sharingGrants}

--- a/front/lib/api/poke/plugins/conversations/index.ts
+++ b/front/lib/api/poke/plugins/conversations/index.ts
@@ -1,2 +1,3 @@
+export * from "./request_sandbox_kill";
 export * from "./unstick";
 export * from "./wake_sandbox";

--- a/front/lib/api/poke/plugins/conversations/request_sandbox_kill.test.ts
+++ b/front/lib/api/poke/plugins/conversations/request_sandbox_kill.test.ts
@@ -1,0 +1,74 @@
+import { pluginManager } from "@app/lib/api/poke/plugin_manager";
+import { requestConversationSandboxKillPlugin } from "@app/lib/api/poke/plugins/conversations/request_sandbox_kill";
+import { wakeConversationSandboxPlugin } from "@app/lib/api/poke/plugins/conversations/wake_sandbox";
+import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
+import { describe, expect, it } from "vitest";
+
+async function setup() {
+  const { authenticator: auth } = await createResourceTest({ role: "admin" });
+  const agent = await AgentConfigurationFactory.createTestAgent(auth);
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: agent.sId,
+    messagesCreatedAt: [],
+  });
+
+  return { auth, conversation };
+}
+
+describe("requestConversationSandboxKillPlugin", () => {
+  it("registers both conversation sandbox plugins", () => {
+    expect(
+      pluginManager.getPluginById("request-conversation-sandbox-kill")
+    ).toBe(requestConversationSandboxKillPlugin);
+    expect(pluginManager.getPluginById("wake-conversation-sandbox")).toBe(
+      wakeConversationSandboxPlugin
+    );
+  });
+
+  it("requests a kill for the conversation sandbox", async () => {
+    const { auth, conversation } = await setup();
+    await SandboxFactory.create(auth, conversation);
+
+    const result = await requestConversationSandboxKillPlugin.execute(
+      auth,
+      conversation,
+      {}
+    );
+
+    expect(result.isOk()).toBe(true);
+    const sandbox = await ConversationSandboxAdapter.fetchSandbox(
+      auth,
+      conversation
+    );
+    expect(sandbox?.killRequestedAt).toEqual(expect.any(Date));
+  });
+
+  it("is not applicable without a live sandbox", async () => {
+    const { auth, conversation } = await setup();
+
+    await expect(
+      requestConversationSandboxKillPlugin.isApplicableTo(auth, conversation)
+    ).resolves.toBe(false);
+
+    await SandboxFactory.create(auth, conversation, { status: "deleted" });
+
+    await expect(
+      requestConversationSandboxKillPlugin.isApplicableTo(auth, conversation)
+    ).resolves.toBe(false);
+  });
+
+  it("is not applicable when a kill is already requested", async () => {
+    const { auth, conversation } = await setup();
+    await SandboxFactory.create(auth, conversation, {
+      killRequestedAt: new Date(),
+    });
+
+    await expect(
+      requestConversationSandboxKillPlugin.isApplicableTo(auth, conversation)
+    ).resolves.toBe(false);
+  });
+});

--- a/front/lib/api/poke/plugins/conversations/request_sandbox_kill.ts
+++ b/front/lib/api/poke/plugins/conversations/request_sandbox_kill.ts
@@ -1,0 +1,41 @@
+import {
+  canRequestSandboxKill,
+  requestSandboxKill,
+} from "@app/lib/api/poke/sandboxes";
+import { createPlugin } from "@app/lib/api/poke/types";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import { Err } from "@app/types/shared/result";
+
+function sandboxTarget(auth: Authenticator, conversation: ConversationType) {
+  return {
+    fetchSandbox: () =>
+      ConversationSandboxAdapter.fetchSandbox(auth, conversation),
+  };
+}
+
+export const requestConversationSandboxKillPlugin = createPlugin({
+  manifest: {
+    id: "request-conversation-sandbox-kill",
+    name: "Request Sandbox Kill",
+    description:
+      "Mark this conversation's sandbox for destruction and recreation on its next access.",
+    warning:
+      "The sandbox will be destroyed. Files stored only inside it will be lost.",
+    resourceTypes: ["conversations"],
+    args: {},
+    requiredRoles: ["support"],
+  },
+  isApplicableTo: async (auth, conversation) =>
+    conversation
+      ? canRequestSandboxKill(sandboxTarget(auth, conversation))
+      : false,
+  execute: async (auth, conversation) => {
+    if (!conversation) {
+      return new Err(new Error("Conversation not found."));
+    }
+
+    return requestSandboxKill(sandboxTarget(auth, conversation));
+  },
+});

--- a/front/lib/api/poke/plugins/files/frame_sandbox.test.ts
+++ b/front/lib/api/poke/plugins/files/frame_sandbox.test.ts
@@ -1,0 +1,75 @@
+import { pluginManager } from "@app/lib/api/poke/plugin_manager";
+import {
+  requestFrameSandboxKillPlugin,
+  wakeFrameSandboxPlugin,
+} from "@app/lib/api/poke/plugins/files/frame_sandbox";
+import { FrameSandboxAdapter } from "@app/lib/resources/frame_sandbox_adapter";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
+import { frameV2ContentType } from "@app/types/files";
+import { describe, expect, it } from "vitest";
+
+async function setupFrame() {
+  const { authenticator: auth, user } = await createResourceTest({
+    role: "admin",
+  });
+  const frame = await FileFactory.create(auth, user, {
+    contentType: frameV2ContentType,
+    fileName: "manifest.json",
+    fileSize: 100,
+    status: "ready",
+    useCase: "conversation",
+  });
+
+  return { auth, frame };
+}
+
+describe("Frame sandbox plugins", () => {
+  it("registers both Frame sandbox plugins", () => {
+    expect(pluginManager.getPluginById("request-frame-sandbox-kill")).toBe(
+      requestFrameSandboxKillPlugin
+    );
+    expect(pluginManager.getPluginById("wake-frame-sandbox")).toBe(
+      wakeFrameSandboxPlugin
+    );
+  });
+
+  it("offers wake only for an unmarked sleeping sandbox", async () => {
+    const { auth, frame } = await setupFrame();
+    await SandboxFactory.createForFrame(auth, frame, { status: "sleeping" });
+
+    await expect(
+      wakeFrameSandboxPlugin.isApplicableTo(auth, frame)
+    ).resolves.toBe(true);
+
+    const sandbox = await FrameSandboxAdapter.fetchSandbox(auth, frame);
+    await sandbox?.requestKill();
+
+    await expect(
+      wakeFrameSandboxPlugin.isApplicableTo(auth, frame)
+    ).resolves.toBe(false);
+  });
+
+  it("requests a kill for the Frame sandbox", async () => {
+    const { auth, frame } = await setupFrame();
+    await SandboxFactory.createForFrame(auth, frame);
+
+    const result = await requestFrameSandboxKillPlugin.execute(auth, frame, {});
+
+    expect(result.isOk()).toBe(true);
+    const sandbox = await FrameSandboxAdapter.fetchSandbox(auth, frame);
+    expect(sandbox?.killRequestedAt).toEqual(expect.any(Date));
+  });
+
+  it("does not offer either plugin when the Frame has no sandbox", async () => {
+    const { auth, frame } = await setupFrame();
+
+    await expect(
+      wakeFrameSandboxPlugin.isApplicableTo(auth, frame)
+    ).resolves.toBe(false);
+    await expect(
+      requestFrameSandboxKillPlugin.isApplicableTo(auth, frame)
+    ).resolves.toBe(false);
+  });
+});

--- a/front/lib/api/poke/plugins/files/frame_sandbox.ts
+++ b/front/lib/api/poke/plugins/files/frame_sandbox.ts
@@ -1,0 +1,62 @@
+import {
+  canRequestSandboxKill,
+  isSandboxSleeping,
+  requestSandboxKill,
+  wakeSleepingSandbox,
+} from "@app/lib/api/poke/sandboxes";
+import { createPlugin } from "@app/lib/api/poke/types";
+import { ensureFrameSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import type { Authenticator } from "@app/lib/auth";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import { FrameSandboxAdapter } from "@app/lib/resources/frame_sandbox_adapter";
+import { Err } from "@app/types/shared/result";
+
+function sandboxTarget(auth: Authenticator, frame: FileResource) {
+  return {
+    ensureReady: () => ensureFrameSandboxReady(auth, frame),
+    fetchSandbox: () => FrameSandboxAdapter.fetchSandbox(auth, frame),
+  };
+}
+
+export const wakeFrameSandboxPlugin = createPlugin({
+  manifest: {
+    id: "wake-frame-sandbox",
+    name: "Wake Sandbox",
+    description: "Resume this Frame's sleeping sandbox.",
+    resourceTypes: ["files"],
+    args: {},
+    requiredRoles: ["support"],
+  },
+  isApplicableTo: async (auth, file) =>
+    file?.isFrameV2 ? isSandboxSleeping(sandboxTarget(auth, file)) : false,
+  execute: async (auth, file) => {
+    if (!file?.isFrameV2) {
+      return new Err(new Error("Frame not found."));
+    }
+
+    return wakeSleepingSandbox(sandboxTarget(auth, file));
+  },
+});
+
+export const requestFrameSandboxKillPlugin = createPlugin({
+  manifest: {
+    id: "request-frame-sandbox-kill",
+    name: "Request Sandbox Kill",
+    description:
+      "Mark this Frame's sandbox for destruction and recreation on its next access.",
+    warning:
+      "The sandbox will be destroyed. Frame databases will be restored from replicated state when it is recreated.",
+    resourceTypes: ["files"],
+    args: {},
+    requiredRoles: ["support"],
+  },
+  isApplicableTo: async (auth, file) =>
+    file?.isFrameV2 ? canRequestSandboxKill(sandboxTarget(auth, file)) : false,
+  execute: async (auth, file) => {
+    if (!file?.isFrameV2) {
+      return new Err(new Error("Frame not found."));
+    }
+
+    return requestSandboxKill(sandboxTarget(auth, file));
+  },
+});

--- a/front/lib/api/poke/plugins/files/index.ts
+++ b/front/lib/api/poke/plugins/files/index.ts
@@ -1,1 +1,2 @@
 export * from "./delete_frame";
+export * from "./frame_sandbox";

--- a/front/lib/api/poke/plugins/spaces/wake_sandbox.test.ts
+++ b/front/lib/api/poke/plugins/spaces/wake_sandbox.test.ts
@@ -32,6 +32,23 @@ describe("wakePodSandboxPlugin", () => {
     );
   });
 
+  it("is not applicable when the sleeping sandbox has a kill request", async () => {
+    const { auth, pod } = await setup();
+    await SandboxFactory.createForPod(auth, pod, {
+      status: "sleeping",
+      killRequestedAt: new Date(),
+    });
+
+    await expect(wakePodSandboxPlugin.isApplicableTo(auth, pod)).resolves.toBe(
+      false
+    );
+
+    const result = await wakePodSandboxPlugin.execute(auth, pod, {});
+
+    expect(result.isErr()).toBe(true);
+    expect(result.isErr() && result.error.message).toContain("kill request");
+  });
+
   it("is not applicable when the pod has no sandbox", async () => {
     const { auth, pod } = await setup();
 

--- a/front/lib/api/poke/sandboxes.ts
+++ b/front/lib/api/poke/sandboxes.ts
@@ -5,11 +5,14 @@ import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
-type SandboxWakeTarget = {
+type SandboxTarget = {
+  fetchSandbox: () => Promise<SandboxResource | null>;
+};
+
+type SandboxWakeTarget = SandboxTarget & {
   // Must go through the owner-specific ready helper, not the owner adapter:
   // waking through the adapter skips the GCS mount and egress bring-up.
   ensureReady: () => Promise<Result<EnsureSandboxReadyResult, Error>>;
-  fetchSandbox: () => Promise<SandboxResource | null>;
 };
 
 export async function isSandboxSleeping({
@@ -17,9 +20,14 @@ export async function isSandboxSleeping({
 }: Pick<SandboxWakeTarget, "fetchSandbox">): Promise<boolean> {
   const sandbox = await fetchSandbox();
 
-  return sandbox?.status === "sleeping";
+  return sandbox?.status === "sleeping" && sandbox.killRequestedAt === null;
 }
 
+/**
+ * @cc [owner:davidebbo,label:product] wake-only-unmarked-sleeping-sandbox
+ * `wakeSleepingSandbox` must only call the owner ready helper for an existing sleeping sandbox
+ * without a pending kill request.
+ */
 export async function wakeSleepingSandbox({
   ensureReady,
   fetchSandbox,
@@ -27,6 +35,11 @@ export async function wakeSleepingSandbox({
   const sandbox = await fetchSandbox();
   if (!sandbox) {
     return new Err(new Error("No sandbox to wake."));
+  }
+  if (sandbox.killRequestedAt) {
+    return new Err(
+      new Error("Sandbox has a pending kill request and cannot be woken.")
+    );
   }
 
   // The ready helper would create a sandbox from scratch if there were none, and
@@ -50,5 +63,45 @@ export async function wakeSleepingSandbox({
     value:
       `Sandbox is now ${woken.status}. Connect with: ` +
       makeSandboxConnectCommand(woken.toPokeJSON()),
+  });
+}
+
+export async function canRequestSandboxKill({
+  fetchSandbox,
+}: SandboxTarget): Promise<boolean> {
+  const sandbox = await fetchSandbox();
+
+  return (
+    sandbox !== null &&
+    sandbox.status !== "deleted" &&
+    sandbox.killRequestedAt === null
+  );
+}
+
+/**
+ * @cc [owner:davidebbo,label:product] request-existing-sandbox-kill
+ * `requestSandboxKill` must only mark an existing, non-deleted sandbox without a pending kill; it
+ * must never create, wake, or destroy a sandbox synchronously.
+ */
+export async function requestSandboxKill({
+  fetchSandbox,
+}: SandboxTarget): Promise<Result<PluginResponse, Error>> {
+  const sandbox = await fetchSandbox();
+  if (!sandbox) {
+    return new Err(new Error("No sandbox to kill."));
+  }
+  if (sandbox.status === "deleted") {
+    return new Err(new Error("Sandbox is already deleted."));
+  }
+  if (sandbox.killRequestedAt) {
+    return new Err(new Error("A sandbox kill is already requested."));
+  }
+
+  await sandbox.requestKill();
+
+  return new Ok({
+    display: "text",
+    value:
+      "Sandbox kill requested. The reaper will destroy it, or the next access will destroy and recreate it.",
   });
 }

--- a/front/tests/utils/SandboxFactory.ts
+++ b/front/tests/utils/SandboxFactory.ts
@@ -1,5 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
+import type { FrameSandboxOwner } from "@app/lib/resources/frame_sandbox_adapter";
+import { FrameSandboxAdapter } from "@app/lib/resources/frame_sandbox_adapter";
 import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
@@ -104,6 +106,40 @@ export class SandboxFactory {
     const result = await PodSandboxAdapter.fetchSandbox(auth, pod);
     if (!result) {
       throw new Error("Pod sandbox not found after creation");
+    }
+    return result;
+  }
+
+  static async createForFrame(
+    auth: Authenticator,
+    frame: FrameSandboxOwner,
+    opts?: {
+      status?: SandboxStatus;
+      killRequestedAt?: Date;
+    }
+  ): Promise<SandboxResource> {
+    const sandbox = await SandboxResource.makeNew(auth, {
+      providerId: `test-provider-${Date.now()}`,
+      status: opts?.status ?? "running",
+      baseImage: "dust-base",
+      version: "0.0.0-test",
+    });
+    if (opts?.killRequestedAt) {
+      await SandboxModel.update(
+        { killRequestedAt: opts.killRequestedAt } as Partial<SandboxModel>,
+        { where: { id: sandbox.id } }
+      );
+    }
+
+    await SandboxOwnerModel.create({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      frameFileModelId: frame.id,
+      sandboxId: sandbox.id,
+    });
+
+    const result = await FrameSandboxAdapter.fetchSandbox(auth, frame);
+    if (!result) {
+      throw new Error("Frame sandbox not found after creation");
     }
     return result;
   }


### PR DESCRIPTION
## Description

- Add a support-only `Request Sandbox Kill` plugin for one conversation or Frame sandbox. The request marks the sandbox for the reaper or the next normal access to destroy and recreate.
- Add `Wake Sandbox` to the Frame Poke page through the Frame lifecycle helper, which restores mounts, egress, and replicated Frame database state.
- Show the shared plugin list on the Frame Poke page. Conversation and Frame pages now expose both controls when each action applies.
- Keep Wake unavailable when a sandbox has a pending kill request.

No API endpoint or schema changes are required. The existing generic Poke plugin routes serve both resource types.

## Tests

Added

## Risk

Low. The plugins are restricted to support users, operate on one resolved resource, and reuse the existing sandbox lifecycle adapters. A kill request does not destroy a sandbox in the request path. The reaper or the next normal access performs the lifecycle transition.

## Deploy Plan

Deploy Front normally. No migration, backfill, or coordinated API rollout is required.