### PR TITLE
Fix seat usage column sort on customer and poke usage pages

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -274,7 +274,7 @@ export function UsagePage() {
   // TODO(avervaet, 2026-09-02): remove once the app page and Poke page usage
   // tables are uniformized.
   const membersOrderColumn =
-    sort?.id === "email"
+    sort?.id === "email" || sort?.id === "seatUsage"
       ? sort.id
       : sort?.id === "consumedFromPoolAwuCredits"
         ? "consumedAwuCredits"

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -18,6 +18,7 @@ import type {
   MemberFairUseUsage,
   MemberUsageType,
 } from "@app/lib/api/credits/members_usage";
+import { computeSeatUsage } from "@app/lib/api/credits/seat_usage";
 import { formatCredits, formatCreditValue } from "@app/lib/client/credits";
 import type { UserModelTierSelection } from "@app/lib/client/model_tier_options";
 import {
@@ -610,46 +611,6 @@ const seatsIconColumn: ColumnDef<RowData, string> = {
   },
 };
 
-function computeSeatUsage({
-  seatType,
-  memberUsageLimit,
-  seatBalanceAwu,
-  consumedFromAllowanceAwuCredits,
-}: {
-  seatType: MembershipSeatType | null;
-  memberUsageLimit: number | null;
-  seatBalanceAwu: number | null;
-  consumedFromAllowanceAwuCredits: number;
-}): {
-  percent: number;
-  isOverAllowance: boolean;
-  consumed: number;
-  allowance: number;
-} {
-  const allowance = memberUsageLimit ?? 0;
-  const isFreeWithBalance =
-    seatType === "free" &&
-    typeof seatBalanceAwu === "number" &&
-    typeof memberUsageLimit === "number";
-  const consumed = isFreeWithBalance
-    ? Math.max(0, memberUsageLimit - seatBalanceAwu)
-    : consumedFromAllowanceAwuCredits;
-  if (allowance <= 0) {
-    return {
-      percent: consumed > 0 ? 100 : 0,
-      isOverAllowance: consumed > 0,
-      consumed,
-      allowance,
-    };
-  }
-  return {
-    percent: Math.min(100, (consumed / allowance) * 100),
-    isOverAllowance: consumed > allowance,
-    consumed,
-    allowance,
-  };
-}
-
 const seatUsageColumn: ColumnDef<RowData, string> = {
   id: "seatUsage" as const,
   header: "Seat usage",
@@ -665,25 +626,20 @@ const seatUsageColumn: ColumnDef<RowData, string> = {
   cell: (info: Info) => {
     const { seatType, memberUsageLimit, seatBalanceAwu, isSeatChangePending } =
       info.row.original;
-    if (
-      isSeatChangePending ||
-      !seatType ||
-      memberUsageLimit === null ||
-      memberUsageLimit <= 0
-    ) {
-      return (
-        <DataTable.CellContent className="justify-center">
-          <span className="text-sm text-muted-foreground">--</span>
-        </DataTable.CellContent>
-      );
-    }
-    const { percent, consumed, allowance } = computeSeatUsage({
+    const { percent, hasPercent, consumed, allowance } = computeSeatUsage({
       seatType,
       memberUsageLimit,
       seatBalanceAwu,
       consumedFromAllowanceAwuCredits:
         info.row.original.consumedFromAllowanceAwuCredits,
     });
+    if (isSeatChangePending || !hasPercent) {
+      return (
+        <DataTable.CellContent className="justify-center">
+          <span className="text-sm text-muted-foreground">--</span>
+        </DataTable.CellContent>
+      );
+    }
     return (
       <DataTable.CellContent className="justify-center">
         <Tooltip

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -266,9 +266,12 @@ export function AwuUsageBar({
     seatType === "free" &&
     typeof seatBalanceAwu === "number" &&
     typeof memberUsageLimit === "number";
-  const lifetimeConsumed = isFreeWithBalance
-    ? Math.max(0, memberUsageLimit - seatBalanceAwu!)
-    : null;
+  const { consumed: seatConsumed } = computeSeatUsage({
+    seatType,
+    memberUsageLimit,
+    seatBalanceAwu: seatBalanceAwu ?? null,
+    consumedFromAllowanceAwuCredits: consumedFromAllowance,
+  });
   // Unlimited/uncapped is not a supported product state right now: a `null`
   // effective limit is treated as no pool access (capped at the seat
   // allowance), same as an explicit "none" seat.
@@ -278,9 +281,6 @@ export function AwuUsageBar({
   // A seat with no pool (poolLimit === 0) shows no pool section —
   // any spend beyond the seat allowance is overage. Zero-width sections are
   // skipped.
-  const seatConsumed = isFreeWithBalance
-    ? lifetimeConsumed!
-    : consumedFromAllowance;
   const seatRemaining = isFreeWithBalance
     ? seatBalanceAwu!
     : Math.max(0, allowance - seatConsumed);
@@ -456,7 +456,7 @@ export function AwuUsageBar({
   );
 
   const headlineConsumed = isFreeWithBalance
-    ? Math.min(lifetimeConsumed! + overage, allowance)
+    ? Math.min(seatConsumed + overage, allowance)
     : Math.min(consumed, resolvedEffectiveLimit);
   const headlineLimit = isFreeWithBalance ? allowance : resolvedEffectiveLimit;
   const headlineLimitLabel = formatCredits(headlineLimit);
@@ -622,18 +622,18 @@ const seatUsageColumn: ColumnDef<RowData, string> = {
       memberUsageLimit: row.memberUsageLimit,
       seatBalanceAwu: row.seatBalanceAwu,
       consumedFromAllowanceAwuCredits: row.consumedFromAllowanceAwuCredits,
-    }).percent.toString(),
+    }).percent?.toString() ?? "",
   cell: (info: Info) => {
     const { seatType, memberUsageLimit, seatBalanceAwu, isSeatChangePending } =
       info.row.original;
-    const { percent, hasPercent, consumed, allowance } = computeSeatUsage({
+    const { percent, consumed, allowance } = computeSeatUsage({
       seatType,
       memberUsageLimit,
       seatBalanceAwu,
       consumedFromAllowanceAwuCredits:
         info.row.original.consumedFromAllowanceAwuCredits,
     });
-    if (isSeatChangePending || !hasPercent) {
+    if (isSeatChangePending || percent === null) {
       return (
         <DataTable.CellContent className="justify-center">
           <span className="text-sm text-muted-foreground">--</span>

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -262,11 +262,7 @@ export function AwuUsageBar({
   );
   // For free seats: use lifetime consumed (derived from the live Metronome
   // balance) instead of period spend, so the bar reflects remaining credit.
-  const isFreeWithBalance =
-    seatType === "free" &&
-    typeof seatBalanceAwu === "number" &&
-    typeof memberUsageLimit === "number";
-  const { consumed: seatConsumed } = computeSeatUsage({
+  const { consumed: seatConsumed, isFreeWithBalance } = computeSeatUsage({
     seatType,
     memberUsageLimit,
     seatBalanceAwu: seatBalanceAwu ?? null,
@@ -616,13 +612,8 @@ const seatUsageColumn: ColumnDef<RowData, string> = {
   header: "Seat usage",
   enableSorting: true,
   sortDescFirst: true,
-  accessorFn: (row) =>
-    computeSeatUsage({
-      seatType: row.seatType,
-      memberUsageLimit: row.memberUsageLimit,
-      seatBalanceAwu: row.seatBalanceAwu,
-      consumedFromAllowanceAwuCredits: row.consumedFromAllowanceAwuCredits,
-    }).percent?.toString() ?? "",
+  // Sorting is server-side; the accessor only exists so the header is sortable.
+  accessorFn: (row) => row.memberUsageLimit?.toString() ?? "",
   cell: (info: Info) => {
     const { seatType, memberUsageLimit, seatBalanceAwu, isSeatChangePending } =
       info.row.original;

--- a/front/lib/api/credits/members_usage.test.ts
+++ b/front/lib/api/credits/members_usage.test.ts
@@ -1,7 +1,9 @@
+import type { MembersUsageSortMeta } from "@app/lib/api/credits/members_usage";
 import {
   fetchConsumedAwuCreditsByApiKeyName,
   fetchSeatDataForMembersTable,
   getEsConsumedProgrammaticAwuCredits,
+  makeMembersUsageComparator,
 } from "@app/lib/api/credits/members_usage";
 import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
 import { Authenticator } from "@app/lib/auth";
@@ -199,5 +201,101 @@ describe("fetchSeatDataForMembersTable", () => {
       billingFrequency: "MONTHLY",
       nextCreditResetAt: "2026-09-01T00:00:00.000Z",
     });
+  });
+});
+
+describe("makeMembersUsageComparator", () => {
+  function sortIds({
+    meta,
+    orderDirection,
+    names = {},
+  }: {
+    meta: Record<string, MembersUsageSortMeta>;
+    orderDirection: "asc" | "desc";
+    names?: Record<string, string>;
+  }): string[] {
+    const ids = Object.keys(meta);
+    const compare = makeMembersUsageComparator({
+      sortMetaByUserId: new Map(Object.entries(meta)),
+      displayNameByUserId: new Map(
+        ids.map((id) => [id, names[id] ?? `user ${id}`])
+      ),
+      orderDirection,
+    });
+    return ids
+      .map((sId) => ({ sId }))
+      .sort(compare)
+      .map((u) => u.sId);
+  }
+
+  it("orders numeric keys in the requested direction", () => {
+    const meta = {
+      a: { sortKey: 10 },
+      b: { sortKey: 30 },
+      c: { sortKey: 20 },
+    };
+    expect(sortIds({ meta, orderDirection: "asc" })).toEqual(["a", "c", "b"]);
+    expect(sortIds({ meta, orderDirection: "desc" })).toEqual(["b", "c", "a"]);
+  });
+
+  it("groups rows without a comparable key last regardless of direction", () => {
+    const meta = {
+      none: { sortKey: null },
+      low: { sortKey: 5 },
+      high: { sortKey: 95 },
+      missing: { sortKey: null },
+    };
+    expect(sortIds({ meta, orderDirection: "asc" })).toEqual([
+      "low",
+      "high",
+      "missing",
+      "none",
+    ]);
+    expect(sortIds({ meta, orderDirection: "desc" })).toEqual([
+      "high",
+      "low",
+      "missing",
+      "none",
+    ]);
+  });
+
+  it("treats users with no computed key as incomparable", () => {
+    const compare = makeMembersUsageComparator({
+      sortMetaByUserId: new Map([["ranked", { sortKey: 0 }]]),
+      displayNameByUserId: new Map([
+        ["ranked", "Zed"],
+        ["unranked", "Amy"],
+      ]),
+      orderDirection: "asc",
+    });
+    expect(compare({ sId: "unranked" }, { sId: "ranked" })).toBeGreaterThan(0);
+    expect(compare({ sId: "ranked" }, { sId: "unranked" })).toBeLessThan(0);
+  });
+
+  it("breaks ties on the directional tiebreak, then the always-descending one", () => {
+    const meta = {
+      a: { sortKey: 50, directionalTiebreak: 1 },
+      b: { sortKey: 50, directionalTiebreak: 3 },
+      c: { sortKey: 50, directionalTiebreak: 3, descendingTiebreak: 10 },
+    };
+    // Same key everywhere: directional tiebreak follows the direction, and the
+    // descending tiebreak puts the larger value first either way.
+    expect(sortIds({ meta, orderDirection: "asc" })).toEqual(["a", "c", "b"]);
+    expect(sortIds({ meta, orderDirection: "desc" })).toEqual(["c", "b", "a"]);
+  });
+
+  it("falls back to a case-insensitive name order, then id", () => {
+    const meta = {
+      z: { sortKey: 1 },
+      y: { sortKey: 1 },
+      x: { sortKey: 1 },
+    };
+    expect(
+      sortIds({
+        meta,
+        orderDirection: "desc",
+        names: { z: "bob", y: "Alice", x: "alice" },
+      })
+    ).toEqual(["x", "y", "z"]);
   });
 });

--- a/front/lib/api/credits/members_usage.test.ts
+++ b/front/lib/api/credits/members_usage.test.ts
@@ -284,6 +284,21 @@ describe("makeMembersUsageComparator", () => {
     expect(sortIds({ meta, orderDirection: "desc" })).toEqual(["c", "b", "a"]);
   });
 
+  it("does not let a NaN sort key produce a NaN comparison", () => {
+    const compare = makeMembersUsageComparator({
+      sortMetaByUserId: new Map([
+        ["a", { sortKey: NaN }],
+        ["b", { sortKey: 50 }],
+      ]),
+      displayNameByUserId: new Map([
+        ["a", "user a"],
+        ["b", "user b"],
+      ]),
+      orderDirection: "asc",
+    });
+    expect(Number.isFinite(compare({ sId: "a" }, { sId: "b" }))).toBe(true);
+  });
+
   it("falls back to a case-insensitive name order, then id", () => {
     const meta = {
       z: { sortKey: 1 },

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1783,6 +1783,13 @@ export async function resolveMatchingMemberUserIds({
  * orders (consumed credits from the analytics index, never from the Metronome per-user usage
  * cache), so the order shown always agrees with the values displayed.
  */
+/**
+ * @cc [owner:avervaet,label:product] seat-usage-order-excludes-non-seat-based
+ * When `orderColumn` is `"seatUsage"`, users on a seat type without a personal usage percentage
+ * (`workspace`/`workspace_yearly`/no seat) always sort after users on `free`/`pro`/`max`,
+ * regardless of `orderDirection`. Within each group, ordering follows seat usage percentage, then
+ * pool/overage consumption as a tiebreaker, both in `orderDirection`.
+ */
 async function resolveMembersUsagePageUsers({
   auth,
   workspace,
@@ -1837,6 +1844,14 @@ async function resolveMembersUsagePageUsers({
 
   const sortKeyByUserId = new Map<string, number | string>();
   const overageLimitByUserId = new Map<string, number>();
+  // Only populated for orderColumn "seatUsage": whether the seat has a
+  // personal usage percentage at all (free/pro/max with a resolved
+  // allowance) versus workspace/none seats, which spend straight from the
+  // pool and render "--" in that column.
+  const hasSeatUsagePercentByUserId = new Map<string, boolean>();
+  // Only populated for orderColumn "seatUsage": pool/overage consumption,
+  // used to break ties between seats at the same usage percentage.
+  const poolUsageTiebreakByUserId = new Map<string, number>();
   switch (orderColumn) {
     case "consumedAwuCredits": {
       // Split consumed credits on seat type so free-seat users sort by their
@@ -2012,6 +2027,17 @@ async function resolveMembersUsagePageUsers({
               ? 100
               : 0
         );
+        // Mirrors the "--" condition in the seat-usage column: workspace/none
+        // seats have no personal allowance, so their percentage isn't
+        // comparable to free/pro/max seats and must never rank above them.
+        hasSeatUsagePercentByUserId.set(u.sId, effectiveAllocationAwu > 0);
+        poolUsageTiebreakByUserId.set(
+          u.sId,
+          Math.max(
+            0,
+            (consumedByUserId.get(u.sId) ?? 0) - effectiveAllocationAwu
+          )
+        );
       }
       break;
     }
@@ -2044,6 +2070,15 @@ async function resolveMembersUsagePageUsers({
 
   const directionFactor = orderDirection === "asc" ? 1 : -1;
   const sortedUsers = [...allUsers].sort((a, b) => {
+    // Seats with a personal usage percentage (free/pro/max) always rank
+    // above workspace/none seats, regardless of sort direction: the latter
+    // have no comparable percentage and render "--" in the column.
+    const hasPercentA = hasSeatUsagePercentByUserId.get(a.sId) ?? true;
+    const hasPercentB = hasSeatUsagePercentByUserId.get(b.sId) ?? true;
+    if (hasPercentA !== hasPercentB) {
+      return hasPercentA ? -1 : 1;
+    }
+
     const keyA = sortKeyByUserId.get(a.sId) ?? 0;
     const keyB = sortKeyByUserId.get(b.sId) ?? 0;
     const cmp =
@@ -2052,6 +2087,13 @@ async function resolveMembersUsagePageUsers({
         : String(keyA).localeCompare(String(keyB));
     if (cmp !== 0) {
       return cmp * directionFactor;
+    }
+    // Tiebreak on pool/overage usage, in the same direction as the primary
+    // sort (only populated for orderColumn "seatUsage").
+    const poolUsageA = poolUsageTiebreakByUserId.get(a.sId) ?? 0;
+    const poolUsageB = poolUsageTiebreakByUserId.get(b.sId) ?? 0;
+    if (poolUsageA !== poolUsageB) {
+      return (poolUsageA - poolUsageB) * directionFactor;
     }
     // Tiebreak on the highest overage limit, always descending
     const overageLimitA = overageLimitByUserId.get(a.sId) ?? 0;

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1842,16 +1842,15 @@ async function resolveMembersUsagePageUsers({
     memberships.map((m) => [m.userId, m])
   );
 
-  const sortKeyByUserId = new Map<string, number | string>();
-  const overageLimitByUserId = new Map<string, number>();
-  // Only populated for orderColumn "seatUsage": whether the seat has a
-  // personal usage percentage at all (free/pro/max with a resolved
-  // allowance) versus workspace/none seats, which spend straight from the
-  // pool and render "--" in that column.
-  const hasSeatUsagePercentByUserId = new Map<string, boolean>();
-  // Only populated for orderColumn "seatUsage": pool/overage consumption,
-  // used to break ties between seats at the same usage percentage.
-  const poolUsageTiebreakByUserId = new Map<string, number>();
+  const sortMetaByUserId = new Map<
+    string,
+    {
+      sortKey: number | string;
+      overageLimit?: number;
+      hasSeatUsagePercent?: boolean;
+      poolUsageTiebreak?: number;
+    }
+  >();
   switch (orderColumn) {
     case "consumedAwuCredits": {
       // Split consumed credits on seat type so free-seat users sort by their
@@ -1866,7 +1865,9 @@ async function resolveMembersUsagePageUsers({
         cycle: spendLimitCycleOverrideForAuth(auth),
       });
       for (const u of allUsers) {
-        sortKeyByUserId.set(u.sId, creditsByUserId.get(u.sId) ?? 0);
+        sortMetaByUserId.set(u.sId, {
+          sortKey: creditsByUserId.get(u.sId) ?? 0,
+        });
       }
       break;
     }
@@ -1926,8 +1927,6 @@ async function resolveMembersUsagePageUsers({
           0,
           totalConsumed - effectiveAllocationAwu
         );
-        sortKeyByUserId.set(u.sId, consumedFromPoolAwuCredits);
-
         const overrideAwuCredits =
           membership?.poolCapOverrideAwuCredits !== null &&
           membership?.poolCapOverrideAwuCredits !== undefined &&
@@ -1948,29 +1947,27 @@ async function resolveMembersUsagePageUsers({
             groupCapAwuCredits,
             defaultAwuCredits,
           });
-        overageLimitByUserId.set(
-          u.sId,
-          effectiveSpendLimitAwuCredits - seatAllowance
-        );
+        sortMetaByUserId.set(u.sId, {
+          sortKey: consumedFromPoolAwuCredits,
+          overageLimit: effectiveSpendLimitAwuCredits - seatAllowance,
+        });
       }
       break;
     }
     case "seatType": {
       for (const u of allUsers) {
-        sortKeyByUserId.set(
-          u.sId,
-          membershipByUserModelId.get(u.id)?.seatType ?? "none"
-        );
+        sortMetaByUserId.set(u.sId, {
+          sortKey: membershipByUserModelId.get(u.id)?.seatType ?? "none",
+        });
       }
       break;
     }
     case "creditState": {
       for (const u of allUsers) {
         const creditState = membershipByUserModelId.get(u.id)?.creditState;
-        sortKeyByUserId.set(
-          u.sId,
-          creditState ? normalizeUserCreditState(creditState) : ""
-        );
+        sortMetaByUserId.set(u.sId, {
+          sortKey: creditState ? normalizeUserCreditState(creditState) : "",
+        });
       }
       break;
     }
@@ -2019,25 +2016,22 @@ async function resolveMembersUsagePageUsers({
                 consumedByUserId.get(u.sId) ?? 0,
                 effectiveAllocationAwu
               );
-        sortKeyByUserId.set(
-          u.sId,
-          effectiveAllocationAwu > 0
-            ? Math.min(100, (consumed / effectiveAllocationAwu) * 100)
-            : consumed > 0
-              ? 100
-              : 0
-        );
-        // Mirrors the "--" condition in the seat-usage column: workspace/none
-        // seats have no personal allowance, so their percentage isn't
-        // comparable to free/pro/max seats and must never rank above them.
-        hasSeatUsagePercentByUserId.set(u.sId, effectiveAllocationAwu > 0);
-        poolUsageTiebreakByUserId.set(
-          u.sId,
-          Math.max(
+        sortMetaByUserId.set(u.sId, {
+          sortKey:
+            effectiveAllocationAwu > 0
+              ? Math.min(100, (consumed / effectiveAllocationAwu) * 100)
+              : consumed > 0
+                ? 100
+                : 0,
+          // Mirrors the "--" condition in the seat-usage column: workspace/none
+          // seats have no personal allowance, so their percentage isn't
+          // comparable to free/pro/max seats and must never rank above them.
+          hasSeatUsagePercent: effectiveAllocationAwu > 0,
+          poolUsageTiebreak: Math.max(
             0,
             (consumedByUserId.get(u.sId) ?? 0) - effectiveAllocationAwu
-          )
-        );
+          ),
+        });
       }
       break;
     }
@@ -2048,7 +2042,9 @@ async function resolveMembersUsagePageUsers({
         users: allUsers.map((u) => ({ id: u.id, sId: u.sId })),
       });
       for (const u of allUsers) {
-        sortKeyByUserId.set(u.sId, usedCountByUserId.get(u.sId) ?? 0);
+        sortMetaByUserId.set(u.sId, {
+          sortKey: usedCountByUserId.get(u.sId) ?? 0,
+        });
       }
       break;
     }
@@ -2060,7 +2056,9 @@ async function resolveMembersUsagePageUsers({
         plan: auth.plan(),
       });
       for (const u of allUsers) {
-        sortKeyByUserId.set(u.sId, usedCreditsByUserId.get(u.sId) ?? 0);
+        sortMetaByUserId.set(u.sId, {
+          sortKey: usedCreditsByUserId.get(u.sId) ?? 0,
+        });
       }
       break;
     }
@@ -2070,17 +2068,20 @@ async function resolveMembersUsagePageUsers({
 
   const directionFactor = orderDirection === "asc" ? 1 : -1;
   const sortedUsers = [...allUsers].sort((a, b) => {
+    const metaA = sortMetaByUserId.get(a.sId);
+    const metaB = sortMetaByUserId.get(b.sId);
+
     // Seats with a personal usage percentage (free/pro/max) always rank
     // above workspace/none seats, regardless of sort direction: the latter
     // have no comparable percentage and render "--" in the column.
-    const hasPercentA = hasSeatUsagePercentByUserId.get(a.sId) ?? true;
-    const hasPercentB = hasSeatUsagePercentByUserId.get(b.sId) ?? true;
+    const hasPercentA = metaA?.hasSeatUsagePercent ?? true;
+    const hasPercentB = metaB?.hasSeatUsagePercent ?? true;
     if (hasPercentA !== hasPercentB) {
       return hasPercentA ? -1 : 1;
     }
 
-    const keyA = sortKeyByUserId.get(a.sId) ?? 0;
-    const keyB = sortKeyByUserId.get(b.sId) ?? 0;
+    const keyA = metaA?.sortKey ?? 0;
+    const keyB = metaB?.sortKey ?? 0;
     const cmp =
       typeof keyA === "number" && typeof keyB === "number"
         ? keyA - keyB
@@ -2090,14 +2091,14 @@ async function resolveMembersUsagePageUsers({
     }
     // Tiebreak on pool/overage usage, in the same direction as the primary
     // sort (only populated for orderColumn "seatUsage").
-    const poolUsageA = poolUsageTiebreakByUserId.get(a.sId) ?? 0;
-    const poolUsageB = poolUsageTiebreakByUserId.get(b.sId) ?? 0;
+    const poolUsageA = metaA?.poolUsageTiebreak ?? 0;
+    const poolUsageB = metaB?.poolUsageTiebreak ?? 0;
     if (poolUsageA !== poolUsageB) {
       return (poolUsageA - poolUsageB) * directionFactor;
     }
     // Tiebreak on the highest overage limit, always descending
-    const overageLimitA = overageLimitByUserId.get(a.sId) ?? 0;
-    const overageLimitB = overageLimitByUserId.get(b.sId) ?? 0;
+    const overageLimitA = metaA?.overageLimit ?? 0;
+    const overageLimitB = metaB?.overageLimit ?? 0;
     if (overageLimitA !== overageLimitB) {
       return overageLimitB - overageLimitA;
     }

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1780,6 +1780,64 @@ export async function resolveMatchingMemberUserIds({
 // for those columns. Every other column is not indexed, so to sort by it we
 // fetch the full matching set with Elasticsearch `search_after`, rank it by
 // the relevant signal, sort in-app, then slice the requested page.
+// Per-user rank for one in-app sort column. A `null` key means the user has no
+// comparable value. Tiebreaks are generic: one follows the requested direction,
+// the other is always descending.
+export type MembersUsageSortMeta = {
+  sortKey: number | string | null;
+  directionalTiebreak?: number;
+  descendingTiebreak?: number;
+};
+
+// Rows without a comparable key group last regardless of direction, then the
+// two tiebreaks apply, then a stable name/id order so pages don't reshuffle.
+export function makeMembersUsageComparator({
+  sortMetaByUserId,
+  displayNameByUserId,
+  orderDirection,
+}: {
+  sortMetaByUserId: ReadonlyMap<string, MembersUsageSortMeta>;
+  displayNameByUserId: ReadonlyMap<string, string>;
+  orderDirection: "asc" | "desc";
+}): (a: { sId: string }, b: { sId: string }) => number {
+  const directionFactor = orderDirection === "asc" ? 1 : -1;
+  return (a, b) => {
+    const metaA = sortMetaByUserId.get(a.sId);
+    const metaB = sortMetaByUserId.get(b.sId);
+
+    const keyA = metaA?.sortKey ?? null;
+    const keyB = metaB?.sortKey ?? null;
+    if ((keyA === null) !== (keyB === null)) {
+      return keyA === null ? 1 : -1;
+    }
+    if (keyA !== null && keyB !== null) {
+      const cmp =
+        typeof keyA === "number" && typeof keyB === "number"
+          ? keyA - keyB
+          : String(keyA).localeCompare(String(keyB));
+      if (cmp !== 0) {
+        return cmp * directionFactor;
+      }
+    }
+    const directionalA = metaA?.directionalTiebreak ?? 0;
+    const directionalB = metaB?.directionalTiebreak ?? 0;
+    if (directionalA !== directionalB) {
+      return (directionalA - directionalB) * directionFactor;
+    }
+    const descendingA = metaA?.descendingTiebreak ?? 0;
+    const descendingB = metaB?.descendingTiebreak ?? 0;
+    if (descendingA !== descendingB) {
+      return descendingB - descendingA;
+    }
+    const nameA = (displayNameByUserId.get(a.sId) ?? "").toLowerCase();
+    const nameB = (displayNameByUserId.get(b.sId) ?? "").toLowerCase();
+    if (nameA !== nameB) {
+      return nameA < nameB ? -1 : 1;
+    }
+    return a.sId < b.sId ? -1 : a.sId > b.sId ? 1 : 0;
+  };
+}
+
 /**
  * @cc [owner:avervaet,label:product] sort-keys-match-rendered-source
  * Every in-app sort key must be derived from the same data source as the response field it
@@ -1838,17 +1896,7 @@ async function resolveMembersUsagePageUsers({
     memberships.map((m) => [m.userId, m])
   );
 
-  // Per-user rank for the requested column. A `null` key means the user has no
-  // comparable value. Tiebreaks are generic: one follows the requested
-  // direction, the other is always descending.
-  const sortMetaByUserId = new Map<
-    string,
-    {
-      sortKey: number | string | null;
-      directionalTiebreak?: number;
-      descendingTiebreak?: number;
-    }
-  >();
+  const sortMetaByUserId = new Map<string, MembersUsageSortMeta>();
   switch (orderColumn) {
     case "consumedAwuCredits": {
       // Split consumed credits on seat type so free-seat users sort by their
@@ -2059,45 +2107,16 @@ async function resolveMembersUsagePageUsers({
       assertNever(orderColumn);
   }
 
-  const directionFactor = orderDirection === "asc" ? 1 : -1;
-  const sortedUsers = [...allUsers].sort((a, b) => {
-    const metaA = sortMetaByUserId.get(a.sId);
-    const metaB = sortMetaByUserId.get(b.sId);
-
-    // Incomparable rows (null key, or no key computed) group last regardless
-    // of direction (see contract on this function).
-    const keyA = metaA?.sortKey ?? null;
-    const keyB = metaB?.sortKey ?? null;
-    if ((keyA === null) !== (keyB === null)) {
-      return keyA === null ? 1 : -1;
-    }
-    if (keyA !== null && keyB !== null) {
-      const cmp =
-        typeof keyA === "number" && typeof keyB === "number"
-          ? keyA - keyB
-          : String(keyA).localeCompare(String(keyB));
-      if (cmp !== 0) {
-        return cmp * directionFactor;
-      }
-    }
-    const directionalA = metaA?.directionalTiebreak ?? 0;
-    const directionalB = metaB?.directionalTiebreak ?? 0;
-    if (directionalA !== directionalB) {
-      return (directionalA - directionalB) * directionFactor;
-    }
-    const descendingA = metaA?.descendingTiebreak ?? 0;
-    const descendingB = metaB?.descendingTiebreak ?? 0;
-    if (descendingA !== descendingB) {
-      return descendingB - descendingA;
-    }
-    // Stable, direction-independent tiebreaker so pages don't reshuffle.
-    const nameA = (a.fullName() || a.name).toLowerCase();
-    const nameB = (b.fullName() || b.name).toLowerCase();
-    if (nameA !== nameB) {
-      return nameA < nameB ? -1 : 1;
-    }
-    return a.sId < b.sId ? -1 : a.sId > b.sId ? 1 : 0;
-  });
+  const displayNameByUserId = new Map(
+    allUsers.map((u) => [u.sId, u.fullName() || u.name])
+  );
+  const sortedUsers = [...allUsers].sort(
+    makeMembersUsageComparator({
+      sortMetaByUserId,
+      displayNameByUserId,
+      orderDirection,
+    })
+  );
 
   return new Ok({
     users: sortedUsers.slice(offset, offset + limit),

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1787,12 +1787,16 @@ export async function resolveMatchingMemberUserIds({
  * cache), so the order shown always agrees with the values displayed.
  */
 /**
- * @cc [owner:avervaet,label:product] seat-usage-order-excludes-non-seat-based
- * When `orderColumn` is `"seatUsage"`, users without a personal usage percentage (no positive
- * allowance: `workspace`/`workspace_yearly`/no seat) always sort after users with one
- * (`free`/`pro`/`max`), regardless of `orderDirection`. Users with a percentage order by it, then
- * by pool/overage consumption; users without one order by pool/overage consumption only. Both
- * follow `orderDirection`.
+ * @cc [owner:avervaet,label:product] incomparable-rows-sort-last
+ * Users whose sort key for `orderColumn` is not comparable (a `null` `percent` for
+ * `"seatUsage"`, or no computed key at all) always sort after every comparable user, regardless
+ * of `orderDirection`; within each group, users order by key then tiebreaks, following
+ * `orderDirection`.
+ */
+/**
+ * @cc [owner:avervaet,label:product] seat-usage-tiebreak-on-pool
+ * When `orderColumn` is `"seatUsage"`, users tied on `percent` (including all incomparable users)
+ * order by `consumedFromPoolAwuCredits`, following `orderDirection`.
  */
 async function resolveMembersUsagePageUsers({
   auth,
@@ -1846,13 +1850,15 @@ async function resolveMembersUsagePageUsers({
     memberships.map((m) => [m.userId, m])
   );
 
+  // Per-user rank for the requested column. A `null` key means the user has no
+  // comparable value. Tiebreaks are generic: one follows the requested
+  // direction, the other is always descending.
   const sortMetaByUserId = new Map<
     string,
     {
-      sortKey: number | string;
-      overageLimit?: number;
-      hasSeatUsagePercent?: boolean;
-      poolUsageTiebreak?: number;
+      sortKey: number | string | null;
+      directionalTiebreak?: number;
+      descendingTiebreak?: number;
     }
   >();
   switch (orderColumn) {
@@ -1953,7 +1959,7 @@ async function resolveMembersUsagePageUsers({
           });
         sortMetaByUserId.set(u.sId, {
           sortKey: consumedFromPoolAwuCredits,
-          overageLimit: effectiveSpendLimitAwuCredits - seatAllowance,
+          descendingTiebreak: effectiveSpendLimitAwuCredits - seatAllowance,
         });
       }
       break;
@@ -2010,14 +2016,14 @@ async function resolveMembersUsagePageUsers({
             ? (freeStartingByUserId.get(u.sId) ?? null)
             : null;
         const effectiveAllocationAwu = freeStartingBalanceAwu ?? awuAllocation;
-        // Same inputs the response builder emits for this row, so the sort
-        // ranks exactly what the column renders.
+        // Same arithmetic the response builder applies to this row; the pool
+        // share is only needed as the tiebreak.
         const { consumedFromAllowanceAwuCredits, consumedFromPoolAwuCredits } =
           splitConsumedAwuCredits({
             totalConsumedAwuCredits: consumedByUserId.get(u.sId) ?? 0,
             allowanceAwuCredits: effectiveAllocationAwu,
           });
-        const { percent, hasPercent } = computeSeatUsage({
+        const { percent } = computeSeatUsage({
           seatType,
           memberUsageLimit:
             effectiveAllocationAwu > 0 ? effectiveAllocationAwu : null,
@@ -2029,8 +2035,7 @@ async function resolveMembersUsagePageUsers({
         });
         sortMetaByUserId.set(u.sId, {
           sortKey: percent,
-          hasSeatUsagePercent: hasPercent,
-          poolUsageTiebreak: consumedFromPoolAwuCredits,
+          directionalTiebreak: consumedFromPoolAwuCredits,
         });
       }
       break;
@@ -2071,35 +2076,31 @@ async function resolveMembersUsagePageUsers({
     const metaA = sortMetaByUserId.get(a.sId);
     const metaB = sortMetaByUserId.get(b.sId);
 
-    // Rows without a comparable percentage group last regardless of
-    // direction (see contract on this function).
-    const hasPercentA = metaA?.hasSeatUsagePercent ?? true;
-    const hasPercentB = metaB?.hasSeatUsagePercent ?? true;
-    if (hasPercentA !== hasPercentB) {
-      return hasPercentA ? -1 : 1;
+    // Incomparable rows (null key, or no key computed) group last regardless
+    // of direction (see contract on this function).
+    const keyA = metaA?.sortKey ?? null;
+    const keyB = metaB?.sortKey ?? null;
+    if ((keyA === null) !== (keyB === null)) {
+      return keyA === null ? 1 : -1;
     }
-
-    const keyA = metaA?.sortKey ?? 0;
-    const keyB = metaB?.sortKey ?? 0;
-    const cmp =
-      typeof keyA === "number" && typeof keyB === "number"
-        ? keyA - keyB
-        : String(keyA).localeCompare(String(keyB));
-    if (cmp !== 0) {
-      return cmp * directionFactor;
+    if (keyA !== null && keyB !== null) {
+      const cmp =
+        typeof keyA === "number" && typeof keyB === "number"
+          ? keyA - keyB
+          : String(keyA).localeCompare(String(keyB));
+      if (cmp !== 0) {
+        return cmp * directionFactor;
+      }
     }
-    // Tiebreak on pool/overage usage, in the same direction as the primary
-    // sort (only populated for orderColumn "seatUsage").
-    const poolUsageA = metaA?.poolUsageTiebreak ?? 0;
-    const poolUsageB = metaB?.poolUsageTiebreak ?? 0;
-    if (poolUsageA !== poolUsageB) {
-      return (poolUsageA - poolUsageB) * directionFactor;
+    const directionalA = metaA?.directionalTiebreak ?? 0;
+    const directionalB = metaB?.directionalTiebreak ?? 0;
+    if (directionalA !== directionalB) {
+      return (directionalA - directionalB) * directionFactor;
     }
-    // Tiebreak on the highest overage limit, always descending
-    const overageLimitA = metaA?.overageLimit ?? 0;
-    const overageLimitB = metaB?.overageLimit ?? 0;
-    if (overageLimitA !== overageLimitB) {
-      return overageLimitB - overageLimitA;
+    const descendingA = metaA?.descendingTiebreak ?? 0;
+    const descendingB = metaB?.descendingTiebreak ?? 0;
+    if (descendingA !== descendingB) {
+      return descendingB - descendingA;
     }
     // Stable, direction-independent tiebreaker so pages don't reshuffle.
     const nameA = (a.fullName() || a.name).toLowerCase();

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1786,18 +1786,6 @@ export async function resolveMatchingMemberUserIds({
  * orders (consumed credits from the analytics index, never from the Metronome per-user usage
  * cache), so the order shown always agrees with the values displayed.
  */
-/**
- * @cc [owner:avervaet,label:product] incomparable-rows-sort-last
- * Users whose sort key for `orderColumn` is not comparable (a `null` `percent` for
- * `"seatUsage"`, or no computed key at all) always sort after every comparable user, regardless
- * of `orderDirection`; within each group, users order by key then tiebreaks, following
- * `orderDirection`.
- */
-/**
- * @cc [owner:avervaet,label:product] seat-usage-tiebreak-on-pool
- * When `orderColumn` is `"seatUsage"`, users tied on `percent` (including all incomparable users)
- * order by `consumedFromPoolAwuCredits`, following `orderDirection`.
- */
 async function resolveMembersUsagePageUsers({
   auth,
   workspace,

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -103,6 +103,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { ONE_DAY_MS } from "@app/types/shared/utils/date_utils";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isNumber } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { estypes } from "@elastic/elasticsearch";
 import { z } from "zod";
@@ -1812,7 +1813,7 @@ export function makeMembersUsageComparator({
     }
     if (keyA !== null && keyB !== null) {
       const cmp =
-        typeof keyA === "number" && typeof keyB === "number"
+        isNumber(keyA) && isNumber(keyB)
           ? keyA - keyB
           : String(keyA).localeCompare(String(keyB));
       if (cmp !== 0) {
@@ -1926,6 +1927,7 @@ async function resolveMembersUsagePageUsers({
       const [
         consumedByUserId,
         { defaultCapAwuCreditsBySeatType, seatAllowanceBySeatType },
+        seatDataByUserId,
         freeSeatCredits,
       ] = await Promise.all([
         fetchConsumedAwuCreditsByUserId({
@@ -1940,6 +1942,10 @@ async function resolveMembersUsagePageUsers({
           defaultPoolCapAwuCredits:
             creditUsageConfig?.defaultPoolCapAwuCredits ?? 0,
           includeAlertLinks: false,
+        }),
+        fetchSeatDataForMembersTable({
+          metronomeCustomerId: workspace.metronomeCustomerId,
+          metronomeContractId: auth.subscription()?.metronomeContractId ?? null,
         }),
         freeSeatUserIds.length > 0
           ? fetchFreeSeatCreditsForMembersTable({
@@ -1968,7 +1974,10 @@ async function resolveMembersUsagePageUsers({
           seatType === "free"
             ? (freeStartingByUserId.get(u.sId) ?? null)
             : null;
-        const effectiveAllocationAwu = freeStartingBalanceAwu ?? seatAllowance;
+        // Same per-user allocation the response builder splits on, so the
+        // in-app sort key agrees with the pool figure it renders.
+        const awuAllocation = seatDataByUserId.get(u.sId)?.awuAllocation ?? 0;
+        const effectiveAllocationAwu = freeStartingBalanceAwu ?? awuAllocation;
         const { consumedFromPoolAwuCredits } = splitConsumedAwuCredits({
           totalConsumedAwuCredits: totalConsumed,
           allowanceAwuCredits: effectiveAllocationAwu,

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -9,6 +9,10 @@ import {
   makeSpendLimitCycleWindowBounds,
   makeSpendLimitLifetimeWindowBounds,
 } from "@app/lib/api/assistant/rate_limits";
+import {
+  computeSeatUsage,
+  splitConsumedAwuCredits,
+} from "@app/lib/api/credits/seat_usage";
 import { computeCreditUsageStatus } from "@app/lib/api/credits/usage_status";
 import {
   bucketsToArray,
@@ -1510,12 +1514,11 @@ export async function getMemberUsage({
   }
   const effectiveAllocationAwu = freeSeatAllowanceAwu ?? awuAllocation;
 
-  const consumedFromAllowanceAwuCredits = Math.min(
-    totalConsumedCredits,
-    effectiveAllocationAwu
-  );
-  const consumedFromPoolAwuCredits =
-    totalConsumedCredits - consumedFromAllowanceAwuCredits;
+  const { consumedFromAllowanceAwuCredits, consumedFromPoolAwuCredits } =
+    splitConsumedAwuCredits({
+      totalConsumedAwuCredits: totalConsumedCredits,
+      allowanceAwuCredits: effectiveAllocationAwu,
+    });
 
   const normalizedSeatType = normalizeToPoolLimitSeatType(membership.seatType);
   const defaultAwuCredits = normalizedSeatType
@@ -1785,10 +1788,11 @@ export async function resolveMatchingMemberUserIds({
  */
 /**
  * @cc [owner:avervaet,label:product] seat-usage-order-excludes-non-seat-based
- * When `orderColumn` is `"seatUsage"`, users on a seat type without a personal usage percentage
- * (`workspace`/`workspace_yearly`/no seat) always sort after users on `free`/`pro`/`max`,
- * regardless of `orderDirection`. Within each group, ordering follows seat usage percentage, then
- * pool/overage consumption as a tiebreaker, both in `orderDirection`.
+ * When `orderColumn` is `"seatUsage"`, users without a personal usage percentage (no positive
+ * allowance: `workspace`/`workspace_yearly`/no seat) always sort after users with one
+ * (`free`/`pro`/`max`), regardless of `orderDirection`. Users with a percentage order by it, then
+ * by pool/overage consumption; users without one order by pool/overage consumption only. Both
+ * follow `orderDirection`.
  */
 async function resolveMembersUsagePageUsers({
   auth,
@@ -1923,10 +1927,10 @@ async function resolveMembersUsagePageUsers({
             ? (freeStartingByUserId.get(u.sId) ?? null)
             : null;
         const effectiveAllocationAwu = freeStartingBalanceAwu ?? seatAllowance;
-        const consumedFromPoolAwuCredits = Math.max(
-          0,
-          totalConsumed - effectiveAllocationAwu
-        );
+        const { consumedFromPoolAwuCredits } = splitConsumedAwuCredits({
+          totalConsumedAwuCredits: totalConsumed,
+          allowanceAwuCredits: effectiveAllocationAwu,
+        });
         const overrideAwuCredits =
           membership?.poolCapOverrideAwuCredits !== null &&
           membership?.poolCapOverrideAwuCredits !== undefined &&
@@ -2006,31 +2010,27 @@ async function resolveMembersUsagePageUsers({
             ? (freeStartingByUserId.get(u.sId) ?? null)
             : null;
         const effectiveAllocationAwu = freeStartingBalanceAwu ?? awuAllocation;
-        const consumed =
-          seatType === "free"
-            ? Math.max(
-                0,
-                effectiveAllocationAwu - (freeBalanceByUserId.get(u.sId) ?? 0)
-              )
-            : Math.min(
-                consumedByUserId.get(u.sId) ?? 0,
-                effectiveAllocationAwu
-              );
+        // Same inputs the response builder emits for this row, so the sort
+        // ranks exactly what the column renders.
+        const { consumedFromAllowanceAwuCredits, consumedFromPoolAwuCredits } =
+          splitConsumedAwuCredits({
+            totalConsumedAwuCredits: consumedByUserId.get(u.sId) ?? 0,
+            allowanceAwuCredits: effectiveAllocationAwu,
+          });
+        const { percent, hasPercent } = computeSeatUsage({
+          seatType,
+          memberUsageLimit:
+            effectiveAllocationAwu > 0 ? effectiveAllocationAwu : null,
+          seatBalanceAwu:
+            seatType === "free"
+              ? (freeBalanceByUserId.get(u.sId) ?? null)
+              : null,
+          consumedFromAllowanceAwuCredits,
+        });
         sortMetaByUserId.set(u.sId, {
-          sortKey:
-            effectiveAllocationAwu > 0
-              ? Math.min(100, (consumed / effectiveAllocationAwu) * 100)
-              : consumed > 0
-                ? 100
-                : 0,
-          // Mirrors the "--" condition in the seat-usage column: workspace/none
-          // seats have no personal allowance, so their percentage isn't
-          // comparable to free/pro/max seats and must never rank above them.
-          hasSeatUsagePercent: effectiveAllocationAwu > 0,
-          poolUsageTiebreak: Math.max(
-            0,
-            (consumedByUserId.get(u.sId) ?? 0) - effectiveAllocationAwu
-          ),
+          sortKey: percent,
+          hasSeatUsagePercent: hasPercent,
+          poolUsageTiebreak: consumedFromPoolAwuCredits,
         });
       }
       break;
@@ -2071,9 +2071,8 @@ async function resolveMembersUsagePageUsers({
     const metaA = sortMetaByUserId.get(a.sId);
     const metaB = sortMetaByUserId.get(b.sId);
 
-    // Seats with a personal usage percentage (free/pro/max) always rank
-    // above workspace/none seats, regardless of sort direction: the latter
-    // have no comparable percentage and render "--" in the column.
+    // Rows without a comparable percentage group last regardless of
+    // direction (see contract on this function).
     const hasPercentA = metaA?.hasSeatUsagePercent ?? true;
     const hasPercentB = metaB?.hasSeatUsagePercent ?? true;
     if (hasPercentA !== hasPercentB) {
@@ -2480,15 +2479,12 @@ export async function getMembersUsage({
         : null;
     const effectiveAllocationAwu = freeStartingBalanceAwu ?? awuAllocation;
 
-    // Credits drain seat-allowance-first, then the workspace pool, so the
-    // allowance covers up to the user's seat allocation and the remainder
-    // overflows to the pool.
-    const consumedFromAllowanceAwuCredits = Math.min(
-      totalConsumedCredits,
-      effectiveAllocationAwu
-    );
-    const consumedFromPoolAwuCredits =
-      totalConsumedCredits - consumedFromAllowanceAwuCredits;
+    // Credits drain seat-allowance-first, then the workspace pool.
+    const { consumedFromAllowanceAwuCredits, consumedFromPoolAwuCredits } =
+      splitConsumedAwuCredits({
+        totalConsumedAwuCredits: totalConsumedCredits,
+        allowanceAwuCredits: effectiveAllocationAwu,
+      });
 
     // Resolve the default cap for this member's seat type, and the user's
     // override if any. Both thresholds are derived from pool-only DB values

--- a/front/lib/api/credits/seat_usage.test.ts
+++ b/front/lib/api/credits/seat_usage.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import { computeSeatUsage, splitConsumedAwuCredits } from "./seat_usage";
+
+describe("splitConsumedAwuCredits", () => {
+  it.each([
+    { total: 0, allowance: 100, fromAllowance: 0, fromPool: 0 },
+    { total: 60, allowance: 100, fromAllowance: 60, fromPool: 0 },
+    { total: 100, allowance: 100, fromAllowance: 100, fromPool: 0 },
+    { total: 150, allowance: 100, fromAllowance: 100, fromPool: 50 },
+    { total: 150, allowance: 0, fromAllowance: 0, fromPool: 150 },
+    { total: 150, allowance: -10, fromAllowance: 0, fromPool: 150 },
+  ])("splits $total against allowance $allowance", ({
+    total,
+    allowance,
+    fromAllowance,
+    fromPool,
+  }) => {
+    const split = splitConsumedAwuCredits({
+      totalConsumedAwuCredits: total,
+      allowanceAwuCredits: allowance,
+    });
+    expect(split).toEqual({
+      consumedFromAllowanceAwuCredits: fromAllowance,
+      consumedFromPoolAwuCredits: fromPool,
+    });
+    expect(
+      split.consumedFromAllowanceAwuCredits + split.consumedFromPoolAwuCredits
+    ).toBe(total);
+  });
+});
+
+describe("computeSeatUsage", () => {
+  it("derives the percent from allowance consumption for paid seats", () => {
+    expect(
+      computeSeatUsage({
+        seatType: "pro",
+        memberUsageLimit: 200,
+        seatBalanceAwu: null,
+        consumedFromAllowanceAwuCredits: 50,
+      })
+    ).toEqual({ percent: 25, consumed: 50, allowance: 200 });
+  });
+
+  it("caps the percent at 100", () => {
+    expect(
+      computeSeatUsage({
+        seatType: "max",
+        memberUsageLimit: 100,
+        seatBalanceAwu: null,
+        consumedFromAllowanceAwuCredits: 250,
+      }).percent
+    ).toBe(100);
+  });
+
+  it("derives free-seat consumption from the live balance when known", () => {
+    expect(
+      computeSeatUsage({
+        seatType: "free",
+        memberUsageLimit: 100,
+        seatBalanceAwu: 30,
+        consumedFromAllowanceAwuCredits: 5,
+      })
+    ).toEqual({ percent: 70, consumed: 70, allowance: 100 });
+  });
+
+  it("floors free-seat consumption at 0 when the balance exceeds the limit", () => {
+    expect(
+      computeSeatUsage({
+        seatType: "free",
+        memberUsageLimit: 100,
+        seatBalanceAwu: 120,
+        consumedFromAllowanceAwuCredits: 5,
+      }).consumed
+    ).toBe(0);
+  });
+
+  it("falls back to allowance consumption for a free seat with unknown balance", () => {
+    expect(
+      computeSeatUsage({
+        seatType: "free",
+        memberUsageLimit: 100,
+        seatBalanceAwu: null,
+        consumedFromAllowanceAwuCredits: 40,
+      })
+    ).toEqual({ percent: 40, consumed: 40, allowance: 100 });
+  });
+
+  it("ignores the balance for non-free seats", () => {
+    expect(
+      computeSeatUsage({
+        seatType: "pro",
+        memberUsageLimit: 100,
+        seatBalanceAwu: 10,
+        consumedFromAllowanceAwuCredits: 40,
+      }).consumed
+    ).toBe(40);
+  });
+
+  it.each([
+    { seatType: "workspace" as const, memberUsageLimit: null },
+    { seatType: "workspace" as const, memberUsageLimit: 0 },
+    { seatType: "pro" as const, memberUsageLimit: 0 },
+    { seatType: "pro" as const, memberUsageLimit: null },
+    { seatType: null, memberUsageLimit: 100 },
+    { seatType: "none" as const, memberUsageLimit: 100 },
+  ])("returns a null percent for seatType=$seatType limit=$memberUsageLimit", ({
+    seatType,
+    memberUsageLimit,
+  }) => {
+    const usage = computeSeatUsage({
+      seatType,
+      memberUsageLimit,
+      seatBalanceAwu: null,
+      consumedFromAllowanceAwuCredits: 10,
+    });
+    expect(usage.percent).toBeNull();
+    expect(usage.consumed).toBe(10);
+  });
+});

--- a/front/lib/api/credits/seat_usage.test.ts
+++ b/front/lib/api/credits/seat_usage.test.ts
@@ -39,7 +39,12 @@ describe("computeSeatUsage", () => {
         seatBalanceAwu: null,
         consumedFromAllowanceAwuCredits: 50,
       })
-    ).toEqual({ percent: 25, consumed: 50, allowance: 200 });
+    ).toEqual({
+      percent: 25,
+      consumed: 50,
+      allowance: 200,
+      isFreeWithBalance: false,
+    });
   });
 
   it("caps the percent at 100", () => {
@@ -61,7 +66,12 @@ describe("computeSeatUsage", () => {
         seatBalanceAwu: 30,
         consumedFromAllowanceAwuCredits: 5,
       })
-    ).toEqual({ percent: 70, consumed: 70, allowance: 100 });
+    ).toEqual({
+      percent: 70,
+      consumed: 70,
+      allowance: 100,
+      isFreeWithBalance: true,
+    });
   });
 
   it("floors free-seat consumption at 0 when the balance exceeds the limit", () => {
@@ -83,7 +93,12 @@ describe("computeSeatUsage", () => {
         seatBalanceAwu: null,
         consumedFromAllowanceAwuCredits: 40,
       })
-    ).toEqual({ percent: 40, consumed: 40, allowance: 100 });
+    ).toEqual({
+      percent: 40,
+      consumed: 40,
+      allowance: 100,
+      isFreeWithBalance: false,
+    });
   });
 
   it("ignores the balance for non-free seats", () => {
@@ -100,6 +115,8 @@ describe("computeSeatUsage", () => {
   it.each([
     { seatType: "workspace" as const, memberUsageLimit: null },
     { seatType: "workspace" as const, memberUsageLimit: 0 },
+    { seatType: "workspace" as const, memberUsageLimit: 100 },
+    { seatType: "workspace_yearly" as const, memberUsageLimit: 100 },
     { seatType: "pro" as const, memberUsageLimit: 0 },
     { seatType: "pro" as const, memberUsageLimit: null },
     { seatType: null, memberUsageLimit: 100 },

--- a/front/lib/api/credits/seat_usage.test.ts
+++ b/front/lib/api/credits/seat_usage.test.ts
@@ -134,4 +134,30 @@ describe("computeSeatUsage", () => {
     expect(usage.percent).toBeNull();
     expect(usage.consumed).toBe(10);
   });
+
+  it("returns a null percent instead of throwing for a seat type the client doesn't recognize", () => {
+    const usage = computeSeatUsage({
+      // A seat type the API added after this bundle was built.
+      seatType: "enterprise" as unknown as Parameters<
+        typeof computeSeatUsage
+      >[0]["seatType"],
+      memberUsageLimit: 100,
+      seatBalanceAwu: null,
+      consumedFromAllowanceAwuCredits: 10,
+    });
+    expect(usage.percent).toBeNull();
+    expect(usage.consumed).toBe(10);
+  });
+
+  it("does not treat a NaN balance as a known value for free seats", () => {
+    const usage = computeSeatUsage({
+      seatType: "free",
+      memberUsageLimit: 100,
+      seatBalanceAwu: NaN,
+      consumedFromAllowanceAwuCredits: 40,
+    });
+    expect(usage.isFreeWithBalance).toBe(false);
+    expect(usage.consumed).toBe(40);
+    expect(usage.percent).toBe(40);
+  });
 });

--- a/front/lib/api/credits/seat_usage.ts
+++ b/front/lib/api/credits/seat_usage.ts
@@ -1,14 +1,12 @@
 import type { MembershipSeatType } from "@app/types/memberships";
+import { isSeatBased } from "@app/types/memberships";
 
 // Pure seat-usage arithmetic. Every place that derives a seat percentage or an
 // allowance/pool split must go through here so the numbers never drift apart.
 
-/**
- * @cc [owner:avervaet,label:product] allowance-first-split
- * `consumedFromAllowanceAwuCredits` is `totalConsumedAwuCredits` capped at
- * `allowanceAwuCredits` (floored at 0), and `consumedFromPoolAwuCredits` is the remainder, so the
- * two always sum to `totalConsumedAwuCredits`.
- */
+// Credits drain seat-allowance-first, then the workspace pool: the allowance
+// share is the total capped at the allowance and the pool share is the rest,
+// so the two always sum back to the total.
 export function splitConsumedAwuCredits({
   totalConsumedAwuCredits,
   allowanceAwuCredits,
@@ -30,17 +28,13 @@ export function splitConsumedAwuCredits({
   };
 }
 
-/**
- * @cc [owner:avervaet,label:product] free-seat-balance-fallback
- * For a `free` seat, `consumed` is `memberUsageLimit - seatBalanceAwu` (floored at 0) only when
- * both are numbers; when either is `null` (balance unknown) it falls back to
- * `consumedFromAllowanceAwuCredits` and must never be treated as fully consumed.
- */
-/**
- * @cc [owner:avervaet,label:product] percent-requires-seat-and-allowance
- * `percent` is a number in `[0, 100]` iff `seatType` is a real seat (not `null`, not `"none"`) and
- * `memberUsageLimit` is positive; otherwise it is `null` and callers must not rank or render it.
- */
+// Free seats hold a lifetime grant, so their consumption is derived from the
+// live balance when it is known. An unknown balance falls back to the period
+// allowance spend rather than being treated as fully consumed.
+//
+// `percent` is only defined for seat types that carry a personal allocation
+// and only when that allocation is positive; otherwise it is `null` and there
+// is nothing to render or rank.
 export function computeSeatUsage({
   seatType,
   memberUsageLimit,
@@ -55,6 +49,7 @@ export function computeSeatUsage({
   percent: number | null;
   consumed: number;
   allowance: number;
+  isFreeWithBalance: boolean;
 } {
   const allowance = memberUsageLimit ?? 0;
   const isFreeWithBalance =
@@ -64,13 +59,13 @@ export function computeSeatUsage({
   const consumed = isFreeWithBalance
     ? Math.max(0, memberUsageLimit - seatBalanceAwu)
     : consumedFromAllowanceAwuCredits;
-  const hasSeat = seatType !== null && seatType !== "none";
   return {
     percent:
-      hasSeat && allowance > 0
+      isSeatBased(seatType) && allowance > 0
         ? Math.min(100, (consumed / allowance) * 100)
         : null,
     consumed,
     allowance,
+    isFreeWithBalance,
   };
 }

--- a/front/lib/api/credits/seat_usage.ts
+++ b/front/lib/api/credits/seat_usage.ts
@@ -1,5 +1,6 @@
 import type { MembershipSeatType } from "@app/types/memberships";
-import { isSeatBased } from "@app/types/memberships";
+import { isMembershipSeatType, isSeatBased } from "@app/types/memberships";
+import { isNumber } from "@app/types/shared/utils/general";
 
 // Pure seat-usage arithmetic. Every place that derives a seat percentage or an
 // allowance/pool split must go through here so the numbers never drift apart.
@@ -54,14 +55,18 @@ export function computeSeatUsage({
   const allowance = memberUsageLimit ?? 0;
   const isFreeWithBalance =
     seatType === "free" &&
-    typeof seatBalanceAwu === "number" &&
-    typeof memberUsageLimit === "number";
+    isNumber(seatBalanceAwu) &&
+    isNumber(memberUsageLimit);
   const consumed = isFreeWithBalance
     ? Math.max(0, memberUsageLimit - seatBalanceAwu)
     : consumedFromAllowanceAwuCredits;
+  // Reached from client-side rendering with seat types sourced from the API,
+  // so a value the client bundle doesn't recognize yet (the server started
+  // emitting a new seat type before the client redeployed) must degrade to
+  // "no percentage" instead of crashing the render.
   return {
     percent:
-      isSeatBased(seatType) && allowance > 0
+      isMembershipSeatType(seatType) && isSeatBased(seatType) && allowance > 0
         ? Math.min(100, (consumed / allowance) * 100)
         : null,
     consumed,

--- a/front/lib/api/credits/seat_usage.ts
+++ b/front/lib/api/credits/seat_usage.ts
@@ -1,7 +1,7 @@
 import type { MembershipSeatType } from "@app/types/memberships";
 
-// Pure seat-usage arithmetic shared by the members usage response builders,
-// their server-side sort, and the client table so the three never drift apart.
+// Pure seat-usage arithmetic. Every place that derives a seat percentage or an
+// allowance/pool split must go through here so the numbers never drift apart.
 
 /**
  * @cc [owner:avervaet,label:product] allowance-first-split
@@ -37,9 +37,9 @@ export function splitConsumedAwuCredits({
  * `consumedFromAllowanceAwuCredits` and must never be treated as fully consumed.
  */
 /**
- * @cc [owner:avervaet,label:product] has-percent-requires-allowance
- * `hasPercent` is true iff `seatType` is non-null and `memberUsageLimit` is a positive number;
- * when false, `percent` is not comparable to other rows and callers must not rank on it.
+ * @cc [owner:avervaet,label:product] percent-requires-seat-and-allowance
+ * `percent` is a number in `[0, 100]` iff `seatType` is a real seat (not `null`, not `"none"`) and
+ * `memberUsageLimit` is positive; otherwise it is `null` and callers must not rank or render it.
  */
 export function computeSeatUsage({
   seatType,
@@ -52,9 +52,7 @@ export function computeSeatUsage({
   seatBalanceAwu: number | null;
   consumedFromAllowanceAwuCredits: number;
 }): {
-  percent: number;
-  hasPercent: boolean;
-  isOverAllowance: boolean;
+  percent: number | null;
   consumed: number;
   allowance: number;
 } {
@@ -66,19 +64,12 @@ export function computeSeatUsage({
   const consumed = isFreeWithBalance
     ? Math.max(0, memberUsageLimit - seatBalanceAwu)
     : consumedFromAllowanceAwuCredits;
-  if (allowance <= 0) {
-    return {
-      percent: consumed > 0 ? 100 : 0,
-      hasPercent: false,
-      isOverAllowance: consumed > 0,
-      consumed,
-      allowance,
-    };
-  }
+  const hasSeat = seatType !== null && seatType !== "none";
   return {
-    percent: Math.min(100, (consumed / allowance) * 100),
-    hasPercent: seatType !== null,
-    isOverAllowance: consumed > allowance,
+    percent:
+      hasSeat && allowance > 0
+        ? Math.min(100, (consumed / allowance) * 100)
+        : null,
     consumed,
     allowance,
   };

--- a/front/lib/api/credits/seat_usage.ts
+++ b/front/lib/api/credits/seat_usage.ts
@@ -1,0 +1,85 @@
+import type { MembershipSeatType } from "@app/types/memberships";
+
+// Pure seat-usage arithmetic shared by the members usage response builders,
+// their server-side sort, and the client table so the three never drift apart.
+
+/**
+ * @cc [owner:avervaet,label:product] allowance-first-split
+ * `consumedFromAllowanceAwuCredits` is `totalConsumedAwuCredits` capped at
+ * `allowanceAwuCredits` (floored at 0), and `consumedFromPoolAwuCredits` is the remainder, so the
+ * two always sum to `totalConsumedAwuCredits`.
+ */
+export function splitConsumedAwuCredits({
+  totalConsumedAwuCredits,
+  allowanceAwuCredits,
+}: {
+  totalConsumedAwuCredits: number;
+  allowanceAwuCredits: number;
+}): {
+  consumedFromAllowanceAwuCredits: number;
+  consumedFromPoolAwuCredits: number;
+} {
+  const consumedFromAllowanceAwuCredits = Math.min(
+    totalConsumedAwuCredits,
+    Math.max(0, allowanceAwuCredits)
+  );
+  return {
+    consumedFromAllowanceAwuCredits,
+    consumedFromPoolAwuCredits:
+      totalConsumedAwuCredits - consumedFromAllowanceAwuCredits,
+  };
+}
+
+/**
+ * @cc [owner:avervaet,label:product] free-seat-balance-fallback
+ * For a `free` seat, `consumed` is `memberUsageLimit - seatBalanceAwu` (floored at 0) only when
+ * both are numbers; when either is `null` (balance unknown) it falls back to
+ * `consumedFromAllowanceAwuCredits` and must never be treated as fully consumed.
+ */
+/**
+ * @cc [owner:avervaet,label:product] has-percent-requires-allowance
+ * `hasPercent` is true iff `seatType` is non-null and `memberUsageLimit` is a positive number;
+ * when false, `percent` is not comparable to other rows and callers must not rank on it.
+ */
+export function computeSeatUsage({
+  seatType,
+  memberUsageLimit,
+  seatBalanceAwu,
+  consumedFromAllowanceAwuCredits,
+}: {
+  seatType: MembershipSeatType | null;
+  memberUsageLimit: number | null;
+  seatBalanceAwu: number | null;
+  consumedFromAllowanceAwuCredits: number;
+}): {
+  percent: number;
+  hasPercent: boolean;
+  isOverAllowance: boolean;
+  consumed: number;
+  allowance: number;
+} {
+  const allowance = memberUsageLimit ?? 0;
+  const isFreeWithBalance =
+    seatType === "free" &&
+    typeof seatBalanceAwu === "number" &&
+    typeof memberUsageLimit === "number";
+  const consumed = isFreeWithBalance
+    ? Math.max(0, memberUsageLimit - seatBalanceAwu)
+    : consumedFromAllowanceAwuCredits;
+  if (allowance <= 0) {
+    return {
+      percent: consumed > 0 ? 100 : 0,
+      hasPercent: false,
+      isOverAllowance: consumed > 0,
+      consumed,
+      allowance,
+    };
+  }
+  return {
+    percent: Math.min(100, (consumed / allowance) * 100),
+    hasPercent: seatType !== null,
+    isOverAllowance: consumed > allowance,
+    consumed,
+    allowance,
+  };
+}

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -461,7 +461,8 @@ export function useMembersUsage({
     | "name"
     | "email"
     | "consumedAwuCredits"
-    | "consumedFromPoolAwuCredits";
+    | "consumedFromPoolAwuCredits"
+    | "seatUsage";
   orderDirection?: "asc" | "desc";
   seatType?: MembershipSeatType | "none";
   groupId?: string;


### PR DESCRIPTION
## Description

Seats without a personal usage percentage (workspace/none seat types) no longer outrank free/pro/max seats when sorting by seat usage, and the customer usage page now forwards `seatUsage` clicks to the server instead of silently falling back to sorting by name.

Extracted the seat-usage arithmetic (`computeSeatUsage`, `splitConsumedAwuCredits`) into a shared `front/lib/api/credits/seat_usage.ts` module, used by the response builders, the server-side sort, and the client table, so the three can't drift apart. The server-side sort by `seatUsage` now reuses the exact same inputs the response builder emits for each row, tiebreaks on pool/overage consumption before overage limit, and groups rows without a comparable percentage last regardless of sort direction.

## Tests

tested on front-edge

## Risk

Low

## Deploy Plan

Deploy front
