### PR TITLE
[front] enh: support redacted admin skill search

### DIFF
--- a/design_docs/SKILL_SEARCH_DESIGN.md
+++ b/design_docs/SKILL_SEARCH_DESIGN.md
@@ -1,0 +1,159 @@
+# Elasticsearch-backed skill search
+
+**Status:** PoC findings and recommended production direction. This note separates the invariants
+production must preserve from the hypotheses that still need validation.
+
+## Problem
+
+The slash menu currently loads every active custom skill before searching. The PoC tests whether
+Elasticsearch can recall a small, permission-aware candidate set without making search depend on a
+caller's complete pod membership set.
+
+PostgreSQL remains the source of truth. Elasticsearch stores a derived projection of committed
+skills, and every result is checked against current PostgreSQL state before it is returned.
+
+## Production invariants
+
+| Invariant                                                   | Enforcement                                                                                                                                                                                                                        |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Tenant isolation                                            | Every ES read and workspace-wide delete filters `workspace_id`. Document IDs and bodies include the workspace. Canonical reads, rebuilds, and relocation are workspace-scoped.                                                     |
+| PostgreSQL and current authorization remain authoritative   | ES applies permission-aware candidate filters. Candidate pods and editors-only hits are checked with the current authenticator, then every permission-bearing indexed field is compared with a fresh DB projection.                |
+| Stale ES state never expands access                         | A missing, inactive, malformed, or permission-mismatched projection drops the hit. Stale restrictive state may temporarily hide a valid skill.                                                                                     |
+| Every requested space is readable                           | `terms_set` and `non_pod_space_count` enforce all non-pods. The one optional pod must exist, still be a project, and pass the current space ACL. Documents with more than one pod are rejected.                                    |
+| Editors-only visibility matches the skill ACL               | For user requests, ES requires either a published availability or `editor_user_ids` to contain `auth.user().id`. A zero-query application check confirms the current `write` grant. API keys keep their existing bypass.           |
+| Authorization precedes the result limit                     | One bounded ES request is followed by current authorization and canonical validation. Slicing happens last.                                                                                                                        |
+| Search never enumerates caller-wide pods                    | Only distinct pod IDs present in the bounded candidate window are fetched. This also preserves access through open pods.                                                                                                           |
+| Index state must converge to the latest valid DB projection | Idempotent workflows rehydrate current state. Backfill repairs active documents, and relocation rebuilds moved workspaces. Not fully enforced: without a transactional outbox or orphan reconciliation, a lost launch can persist. |
+| Command-menu composition remains client-owned               | Code-defined skills and tools stay outside ES. The client keeps the final cross-kind ranking. Favorites are intentionally out of scope.                                                                                            |
+
+Normal request-snapshot and authenticator freshness limits still apply. Elasticsearch must not
+become a second source of permission truth.
+
+## Hypotheses to validate
+
+| Hypothesis                                                                            | Why it matters                                                                                                                                           | Validation                                                                                    |
+| ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Readable non-pod sets and per-skill non-pod requirements remain reasonably small.     | Readable non-pod IDs are sent to `terms_set`; canonical validation loads the candidates' requested spaces.                                               | Measure p50, p95, and max counts, payload size, rows, and latency by workspace size.          |
+| A 200-hit candidate window provides acceptable authorized top-K recall.               | Pod-inaccessible and stale candidates can crowd out later valid hits. Editors-only skills are filtered in ES and should not normally consume the window. | Shadow the previous full-list result and track rejection, underfill, and no-result rates.     |
+| Subsequence wildcard recall is relevant and affordable at production scale.           | `size: 200` limits returned hits, not ES query evaluation work.                                                                                          | Run relevance fixtures and load tests across index size, concurrency, and query length.       |
+| One ES request plus bounded, batched DB validation meets interactive latency targets. | The path still reads current spaces, candidate pods, skills, requested spaces, and editor grants.                                                        | Trace p50, p95, and p99 latency, query count, and rows read.                                  |
+| Eventual visibility and temporary false negatives fit an explicit UX SLO.             | Temporal scheduling and ES refresh delay newly changed skills.                                                                                           | Measure mutation-to-visible lag, stale age, and user-visible misses.                          |
+| Caller-owned indexation plus repair keeps drift within an explicit repair SLO.        | There is no outbox or DB fallback; a lost or omitted workflow launch can persist.                                                                        | Compare mutations with accepted workflows and measure missing, stale, and orphan repair time. |
+| Editor lists remain bounded enough to store on one skill document.                    | Editor IDs are intentionally denormalized to make editors-only filtering part of the ES query.                                                           | Measure editor counts and document size, and define a supported upper bound.                  |
+
+If a hypothesis fails, we should change the mechanism or add durability rather than weaken these
+invariants.
+
+## Index document
+
+The stable alias is `front.skill_search`; the first physical index is `front.skill_search_1`. The
+mapping is strict, and the deterministic document ID is `<workspaceId>_<skillId>`.
+
+| Field                      | Mapping                         | Purpose                                                  |
+| -------------------------- | ------------------------------- | -------------------------------------------------------- |
+| `workspace_id`, `skill_id` | `keyword`                       | Tenant scope, identity, and stable sorting.              |
+| `status`, `availability`   | `keyword`                       | Active-state and publication filters.                    |
+| `name`                     | `text` + `keyword` + `wildcard` | Relevance, alphabetical sort, and subsequence matching.  |
+| `user_facing_description`  | `text` + `wildcard`             | Relevance, subsequence matching, and display.            |
+| `non_pod_space_ids`        | `keyword[]`                     | Required non-pod spaces used by the ES all-of filter.    |
+| `non_pod_space_count`      | `integer`                       | Minimum number of required non-pod matches.              |
+| `editor_user_ids`          | `long[]`                        | Internal user model IDs used by the editors-only filter. |
+| `pod_space_id`             | source-only nullable `keyword`  | The optional pod, authorized after ES.                   |
+| `requested_space_ids`      | source-only `keyword[]`         | Canonical space projection and API response.             |
+| `icon`, `edited_by`        | source-only `keyword` / `long`  | Display fields.                                          |
+| `updated_at`               | source-only `date`              | Diagnostic and migration metadata.                       |
+
+Source-only means `index: false, doc_values: false`.
+
+`name` uses a `word_delimiter_graph` analyzer with the `keyword` tokenizer, original-token
+preservation, concatenation, and lowercasing. A name such as `WeeklyReportBot` is searchable by the
+whole name and its component words.
+
+The DB projector derives two permission projections: it splits requested spaces into non-pods and
+one optional pod, and it resolves the active memberships of the skill's canonical editor-grant
+group into sorted, deduplicated internal user IDs. It rejects duplicate, missing, or
+cross-workspace requested spaces and more than one pod.
+
+Editor IDs deliberately do not depend on current workspace membership. A workspace-membership-only
+revoke or rejoin therefore does not fan out into skill reindexing; an inactive caller cannot
+authenticate into the workspace, and the existing editor grant becomes effective again after a
+rejoin. Flows that physically end or restore editor-group memberships, such as WorkOS
+deprovisioning, do reindex affected skills.
+
+## Query and permission enforcement
+
+Each request follows one bounded path:
+
+1. Derive the caller's readable non-pod space IDs; projects are excluded.
+2. Run one ES query filtered by `workspace_id`, `status: active`, the non-pod all-of predicate, and
+   availability. User requests admit published skills or editors-only skills whose
+   `editor_user_ids` contain the current user's model ID. API keys omit the availability filter to
+   preserve existing behavior.
+3. Fetch only pod IDs appearing in the ES candidates and apply the current space ACL. The pod must
+   still exist and still be a project.
+4. Recheck editors-only candidates with the current authenticator. This uses already-hydrated
+   grants and adds no query.
+5. Rebuild survivors from PostgreSQL and compare all permission-bearing fields before applying the
+   final result limit.
+
+The non-pod predicate is an all-of check. Skills with no non-pod requirement match directly;
+otherwise `terms_set` uses `non_pod_space_count` as `minimum_should_match_field`, proving:
+
+```text
+skill required non-pod spaces ⊆ caller readable non-pod spaces
+```
+
+Text recall combines boosted `bool_prefix` matching with case-insensitive subsequence wildcards on
+name and user-facing description, preserving matches such as `sand` →
+`Search And Navigate Data`. The PoC uses a 50–200 candidate window.
+
+All database work is batched; there is no result-level N+1. The search-specific ES payload and pod
+fetch never enumerate the caller's complete pod set.
+
+## Invalidation and lifecycle
+
+Skill create, update, import, archive, restore, availability, requested-space, and editor mutations
+enqueue per-skill Temporal indexation after the database mutation. Editor membership changes made
+through file import, Poke, user merge, or WorkOS deprovision/rejoin must enqueue every affected
+skill. The activity rehydrates the latest DB projection and indexes it, or deletes the document
+when no active valid projection remains.
+
+Changing an existing space's membership, groups, ACL, or open/restricted state does not reindex
+skills. Non-pod access comes from the caller's current readable-space set, and pod access is checked
+live. Changing which spaces a skill requests does reindex that skill.
+
+Workspace scrub asynchronously enqueues workspace-wide deletion. Backfill pages active skills and
+enqueues the same workflows. Completion requires waiting for the queue and ES refresh, and orphaned
+documents need separate reconciliation. Relocation clears and rebuilds a workspace in its
+destination region, restarting from the beginning on activity retry.
+
+There is no transactional outbox between the DB commit and Temporal acceptance. A lost or omitted
+launch can leave a skill hidden or stale until another mutation or repair. New mutation paths must
+schedule indexation explicitly.
+
+## Alternatives rejected
+
+- Sending every user pod ID to ES: the list is unbounded and omits readable open pods.
+- Denormalizing space viewers or caller ACL documents: membership and ACL churn would create a
+  security-critical fan-out and synchronization problem.
+- Filtering every requested space only after ES: inaccessible non-pod skills would consume the
+  bounded candidate window.
+- A second ES query: it adds a round trip and ordering reconciliation without fixing bounded
+  recall.
+
+The narrow denormalization of per-skill editor IDs is accepted because the list belongs to one
+skill, has explicit mutation paths, and moves editors-only filtering into the first ES request.
+
+## Rollout
+
+Create the final index and alias in every region, deploy writers, backfill every active skill
+including `editor_user_ids`, and wait for workflow completion and ES refresh. Before enabling the
+reader, verify DB-to-ES parity for valid active projections and check for orphaned documents.
+Missing editor IDs fail closed for editors-only skills. The reader has no database fallback.
+
+## Code map
+
+- Canonical projection: `front/lib/resources/skill/skill_search_document_resource.ts`
+- ES mapping, reads, and writes: `front/lib/skill_search/`
+- Lifecycle and repair: `front/temporal/es_indexation/`, `front/scripts/backfill_skill_search.ts`,
+  and `front/temporal/relocation/`

--- a/front-api/routes/v1/w/[wId]/skills/[skillId].ts
+++ b/front-api/routes/v1/w/[wId]/skills/[skillId].ts
@@ -1,5 +1,6 @@
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { isResourceSId } from "@app/lib/resources/string_ids";
+import { launchSkillSearchIndexation } from "@app/lib/skill_search/indexation";
 import type { DeleteSkillResponseBody } from "@app/types/api/skills";
 import { publicApiApp } from "@front-api/middlewares/ctx";
 import { ensureIsBuilder } from "@front-api/middlewares/ensure_role";
@@ -91,7 +92,13 @@ app.delete(
       });
     }
 
-    await skill.archive(auth);
+    const { affectedCount } = await skill.archive(auth);
+    if (affectedCount > 0) {
+      await launchSkillSearchIndexation({
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        skillId: skill.sId,
+      });
+    }
 
     return ctx.json({ success: true });
   }

--- a/front-api/routes/w/[wId]/skills/[sId]/editors.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/editors.test.ts
@@ -1,13 +1,14 @@
 import { Authenticator } from "@app/lib/auth";
 import { GroupPermissions } from "@app/lib/resources/group_permission_registry";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { launchIndexSkillSearchWorkflow } from "@app/temporal/es_indexation/client";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { honoApp } from "@front-api/app";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 async function setup() {
   const { workspace, user, globalSpace } = await createPrivateApiMockRequest({
@@ -40,6 +41,10 @@ function get(workspace: { sId: string }, sId: string) {
 }
 
 describe("PATCH /api/w/:wId/skills/:sId/editors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("refuses to change the editors of an archived skill", async () => {
     const { workspace, auth } = await setup();
 
@@ -90,6 +95,11 @@ describe("PATCH /api/w/:wId/skills/:sId/editors", () => {
     expect(data.editors.map((e: { sId: string }) => e.sId)).toContain(
       builderUser.sId
     );
+    expect(vi.mocked(launchIndexSkillSearchWorkflow)).toHaveBeenCalledOnce();
+    expect(vi.mocked(launchIndexSkillSearchWorkflow)).toHaveBeenCalledWith({
+      workspaceId: workspace.sId,
+      skillId: skill.sId,
+    });
   });
 
   it("allows adding admin as editor", async () => {
@@ -226,6 +236,7 @@ describe("PATCH /api/w/:wId/skills/:sId/editors", () => {
     const editorsResponse = await get(workspace, skill.sId);
     const data = await editorsResponse.json();
     expect(data.editors.map((e: { sId: string }) => e.sId)).toEqual([user.sId]);
+    expect(vi.mocked(launchIndexSkillSearchWorkflow)).not.toHaveBeenCalled();
   });
 
   it("allows adding an editor that is a member of the restricted space", async () => {

--- a/front-api/routes/w/[wId]/skills/[sId]/editors.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/editors.ts
@@ -2,6 +2,7 @@ import { findSkillEditorsWithoutSpaceAccess } from "@app/lib/api/skills/space_re
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { launchSkillSearchIndexation } from "@app/lib/skill_search/indexation";
 import type {
   PatchSkillEditorsRequestBody,
   SkillEditorsResponseBody,
@@ -161,6 +162,12 @@ app.patch(
     // Editors are per-user grants on the skill (`grantToUser`), not group memberships.
     const addRes = await skillRes.addEditors(auth, usersToAddResources);
     if (addRes.isErr()) {
+      if (usersToAddResources.length > 0) {
+        await launchSkillSearchIndexation({
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          skillId: skillRes.sId,
+        });
+      }
       switch (addRes.error.code) {
         case "unauthorized":
           return apiError(ctx, {
@@ -187,6 +194,12 @@ app.patch(
       auth,
       usersToRemoveResources
     );
+    if (usersToAddResources.length > 0 || usersToRemoveResources.length > 0) {
+      await launchSkillSearchIndexation({
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        skillId: skillRes.sId,
+      });
+    }
     if (removeRes.isErr()) {
       switch (removeRes.error.code) {
         case "unauthorized":

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -12,6 +12,7 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { isResourceSId } from "@app/lib/resources/string_ids";
+import { launchSkillSearchIndexation } from "@app/lib/skill_search/indexation";
 import logger from "@app/logger/logger";
 import type {
   DeleteSkillResponseBody,
@@ -494,6 +495,11 @@ app.patch(
       ...(shouldActivate ? { status: "active" as const } : {}),
     });
 
+    await launchSkillSearchIndexation({
+      workspaceId: owner.sId,
+      skillId: skill.sId,
+    });
+
     await pruneOutdatedSkillEditSuggestions(auth, skill);
 
     return ctx.json({ skill: skill.toJSON(auth) });
@@ -544,7 +550,13 @@ app.delete(
       );
     }
 
-    await skill.archive(auth);
+    const { affectedCount } = await skill.archive(auth);
+    if (affectedCount > 0) {
+      await launchSkillSearchIndexation({
+        workspaceId: owner.sId,
+        skillId: skill.sId,
+      });
+    }
 
     return ctx.json({ success: true });
   }

--- a/front-api/routes/w/[wId]/skills/[sId]/restore.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/restore.ts
@@ -1,4 +1,5 @@
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { launchSkillSearchIndexation } from "@app/lib/skill_search/indexation";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -58,7 +59,13 @@ app.post(
       });
     }
 
-    await skillResource.restore(auth);
+    const { affectedCount } = await skillResource.restore(auth);
+    if (affectedCount > 0) {
+      await launchSkillSearchIndexation({
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        skillId: skillResource.sId,
+      });
+    }
 
     return ctx.json({ success: true });
   }

--- a/front-api/routes/w/[wId]/skills/archive.ts
+++ b/front-api/routes/w/[wId]/skills/archive.ts
@@ -1,5 +1,6 @@
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { isResourceSId } from "@app/lib/resources/string_ids";
+import { launchSkillSearchIndexation } from "@app/lib/skill_search/indexation";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -75,7 +76,13 @@ app.post(
     // Archiving a skill updates its dependent agents, parent skills, and editor
     // memberships in one transaction, so preserve that resource-level operation.
     for (const skill of skills) {
-      await skill.archive(auth);
+      const { affectedCount } = await skill.archive(auth);
+      if (affectedCount > 0) {
+        await launchSkillSearchIndexation({
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          skillId: skill.sId,
+        });
+      }
     }
 
     return ctx.json({ archived: skills.length });

--- a/front-api/routes/w/[wId]/skills/availability.ts
+++ b/front-api/routes/w/[wId]/skills/availability.ts
@@ -1,5 +1,6 @@
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { isResourceSId } from "@app/lib/resources/string_ids";
+import { launchSkillsSearchIndexation } from "@app/lib/skill_search/indexation";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import { SKILL_AVAILABILITIES } from "@app/types/assistant/skill_configuration";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -117,7 +118,15 @@ app.patch(
       }
     }
 
+    const changedSkillIds = skills
+      .filter((skill) => skill.availability !== availability)
+      .map((skill) => skill.sId);
+
     await SkillResource.updateAvailabilities(auth, skills, availability);
+    await launchSkillsSearchIndexation({
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      skillIds: changedSkillIds,
+    });
 
     // Re-fetch: the bulk update does not refresh the in-memory resources.
     const updatedSkills = await SkillResource.fetchByIds(auth, skillIds, {

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -37,6 +37,7 @@ import detect from "./detect";
 import importRoute from "./import";
 import reinforcementDailySpend from "./reinforcement_daily_spend";
 import reinforcementSpend from "./reinforcement_spend";
+import search from "./search";
 import similar from "./similar";
 
 const SkillStatusSchema = z
@@ -116,6 +117,7 @@ app.route("/detect", detect);
 app.route("/import", importRoute);
 app.route("/reinforcement_daily_spend", reinforcementDailySpend);
 app.route("/reinforcement_spend", reinforcementSpend);
+app.route("/search", search);
 app.route("/similar", similar);
 
 /** @ignoreswagger */

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -9,6 +9,7 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { launchSkillSearchIndexation } from "@app/lib/skill_search/indexation";
 import logger from "@app/logger/logger";
 import type {
   GetSkillsResponseBody,
@@ -553,6 +554,11 @@ app.post(
         fileAttachments: files,
       }
     );
+
+    await launchSkillSearchIndexation({
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      skillId: newSkill.sId,
+    });
 
     // Update file useCaseMetadata with the newly created skill's sId.
     if (files) {

--- a/front-api/routes/w/[wId]/skills/search.test.ts
+++ b/front-api/routes/w/[wId]/skills/search.test.ts
@@ -1,0 +1,53 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const searchSkillsForCommandMenu = vi.hoisted(() => vi.fn());
+
+vi.mock("@app/lib/api/skills/search", () => ({
+  searchSkillsForCommandMenu,
+}));
+
+describe("GET /api/w/:wId/skills/search", () => {
+  beforeEach(() => {
+    searchSkillsForCommandMenu.mockReset();
+  });
+
+  it("routes the query to the skill command-menu search", async () => {
+    const { workspace } = await createPrivateApiMockRequest();
+    searchSkillsForCommandMenu.mockResolvedValue(
+      new Ok([
+        {
+          editedBy: null,
+          icon: null,
+          name: "Search result",
+          requestedSpaceIds: [],
+          sId: "search-result",
+          userFacingDescription: "Description",
+        },
+      ])
+    );
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/skills/search?query=research`
+    );
+
+    expect(response.status).toBe(200);
+    expect(searchSkillsForCommandMenu).toHaveBeenCalledWith(expect.anything(), {
+      searchTerm: "research",
+    });
+    expect(await response.json()).toEqual({
+      skills: [
+        {
+          editedBy: null,
+          icon: null,
+          name: "Search result",
+          requestedSpaceIds: [],
+          sId: "search-result",
+          userFacingDescription: "Description",
+        },
+      ],
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/skills/search.test.ts
+++ b/front-api/routes/w/[wId]/skills/search.test.ts
@@ -42,6 +42,7 @@ describe("GET /api/w/:wId/skills/search", () => {
       searchTerm: "research",
       limit: undefined,
       cursor: undefined,
+      permissionFiltering: undefined,
     });
     expect(await response.json()).toEqual({
       nextCursor: null,
@@ -72,6 +73,7 @@ describe("GET /api/w/:wId/skills/search", () => {
       searchTerm: "research",
       limit: 10,
       cursor,
+      permissionFiltering: undefined,
     });
     const body = await response.json();
     expect(body).toEqual({ skills: [], nextCursor: cursor });
@@ -82,6 +84,7 @@ describe("GET /api/w/:wId/skills/search", () => {
     "limit=151",
     "limit=1.5",
     "cursor=invalid",
+    "permissionFiltering=dangerously_skip",
   ])("rejects invalid pagination: %s", async (query) => {
     const { workspace } = await createPrivateApiMockRequest();
     const response = await honoApp.request(
@@ -103,5 +106,35 @@ describe("GET /api/w/:wId/skills/search", () => {
     const body = await response.json();
     expect(body.error.type).toBe("invalid_request_error");
     expect(body.error.message).toContain("Restart the search");
+  });
+
+  it("allows admins to opt into redacted search", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
+    searchSkillsForCommandMenu.mockResolvedValue(
+      new Ok({ skills: [], nextCursor: null })
+    );
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/skills/search?permissionFiltering=redact_unreadable`
+    );
+    expect(response.status).toBe(200);
+    expect(searchSkillsForCommandMenu).toHaveBeenCalledWith(expect.anything(), {
+      searchTerm: "",
+      limit: undefined,
+      cursor: undefined,
+      permissionFiltering: "redact_unreadable",
+    });
+  });
+
+  it.each([
+    "user",
+    "builder",
+    "manager",
+  ] as const)("rejects redacted search for a %s before searching", async (role) => {
+    const { workspace } = await createPrivateApiMockRequest({ role });
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/skills/search?permissionFiltering=redact_unreadable`
+    );
+    expect(response.status).toBe(403);
+    expect(searchSkillsForCommandMenu).not.toHaveBeenCalled();
   });
 });

--- a/front-api/routes/w/[wId]/skills/search.test.ts
+++ b/front-api/routes/w/[wId]/skills/search.test.ts
@@ -1,5 +1,6 @@
+import { SkillSearchCursorError } from "@app/lib/skill_search/cursor";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -17,16 +18,19 @@ describe("GET /api/w/:wId/skills/search", () => {
   it("routes the query to the skill command-menu search", async () => {
     const { workspace } = await createPrivateApiMockRequest();
     searchSkillsForCommandMenu.mockResolvedValue(
-      new Ok([
-        {
-          editedBy: null,
-          icon: null,
-          name: "Search result",
-          requestedSpaceIds: [],
-          sId: "search-result",
-          userFacingDescription: "Description",
-        },
-      ])
+      new Ok({
+        skills: [
+          {
+            editedBy: null,
+            icon: null,
+            name: "Search result",
+            requestedSpaceIds: [],
+            sId: "search-result",
+            userFacingDescription: "Description",
+          },
+        ],
+        nextCursor: null,
+      })
     );
 
     const response = await honoApp.request(
@@ -36,8 +40,11 @@ describe("GET /api/w/:wId/skills/search", () => {
     expect(response.status).toBe(200);
     expect(searchSkillsForCommandMenu).toHaveBeenCalledWith(expect.anything(), {
       searchTerm: "research",
+      limit: undefined,
+      cursor: undefined,
     });
     expect(await response.json()).toEqual({
+      nextCursor: null,
       skills: [
         {
           editedBy: null,
@@ -49,5 +56,52 @@ describe("GET /api/w/:wId/skills/search", () => {
         },
       ],
     });
+  });
+
+  it("accepts an optional page size and cursor", async () => {
+    const { workspace } = await createPrivateApiMockRequest();
+    const cursor = "00000000-0000-4000-8000-000000000000";
+    searchSkillsForCommandMenu.mockResolvedValue(
+      new Ok({ skills: [], nextCursor: cursor })
+    );
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/skills/search?query=research&limit=10&cursor=${cursor}`
+    );
+    expect(response.status).toBe(200);
+    expect(searchSkillsForCommandMenu).toHaveBeenCalledWith(expect.anything(), {
+      searchTerm: "research",
+      limit: 10,
+      cursor,
+    });
+    const body = await response.json();
+    expect(body).toEqual({ skills: [], nextCursor: cursor });
+  });
+
+  it.each([
+    "limit=0",
+    "limit=151",
+    "limit=1.5",
+    "cursor=invalid",
+  ])("rejects invalid pagination: %s", async (query) => {
+    const { workspace } = await createPrivateApiMockRequest();
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/skills/search?${query}`
+    );
+    expect(response.status).toBe(400);
+    expect(searchSkillsForCommandMenu).not.toHaveBeenCalled();
+  });
+
+  it("tells the caller to restart an expired or mismatched cursor", async () => {
+    const { workspace } = await createPrivateApiMockRequest();
+    searchSkillsForCommandMenu.mockResolvedValue(
+      new Err(new SkillSearchCursorError())
+    );
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/skills/search?cursor=00000000-0000-4000-8000-000000000000`
+    );
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error.type).toBe("invalid_request_error");
+    expect(body.error.message).toContain("Restart the search");
   });
 });

--- a/front-api/routes/w/[wId]/skills/search.ts
+++ b/front-api/routes/w/[wId]/skills/search.ts
@@ -1,0 +1,49 @@
+import { searchSkillsForCommandMenu } from "@app/lib/api/skills/search";
+import logger from "@app/logger/logger";
+import type { SearchSkillsResponseBody } from "@app/types/api/skills";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const SearchSkillsQuerySchema = z.object({
+  query: z.string().max(200).optional().default(""),
+});
+
+// Mounted at /api/w/:wId/skills/search.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  validate("query", SearchSkillsQuerySchema),
+  async (ctx): HandlerResult<SearchSkillsResponseBody> => {
+    const auth = ctx.get("auth");
+    const { query } = ctx.req.valid("query");
+    const result = await searchSkillsForCommandMenu(auth, {
+      searchTerm: query,
+    });
+
+    if (result.isErr()) {
+      logger.error(
+        {
+          error: result.error,
+          workspaceId: auth.getNonNullableWorkspace().sId,
+        },
+        "Failed to search skills"
+      );
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to search skills",
+        },
+      });
+    }
+
+    return ctx.json({ skills: result.value });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/skills/search.ts
+++ b/front-api/routes/w/[wId]/skills/search.ts
@@ -1,4 +1,6 @@
 import { searchSkillsForCommandMenu } from "@app/lib/api/skills/search";
+import { SkillSearchCursorError } from "@app/lib/skill_search/cursor";
+import { MAX_SKILL_SEARCH_RESULTS } from "@app/lib/skill_search/search";
 import logger from "@app/logger/logger";
 import type { SearchSkillsResponseBody } from "@app/types/api/skills";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -9,23 +11,47 @@ import { z } from "zod";
 
 const SearchSkillsQuerySchema = z.object({
   query: z.string().max(200).optional().default(""),
+  limit: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(MAX_SKILL_SEARCH_RESULTS)
+    .optional(),
+  cursor: z.string().uuid().optional(),
 });
 
 // Mounted at /api/w/:wId/skills/search.
 const app = workspaceApp();
 
-/** @ignoreswagger */
+/**
+ * @ignoreswagger
+ * Optional limit/cursor paginate one ranked stream of custom and code-defined
+ * skills. The response adds nextCursor (null when exhausted) and per-hit score.
+ * Cursors expire after five minutes; an invalid/expired cursor returns 400.
+ * ACL filtering may produce a short or empty page with a continuation cursor.
+ */
 app.get(
   "/",
   validate("query", SearchSkillsQuerySchema),
   async (ctx): HandlerResult<SearchSkillsResponseBody> => {
     const auth = ctx.get("auth");
-    const { query } = ctx.req.valid("query");
+    const { query, limit, cursor } = ctx.req.valid("query");
     const result = await searchSkillsForCommandMenu(auth, {
       searchTerm: query,
+      limit,
+      cursor,
     });
 
     if (result.isErr()) {
+      if (result.error instanceof SkillSearchCursorError) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: result.error.message,
+          },
+        });
+      }
       logger.error(
         {
           error: result.error,
@@ -42,7 +68,7 @@ app.get(
       });
     }
 
-    return ctx.json({ skills: result.value });
+    return ctx.json(result.value);
   }
 );
 

--- a/front-api/routes/w/[wId]/skills/search.ts
+++ b/front-api/routes/w/[wId]/skills/search.ts
@@ -18,6 +18,7 @@ const SearchSkillsQuerySchema = z.object({
     .max(MAX_SKILL_SEARCH_RESULTS)
     .optional(),
   cursor: z.string().uuid().optional(),
+  permissionFiltering: z.enum(["strict", "redact_unreadable"]).optional(),
 });
 
 // Mounted at /api/w/:wId/skills/search.
@@ -29,17 +30,31 @@ const app = workspaceApp();
  * skills. The response adds nextCursor (null when exhausted) and per-hit score.
  * Cursors expire after five minutes; an invalid/expired cursor returns 400.
  * ACL filtering may produce a short or empty page with a continuation cursor.
+ * permissionFiltering defaults to strict. Admins may opt into redact_unreadable:
+ * retains listing metadata with canRead=false for unreadable skills; no private
+ * fields (instructions/tools/files) are returned. Non-admins receive 403.
  */
 app.get(
   "/",
   validate("query", SearchSkillsQuerySchema),
   async (ctx): HandlerResult<SearchSkillsResponseBody> => {
     const auth = ctx.get("auth");
-    const { query, limit, cursor } = ctx.req.valid("query");
+    const { query, limit, cursor, permissionFiltering } =
+      ctx.req.valid("query");
+    if (permissionFiltering === "redact_unreadable" && !auth.isAdmin()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message: "Only admins can search unreadable skills.",
+        },
+      });
+    }
     const result = await searchSkillsForCommandMenu(auth, {
       searchTerm: query,
       limit,
       cursor,
+      permissionFiltering,
     });
 
     if (result.isErr()) {

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
@@ -381,6 +381,61 @@ describe("getToolSlashCommandItem", () => {
 });
 
 describe("buildCapabilitySlashCommandItems", () => {
+  it("preserves server ranking instead of reranking each skill page", () => {
+    const result = buildCapabilitySlashCommandItems({
+      query: "guide",
+      useSearchRanking: true,
+      skills: [
+        {
+          ...skillSuggestion({ name: "Create detailed guide", sId: "a" }),
+          score: 60,
+        },
+        { ...skillSuggestion({ name: "Create guide", sId: "b" }), score: 60 },
+      ],
+      tools: [],
+    });
+    // Same score: ES keyword name order wins, not substring position.
+    expect(result.map((item) => item.id)).toEqual(["a", "b"]);
+  });
+
+  it("merges tools with server-ranked skills using the shared match tiers", () => {
+    const result = buildCapabilitySlashCommandItems({
+      query: "guide",
+      useSearchRanking: true,
+      skills: [
+        {
+          ...skillSuggestion({ name: "Guide builder", sId: "prefix" }),
+          score: 80,
+        },
+        {
+          ...skillSuggestion({ name: "A guide", sId: "substring" }),
+          score: 60,
+          isFavorite: true,
+        },
+      ],
+      tools: [toolSuggestion({ label: "Guide", sId: "tool" })],
+    });
+    expect(result.map((item) => item.id)).toEqual([
+      "tool",
+      "prefix",
+      "substring",
+    ]);
+  });
+
+  it("falls back to shared scoring when talking to an older search server", () => {
+    const result = buildCapabilitySlashCommandItems({
+      query: "Deep Dive",
+      useSearchRanking: true,
+      skills: [
+        skillSuggestion({ name: "Deep Dive Assistant", sId: "custom" }),
+        skillSuggestion({ name: "Go Deep", sId: "go-deep" }),
+        skillSuggestion({ name: "Unrelated", sId: "unrelated" }),
+      ],
+      tools: [],
+    });
+    expect(result.map((item) => item.id)).toEqual(["go-deep", "custom"]);
+  });
+
   it("matches a global skill by its configured search aliases", () => {
     const goDeep = skillSuggestion({
       name: "Go Deep",

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -143,7 +143,7 @@ export type SlashCommandSkillSuggestion = Pick<
   | "requestedSpaceIds"
   | "sId"
   | "userFacingDescription"
->;
+> & { score?: number };
 
 export type SlashCommandToolSuggestion<
   V extends MCPServerViewLightType = MCPServerViewLightType,

--- a/front/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems.ts
@@ -6,13 +6,19 @@ import {
   getSkillSlashCommandItem,
   getToolSlashCommandItem,
   getToolSlashCommandLabel,
+  MAX_RENDERED_CAPABILITY_ITEMS,
   searchCapabilityIndex,
 } from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
 import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
 import { getMcpServerViewDescription } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewLightType } from "@app/lib/api/mcp";
+import {
+  compareRankedSkills,
+  getSkillSearchScore,
+} from "@app/lib/skill_search/ranking";
 import { GLOBAL_SKILL_SEARCH_ALIASES } from "@app/lib/skills/global_search_aliases";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { removeNulls } from "@app/types/shared/utils/general";
 
 export function filterSlashCommandItems(
   items: SlashCommand[],
@@ -41,6 +47,7 @@ export function buildCapabilitySlashCommandItems<
   skills,
   toolFilter,
   tools,
+  useSearchRanking = false,
 }: {
   excludeSkillId?: string | null;
   query: string;
@@ -48,41 +55,71 @@ export function buildCapabilitySlashCommandItems<
   skills: SlashCommandSkillSuggestion[];
   toolFilter?: (tool: SlashCommandToolSuggestion<V>) => boolean;
   tools: SlashCommandToolSuggestion<V>[];
+  useSearchRanking?: boolean;
 }): SlashCommand[] {
-  const matches = searchCapabilityIndex({
-    query,
-    items: [
-      ...skills
-        .filter((skill) => skill.sId !== excludeSkillId)
-        .filter((skill) => skillFilter?.(skill) ?? true)
-        .map((skill) => ({
-          isFavorite: skill.isFavorite ?? false,
-          kind: "skill" as const,
-          normalizedDescription: skill.userFacingDescription?.toLowerCase(),
-          searchAliases: GLOBAL_SKILL_SEARCH_ALIASES[skill.sId],
-          skill,
-          sortName: skill.name,
-        })),
-      ...tools
-        .filter((tool) => toolFilter?.(tool) ?? true)
-        .map((tool) => ({
-          kind: "tool" as const,
-          normalizedDescription:
-            getMcpServerViewDescription(tool)?.toLowerCase(),
-          tool,
-          sortName: getToolSlashCommandLabel(tool),
-        })),
-    ],
-  });
+  const items = [
+    ...skills
+      .filter((skill) => skill.sId !== excludeSkillId)
+      .filter((skill) => skillFilter?.(skill) ?? true)
+      .map((skill) => ({
+        isFavorite: skill.isFavorite ?? false,
+        score: skill.score,
+        sId: skill.sId,
+        description: skill.userFacingDescription,
+        kind: "skill" as const,
+        normalizedDescription: skill.userFacingDescription?.toLowerCase(),
+        searchAliases: GLOBAL_SKILL_SEARCH_ALIASES[skill.sId],
+        skill,
+        sortName: skill.name,
+      })),
+    ...tools
+      .filter((tool) => toolFilter?.(tool) ?? true)
+      .map((tool) => ({
+        kind: "tool" as const,
+        score: undefined,
+        sId: tool.sId,
+        description: getMcpServerViewDescription(tool),
+        searchAliases: undefined,
+        normalizedDescription: getMcpServerViewDescription(tool)?.toLowerCase(),
+        tool,
+        sortName: getToolSlashCommandLabel(tool),
+      })),
+  ];
 
-  return matches.map((match) => {
-    switch (match.kind) {
-      case "skill":
-        return getSkillSlashCommandItem(match.skill);
-      case "tool":
-        return getToolSlashCommandItem(match.tool);
-      default:
-        return assertNever(match);
-    }
-  });
+  // Search-backed skills keep their server scores. Tools use the same scoring
+  // rules; the legacy builder keeps its existing favorites/autocomplete order.
+  const matches = useSearchRanking
+    ? items
+        .map((item) => ({
+          item,
+          score:
+            item.score ??
+            getSkillSearchScore({
+              searchTerm: query,
+              name: item.sortName,
+              description: item.description ?? "",
+              aliases: item.searchAliases,
+            }),
+          name: item.sortName,
+          sId: item.sId,
+        }))
+        .filter((item) => item.score > 0)
+        .sort(compareRankedSkills)
+        .slice(0, MAX_RENDERED_CAPABILITY_ITEMS)
+        .map(({ item }) => item)
+    : searchCapabilityIndex({ query, items });
+
+  return removeNulls(
+    matches.map((match) => {
+      switch (match.kind) {
+        case "skill":
+          return getSkillSlashCommandItem(match.skill);
+        case "tool":
+          return getToolSlashCommandItem(match.tool);
+        default:
+          assertNeverAndIgnore(match);
+          return null;
+      }
+    })
+  );
 }

--- a/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
@@ -9,7 +9,7 @@ import {
   useJITMCPServerViewsFromSpaces,
   useMCPServerViewsFromSpaces,
 } from "@app/lib/swr/mcp_servers";
-import { useSkills } from "@app/lib/swr/skill_configurations";
+import { useSearchSkills, useSkills } from "@app/lib/swr/skill_configurations";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { RefObject } from "react";
@@ -74,9 +74,9 @@ export function useInputBarSlashCommandCapabilities({
     kinds: ["global"],
     swrOptions: CAPABILITIES_SWR_OPTIONS,
   });
-  const { skills, isSkillsLoading } = useSkills({
+  const { skills, isSkillsLoading } = useSearchSkills({
     owner,
-    status: "active",
+    searchTerm: query,
     swrOptions: CAPABILITIES_SWR_OPTIONS,
   });
   // The JIT views endpoint only returns views whose tools can be enabled directly in a

--- a/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
@@ -92,7 +92,8 @@ export function useInputBarSlashCommandCapabilities({
     () =>
       buildCapabilitySlashCommandItems({
         excludeSkillId,
-        query,
+        query: query.slice(0, 200),
+        useSearchRanking: true,
         skills,
         tools: serverViews,
         toolFilter: (serverView) =>

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.ts
@@ -24,6 +24,7 @@ import { pruneOutdatedSkillEditSuggestions } from "@app/lib/reinforcement/skill_
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { isResourceSId } from "@app/lib/resources/string_ids";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { launchSkillSearchIndexation } from "@app/lib/skill_search/indexation";
 import { extractUniqueSkillReferenceIds } from "@app/lib/skills/format";
 import { extractToolTags, serializeToolTag } from "@app/lib/tools/format";
 import logger from "@app/logger/logger";
@@ -333,6 +334,11 @@ export async function createSkill(
     }
   );
 
+  await launchSkillSearchIndexation({
+    workspaceId: auth.getNonNullableWorkspace().sId,
+    skillId: skill.sId,
+  });
+
   await auth.refresh();
 
   return new Ok(skill);
@@ -638,9 +644,14 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
         userFacingDescription ?? skill.userFacingDescription,
     });
 
+    const owner = auth.getNonNullableWorkspace();
+    await launchSkillSearchIndexation({
+      workspaceId: owner.sId,
+      skillId: skill.sId,
+    });
+
     await pruneOutdatedSkillEditSuggestions(auth, skill);
 
-    const owner = auth.getNonNullableWorkspace();
     const text = `Updated skill "${skill.name}".`;
 
     return new Ok([

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -14,11 +14,12 @@ export const CONSUMPTION_ANALYTICS_ALIAS_NAME =
 export const USER_SEARCH_ALIAS_NAME = "front.user_search";
 export const AGENT_DOCUMENT_OUTPUTS_ALIAS_NAME = "front.agent_document_outputs";
 export const CONVERSATION_SEARCH_ALIAS_NAME = "front.conversation_search";
+export const SKILL_SEARCH_ALIAS_NAME = "front.skill_search";
 
 /**
- * Registry of front-owned indices: where the settings/mappings files live and
- * the current version. A version bump here must ship with the matching
- * [name]_[version].settings.[region].json and [name]_[version].mappings.json.
+ * @cc [owner:aubin-tchoi,label:backend] registered-index-files
+ * Every registered index must have matching [name]_[version].mappings.json and
+ * [name]_[version].settings.[region].json files in its directory for each region.
  */
 export const INDEX_REGISTRY: Record<
   string,
@@ -30,6 +31,7 @@ export const INDEX_REGISTRY: Record<
     directory: "lib/analytics/indices",
     version: 1,
   },
+  skill_search: { directory: "lib/skill_search/indices", version: 1 },
   user_search: { directory: "lib/user_search/indices", version: 1 },
 };
 

--- a/front/lib/api/membership.test.ts
+++ b/front/lib/api/membership.test.ts
@@ -3,6 +3,8 @@ import { createAndTrackMembership } from "@app/lib/api/membership";
 import type { CachedContract } from "@app/lib/metronome/plan_type";
 import * as planType from "@app/lib/metronome/plan_type";
 import * as seatTypes from "@app/lib/metronome/seat_types";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { UserFactory } from "@app/tests/utils/UserFactory";
@@ -32,6 +34,10 @@ vi.mock("@app/lib/api/audit/workos_audit", async () => {
   return { ...actual, emitAuditLogEventDirect: vi.fn() };
 });
 
+vi.mock("@app/lib/skill_search/indexation", () => ({
+  launchSkillsSearchIndexationForGroups: vi.fn(),
+}));
+
 vi.mock("@app/temporal/usage_queue/client", async () => {
   const actual = await vi.importActual<
     typeof import("@app/temporal/usage_queue/client")
@@ -43,6 +49,7 @@ vi.mock("@app/temporal/usage_queue/client", async () => {
   };
 });
 
+import { launchSkillsSearchIndexationForGroups } from "@app/lib/skill_search/indexation";
 import {
   launchMetronomeSeatCountSyncWorkflow,
   launchUpdateUsageWorkflow,
@@ -84,9 +91,44 @@ beforeEach(() => {
     new Ok(undefined)
   );
   trackCreateMembershipSpy.mockResolvedValue(undefined);
+  vi.mocked(launchSkillsSearchIndexationForGroups).mockResolvedValue(undefined);
 });
 
 describe("createAndTrackMembership", () => {
+  it("reindexes editor grants restored for a returning member", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    const revokedAt = new Date();
+    const latestMembershipSpy = vi
+      .spyOn(MembershipResource, "getLatestMembershipOfUserInWorkspace")
+      .mockResolvedValue({
+        endAt: revokedAt,
+        isRevoked: () => true,
+      } as MembershipResource);
+    const restoreSpy = vi
+      .spyOn(GroupResource, "dangerouslyRestoreGroupMembershipsRevokedWith")
+      .mockResolvedValue([11, 12]);
+
+    await createAndTrackMembership({
+      user,
+      workspace,
+      role: "user",
+      origin: "invited",
+    });
+
+    expect(restoreSpy).toHaveBeenCalledWith({
+      user,
+      workspace,
+      revokedAt,
+    });
+    expect(launchSkillsSearchIndexationForGroups).toHaveBeenCalledWith({
+      workspace,
+      groupModelIds: [11, 12],
+    });
+    latestMembershipSpy.mockRestore();
+    restoreSpy.mockRestore();
+  });
+
   it("assigns free instead of a committed paid seat on a free plan", async () => {
     setupEntitledSeats(["free", "pro"]);
 

--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -34,6 +34,7 @@ import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
+import { launchSkillsSearchIndexationForGroups } from "@app/lib/skill_search/indexation";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
@@ -283,17 +284,25 @@ export async function createAndTrackMembership({
   });
 
   if (prevRevokedAt) {
-    const restoredCount =
+    const restoredGroupModelIds =
       await GroupResource.dangerouslyRestoreGroupMembershipsRevokedWith({
         user,
         workspace: w,
         revokedAt: prevRevokedAt,
       });
-    if (restoredCount > 0) {
+    if (restoredGroupModelIds.length > 0) {
       logger.info(
-        { userId: user.sId, workspaceId: w.sId, restoredCount },
+        {
+          userId: user.sId,
+          workspaceId: w.sId,
+          restoredCount: restoredGroupModelIds.length,
+        },
         "[Membership] Restored group memberships for rejoining user"
       );
+      await launchSkillsSearchIndexationForGroups({
+        workspace: w,
+        groupModelIds: restoredGroupModelIds,
+      });
     }
   }
 

--- a/front/lib/api/poke/plugins/skills/skill_editors.ts
+++ b/front/lib/api/poke/plugins/skills/skill_editors.ts
@@ -1,6 +1,7 @@
 import { createPlugin } from "@app/lib/api/poke/types";
 import { getMembers } from "@app/lib/api/workspace";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { launchSkillSearchIndexation } from "@app/lib/skill_search/indexation";
 import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -90,8 +91,7 @@ export const updateSkillEditorsPlugin = createPlugin({
       userResources.map((user) => [user.sId, user.toJSON()])
     );
 
-    // Go through the resource rather than the group directly: it keeps the per-user grants in sync
-    // with the editor-group membership (see `SkillResource.writeEditorUserGrants`).
+    // Keep editor permission mutations behind SkillResource.
     const userResourceMap = new Map(
       userResources.map((user) => [user.sId, user])
     );
@@ -102,6 +102,10 @@ export const updateSkillEditorsPlugin = createPlugin({
         removeNulls(usersToAdd.map((id) => userResourceMap.get(id)))
       );
       if (addResult.isErr()) {
+        await launchSkillSearchIndexation({
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          skillId: resource.sId,
+        });
         return new Err(
           new Error(`Failed to add editors: ${addResult.error.message}`)
         );
@@ -114,11 +118,20 @@ export const updateSkillEditorsPlugin = createPlugin({
         removeNulls(usersToRemove.map((id) => userResourceMap.get(id)))
       );
       if (removeResult.isErr()) {
+        await launchSkillSearchIndexation({
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          skillId: resource.sId,
+        });
         return new Err(
           new Error(`Failed to remove editors: ${removeResult.error.message}`)
         );
       }
     }
+
+    await launchSkillSearchIndexation({
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      skillId: resource.sId,
+    });
 
     // Prepare success message.
     const addedNames = removeNulls(usersToAdd.map((id) => userMap.get(id))).map(

--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -68,6 +68,7 @@ export type RedisUsageTagsType =
   | "lock"
   | "sandbox_exec_tokens"
   | "sandbox_function_invocation_events"
+  | "skill_search_cursor"
   | "mcp_client_side_request"
   | "mcp_client_side_results"
   | "mentions_count"

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -12,6 +12,7 @@ import { convertMarkdownToBlockHtml } from "@app/lib/reinforcement/skill_instruc
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { launchSkillSearchIndexation } from "@app/lib/skill_search/indexation";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type {
@@ -202,6 +203,7 @@ export async function importSkillsFromFiles(
   const editorUsers = editorUsersResult.value;
 
   const user = auth.user();
+  const workspace = auth.getNonNullableWorkspace();
   const imported: SkillResource[] = [];
   const updated: SkillResource[] = [];
   const skipped: { name: string; message: string }[] = [];
@@ -261,11 +263,20 @@ export async function importSkillsFromFiles(
         sourceMetadata: { filePath: skill.skillMdPath },
       });
 
+      await launchSkillSearchIndexation({
+        workspaceId: workspace.sId,
+        skillId: existing.sId,
+      });
+
       await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
         skillId: existing.sId,
       });
 
       const editorsResult = await existing.upsertEditors(auth, editorUsers);
+      await launchSkillSearchIndexation({
+        workspaceId: workspace.sId,
+        skillId: existing.sId,
+      });
       if (editorsResult.isErr()) {
         return editorsResult;
       }
@@ -315,6 +326,11 @@ export async function importSkillsFromFiles(
         }
       );
 
+      await launchSkillSearchIndexation({
+        workspaceId: workspace.sId,
+        skillId: skillResource.sId,
+      });
+
       await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
         skillId: skillResource.sId,
       });
@@ -323,6 +339,10 @@ export async function importSkillsFromFiles(
         auth,
         editorUsers
       );
+      await launchSkillSearchIndexation({
+        workspaceId: workspace.sId,
+        skillId: skillResource.sId,
+      });
       if (editorsResult.isErr()) {
         return editorsResult;
       }

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -19,6 +19,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { convertMarkdownToBlockHtml } from "@app/lib/reinforcement/skill_instructions_html";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { launchSkillSearchIndexation } from "@app/lib/skill_search/indexation";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
@@ -120,6 +121,7 @@ export async function importSkillsFromGitHub(
   const existingSkillsMap = new Map(existingSkills.map((s) => [s.name, s]));
 
   const user = auth.getNonNullableUser();
+  const workspace = auth.getNonNullableWorkspace();
   const imported: SkillResource[] = [];
   const updated: SkillResource[] = [];
   const skipped: { name: string; message: string }[] = [];
@@ -172,6 +174,11 @@ export async function importSkillsFromGitHub(
         },
       });
 
+      await launchSkillSearchIndexation({
+        workspaceId: workspace.sId,
+        skillId: existing.sId,
+      });
+
       await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
         skillId: existing.sId,
       });
@@ -222,6 +229,11 @@ export async function importSkillsFromGitHub(
           fileAttachments,
         }
       );
+
+      await launchSkillSearchIndexation({
+        workspaceId: workspace.sId,
+        skillId: skillResource.sId,
+      });
 
       await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
         skillId: skillResource.sId,

--- a/front/lib/api/skills/search.test.ts
+++ b/front/lib/api/skills/search.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findGlobalSkills: vi.fn(),
+  findSystemSkills: vi.fn(),
+  searchSkillDocuments: vi.fn(),
+}));
+
+vi.mock("@app/lib/resources/skill/code_defined/global_registry", () => ({
+  GlobalSkillsRegistry: { findAll: mocks.findGlobalSkills },
+}));
+vi.mock("@app/lib/resources/skill/code_defined/system_registry", () => ({
+  SystemSkillsRegistry: { findAll: mocks.findSystemSkills },
+}));
+vi.mock("@app/lib/skill_search/search", () => ({
+  MAX_SKILL_SEARCH_RESULTS: 150,
+  searchSkillDocuments: mocks.searchSkillDocuments,
+}));
+
+import { searchSkillsForCommandMenu } from "@app/lib/api/skills/search";
+import type { Authenticator } from "@app/lib/auth";
+import { Ok } from "@app/types/shared/result";
+import type { SkillSearchDocument } from "@app/types/skill_search/skill_search";
+
+const customSkillDocument: SkillSearchDocument = {
+  workspace_id: "workspace",
+  skill_id: "custom-skill",
+  status: "active",
+  availability: "workspace_users",
+  name: "Custom Skill",
+  user_facing_description: "Custom description",
+  icon: null,
+  edited_by: 123,
+  editor_user_ids: [123],
+  requested_space_ids: ["space"],
+  non_pod_space_ids: ["space"],
+  non_pod_space_count: 1,
+  pod_space_id: null,
+  updated_at: "2026-08-01T00:00:00.000Z",
+};
+
+describe("searchSkillsForCommandMenu", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findGlobalSkills.mockResolvedValue([
+      {
+        sId: "global-skill",
+        icon: "ActionGlobeAltIcon",
+        name: "Global Skill",
+        userFacingDescription: "Global description",
+      },
+    ]);
+    mocks.findSystemSkills.mockResolvedValue([
+      {
+        sId: "system-skill",
+        icon: "ActionRobotIcon",
+        name: "System Skill",
+        userFacingDescription: "System description",
+      },
+    ]);
+    mocks.searchSkillDocuments.mockResolvedValue(new Ok([customSkillDocument]));
+  });
+
+  it("returns minimal custom hits and every allowed code-defined skill", async () => {
+    const auth = {} as Authenticator;
+    const result = await searchSkillsForCommandMenu(auth, {
+      searchTerm: "alias-only query",
+    });
+
+    expect(mocks.searchSkillDocuments).toHaveBeenCalledWith(auth, {
+      searchTerm: "alias-only query",
+      limit: 150,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value).toEqual([
+      {
+        editedBy: 123,
+        icon: null,
+        name: "Custom Skill",
+        requestedSpaceIds: ["space"],
+        sId: "custom-skill",
+        userFacingDescription: "Custom description",
+      },
+      {
+        editedBy: null,
+        icon: "ActionGlobeAltIcon",
+        name: "Global Skill",
+        requestedSpaceIds: [],
+        sId: "global-skill",
+        userFacingDescription: "Global description",
+      },
+      {
+        editedBy: null,
+        icon: "ActionRobotIcon",
+        name: "System Skill",
+        requestedSpaceIds: [],
+        sId: "system-skill",
+        userFacingDescription: "System description",
+      },
+    ]);
+  });
+});

--- a/front/lib/api/skills/search.test.ts
+++ b/front/lib/api/skills/search.test.ts
@@ -1,105 +1,319 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({
-  findGlobalSkills: vi.fn(),
-  findSystemSkills: vi.fn(),
-  searchSkillDocuments: vi.fn(),
-}));
+const mockSearch = vi.hoisted(() => vi.fn());
+const mockOpenPit = vi.hoisted(() => vi.fn());
+const mockClosePit = vi.hoisted(() => vi.fn());
 
-vi.mock("@app/lib/resources/skill/code_defined/global_registry", () => ({
-  GlobalSkillsRegistry: { findAll: mocks.findGlobalSkills },
-}));
-vi.mock("@app/lib/resources/skill/code_defined/system_registry", () => ({
-  SystemSkillsRegistry: { findAll: mocks.findSystemSkills },
-}));
-vi.mock("@app/lib/skill_search/search", () => ({
-  MAX_SKILL_SEARCH_RESULTS: 150,
-  searchSkillDocuments: mocks.searchSkillDocuments,
-}));
+vi.mock("@app/lib/api/elasticsearch", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/elasticsearch")>();
+  return {
+    ...actual,
+    withEs: async (
+      fn: (client: {
+        search: typeof mockSearch;
+        openPointInTime: typeof mockOpenPit;
+        closePointInTime: typeof mockClosePit;
+      }) => Promise<unknown>
+    ) => {
+      const { Ok } = await import("@app/types/shared/result");
+      return new Ok(
+        await fn({
+          search: mockSearch,
+          openPointInTime: mockOpenPit,
+          closePointInTime: mockClosePit,
+        })
+      );
+    },
+  };
+});
 
 import { searchSkillsForCommandMenu } from "@app/lib/api/skills/search";
-import type { Authenticator } from "@app/lib/auth";
-import { Ok } from "@app/types/shared/result";
+import { Authenticator } from "@app/lib/auth";
+import { GlobalSkillsRegistry } from "@app/lib/resources/skill/code_defined/global_registry";
+import { SystemSkillsRegistry } from "@app/lib/resources/skill/code_defined/system_registry";
+import { SkillSearchDocumentResource } from "@app/lib/resources/skill/skill_search_document_resource";
+import { SkillSearchCursorError } from "@app/lib/skill_search/cursor";
+import {
+  compareRankedSkills,
+  getSkillSearchScore,
+} from "@app/lib/skill_search/ranking";
+import { GLOBAL_SKILL_SEARCH_ALIASES } from "@app/lib/skills/global_search_aliases";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { SkillSearchDocument } from "@app/types/skill_search/skill_search";
+import type { estypes } from "@elastic/elasticsearch";
+import assert from "assert";
 
-const customSkillDocument: SkillSearchDocument = {
-  workspace_id: "workspace",
-  skill_id: "custom-skill",
-  status: "active",
-  availability: "workspace_users",
-  name: "Custom Skill",
-  user_facing_description: "Custom description",
-  icon: null,
-  edited_by: 123,
-  editor_user_ids: [123],
-  requested_space_ids: ["space"],
-  non_pod_space_ids: ["space"],
-  non_pod_space_count: 1,
-  pod_space_id: null,
-  updated_at: "2026-08-01T00:00:00.000Z",
-};
+// Only ES is mocked: the registries, Redis cursors and canonical DB/ACL checks run.
+function serveDocuments(documents: SkillSearchDocument[], searchTerm = "") {
+  const ordered = documents
+    .map((document) => ({
+      document,
+      score: getSkillSearchScore({
+        searchTerm,
+        name: document.name,
+        description: document.user_facing_description ?? "",
+      }),
+      name: document.name,
+      sId: document.skill_id,
+    }))
+    .filter((hit) => hit.score > 0)
+    .sort(compareRankedSkills);
+  mockSearch.mockImplementation(async (request: estypes.SearchRequest) => {
+    const after = request.search_after?.[3];
+    const offset = typeof after === "number" ? after + 1 : 0;
+    return {
+      pit_id: "pit-latest",
+      hits: {
+        hits: ordered
+          .slice(offset, offset + (request.size ?? 50))
+          .map((hit, index) => ({
+            _source: hit.document,
+            sort: [hit.score, hit.name, hit.sId, offset + index],
+          })),
+      },
+    };
+  });
+}
 
-describe("searchSkillsForCommandMenu", () => {
+async function createDocument(
+  auth: Authenticator,
+  name: string,
+  podModelId?: number
+) {
+  const skill = await SkillFactory.create(auth, {
+    name,
+    availability: "workspace_users",
+    requestedSpaceIds: podModelId === undefined ? [] : [podModelId],
+  });
+  const document = await SkillSearchDocumentResource.fetchSearchDocument(
+    auth,
+    skill.sId
+  );
+  assert(document);
+  return document;
+}
+
+async function allowedGlobals(auth: Authenticator) {
+  const globals = await GlobalSkillsRegistry.findAll(auth);
+  const systems = await SystemSkillsRegistry.findAll(auth);
+  return [...globals, ...systems].sort(
+    (a, b) =>
+      Buffer.compare(Buffer.from(a.name), Buffer.from(b.name)) ||
+      Buffer.compare(Buffer.from(a.sId), Buffer.from(b.sId))
+  );
+}
+
+describe("searchSkillsForCommandMenu pagination", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    mocks.findGlobalSkills.mockResolvedValue([
-      {
-        sId: "global-skill",
-        icon: "ActionGlobeAltIcon",
-        name: "Global Skill",
-        userFacingDescription: "Global description",
-      },
-    ]);
-    mocks.findSystemSkills.mockResolvedValue([
-      {
-        sId: "system-skill",
-        icon: "ActionRobotIcon",
-        name: "System Skill",
-        userFacingDescription: "System description",
-      },
-    ]);
-    mocks.searchSkillDocuments.mockResolvedValue(new Ok([customSkillDocument]));
+    vi.restoreAllMocks();
+    mockSearch.mockReset();
+    mockOpenPit.mockReset().mockResolvedValue({ id: "pit-initial" });
+    mockClosePit.mockReset().mockResolvedValue({ succeeded: true });
   });
 
-  it("returns minimal custom hits and every allowed code-defined skill", async () => {
-    const auth = {} as Authenticator;
+  it("refetches custom hits displaced by globals without skips or duplicates", async () => {
+    const { auth } = await createPrivateApiMockRequest({ role: "user" });
+    const globals = await allowedGlobals(auth);
+    const documents: SkillSearchDocument[] = [];
+    for (const name of ["zzzz 01", "zzzz 02", "zzzz 03", "zzzz 04"]) {
+      const document = await createDocument(auth, name);
+      documents.push(document);
+    }
+    serveDocuments(documents);
+    const first = await searchSkillsForCommandMenu(auth, {
+      searchTerm: "",
+      limit: globals.length + 2,
+    });
+    assert(first.isOk() && first.value.nextCursor);
+    expect(first.value.skills.map((skill) => skill.sId)).toEqual([
+      ...globals.map((skill) => skill.sId),
+      documents[0].skill_id,
+      documents[1].skill_id,
+    ]);
+    expect(mockSearch).toHaveBeenCalledOnce();
+
+    const second = await searchSkillsForCommandMenu(auth, {
+      searchTerm: "",
+      limit: globals.length + 2,
+      cursor: first.value.nextCursor,
+    });
+    assert(second.isOk());
+    expect(mockSearch.mock.calls[1][0].search_after).toEqual([
+      1,
+      documents[1].name,
+      documents[1].skill_id,
+      1,
+    ]);
+    expect(second.value.skills.map((skill) => skill.sId)).toEqual(
+      documents.slice(2).map((doc) => doc.skill_id)
+    );
+    expect(second.value.nextCursor).toBeNull();
+    expect(mockOpenPit).toHaveBeenCalledOnce();
+    expect(mockSearch.mock.calls[1][0].pit.id).toBe("pit-latest");
+
+    // An immutable cursor can be retried without moving the global position.
+    const retry = await searchSkillsForCommandMenu(auth, {
+      searchTerm: "",
+      limit: globals.length + 2,
+      cursor: first.value.nextCursor,
+    });
+    assert(retry.isOk());
+    expect(retry.value.skills).toEqual(second.value.skills);
+  });
+
+  it("does not advance ES when a page contains only globals", async () => {
+    const { auth } = await createPrivateApiMockRequest();
+    const globals = await allowedGlobals(auth);
+    const document = await createDocument(auth, "zzzz custom");
+    serveDocuments([document]);
+    const first = await searchSkillsForCommandMenu(auth, {
+      searchTerm: "",
+      limit: 1,
+    });
+    assert(first.isOk() && first.value.nextCursor);
+    expect(first.value.skills[0].sId).toBe(globals[0].sId);
+    const second = await searchSkillsForCommandMenu(auth, {
+      searchTerm: "",
+      limit: 1,
+      cursor: first.value.nextCursor,
+    });
+    assert(second.isOk());
+    expect(second.value.skills[0].sId).toBe(globals[1].sId);
+    expect(mockSearch.mock.calls[1][0].search_after).toBeUndefined();
+  });
+
+  it("paginates remaining globals after ES is exhausted without querying ES again", async () => {
+    const { auth } = await createPrivateApiMockRequest();
+    const globals = await allowedGlobals(auth);
+    serveDocuments([]);
+    const first = await searchSkillsForCommandMenu(auth, {
+      searchTerm: "",
+      limit: 1,
+    });
+    assert(first.isOk() && first.value.nextCursor);
+    const second = await searchSkillsForCommandMenu(auth, {
+      searchTerm: "",
+      limit: 150,
+      cursor: first.value.nextCursor,
+    });
+    assert(second.isOk());
+    expect(second.value.skills.map((skill) => skill.sId)).toEqual(
+      globals.slice(1).map((skill) => skill.sId)
+    );
+    expect(second.value.nextCursor).toBeNull();
+    expect(mockSearch).toHaveBeenCalledOnce();
+  });
+
+  it("matches global aliases and does not return restricted globals", async () => {
+    const { auth } = await createPrivateApiMockRequest({ role: "user" });
+    serveDocuments([], "Deep Dive");
     const result = await searchSkillsForCommandMenu(auth, {
-      searchTerm: "alias-only query",
+      searchTerm: "Deep Dive",
+    });
+    assert(result.isOk());
+    expect(GLOBAL_SKILL_SEARCH_ALIASES["go-deep"]).toContain("Deep Dive");
+    expect(result.value.skills[0]).toMatchObject({
+      sId: "go-deep",
+      score: 100,
     });
 
-    expect(mocks.searchSkillDocuments).toHaveBeenCalledWith(auth, {
-      searchTerm: "alias-only query",
-      limit: 150,
+    serveDocuments([], "Workspace Analytics");
+    const restricted = await searchSkillsForCommandMenu(auth, {
+      searchTerm: "Workspace Analytics",
     });
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) {
-      return;
+    assert(restricted.isOk());
+    expect(
+      restricted.value.skills.some(
+        (skill) => skill.sId === "workspace-analytics"
+      )
+    ).toBe(false);
+  });
+
+  it("rejects a cursor for another query, workspace, caller, or missing state", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      role: "user",
+    });
+    serveDocuments([]);
+    const first = await searchSkillsForCommandMenu(auth, {
+      searchTerm: "",
+      limit: 1,
+    });
+    assert(first.isOk() && first.value.nextCursor);
+    const other = await createPrivateApiMockRequest({ role: "user" });
+    // Use a valid workspace authenticator with a different identity (internal admin).
+    const internal = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    for (const [caller, searchTerm, cursor] of [
+      [auth, "different query", first.value.nextCursor],
+      [other.auth, "", first.value.nextCursor],
+      [internal, "", first.value.nextCursor],
+      [auth, "", "00000000-0000-4000-8000-000000000000"],
+    ] as const) {
+      const result = await searchSkillsForCommandMenu(caller, {
+        searchTerm,
+        cursor,
+      });
+      assert(result.isErr());
+      expect(result.error).toBeInstanceOf(SkillSearchCursorError);
     }
-    expect(result.value).toEqual([
-      {
-        editedBy: 123,
-        icon: null,
-        name: "Custom Skill",
-        requestedSpaceIds: ["space"],
-        sId: "custom-skill",
-        userFacingDescription: "Custom description",
-      },
-      {
-        editedBy: null,
-        icon: "ActionGlobeAltIcon",
-        name: "Global Skill",
-        requestedSpaceIds: [],
-        sId: "global-skill",
-        userFacingDescription: "Global description",
-      },
-      {
-        editedBy: null,
-        icon: "ActionRobotIcon",
-        name: "System Skill",
-        requestedSpaceIds: [],
-        sId: "system-skill",
-        userFacingDescription: "System description",
-      },
+    expect(mockOpenPit).toHaveBeenCalledOnce();
+  });
+
+  it("rechecks pod access between pages and skips revoked candidates", async () => {
+    const { auth, workspace, user } = await createPrivateApiMockRequest({
+      role: "user",
+    });
+    const pod = await SpaceFactory.project(workspace, user.id);
+    await auth.refresh();
+    const firstDoc = await createDocument(auth, "000 custom");
+    const podDoc = await createDocument(auth, "001 pod", pod.id);
+    const lastDoc = await createDocument(auth, "002 custom");
+    serveDocuments([firstDoc, podDoc, lastDoc]);
+    const first = await searchSkillsForCommandMenu(auth, {
+      searchTerm: "",
+      limit: 1,
+    });
+    assert(first.isOk() && first.value.nextCursor);
+    await pod.writeGroupPermissions(auth, { members: [], editors: [] });
+    await auth.refresh();
+    const next = await searchSkillsForCommandMenu(auth, {
+      searchTerm: "",
+      limit: 1,
+      cursor: first.value.nextCursor,
+    });
+    assert(next.isOk());
+    expect(next.value.skills.map((skill) => skill.sId)).toEqual([
+      lastDoc.skill_id,
     ]);
+  });
+
+  it("keeps progress through a bounded run of denied hits without emitting globals early", async () => {
+    const { auth } = await createPrivateApiMockRequest({ role: "user" });
+    const visible = await createDocument(auth, "000 visible");
+    // Duplicate stale hits simulate full candidate batches without creating 250 DB rows.
+    const stale = { ...visible, skill_id: "missing-skill", name: "000 denied" };
+    serveDocuments([...Array.from({ length: 250 }, () => stale), visible]);
+    const first = await searchSkillsForCommandMenu(auth, {
+      searchTerm: "",
+      limit: 1,
+    });
+    assert(first.isOk() && first.value.nextCursor);
+    expect(first.value.skills).toEqual([]);
+    expect(mockSearch).toHaveBeenCalledTimes(5);
+    const second = await searchSkillsForCommandMenu(auth, {
+      searchTerm: "",
+      limit: 1,
+      cursor: first.value.nextCursor,
+    });
+    assert(second.isOk());
+    expect(second.value.skills[0].sId).toBe(visible.skill_id);
+    expect(mockSearch.mock.calls[5][0].search_after[3]).toBe(249);
+    expect(mockSearch.mock.calls[5][0].query.bool.filter).toContainEqual({
+      term: { workspace_id: auth.getNonNullableWorkspace().sId },
+    });
   });
 });

--- a/front/lib/api/skills/search.test.ts
+++ b/front/lib/api/skills/search.test.ts
@@ -32,6 +32,7 @@ import { searchSkillsForCommandMenu } from "@app/lib/api/skills/search";
 import { Authenticator } from "@app/lib/auth";
 import { GlobalSkillsRegistry } from "@app/lib/resources/skill/code_defined/global_registry";
 import { SystemSkillsRegistry } from "@app/lib/resources/skill/code_defined/system_registry";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SkillSearchDocumentResource } from "@app/lib/resources/skill/skill_search_document_resource";
 import { SkillSearchCursorError } from "@app/lib/skill_search/cursor";
 import {
@@ -315,5 +316,180 @@ describe("searchSkillsForCommandMenu pagination", () => {
     expect(mockSearch.mock.calls[5][0].query.bool.filter).toContainEqual({
       term: { workspace_id: auth.getNonNullableWorkspace().sId },
     });
+  });
+
+  it("retains admin listing metadata with canonical redaction for spaces, pods, and editors-only skills", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    const restrictedPod = await SpaceFactory.project(workspace);
+    const skills: SkillResource[] = [];
+    for (const spaceIds of [[], [restrictedSpace.id], [restrictedPod.id]]) {
+      for (const availability of ["workspace_users", "editors"] as const) {
+        const skill = await SkillFactory.create(auth, {
+          name: `000 redaction ${skills.length}`,
+          instructions: "Secret instructions must never appear in search",
+          userFacingDescription: "Listing description remains visible",
+          requestedSpaceIds: spaceIds,
+          availability,
+          addCurrentUserAsEditor: false,
+        });
+        skills.push(skill);
+      }
+    }
+    const skillIds = skills.map((skill) => skill.sId);
+    const documents = await SkillSearchDocumentResource.fetchSearchDocuments(
+      auth,
+      skillIds
+    );
+    serveDocuments(documents);
+    const result = await searchSkillsForCommandMenu(auth, {
+      searchTerm: "",
+      limit: skills.length,
+      permissionFiltering: "redact_unreadable",
+    });
+    assert(result.isOk());
+    const canonical = await SkillResource.fetchByIds(auth, skillIds, {
+      permissionFiltering: "redact_unreadable",
+    });
+    const canonicalById = new Map(
+      canonical.map((skill) => [skill.sId, skill.toJSON(auth)])
+    );
+    expect(result.value.skills).toHaveLength(skills.length);
+    for (const hit of result.value.skills) {
+      const expected = canonicalById.get(hit.sId);
+      assert(expected);
+      expect(hit).toEqual({
+        sId: expected.sId,
+        name: expected.name,
+        userFacingDescription: expected.userFacingDescription,
+        icon: expected.icon,
+        editedBy: expected.editedBy,
+        requestedSpaceIds: expected.requestedSpaceIds,
+        canRead: expected.canRead,
+        score: 1,
+      });
+    }
+    expect(
+      result.value.skills.filter((skill) => skill.canRead === false)
+    ).toHaveLength(4);
+    expect(JSON.stringify(result.value)).not.toContain("Secret instructions");
+    expect(mockSearch.mock.calls[0][0].query.bool.must[0].bool.filter).toEqual([
+      { term: { workspace_id: workspace.sId } },
+      { term: { status: "active" } },
+    ]);
+  });
+
+  it.each([
+    "user",
+    "builder",
+    "manager",
+  ] as const)("refuses redaction to a %s before opening ES", async (role) => {
+    const { auth } = await createPrivateApiMockRequest({ role });
+    await expect(
+      searchSkillsForCommandMenu(auth, {
+        searchTerm: "",
+        permissionFiltering: "redact_unreadable",
+      })
+    ).rejects.toThrow("Only admins");
+    expect(mockOpenPit).not.toHaveBeenCalled();
+    expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "strict",
+    "redact_unreadable",
+  ] as const)("does not reuse a %s cursor in the other permission mode", async (permissionFiltering) => {
+    const { auth } = await createPrivateApiMockRequest({ role: "admin" });
+    serveDocuments([]);
+    const first = await searchSkillsForCommandMenu(auth, {
+      searchTerm: "",
+      limit: 1,
+      permissionFiltering,
+    });
+    assert(first.isOk() && first.value.nextCursor);
+    const second = await searchSkillsForCommandMenu(auth, {
+      searchTerm: "",
+      cursor: first.value.nextCursor,
+      permissionFiltering:
+        permissionFiltering === "strict" ? "redact_unreadable" : "strict",
+    });
+    assert(second.isErr());
+    expect(second.error).toBeInstanceOf(SkillSearchCursorError);
+    expect(mockSearch).toHaveBeenCalledOnce();
+  });
+
+  it("redacts newly unreadable pods on the next page without dropping their metadata", async () => {
+    const { auth, workspace, user } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace, user.id);
+    await auth.refresh();
+    const firstDoc = await createDocument(auth, "000 first");
+    const podDoc = await createDocument(auth, "001 pod", pod.id);
+    serveDocuments([firstDoc, podDoc]);
+    const first = await searchSkillsForCommandMenu(auth, {
+      searchTerm: "",
+      limit: 1,
+      permissionFiltering: "redact_unreadable",
+    });
+    assert(first.isOk() && first.value.nextCursor);
+    expect(first.value.skills[0]).toMatchObject({
+      sId: firstDoc.skill_id,
+      canRead: true,
+    });
+    await pod.writeGroupPermissions(auth, { members: [], editors: [] });
+    await auth.refresh();
+    const next = await searchSkillsForCommandMenu(auth, {
+      searchTerm: "",
+      limit: 1,
+      cursor: first.value.nextCursor,
+      permissionFiltering: "redact_unreadable",
+    });
+    assert(next.isOk());
+    expect(next.value.skills).toHaveLength(1);
+    expect(next.value.skills[0]).toMatchObject({
+      sId: podDoc.skill_id,
+      canRead: false,
+    });
+  });
+
+  it("uses committed metadata and excludes archived and cross-workspace hits in redaction mode", async () => {
+    const { auth } = await createPrivateApiMockRequest({ role: "admin" });
+    const current = await createDocument(auth, "000 current");
+    const archivedSkill = await SkillFactory.create(auth, {
+      name: "001 archived",
+    });
+    const archived = await SkillSearchDocumentResource.fetchSearchDocument(
+      auth,
+      archivedSkill.sId
+    );
+    assert(archived);
+    await archivedSkill.archive(auth);
+    const other = await createPrivateApiMockRequest({ role: "admin" });
+    const foreign = await createDocument(other.auth, "002 foreign");
+    serveDocuments([
+      {
+        ...current,
+        user_facing_description: "Stale description",
+        instructions: "Never return this",
+      },
+      archived,
+      foreign,
+    ]);
+    const result = await searchSkillsForCommandMenu(auth, {
+      searchTerm: "",
+      limit: 50,
+      permissionFiltering: "redact_unreadable",
+    });
+    assert(result.isOk());
+    const custom = result.value.skills.filter((skill) =>
+      skill.sId.startsWith("skl_")
+    );
+    expect(custom).toEqual([
+      SkillSearchDocumentResource.toSearchJSON(current, 1),
+    ]);
+    expect(JSON.stringify(result.value)).not.toContain("Never return this");
   });
 });

--- a/front/lib/api/skills/search.ts
+++ b/front/lib/api/skills/search.ts
@@ -1,0 +1,52 @@
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { GlobalSkillsRegistry } from "@app/lib/resources/skill/code_defined/global_registry";
+import { SystemSkillsRegistry } from "@app/lib/resources/skill/code_defined/system_registry";
+import {
+  MAX_SKILL_SEARCH_RESULTS,
+  searchSkillDocuments,
+} from "@app/lib/skill_search/search";
+import type { SkillSearchResult } from "@app/types/api/skills";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export async function searchSkillsForCommandMenu(
+  auth: Authenticator,
+  { searchTerm }: { searchTerm: string }
+): Promise<Result<SkillSearchResult[], ElasticsearchError>> {
+  const customSkillsResult = await searchSkillDocuments(auth, {
+    searchTerm,
+    limit: MAX_SKILL_SEARCH_RESULTS,
+  });
+  if (customSkillsResult.isErr()) {
+    return new Err(customSkillsResult.error);
+  }
+
+  // Keep every allowed code-defined skill in the response. Their aliases are
+  // owned by the client-side command-menu ranking and may match terms that are
+  // absent from their canonical name and description.
+  const globalSkills = await GlobalSkillsRegistry.findAll(auth);
+  const systemSkills = await SystemSkillsRegistry.findAll(auth);
+
+  const customSkillSuggestions = customSkillsResult.value.map(
+    (skill): SkillSearchResult => ({
+      editedBy: skill.edited_by,
+      icon: skill.icon,
+      name: skill.name,
+      requestedSpaceIds: skill.requested_space_ids,
+      sId: skill.skill_id,
+      userFacingDescription: skill.user_facing_description ?? "",
+    })
+  );
+  const codeDefinedSkillSuggestions = [...globalSkills, ...systemSkills].map(
+    (skill): SkillSearchResult => ({
+      editedBy: null,
+      icon: skill.icon,
+      name: skill.name,
+      requestedSpaceIds: [],
+      sId: skill.sId,
+      userFacingDescription: skill.userFacingDescription,
+    })
+  );
+  return new Ok([...customSkillSuggestions, ...codeDefinedSkillSuggestions]);
+}

--- a/front/lib/api/skills/search.ts
+++ b/front/lib/api/skills/search.ts
@@ -1,52 +1,192 @@
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import { SKILL_SEARCH_ALIAS_NAME, withEs } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import { GlobalSkillsRegistry } from "@app/lib/resources/skill/code_defined/global_registry";
 import { SystemSkillsRegistry } from "@app/lib/resources/skill/code_defined/system_registry";
+import type { SkillSearchCursor } from "@app/lib/skill_search/cursor";
+import {
+  getSkillSearchFingerprint,
+  readSkillSearchCursor,
+  SkillSearchCursorError,
+  writeSkillSearchCursor,
+} from "@app/lib/skill_search/cursor";
+import {
+  compareRankedSkills,
+  getSkillSearchScore,
+} from "@app/lib/skill_search/ranking";
 import {
   MAX_SKILL_SEARCH_RESULTS,
-  searchSkillDocuments,
+  prepareSkillSearchQuery,
+  SKILL_SEARCH_KEEP_ALIVE_SECONDS,
+  searchSkillDocumentCandidates,
 } from "@app/lib/skill_search/search";
-import type { SkillSearchResult } from "@app/types/api/skills";
+import { GLOBAL_SKILL_SEARCH_ALIASES } from "@app/lib/skills/global_search_aliases";
+import type {
+  SearchSkillsResponseBody,
+  SkillSearchResult,
+} from "@app/types/api/skills";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import assert from "assert";
+
+const MAX_CANDIDATE_BATCHES = 5;
 
 export async function searchSkillsForCommandMenu(
   auth: Authenticator,
-  { searchTerm }: { searchTerm: string }
-): Promise<Result<SkillSearchResult[], ElasticsearchError>> {
-  const customSkillsResult = await searchSkillDocuments(auth, {
+  {
     searchTerm,
-    limit: MAX_SKILL_SEARCH_RESULTS,
-  });
-  if (customSkillsResult.isErr()) {
-    return new Err(customSkillsResult.error);
+    limit = MAX_SKILL_SEARCH_RESULTS,
+    cursor,
+  }: {
+    searchTerm: string;
+    limit?: number;
+    cursor?: string;
   }
-
-  // Keep every allowed code-defined skill in the response. Their aliases are
-  // owned by the client-side command-menu ranking and may match terms that are
-  // absent from their canonical name and description.
+): Promise<
+  Result<SearchSkillsResponseBody, ElasticsearchError | SkillSearchCursorError>
+> {
+  assert(
+    Number.isInteger(limit) && limit > 0 && limit <= MAX_SKILL_SEARCH_RESULTS
+  );
+  const query = await prepareSkillSearchQuery(auth, searchTerm);
   const globalSkills = await GlobalSkillsRegistry.findAll(auth);
   const systemSkills = await SystemSkillsRegistry.findAll(auth);
-
-  const customSkillSuggestions = customSkillsResult.value.map(
-    (skill): SkillSearchResult => ({
-      editedBy: skill.edited_by,
-      icon: skill.icon,
-      name: skill.name,
-      requestedSpaceIds: skill.requested_space_ids,
-      sId: skill.skill_id,
-      userFacingDescription: skill.user_facing_description ?? "",
-    })
-  );
-  const codeDefinedSkillSuggestions = [...globalSkills, ...systemSkills].map(
-    (skill): SkillSearchResult => ({
+  const codeDefinedSkills = [...globalSkills, ...systemSkills]
+    .map((skill) => ({
       editedBy: null,
       icon: skill.icon,
       name: skill.name,
       requestedSpaceIds: [],
       sId: skill.sId,
       userFacingDescription: skill.userFacingDescription,
-    })
-  );
-  return new Ok([...customSkillSuggestions, ...codeDefinedSkillSuggestions]);
+      score: getSkillSearchScore({
+        searchTerm,
+        name: skill.name,
+        description: skill.userFacingDescription,
+        aliases: GLOBAL_SKILL_SEARCH_ALIASES[skill.sId],
+      }),
+    }))
+    .filter((skill) => skill.score > 0)
+    .sort(compareRankedSkills);
+
+  const fingerprint = getSkillSearchFingerprint({
+    version: 1,
+    workspaceId: auth.getNonNullableWorkspace().sId,
+    userId: auth.user()?.sId,
+    keyId: auth.key()?.id,
+    query,
+    codeDefinedSkills,
+  });
+  let state: SkillSearchCursor;
+  if (cursor) {
+    const saved = await readSkillSearchCursor(fingerprint, cursor);
+    if (!saved) {
+      return new Err(new SkillSearchCursorError());
+    }
+    state = saved;
+  } else {
+    const pit = await withEs((client) =>
+      client.openPointInTime({
+        index: SKILL_SEARCH_ALIAS_NAME,
+        keep_alive: `${SKILL_SEARCH_KEEP_ALIVE_SECONDS}s`,
+      })
+    );
+    if (pit.isErr()) {
+      return pit;
+    }
+    state = {
+      pitId: pit.value.id,
+      searchAfter: null,
+      globalOffset: 0,
+      customExhausted: false,
+    };
+  }
+
+  const skills: SkillSearchResult[] = [];
+  const candidateLimit = Math.min(200, Math.max(50, limit * 3));
+  // Bounded batch reads, never one SQL request per skill or per user pod.
+  for (
+    let batch = 0;
+    batch < MAX_CANDIDATE_BATCHES && skills.length < limit;
+    batch++
+  ) {
+    if (state.customExhausted) {
+      break;
+    }
+    const result = await searchSkillDocumentCandidates(auth, {
+      query,
+      pitId: state.pitId,
+      searchAfter: state.searchAfter,
+      limit: candidateLimit,
+    });
+    if (result.isErr()) {
+      return result.error.statusCode === 404
+        ? new Err(new SkillSearchCursorError())
+        : result;
+    }
+    state.pitId = result.value.pitId;
+    let consumed = 0;
+    for (const candidate of result.value.candidates) {
+      if (skills.length === limit) {
+        break;
+      }
+      if (candidate.document) {
+        const [score, name, sId] = candidate.sort;
+        while (
+          state.globalOffset < codeDefinedSkills.length &&
+          skills.length < limit
+        ) {
+          const global = codeDefinedSkills[state.globalOffset];
+          if (compareRankedSkills(global, { score, name, sId }) > 0) {
+            break;
+          }
+          skills.push(global);
+          state.globalOffset++;
+        }
+        if (skills.length === limit) {
+          break;
+        }
+        const document = candidate.document;
+        skills.push({
+          editedBy: document.edited_by,
+          icon: document.icon,
+          name: document.name,
+          requestedSpaceIds: document.requested_space_ids,
+          sId: document.skill_id,
+          userFacingDescription: document.user_facing_description ?? "",
+          score,
+        });
+      }
+      // Advance ONLY past returned or denied hits. Fetched hits displaced by
+      // globals are deliberately refetched on the next page.
+      state.searchAfter = candidate.sort;
+      consumed++;
+    }
+    state.customExhausted =
+      result.value.exhausted && consumed === result.value.candidates.length;
+  }
+
+  // Without proof that ES is exhausted, emitting remaining globals here could
+  // put a low-scoring global ahead of a higher-scoring unseen custom skill.
+  if (state.customExhausted) {
+    const remaining = codeDefinedSkills.slice(
+      state.globalOffset,
+      state.globalOffset + limit - skills.length
+    );
+    skills.push(...remaining);
+    state.globalOffset += remaining.length;
+  }
+  const hasMore =
+    !state.customExhausted || state.globalOffset < codeDefinedSkills.length;
+  let nextCursor: string | null = null;
+  if (hasMore) {
+    nextCursor = await writeSkillSearchCursor(fingerprint, state);
+  } else if (!cursor) {
+    // Most slash searches fit in one page. Release those snapshots immediately;
+    // only real pagination sessions need to retain a PIT for cursor retries.
+    await withEs((client) => client.closePointInTime({ id: state.pitId }));
+  }
+  // PITs expire naturally. Keeping them alive until then also permits retries
+  // of an earlier page after the client has reached the last one.
+  return new Ok({ skills, nextCursor });
 }

--- a/front/lib/api/skills/search.ts
+++ b/front/lib/api/skills/search.ts
@@ -23,6 +23,7 @@ import {
 import { GLOBAL_SKILL_SEARCH_ALIASES } from "@app/lib/skills/global_search_aliases";
 import type {
   SearchSkillsResponseBody,
+  SkillSearchPermissionFiltering,
   SkillSearchResult,
 } from "@app/types/api/skills";
 import type { Result } from "@app/types/shared/result";
@@ -37,10 +38,12 @@ export async function searchSkillsForCommandMenu(
     searchTerm,
     limit = MAX_SKILL_SEARCH_RESULTS,
     cursor,
+    permissionFiltering = "strict",
   }: {
     searchTerm: string;
     limit?: number;
     cursor?: string;
+    permissionFiltering?: SkillSearchPermissionFiltering;
   }
 ): Promise<
   Result<SearchSkillsResponseBody, ElasticsearchError | SkillSearchCursorError>
@@ -48,7 +51,11 @@ export async function searchSkillsForCommandMenu(
   assert(
     Number.isInteger(limit) && limit > 0 && limit <= MAX_SKILL_SEARCH_RESULTS
   );
-  const query = await prepareSkillSearchQuery(auth, searchTerm);
+  const query = await prepareSkillSearchQuery(
+    auth,
+    searchTerm,
+    permissionFiltering
+  );
   const globalSkills = await GlobalSkillsRegistry.findAll(auth);
   const systemSkills = await SystemSkillsRegistry.findAll(auth);
   const codeDefinedSkills = [...globalSkills, ...systemSkills]
@@ -65,6 +72,7 @@ export async function searchSkillsForCommandMenu(
         description: skill.userFacingDescription,
         aliases: GLOBAL_SKILL_SEARCH_ALIASES[skill.sId],
       }),
+      canRead: true,
     }))
     .filter((skill) => skill.score > 0)
     .sort(compareRankedSkills);
@@ -75,6 +83,7 @@ export async function searchSkillsForCommandMenu(
     userId: auth.user()?.sId,
     keyId: auth.key()?.id,
     query,
+    permissionFiltering,
     codeDefinedSkills,
   });
   let state: SkillSearchCursor;
@@ -118,6 +127,7 @@ export async function searchSkillsForCommandMenu(
       pitId: state.pitId,
       searchAfter: state.searchAfter,
       limit: candidateLimit,
+      permissionFiltering,
     });
     if (result.isErr()) {
       return result.error.statusCode === 404
@@ -130,7 +140,7 @@ export async function searchSkillsForCommandMenu(
       if (skills.length === limit) {
         break;
       }
-      if (candidate.document) {
+      if (candidate.skill) {
         const [score, name, sId] = candidate.sort;
         while (
           state.globalOffset < codeDefinedSkills.length &&
@@ -146,16 +156,7 @@ export async function searchSkillsForCommandMenu(
         if (skills.length === limit) {
           break;
         }
-        const document = candidate.document;
-        skills.push({
-          editedBy: document.edited_by,
-          icon: document.icon,
-          name: document.name,
-          requestedSpaceIds: document.requested_space_ids,
-          sId: document.skill_id,
-          userFacingDescription: document.user_facing_description ?? "",
-          score,
-        });
+        skills.push(candidate.skill);
       }
       // Advance ONLY past returned or denied hits. Fetched hits displaced by
       // globals are deliberately refetched on the next page.

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -1346,6 +1346,49 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
   });
 
   describe("requestedSpaceIds cleanup", () => {
+    it("reindexes skill updates committed before space cleanup fails", async () => {
+      const spaceResult = await createSpaceAndGroup(
+        adminAuth,
+        {
+          name: "Space With Failing Cleanup",
+          isRestricted: false,
+          spaceKind: "regular",
+          managementMode: "manual",
+          memberIds: [],
+        },
+        { ignoreWorkspaceLimit: true }
+      );
+      expect(spaceResult.isOk()).toBe(true);
+      const space = spaceResult.isOk() ? spaceResult.value : null;
+      expect(space).not.toBeNull();
+
+      const skill = await SkillFactory.create(adminAuth, {
+        name: "Skill Updated Before Cleanup Failure",
+        requestedSpaceIds: [space!.id],
+        manuallyRequestedSpaceIds: [space!.id],
+      });
+      const skillSearchIndexation = await import(
+        "@app/lib/skill_search/indexation"
+      );
+      const launchIndexationSpy = vi
+        .spyOn(skillSearchIndexation, "launchSkillsSearchIndexation")
+        .mockResolvedValue(undefined);
+      vi.spyOn(space!, "delete").mockResolvedValue(
+        new Err(new Error("space delete failed"))
+      );
+
+      await expect(
+        softDeleteSpaceAndLaunchScrubWorkflow(adminAuth, space!, true)
+      ).rejects.toThrow("space delete failed");
+
+      expect(launchIndexationSpy).toHaveBeenCalledWith({
+        workspaceId: workspace.sId,
+        skillIds: [skill.sId],
+      });
+      const skillAfter = await SkillResource.fetchById(adminAuth, skill.sId);
+      expect(skillAfter?.requestedSpaceIds).not.toContain(space!.id);
+    });
+
     it("should remove deleted space from skill requestedSpaceIds", async () => {
       // Create a non-restricted regular space (accessible via global group)
       const spaceResult = await createSpaceAndGroup(

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -29,6 +29,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
+import { launchSkillsSearchIndexation } from "@app/lib/skill_search/indexation";
 import { isPrivateSpacesLimitReached } from "@app/lib/spaces_utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
@@ -246,6 +247,8 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
     "softDeleteSpace: starting agent requestedSpaceIds cleanup"
   );
 
+  const updatedSkillIds: string[] = [];
+  let cleanupError: unknown = null;
   try {
     await withTransaction(async (t) => {
       // Soft delete all data source views.
@@ -437,6 +440,7 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
           manuallyRequestedSpaceIds,
           requestedSpaceIds,
         });
+        updatedSkillIds.push(skill.sId);
       }
 
       // Strip the space from every agent still referencing it, atomically with
@@ -490,11 +494,32 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
       }
     });
   } catch (err) {
+    cleanupError = err;
     logger.error(
       { ...logContext, error: err },
       "softDeleteSpace: agent requestedSpaceIds cleanup failed — scrub workflow will NOT be launched"
     );
-    throw err;
+  }
+
+  if (updatedSkillIds.length > 0) {
+    try {
+      await launchSkillsSearchIndexation({
+        workspaceId,
+        skillIds: updatedSkillIds,
+      });
+    } catch (indexationError) {
+      if (cleanupError === null) {
+        throw indexationError;
+      }
+      logger.error(
+        { ...logContext, error: indexationError },
+        "softDeleteSpace: failed to index skills committed before cleanup failed"
+      );
+    }
+  }
+
+  if (cleanupError !== null) {
+    throw cleanupError;
   }
 
   logger.info(

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -17,6 +17,7 @@ import { KeyModel } from "@app/lib/resources/storage/models/keys";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { launchSkillsSearchIndexationForGroups } from "@app/lib/skill_search/indexation";
 import { guessFirstAndLastNameFromFullName } from "@app/lib/user";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -269,7 +270,8 @@ export async function mergeUserIdentities({
     );
   }
 
-  const workspaceId = auth.getNonNullableWorkspace().id;
+  const workspace = auth.getNonNullableWorkspace();
+  const workspaceId = workspace.id;
 
   // Ensure that primary user has a membership in the workspace.
   const primaryMemberships = await MembershipResource.fetchByUserIds([
@@ -329,10 +331,15 @@ export async function mergeUserIdentities({
   // Migrate authorship of agent memories from the secondary user to the primary user.
   await AgentMemoryModel.update(userIdValues, userIdOptions);
 
-  // Migrate group memberships from secondary user to primary user
-  await GroupResource.migrateUserMemberships(auth, {
-    primaryUser,
-    secondaryUser,
+  // Migrate group memberships from secondary user to primary user.
+  const potentiallyAffectedGroupIds =
+    await GroupResource.migrateUserMemberships(auth, {
+      primaryUser,
+      secondaryUser,
+    });
+  await launchSkillsSearchIndexationForGroups({
+    workspace,
+    groupModelIds: potentiallyAffectedGroupIds,
   });
 
   // Delete all agent-user relations for the secondary user that already have a relation.

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -393,6 +393,41 @@ describe("GroupResource", () => {
 
       expect(inJanuary).toEqual([]);
     });
+
+    it("can resolve active group rows after the workspace membership ended", async () => {
+      const member = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, member, { role: "user" });
+      const editorGroup = await GroupResource.makeNew({
+        name: "Skill editors",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+      await editorGroup.dangerouslyAddMembers(authenticator, {
+        users: [member.toJSON()],
+      });
+      const revokeResult = await MembershipResource.revokeMembership({
+        user: member,
+        workspace,
+      });
+      expect(revokeResult.isOk()).toBe(true);
+
+      const gatedGroups =
+        await GroupResource.dangerouslyListAllUserGroupsInWorkspace({
+          auth: authenticator,
+          user: member,
+          groupKinds: ["regular_auto"],
+        });
+      const rawGroups =
+        await GroupResource.dangerouslyListAllUserGroupsInWorkspace({
+          auth: authenticator,
+          user: member,
+          groupKinds: ["regular_auto"],
+          dangerouslySkipMembershipCheck: true,
+        });
+
+      expect(gatedGroups).toEqual([]);
+      expect(rawGroups.map((group) => group.id)).toEqual([editorGroup.id]);
+    });
   });
 
   describe("dangerouslyListUserGroupsForAuth caching", () => {
@@ -679,6 +714,44 @@ describe("GroupResource", () => {
         },
       });
       expect(secondaryMembership).toBeNull();
+    });
+
+    it("returns potentially affected groups across identity-merge retries", async () => {
+      const secondaryUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, secondaryUser, {
+        role: "user",
+      });
+
+      const regularGroup = await GroupResource.makeNew({
+        name: "Historical Primary Migration Test",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+      await regularGroup.dangerouslyAddMembers(authenticator, {
+        users: [user.toJSON(), secondaryUser.toJSON()],
+      });
+      const removePrimaryResult = await regularGroup.dangerouslyRemoveMembers(
+        authenticator,
+        { users: [user.toJSON()] }
+      );
+      expect(removePrimaryResult.isOk()).toBe(true);
+
+      const potentiallyAffectedGroupIds =
+        await GroupResource.migrateUserMemberships(authenticator, {
+          primaryUser: user,
+          secondaryUser,
+        });
+
+      expect(potentiallyAffectedGroupIds).toEqual([regularGroup.id]);
+      const activeMembers = await regularGroup.getActiveMembers(authenticator);
+      expect(activeMembers).toEqual([]);
+
+      const retryPotentiallyAffectedGroupIds =
+        await GroupResource.migrateUserMemberships(authenticator, {
+          primaryUser: user,
+          secondaryUser,
+        });
+      expect(retryPotentiallyAffectedGroupIds).toEqual([regularGroup.id]);
     });
 
     it("invalidates cache for both users", async () => {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1483,7 +1483,8 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   static async getActiveMembershipsForGroups(
     auth: Authenticator,
-    groups: GroupResource[]
+    groups: GroupResource[],
+    { transaction }: { transaction?: Transaction } = {}
   ): Promise<Record<ModelId, ModelId[]>> {
     const owner = auth.getNonNullableWorkspace();
     const res = await GroupMembershipModel.findAll({
@@ -1494,6 +1495,7 @@ export class GroupResource extends BaseResource<GroupModel> {
         startAt: { [Op.lte]: new Date() },
         [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
       },
+      transaction,
     });
 
     return res.reduce<Record<ModelId, ModelId[]>>((acc, m) => {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -60,6 +60,7 @@ import { col, fn, Op, QueryTypes } from "sequelize";
 
 export const ADMIN_GROUP_NAME = "dust-admins";
 export const MANAGER_GROUP_NAME = "dust-managers";
+export const GROUP_MEMBERSHIP_RESTORE_TOLERANCE_MS = 60_000;
 
 /**
  * ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
@@ -303,6 +304,9 @@ export class GroupResource extends BaseResource<GroupModel> {
   /**
    * Migrates all group memberships from one user to another within a workspace.
    * Handles duplicate memberships by destroying them first.
+   * Returns regular_auto groups that may carry an affected editor grant. The
+   * result includes both users' membership history so a retry after a completed
+   * migration returns the same groups and can retry a failed invalidation.
    */
   static async migrateUserMemberships(
     auth: Authenticator,
@@ -313,8 +317,27 @@ export class GroupResource extends BaseResource<GroupModel> {
       primaryUser: UserResource;
       secondaryUser: UserResource;
     }
-  ): Promise<void> {
+  ): Promise<ModelId[]> {
     const workspace = auth.getNonNullableWorkspace();
+    const potentiallyAffectedMemberships = await GroupMembershipModel.findAll({
+      attributes: ["groupId"],
+      where: {
+        userId: [primaryUser.id, secondaryUser.id],
+        workspaceId: workspace.id,
+      },
+      include: [
+        {
+          model: GroupModel,
+          as: "group",
+          attributes: [],
+          required: true,
+          where: {
+            workspaceId: workspace.id,
+            kind: "regular_auto",
+          },
+        },
+      ],
+    });
     const primaryMemberships = await GroupMembershipModel.findAll({
       where: { userId: primaryUser.id, workspaceId: workspace.id },
       attributes: ["groupId"],
@@ -341,6 +364,12 @@ export class GroupResource extends BaseResource<GroupModel> {
       [{ user: { id: primaryUser.id }, workspace: { id: workspace.id } }],
       [{ user: { id: secondaryUser.id }, workspace: { id: workspace.id } }],
     ]);
+
+    return [
+      ...new Set(
+        potentiallyAffectedMemberships.map((membership) => membership.groupId)
+      ),
+    ];
   }
 
   static async makeNew(
@@ -1218,7 +1247,9 @@ export class GroupResource extends BaseResource<GroupModel> {
   /**
    * Same as `listUserGroupsInWorkspace`, but also accepts the internal kinds that are never
    * surfaced to users. Reserved for system flows that must act on a user's whole membership
-   * set, such as directory-sync deprovisioning.
+   * set, such as directory-sync deprovisioning. `dangerouslySkipMembershipCheck` also exposes
+   * active group rows for a user without an active workspace membership and is only for trusted
+   * repair or migration flows.
    */
   static async dangerouslyListAllUserGroupsInWorkspace({
     auth,
@@ -1226,12 +1257,14 @@ export class GroupResource extends BaseResource<GroupModel> {
     groupKinds,
     transaction,
     at,
+    dangerouslySkipMembershipCheck,
   }: {
     auth: Authenticator;
     user: UserResource;
     groupKinds: Exclude<GroupKind, "system">[];
     transaction?: Transaction;
     at?: Date;
+    dangerouslySkipMembershipCheck?: boolean;
   }): Promise<GroupResource[]> {
     const { groupModelIds } = await this.listUserGroupModelIdsInWorkspace({
       user,
@@ -1239,6 +1272,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       groupKinds,
       transaction,
       at,
+      dangerouslySkipMembershipCheck,
     });
 
     if (groupModelIds.length === 0) {
@@ -2064,7 +2098,7 @@ export class GroupResource extends BaseResource<GroupModel> {
    * (membership is implicit). Skips groups that no longer exist or where the
    * user already has an active membership.
    *
-   * Returns the number of group memberships restored.
+   * Returns the model IDs of the restored groups.
    *
    * Dangerous: deliberately skips the `canRead` check on the groups — it
    * restores regular_auto memberships together with provisioned and manual
@@ -2074,7 +2108,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     user,
     workspace,
     revokedAt,
-    toleranceMs = 60_000,
+    toleranceMs = GROUP_MEMBERSHIP_RESTORE_TOLERANCE_MS,
     transaction,
   }: {
     user: UserResource;
@@ -2082,7 +2116,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     revokedAt: Date;
     toleranceMs?: number;
     transaction?: Transaction;
-  }): Promise<number> {
+  }): Promise<ModelId[]> {
     const rangeStart = new Date(revokedAt.getTime() - toleranceMs);
     const rangeEnd = new Date(revokedAt.getTime() + toleranceMs);
 
@@ -2100,7 +2134,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     });
 
     if (revokedMemberships.length === 0) {
-      return 0;
+      return [];
     }
 
     const groupIds = [...new Set(revokedMemberships.map((m) => m.groupId))];
@@ -2116,7 +2150,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     });
 
     if (groups.length === 0) {
-      return 0;
+      return [];
     }
 
     const validGroupIds = new Set(groups.map((g) => g.id));
@@ -2141,7 +2175,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     );
 
     if (groupIdsToRestore.length === 0) {
-      return 0;
+      return [];
     }
 
     await GroupMembershipModel.bulkCreate(
@@ -2165,7 +2199,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       });
     });
 
-    return groupIdsToRestore.length;
+    return groupIdsToRestore;
   }
 
   /**

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -3010,6 +3010,59 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   /**
+   * Batch list the user IDs holding an editor grant, keyed by skill model ID.
+   * Unlike `batchListEditors`, this includes users without a current workspace
+   * membership so permission projections do not churn when membership changes.
+   */
+  static async batchListEditorGrantUserIdsByModelId(
+    auth: Authenticator,
+    skillModelIds: ModelId[],
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Map<ModelId, ModelId[]>> {
+    const uniqueSkillModelIds = [...new Set(skillModelIds)];
+    const result = new Map<ModelId, ModelId[]>(
+      uniqueSkillModelIds.map((skillModelId) => [skillModelId, []])
+    );
+    if (uniqueSkillModelIds.length === 0) {
+      return result;
+    }
+
+    const editorGrantSpec = (skillModelId: ModelId) => ({
+      grantType: SKILL_EDITOR_GRANT_TYPE,
+      resourceType: "skill" as const,
+      resourceId: skillModelId,
+    });
+    const groupByGrant =
+      await GroupPermissionResource.findRegularAutoGroupsForGrants(auth, {
+        grants: uniqueSkillModelIds.map(editorGrantSpec),
+        transaction,
+      });
+    const groupBySkillModelId = new Map<ModelId, GroupResource>(
+      removeNulls(
+        uniqueSkillModelIds.map((skillModelId) => {
+          const group = groupByGrant.get(
+            grantKey(editorGrantSpec(skillModelId))
+          );
+          return group ? ([skillModelId, group] as const) : null;
+        })
+      )
+    );
+    const membershipsByGroupId =
+      await GroupResource.getActiveMembershipsForGroups(
+        auth,
+        [...groupBySkillModelId.values()],
+        { transaction }
+      );
+    for (const skillModelId of uniqueSkillModelIds) {
+      const group = groupBySkillModelId.get(skillModelId);
+      const userIds = group ? (membershipsByGroupId[group.id] ?? []) : [];
+      result.set(skillModelId, [...new Set(userIds)]);
+    }
+
+    return result;
+  }
+
+  /**
    * Batch list editors for multiple skills. Keyed by skill sId. The batched counterpart of
    * `listEditors` — see it for why editors are only ever read through these two methods.
    */
@@ -3028,64 +3081,41 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return result;
     }
 
-    // Editors come from the per-user grants: one regular_auto group per skill — see `listEditors`.
-    const editorGrantSpec = (skill: SkillResource) => ({
-      grantType: SKILL_EDITOR_GRANT_TYPE,
-      resourceType: "skill" as const,
-      resourceId: skill.id,
-    });
-
-    const groupByGrant =
-      await GroupPermissionResource.findRegularAutoGroupsForGrants(auth, {
-        grants: customSkills.map(editorGrantSpec),
-      });
-
-    const groupBySkillModelId = new Map<ModelId, GroupResource>(
-      removeNulls(
-        customSkills.map((skill) => {
-          const group = groupByGrant.get(grantKey(editorGrantSpec(skill)));
-
-          return group ? ([skill.id, group] as const) : null;
-        })
-      )
-    );
-
-    const membershipsByGroupId =
-      await GroupResource.getActiveMembershipsForGroups(auth, [
-        ...groupBySkillModelId.values(),
-      ]);
-
-    const allUserIds = [...new Set(Object.values(membershipsByGroupId).flat())];
-
-    if (allUserIds.length === 0) {
+    const grantUserIdsBySkillModelId =
+      await this.batchListEditorGrantUserIdsByModelId(
+        auth,
+        customSkills.map((skill) => skill.id)
+      );
+    const allGrantUserIds = [
+      ...new Set([...grantUserIdsBySkillModelId.values()].flat()),
+    ];
+    if (allGrantUserIds.length === 0) {
       return result;
     }
 
-    const allUsers = await UserResource.fetchByModelIds(allUserIds);
-
-    // Filter to only keep users with an active workspace membership,
-    // matching the behavior of getActiveMembers.
+    const allGrantUsers = await UserResource.fetchByModelIds(allGrantUserIds);
     const workspace = auth.getNonNullableWorkspace();
     const { memberships: workspaceMemberships } =
       await MembershipResource.getActiveMemberships({
-        users: allUsers,
+        users: allGrantUsers,
         workspace,
       });
     const activeWorkspaceUserIds = new Set(
-      workspaceMemberships.map((m) => m.userId)
+      workspaceMemberships.map((membership) => membership.userId)
     );
-
-    const userById = new Map(
-      allUsers
-        .filter((u) => activeWorkspaceUserIds.has(u.id))
-        .map((u) => [u.id, u])
-    );
+    const grantUserById = new Map(allGrantUsers.map((user) => [user.id, user]));
 
     for (const skill of customSkills) {
-      const group = groupBySkillModelId.get(skill.id);
-      const userIds = group ? (membershipsByGroupId[group.id] ?? []) : [];
-      const users = removeNulls(userIds.map((id) => userById.get(id) ?? null));
-      result.set(skill.sId, users);
+      const editorIds = grantUserIdsBySkillModelId.get(skill.id) ?? [];
+      const activeEditors = removeNulls(
+        editorIds.map((editorId) => {
+          if (!activeWorkspaceUserIds.has(editorId)) {
+            return null;
+          }
+          return grantUserById.get(editorId) ?? null;
+        })
+      );
+      result.set(skill.sId, activeEditors);
     }
 
     return result;

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -66,6 +66,7 @@ import {
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import type { SkillSearchResult } from "@app/types/api/skills";
 import type {
   AgentConfigurationWithoutModelType,
   LightAgentConfigurationType,
@@ -4539,6 +4540,26 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     ) {
       await this.update({ instructions, instructionsHtml }, transaction);
     }
+  }
+
+  /**
+   * @cc [owner:aubin-tchoi,label:security] search-listing-redaction
+   * Search serialization exposes only listing metadata and the canonical canRead
+   * flag, never instructions, tools, file attachments, or editor grants.
+   */
+  toSearchJSON(auth: Authenticator, score: number): SkillSearchResult {
+    return {
+      editedBy: this.globalSId ? null : this.editedBy,
+      icon: this.icon ?? null,
+      name: this.name,
+      requestedSpaceIds: this.requestedSpaceIds.map((id) =>
+        SpaceResource.modelIdToSId({ id, workspaceId: this.workspaceId })
+      ),
+      sId: this.sId,
+      userFacingDescription: this.userFacingDescription ?? "",
+      canRead: this.canRead(auth),
+      score,
+    };
   }
 
   toJSON(auth: Authenticator): SkillType {

--- a/front/lib/resources/skill/skill_search_document_resource.test.ts
+++ b/front/lib/resources/skill/skill_search_document_resource.test.ts
@@ -83,4 +83,42 @@ describe("SkillSearchDocumentResource", () => {
       )
     ).resolves.toBeNull();
   });
+  it("pages active skills by model ID", async () => {
+    const firstActiveSkill = await SkillFactory.create(
+      testContext.authenticator,
+      { name: "First active skill" }
+    );
+    await SkillFactory.create(testContext.authenticator, {
+      name: "Archived skill",
+      status: "archived",
+    });
+    const secondActiveSkill = await SkillFactory.create(
+      testContext.authenticator,
+      { name: "Second active skill" }
+    );
+
+    const firstPage =
+      await SkillSearchDocumentResource.listActiveSearchIndexSkillIds(
+        testContext.authenticator,
+        { afterSkillModelId: null, limit: 1 }
+      );
+    expect(firstPage).toEqual([
+      {
+        skillId: firstActiveSkill.sId,
+        skillModelId: firstActiveSkill.id,
+      },
+    ]);
+
+    const secondPage =
+      await SkillSearchDocumentResource.listActiveSearchIndexSkillIds(
+        testContext.authenticator,
+        { afterSkillModelId: firstPage[0].skillModelId, limit: 10 }
+      );
+    expect(secondPage).toEqual([
+      {
+        skillId: secondActiveSkill.sId,
+        skillModelId: secondActiveSkill.id,
+      },
+    ]);
+  });
 });

--- a/front/lib/resources/skill/skill_search_document_resource.test.ts
+++ b/front/lib/resources/skill/skill_search_document_resource.test.ts
@@ -1,0 +1,86 @@
+import { SkillSearchDocumentResource } from "@app/lib/resources/skill/skill_search_document_resource";
+import { makeSId } from "@app/lib/resources/string_ids";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("SkillSearchDocumentResource", () => {
+  let testContext: Awaited<ReturnType<typeof createResourceTest>>;
+
+  beforeEach(async () => {
+    testContext = await createResourceTest({ role: "admin" });
+  });
+
+  it("batch-hydrates active documents in input order", async () => {
+    const regularSpace = await SpaceFactory.regular(testContext.workspace);
+    const pod = await SpaceFactory.project(
+      testContext.workspace,
+      testContext.user.id
+    );
+    const firstSkill = await SkillFactory.create(testContext.authenticator, {
+      name: "First skill",
+      requestedSpaceIds: [regularSpace.id, pod.id],
+    });
+    const additionalEditor = await UserFactory.basic();
+    await MembershipFactory.associate(testContext.workspace, additionalEditor, {
+      role: "user",
+    });
+    const addEditorResult = await firstSkill.addEditors(
+      testContext.authenticator,
+      [additionalEditor]
+    );
+    expect(addEditorResult.isOk()).toBe(true);
+    const secondSkill = await SkillFactory.create(testContext.authenticator, {
+      name: "Second skill",
+    });
+    const archivedSkill = await SkillFactory.create(testContext.authenticator, {
+      name: "Archived skill",
+      status: "archived",
+    });
+
+    const documents = await withTransaction((transaction) =>
+      SkillSearchDocumentResource.fetchSearchDocuments(
+        testContext.authenticator,
+        [secondSkill.sId, "invalid", firstSkill.sId, archivedSkill.sId],
+        { transaction }
+      )
+    );
+
+    expect(documents.map((document) => document.skill_id)).toEqual([
+      secondSkill.sId,
+      firstSkill.sId,
+    ]);
+    expect(documents[1]).toMatchObject({
+      workspace_id: testContext.workspace.sId,
+      status: "active",
+      editor_user_ids: [testContext.user.id, additionalEditor.id].sort(
+        (a, b) => a - b
+      ),
+      requested_space_ids: [regularSpace.sId, pod.sId],
+      non_pod_space_ids: [regularSpace.sId],
+      non_pod_space_count: 1,
+      pod_space_id: pod.sId,
+    });
+  });
+
+  it("rejects a skill ID encoded for another workspace", async () => {
+    const skill = await SkillFactory.create(testContext.authenticator);
+    const otherWorkspace = await WorkspaceFactory.basic();
+    const crossWorkspaceSkillId = makeSId("skill", {
+      id: skill.id,
+      workspaceId: otherWorkspace.id,
+    });
+
+    await expect(
+      SkillSearchDocumentResource.fetchSearchDocument(
+        testContext.authenticator,
+        crossWorkspaceSkillId
+      )
+    ).resolves.toBeNull();
+  });
+});

--- a/front/lib/resources/skill/skill_search_document_resource.test.ts
+++ b/front/lib/resources/skill/skill_search_document_resource.test.ts
@@ -83,6 +83,57 @@ describe("SkillSearchDocumentResource", () => {
       )
     ).resolves.toBeNull();
   });
+  it("fails closed when permission-bearing fields are stale", async () => {
+    const regularSpace = await SpaceFactory.regular(testContext.workspace);
+    const skill = await SkillFactory.create(testContext.authenticator, {
+      requestedSpaceIds: [regularSpace.id],
+    });
+    const document = await SkillSearchDocumentResource.fetchSearchDocument(
+      testContext.authenticator,
+      skill.sId
+    );
+    expect(document).not.toBeNull();
+    if (!document) {
+      return;
+    }
+
+    const staleDocuments = [
+      { ...document, availability: "workspace_users" as const },
+      { ...document, requested_space_ids: [] },
+      { ...document, non_pod_space_ids: [], non_pod_space_count: 0 },
+      { ...document, pod_space_id: regularSpace.sId },
+      { ...document, editor_user_ids: [999_999_999] },
+      {
+        ...document,
+        editor_user_ids: 999_999_999 as unknown as number[],
+      },
+      {
+        ...document,
+        requested_space_ids: regularSpace.sId as unknown as string[],
+      },
+      {
+        ...document,
+        non_pod_space_ids: undefined as unknown as string[],
+      },
+      { ...document, workspace_id: "workspace-invalid" },
+    ];
+
+    await expect(
+      SkillSearchDocumentResource.filterSearchDocumentsByCurrentState(
+        testContext.authenticator,
+        [document, ...staleDocuments]
+      )
+    ).resolves.toEqual([document]);
+
+    await skill.archive(testContext.authenticator);
+    await expect(
+      SkillSearchDocumentResource.filterSearchDocumentsByCurrentState(
+        testContext.authenticator,
+        [document]
+      )
+    ).resolves.toEqual([]);
+  });
+
   it("pages active skills by model ID", async () => {
     const firstActiveSkill = await SkillFactory.create(
       testContext.authenticator,

--- a/front/lib/resources/skill/skill_search_document_resource.ts
+++ b/front/lib/resources/skill/skill_search_document_resource.ts
@@ -11,6 +11,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { SkillSearchDocument } from "@app/types/skill_search/skill_search";
 import assert from "assert";
+import isEqual from "lodash/isEqual";
 import type { Transaction, WhereOptions } from "sequelize";
 import { Op } from "sequelize";
 
@@ -248,5 +249,56 @@ export class SkillSearchDocumentResource {
         })
       );
     }, existingTransaction);
+  }
+
+  /**
+   * Fail closed when an Elasticsearch document's permission-bearing fields no
+   * longer match the canonical database state.
+   */
+  static async filterSearchDocumentsByCurrentState(
+    auth: Authenticator,
+    documents: readonly SkillSearchDocument[],
+    options: TransactionOptions = {}
+  ): Promise<SkillSearchDocument[]> {
+    if (documents.length === 0) {
+      return [];
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    const currentDocuments = await this.fetchSearchDocuments(
+      auth,
+      documents.map((document) => document.skill_id),
+      options
+    );
+    const currentDocumentBySkillId = new Map(
+      currentDocuments.map((document) => [document.skill_id, document])
+    );
+
+    return documents.filter((document) => {
+      const currentDocument = currentDocumentBySkillId.get(document.skill_id);
+      return (
+        document.workspace_id === workspace.sId &&
+        currentDocument !== undefined &&
+        document.status === currentDocument.status &&
+        document.availability === currentDocument.availability &&
+        Array.isArray(document.requested_space_ids) &&
+        isEqual(
+          [...document.requested_space_ids].sort(),
+          [...currentDocument.requested_space_ids].sort()
+        ) &&
+        Array.isArray(document.non_pod_space_ids) &&
+        isEqual(
+          [...document.non_pod_space_ids].sort(),
+          [...currentDocument.non_pod_space_ids].sort()
+        ) &&
+        document.non_pod_space_count === currentDocument.non_pod_space_count &&
+        document.pod_space_id === currentDocument.pod_space_id &&
+        Array.isArray(document.editor_user_ids) &&
+        isEqual(
+          [...document.editor_user_ids].sort((a, b) => a - b),
+          [...currentDocument.editor_user_ids].sort((a, b) => a - b)
+        )
+      );
+    });
   }
 }

--- a/front/lib/resources/skill/skill_search_document_resource.ts
+++ b/front/lib/resources/skill/skill_search_document_resource.ts
@@ -10,7 +10,8 @@ import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { ModelId } from "@app/types/shared/model_id";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { SkillSearchDocument } from "@app/types/skill_search/skill_search";
-import type { Transaction } from "sequelize";
+import assert from "assert";
+import type { Transaction, WhereOptions } from "sequelize";
 import { Op } from "sequelize";
 
 interface TransactionOptions {
@@ -56,6 +57,48 @@ export class SkillSearchDocumentResource {
         return { skillId, skillModelId: parsed.resourceModelId };
       })
     );
+  }
+
+  static async listActiveSearchIndexSkillIds(
+    auth: Authenticator,
+    {
+      afterSkillModelId,
+      limit,
+      transaction: existingTransaction,
+    }: {
+      afterSkillModelId: ModelId | null;
+      limit: number;
+      transaction?: Transaction;
+    }
+  ): Promise<{ skillId: string; skillModelId: ModelId }[]> {
+    assert(Number.isInteger(limit) && limit > 0, "limit must be positive");
+
+    return withTransaction(async (transaction) => {
+      const workspace = auth.getNonNullableWorkspace();
+      const where: WhereOptions<SkillConfigurationModel> = {
+        workspaceId: workspace.id,
+        status: "active",
+      };
+      if (afterSkillModelId !== null) {
+        where.id = { [Op.gt]: afterSkillModelId };
+      }
+
+      const skills = await SkillConfigurationModel.findAll({
+        attributes: ["id"],
+        where,
+        order: [["id", "ASC"]],
+        limit,
+        transaction,
+      });
+
+      return skills.map((skill) => ({
+        skillId: this.modelIdToSId({
+          id: skill.id,
+          workspaceId: workspace.id,
+        }),
+        skillModelId: skill.id,
+      }));
+    }, existingTransaction);
   }
 
   static async fetchSearchDocument(

--- a/front/lib/resources/skill/skill_search_document_resource.ts
+++ b/front/lib/resources/skill/skill_search_document_resource.ts
@@ -1,0 +1,209 @@
+import type { Authenticator } from "@app/lib/auth";
+import { SkillConfigurationModel } from "@app/lib/models/skill";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import {
+  getResourceNameAndIdFromSId,
+  makeSId,
+} from "@app/lib/resources/string_ids";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import type { ModelId } from "@app/types/shared/model_id";
+import { removeNulls } from "@app/types/shared/utils/general";
+import type { SkillSearchDocument } from "@app/types/skill_search/skill_search";
+import type { Transaction } from "sequelize";
+import { Op } from "sequelize";
+
+interface TransactionOptions {
+  transaction?: Transaction;
+}
+
+interface ParsedSkillId {
+  skillId: string;
+  skillModelId: ModelId;
+}
+
+/**
+ * Builds and validates skill-search documents from canonical database state.
+ * Elasticsearch and workflow side effects deliberately live outside Resources.
+ */
+export class SkillSearchDocumentResource {
+  private static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("skill", { id, workspaceId });
+  }
+
+  private static parseSkillIds(
+    auth: Authenticator,
+    skillIds: readonly string[]
+  ): ParsedSkillId[] {
+    const workspace = auth.getNonNullableWorkspace();
+
+    return removeNulls(
+      skillIds.map((skillId) => {
+        const parsed = getResourceNameAndIdFromSId(skillId);
+        if (
+          parsed?.resourceName !== "skill" ||
+          parsed.workspaceModelId !== workspace.id
+        ) {
+          return null;
+        }
+
+        return { skillId, skillModelId: parsed.resourceModelId };
+      })
+    );
+  }
+
+  static async fetchSearchDocument(
+    auth: Authenticator,
+    skillId: string,
+    options: TransactionOptions = {}
+  ): Promise<SkillSearchDocument | null> {
+    const [document] = await this.fetchSearchDocuments(
+      auth,
+      [skillId],
+      options
+    );
+    return document ?? null;
+  }
+
+  static async fetchSearchDocuments(
+    auth: Authenticator,
+    skillIds: readonly string[],
+    { transaction: existingTransaction }: TransactionOptions = {}
+  ): Promise<SkillSearchDocument[]> {
+    const parsedSkillIds = this.parseSkillIds(auth, skillIds);
+    if (parsedSkillIds.length === 0) {
+      return [];
+    }
+
+    return withTransaction(async (transaction) => {
+      const workspace = auth.getNonNullableWorkspace();
+      const skillModelIds = [
+        ...new Set(parsedSkillIds.map(({ skillModelId }) => skillModelId)),
+      ];
+      const skills = await SkillConfigurationModel.findAll({
+        attributes: [
+          "id",
+          "status",
+          "availability",
+          "name",
+          "userFacingDescription",
+          "icon",
+          "editedBy",
+          "requestedSpaceIds",
+          "updatedAt",
+        ],
+        where: {
+          id: { [Op.in]: skillModelIds },
+          workspaceId: workspace.id,
+          status: "active",
+        },
+        transaction,
+      });
+      if (skills.length === 0) {
+        return [];
+      }
+
+      const activeSkillModelIds = skills.map((skill) => skill.id);
+
+      const requestedSpaceModelIds = [
+        ...new Set(skills.flatMap((skill) => skill.requestedSpaceIds)),
+      ];
+      const requestedSpaces = await SpaceResource.fetchByIds(
+        auth,
+        requestedSpaceModelIds.map((id) =>
+          SpaceResource.modelIdToSId({ id, workspaceId: workspace.id })
+        ),
+        { transaction }
+      );
+      const requestedSpaceByModelId = new Map(
+        requestedSpaces.map((space) => [space.id, space])
+      );
+
+      const editorGrantUserIdsBySkillModelId =
+        await SkillResource.batchListEditorGrantUserIdsByModelId(
+          auth,
+          activeSkillModelIds,
+          { transaction }
+        );
+
+      const documentBySkillModelId = new Map<ModelId, SkillSearchDocument>();
+      for (const skill of skills) {
+        if (
+          new Set(skill.requestedSpaceIds).size !==
+          skill.requestedSpaceIds.length
+        ) {
+          continue;
+        }
+
+        const spaces = removeNulls(
+          skill.requestedSpaceIds.map((spaceModelId) =>
+            requestedSpaceByModelId.get(spaceModelId)
+          )
+        );
+        if (spaces.length !== skill.requestedSpaceIds.length) {
+          continue;
+        }
+
+        const podSpaceIds = [
+          ...new Set(
+            spaces
+              .filter((space) => space.isProject())
+              .map((space) => space.sId)
+          ),
+        ];
+        if (podSpaceIds.length > 1) {
+          continue;
+        }
+
+        const requestedSpaceIds = skill.requestedSpaceIds.map((spaceModelId) =>
+          SpaceResource.modelIdToSId({
+            id: spaceModelId,
+            workspaceId: workspace.id,
+          })
+        );
+        const nonPodSpaceIds = [
+          ...new Set(
+            spaces
+              .filter((space) => !space.isProject())
+              .map((space) => space.sId)
+          ),
+        ];
+
+        documentBySkillModelId.set(skill.id, {
+          workspace_id: workspace.sId,
+          skill_id: this.modelIdToSId({
+            id: skill.id,
+            workspaceId: workspace.id,
+          }),
+          status: skill.status,
+          availability: skill.availability,
+          name: skill.name,
+          user_facing_description: skill.userFacingDescription,
+          icon: skill.icon,
+          edited_by: skill.editedBy,
+          editor_user_ids: [
+            ...new Set(editorGrantUserIdsBySkillModelId.get(skill.id) ?? []),
+          ].sort((a, b) => a - b),
+          requested_space_ids: requestedSpaceIds,
+          non_pod_space_ids: nonPodSpaceIds,
+          non_pod_space_count: nonPodSpaceIds.length,
+          pod_space_id: podSpaceIds[0] ?? null,
+          updated_at: skill.updatedAt.toISOString(),
+        });
+      }
+
+      return removeNulls(
+        parsedSkillIds.map(({ skillId, skillModelId }) => {
+          const document = documentBySkillModelId.get(skillModelId);
+          return document?.skill_id === skillId ? document : null;
+        })
+      );
+    }, existingTransaction);
+  }
+}

--- a/front/lib/resources/skill/skill_search_document_resource.ts
+++ b/front/lib/resources/skill/skill_search_document_resource.ts
@@ -7,6 +7,7 @@ import {
   makeSId,
 } from "@app/lib/resources/string_ids";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import type { SkillSearchResult } from "@app/types/api/skills";
 import type { ModelId } from "@app/types/shared/model_id";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { SkillSearchDocument } from "@app/types/skill_search/skill_search";
@@ -29,6 +30,27 @@ interface ParsedSkillId {
  * Elasticsearch and workflow side effects deliberately live outside Resources.
  */
 export class SkillSearchDocumentResource {
+  /**
+   * @cc [owner:aubin-tchoi,label:security] authorized-search-document
+   * Callers must establish readability before serializing an indexed document;
+   * this metadata-only serializer does not authorize access itself.
+   */
+  static toSearchJSON(
+    document: SkillSearchDocument,
+    score: number
+  ): SkillSearchResult {
+    return {
+      editedBy: document.edited_by,
+      icon: document.icon,
+      name: document.name,
+      requestedSpaceIds: document.requested_space_ids,
+      sId: document.skill_id,
+      userFacingDescription: document.user_facing_description ?? "",
+      canRead: true,
+      score,
+    };
+  }
+
   private static modelIdToSId({
     id,
     workspaceId,

--- a/front/lib/skill_search/README.md
+++ b/front/lib/skill_search/README.md
@@ -1,0 +1,33 @@
+# Ranked skill search
+
+Custom skills stay in the workspace-scoped ES index. Global and system skills
+stay in their code registries; adding one requires no search migration or sync.
+
+ES and TypeScript use the same fixed relevance tiers: exact name/alias (100),
+prefix (80), substring (60), subsequence (40), description substring (20), and
+description subsequence (10). The best match wins. Empty queries score 1.
+Ties use name and skill ID in ES keyword byte order. Wildcard matching folds
+ASCII case only, matching ES 8's behavior. BM25 is not the final ranking.
+
+`GET /api/w/:wId/skills/search` accepts optional `limit` (1–150) and `cursor`.
+It returns `skills` with scores and `nextCursor` (null when exhausted).
+
+The backend merges two sorted streams. The ES cursor advances past returned or
+permission-rejected candidates, never authorized hits displaced by globals.
+Unconsumed hits are refetched. Globals have an independent position.
+
+Cursors are immutable opaque Redis keys with a five-minute TTL, bound to the
+workspace, caller, ES query and matching global catalog. Changed eligibility,
+catalog or query, missing cursor state, or an expired PIT requires restarting
+the search (400). Permission checks still run live on each candidate batch;
+a PIT freezes index state, not authorization.
+
+Each request prepares readable non-pod IDs once and runs at most five batches
+of 50–200 ES candidates. Pod and canonical DB validation remain batched. A short
+or empty page can have a continuation cursor: consumers must use `nextCursor`,
+not the number of results, to decide whether search is exhausted.
+
+The first page also opens a PIT. Single-page searches close it immediately;
+paginated snapshots expire naturally so earlier cursors remain retryable.
+Continuation pages read one Redis cursor, and pages with more results write
+one. No skill documents, permission grants or result bodies are cached there.

--- a/front/lib/skill_search/cursor.ts
+++ b/front/lib/skill_search/cursor.ts
@@ -1,0 +1,60 @@
+import { getRedisCacheClient } from "@app/lib/api/redis";
+import {
+  SKILL_SEARCH_KEEP_ALIVE_SECONDS,
+  SkillSearchSortSchema,
+} from "@app/lib/skill_search/search";
+import { safeParseJSON } from "@app/types/shared/utils/json_utils";
+import { createHash, randomUUID } from "crypto";
+import { z } from "zod";
+
+const CursorSchema = z.object({
+  pitId: z.string(),
+  searchAfter: SkillSearchSortSchema.nullable(),
+  globalOffset: z.number().int().nonnegative(),
+  customExhausted: z.boolean(),
+});
+export type SkillSearchCursor = z.infer<typeof CursorSchema>;
+
+export class SkillSearchCursorError extends Error {
+  constructor() {
+    super("Invalid or expired skill search cursor. Restart the search.");
+  }
+}
+
+export function getSkillSearchFingerprint(context: unknown): string {
+  return createHash("sha256").update(JSON.stringify(context)).digest("hex");
+}
+
+// Opaque, immutable cursors avoid exposing names, ACLs or PIT details in URLs.
+// Binding the key to the caller/query/catalog also makes cursor replay across
+// workspaces or a changed catalog fail closed. A retry never consumes a cursor.
+export async function readSkillSearchCursor(
+  fingerprint: string,
+  cursor: string
+): Promise<SkillSearchCursor | null> {
+  const redis = await getRedisCacheClient({ origin: "skill_search_cursor" });
+  const raw = await redis.get(`skill_search_cursor:${fingerprint}:${cursor}`);
+  if (!raw) {
+    return null;
+  }
+  const json = safeParseJSON(raw);
+  if (json.isErr()) {
+    return null;
+  }
+  const parsed = CursorSchema.safeParse(json.value);
+  return parsed.success ? parsed.data : null;
+}
+
+export async function writeSkillSearchCursor(
+  fingerprint: string,
+  state: SkillSearchCursor
+): Promise<string> {
+  const cursor = randomUUID();
+  const redis = await getRedisCacheClient({ origin: "skill_search_cursor" });
+  await redis.set(
+    `skill_search_cursor:${fingerprint}:${cursor}`,
+    JSON.stringify(state),
+    { EX: SKILL_SEARCH_KEEP_ALIVE_SECONDS }
+  );
+  return cursor;
+}

--- a/front/lib/skill_search/index.test.ts
+++ b/front/lib/skill_search/index.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  deleteByQuery: vi.fn(),
+  index: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/elasticsearch", async () => {
+  const { Err, Ok } = await import("@app/types/shared/result");
+
+  return {
+    SKILL_SEARCH_ALIAS_NAME: "front.skill_search",
+    withEs: async (
+      fn: (client: typeof mocks) => Promise<unknown>
+    ): Promise<unknown> => {
+      try {
+        return new Ok(await fn(mocks));
+      } catch (error) {
+        return new Err(error);
+      }
+    },
+  };
+});
+
+import {
+  deleteSkillDocument,
+  deleteWorkspaceSkillDocuments,
+  indexSkillDocument,
+} from "@app/lib/skill_search";
+import type { SkillSearchDocument } from "@app/types/skill_search/skill_search";
+
+const document: SkillSearchDocument = {
+  workspace_id: "workspace-1",
+  skill_id: "skill-1",
+  status: "active",
+  availability: "workspace_users",
+  name: "Skill",
+  user_facing_description: "Description",
+  icon: null,
+  edited_by: null,
+  editor_user_ids: [1],
+  requested_space_ids: [],
+  non_pod_space_ids: [],
+  non_pod_space_count: 0,
+  pod_space_id: null,
+  updated_at: "2026-08-01T00:00:00.000Z",
+};
+
+describe("skill search indexing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.deleteByQuery.mockResolvedValue({
+      failures: [],
+      timed_out: false,
+      version_conflicts: 0,
+    });
+  });
+
+  it("includes the workspace in indexed documents and IDs", async () => {
+    await indexSkillDocument(document);
+
+    expect(mocks.index).toHaveBeenCalledWith({
+      index: "front.skill_search",
+      id: "workspace-1_skill-1",
+      body: document,
+    });
+  });
+
+  it("scopes single-skill deletion by workspace and skill", async () => {
+    await deleteSkillDocument({
+      workspaceId: "workspace-1",
+      skillId: "skill-1",
+    });
+
+    expect(mocks.deleteByQuery).toHaveBeenCalledWith({
+      index: "front.skill_search",
+      query: {
+        bool: {
+          filter: [
+            { term: { workspace_id: "workspace-1" } },
+            { term: { skill_id: "skill-1" } },
+          ],
+        },
+      },
+      refresh: false,
+    });
+  });
+
+  it("scopes workspace deletion by workspace", async () => {
+    await deleteWorkspaceSkillDocuments({ workspaceId: "workspace-1" });
+
+    expect(mocks.deleteByQuery).toHaveBeenCalledWith({
+      index: "front.skill_search",
+      query: { term: { workspace_id: "workspace-1" } },
+      refresh: false,
+    });
+  });
+
+  it.each([
+    ["a timeout", { timed_out: true }],
+    ["a failure", { failures: [{}] }],
+    ["a version conflict", { version_conflicts: 1 }],
+  ])("reports %s as an incomplete deletion", async (_label, response) => {
+    mocks.deleteByQuery.mockResolvedValueOnce(response);
+
+    const result = await deleteSkillDocument({
+      workspaceId: "workspace-1",
+      skillId: "skill-1",
+    });
+
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/front/lib/skill_search/index.ts
+++ b/front/lib/skill_search/index.ts
@@ -1,0 +1,85 @@
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import { SKILL_SEARCH_ALIAS_NAME, withEs } from "@app/lib/api/elasticsearch";
+import type { Result } from "@app/types/shared/result";
+import type { SkillSearchDocument } from "@app/types/skill_search/skill_search";
+import type { estypes } from "@elastic/elasticsearch";
+
+function ensureDeleteByQueryCompleted(
+  response: estypes.DeleteByQueryResponse
+): void {
+  const failureCount = response.failures?.length ?? 0;
+  const versionConflictCount = response.version_conflicts ?? 0;
+  if (response.timed_out || failureCount > 0 || versionConflictCount > 0) {
+    throw new Error(
+      `Skill search deletion did not complete: timedOut=${response.timed_out ?? false}, failures=${failureCount}, versionConflicts=${versionConflictCount}`
+    );
+  }
+}
+
+function makeSkillDocumentId({
+  workspaceId,
+  skillId,
+}: {
+  workspaceId: string;
+  skillId: string;
+}): string {
+  return `${workspaceId}_${skillId}`;
+}
+
+export async function indexSkillDocument(
+  document: SkillSearchDocument
+): Promise<Result<void, ElasticsearchError>> {
+  const documentId = makeSkillDocumentId({
+    workspaceId: document.workspace_id,
+    skillId: document.skill_id,
+  });
+
+  return withEs(async (client) => {
+    await client.index({
+      index: SKILL_SEARCH_ALIAS_NAME,
+      id: documentId,
+      body: document,
+    });
+  });
+}
+
+export async function deleteSkillDocument({
+  workspaceId,
+  skillId,
+}: {
+  workspaceId: string;
+  skillId: string;
+}): Promise<Result<void, ElasticsearchError>> {
+  return withEs(async (client) => {
+    const response = await client.deleteByQuery({
+      index: SKILL_SEARCH_ALIAS_NAME,
+      query: {
+        bool: {
+          filter: [
+            { term: { workspace_id: workspaceId } },
+            { term: { skill_id: skillId } },
+          ],
+        },
+      },
+      refresh: false,
+    });
+    ensureDeleteByQueryCompleted(response);
+  });
+}
+
+export async function deleteWorkspaceSkillDocuments({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<Result<void, ElasticsearchError>> {
+  return withEs(async (client) => {
+    const response = await client.deleteByQuery({
+      index: SKILL_SEARCH_ALIAS_NAME,
+      query: {
+        term: { workspace_id: workspaceId },
+      },
+      refresh: false,
+    });
+    ensureDeleteByQueryCompleted(response);
+  });
+}

--- a/front/lib/skill_search/indexation.test.ts
+++ b/front/lib/skill_search/indexation.test.ts
@@ -1,0 +1,77 @@
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import { makeSId } from "@app/lib/resources/string_ids";
+import { launchSkillsSearchIndexationForGroups } from "@app/lib/skill_search/indexation";
+import { Ok } from "@app/types/shared/result";
+import type { LightWorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  launchIndexSkillSearchWorkflow: vi.fn(),
+}));
+
+vi.mock("@app/temporal/es_indexation/client", () => ({
+  launchDeleteWorkspaceSkillSearchWorkflow: vi.fn(),
+  launchIndexSkillSearchWorkflow: mocks.launchIndexSkillSearchWorkflow,
+}));
+
+describe("skill search indexation", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mocks.launchIndexSkillSearchWorkflow.mockReset();
+    mocks.launchIndexSkillSearchWorkflow.mockResolvedValue(new Ok(undefined));
+  });
+
+  it("reindexes each skill granted to the affected editor groups", async () => {
+    const workspace = {
+      id: 1,
+      sId: "workspace-1",
+    } as LightWorkspaceType;
+    const listForGroupsSpy = vi
+      .spyOn(GroupPermissionResource, "listForGroups")
+      .mockResolvedValue([
+        {
+          groupId: 10,
+          grantType: "editor",
+          resourceType: "skill",
+          resourceId: 20,
+        },
+        {
+          groupId: 11,
+          grantType: "editor",
+          resourceType: "skill",
+          resourceId: 20,
+        },
+        {
+          groupId: 11,
+          grantType: "editor",
+          resourceType: "skill",
+          resourceId: 21,
+        },
+      ]);
+
+    await launchSkillsSearchIndexationForGroups({
+      workspace,
+      groupModelIds: [10, 11, 10],
+    });
+
+    expect(listForGroupsSpy).toHaveBeenCalledWith(workspace, {
+      groupModelIds: [10, 11],
+      grantType: "editor",
+      resourceType: "skill",
+    });
+    expect(mocks.launchIndexSkillSearchWorkflow.mock.calls).toEqual([
+      [
+        {
+          workspaceId: workspace.sId,
+          skillId: makeSId("skill", { id: 20, workspaceId: workspace.id }),
+        },
+      ],
+      [
+        {
+          workspaceId: workspace.sId,
+          skillId: makeSId("skill", { id: 21, workspaceId: workspace.id }),
+        },
+      ],
+    ]);
+  });
+});

--- a/front/lib/skill_search/indexation.ts
+++ b/front/lib/skill_search/indexation.ts
@@ -1,0 +1,97 @@
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import { makeSId } from "@app/lib/resources/string_ids";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import {
+  launchDeleteWorkspaceSkillSearchWorkflow,
+  launchIndexSkillSearchWorkflow,
+} from "@app/temporal/es_indexation/client";
+import type { ModelId } from "@app/types/shared/model_id";
+import { removeNulls } from "@app/types/shared/utils/general";
+import type { LightWorkspaceType } from "@app/types/user";
+
+const SKILL_SEARCH_INDEXATION_CONCURRENCY = 8;
+
+export async function launchSkillSearchIndexation({
+  workspaceId,
+  skillId,
+}: {
+  workspaceId: string;
+  skillId: string;
+}): Promise<void> {
+  const result = await launchIndexSkillSearchWorkflow({ workspaceId, skillId });
+  if (result.isErr()) {
+    throw result.error;
+  }
+}
+
+export async function launchSkillsSearchIndexation({
+  workspaceId,
+  skillIds,
+}: {
+  workspaceId: string;
+  skillIds: readonly string[];
+}): Promise<void> {
+  const results = await concurrentExecutor(
+    skillIds,
+    (skillId) => launchIndexSkillSearchWorkflow({ workspaceId, skillId }),
+    { concurrency: SKILL_SEARCH_INDEXATION_CONCURRENCY }
+  );
+  const failedResult = results.find((result) => result.isErr());
+  if (failedResult?.isErr()) {
+    throw failedResult.error;
+  }
+}
+
+export async function launchSkillsSearchIndexationForGroups({
+  workspace,
+  groupModelIds,
+}: {
+  workspace: LightWorkspaceType;
+  groupModelIds: readonly ModelId[];
+}): Promise<void> {
+  const uniqueGroupModelIds = [...new Set(groupModelIds)];
+  if (uniqueGroupModelIds.length === 0) {
+    return;
+  }
+
+  const skillEditorGrants = await GroupPermissionResource.listForGroups(
+    workspace,
+    {
+      groupModelIds: uniqueGroupModelIds,
+      grantType: "editor",
+      resourceType: "skill",
+    }
+  );
+  const skillIds = [
+    ...new Set(
+      removeNulls(
+        skillEditorGrants.map((grant) =>
+          grant.resourceId > 0
+            ? makeSId("skill", {
+                id: grant.resourceId,
+                workspaceId: workspace.id,
+              })
+            : null
+        )
+      )
+    ),
+  ];
+
+  await launchSkillsSearchIndexation({
+    workspaceId: workspace.sId,
+    skillIds,
+  });
+}
+
+export async function launchWorkspaceSkillSearchDeletion({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<void> {
+  const result = await launchDeleteWorkspaceSkillSearchWorkflow({
+    workspaceId,
+  });
+  if (result.isErr()) {
+    throw result.error;
+  }
+}

--- a/front/lib/skill_search/indices/skill_search_1.mappings.json
+++ b/front/lib/skill_search/indices/skill_search_1.mappings.json
@@ -1,0 +1,73 @@
+{
+  "dynamic": "strict",
+  "properties": {
+    "workspace_id": {
+      "type": "keyword"
+    },
+    "skill_id": {
+      "type": "keyword"
+    },
+    "status": {
+      "type": "keyword"
+    },
+    "availability": {
+      "type": "keyword"
+    },
+    "name": {
+      "type": "text",
+      "analyzer": "skill_name_analyzer",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 256
+        },
+        "subsequence": {
+          "type": "wildcard"
+        }
+      }
+    },
+    "user_facing_description": {
+      "type": "text",
+      "fields": {
+        "subsequence": {
+          "type": "wildcard"
+        }
+      }
+    },
+    "icon": {
+      "type": "keyword",
+      "index": false,
+      "doc_values": false
+    },
+    "edited_by": {
+      "type": "long",
+      "index": false,
+      "doc_values": false
+    },
+    "editor_user_ids": {
+      "type": "long",
+      "doc_values": false
+    },
+    "requested_space_ids": {
+      "type": "keyword",
+      "index": false,
+      "doc_values": false
+    },
+    "non_pod_space_ids": {
+      "type": "keyword"
+    },
+    "non_pod_space_count": {
+      "type": "integer"
+    },
+    "pod_space_id": {
+      "type": "keyword",
+      "index": false,
+      "doc_values": false
+    },
+    "updated_at": {
+      "type": "date",
+      "index": false,
+      "doc_values": false
+    }
+  }
+}

--- a/front/lib/skill_search/indices/skill_search_1.settings.europe-west1.json
+++ b/front/lib/skill_search/indices/skill_search_1.settings.europe-west1.json
@@ -1,0 +1,21 @@
+{
+  "number_of_shards": 3,
+  "number_of_replicas": 1,
+  "refresh_interval": "30s",
+  "analysis": {
+    "filter": {
+      "skill_name_parts": {
+        "type": "word_delimiter_graph",
+        "catenate_all": true,
+        "preserve_original": true
+      }
+    },
+    "analyzer": {
+      "skill_name_analyzer": {
+        "type": "custom",
+        "tokenizer": "keyword",
+        "filter": ["skill_name_parts", "lowercase"]
+      }
+    }
+  }
+}

--- a/front/lib/skill_search/indices/skill_search_1.settings.local.json
+++ b/front/lib/skill_search/indices/skill_search_1.settings.local.json
@@ -1,0 +1,21 @@
+{
+  "number_of_shards": 1,
+  "number_of_replicas": 0,
+  "refresh_interval": "1s",
+  "analysis": {
+    "filter": {
+      "skill_name_parts": {
+        "type": "word_delimiter_graph",
+        "catenate_all": true,
+        "preserve_original": true
+      }
+    },
+    "analyzer": {
+      "skill_name_analyzer": {
+        "type": "custom",
+        "tokenizer": "keyword",
+        "filter": ["skill_name_parts", "lowercase"]
+      }
+    }
+  }
+}

--- a/front/lib/skill_search/indices/skill_search_1.settings.us-central1.json
+++ b/front/lib/skill_search/indices/skill_search_1.settings.us-central1.json
@@ -1,0 +1,21 @@
+{
+  "number_of_shards": 3,
+  "number_of_replicas": 1,
+  "refresh_interval": "30s",
+  "analysis": {
+    "filter": {
+      "skill_name_parts": {
+        "type": "word_delimiter_graph",
+        "catenate_all": true,
+        "preserve_original": true
+      }
+    },
+    "analyzer": {
+      "skill_name_analyzer": {
+        "type": "custom",
+        "tokenizer": "keyword",
+        "filter": ["skill_name_parts", "lowercase"]
+      }
+    }
+  }
+}

--- a/front/lib/skill_search/ranking.test.ts
+++ b/front/lib/skill_search/ranking.test.ts
@@ -1,0 +1,75 @@
+import {
+  buildSkillMatchQuery,
+  compareRankedSkills,
+  getSkillSearchScore,
+} from "@app/lib/skill_search/ranking";
+import { describe, expect, it } from "vitest";
+
+describe("shared skill ranking", () => {
+  it.each([
+    ["", "Anything", "", 1],
+    ["skill", "SKILL", "", 100],
+    ["skill", "Skill builder", "", 80],
+    ["skill", "My skill", "", 60],
+    ["sand", "Search And Navigate Data", "", 40],
+    ["skill", "Other", "Find a skill", 20],
+    ["sand", "Other", "Search And Navigate Data", 10],
+    ["missing", "Other", "Description", 0],
+    ["*?\\", "*?\\", "", 100],
+    ["a.b", "axb", "", 0],
+    ["ab", "A\nB", "", 40],
+    ["skill", "skill\n", "", 80],
+    ["😀", "A😀B", "", 60],
+    // ES 8 wildcard case folding is ASCII-only, not JS Unicode /iu matching.
+    ["Ä", "ä", "", 0],
+    ["Ä", "Ä", "", 100],
+    ["k", "K", "", 0],
+  ])("scores %j against %j consistently with ES", (searchTerm, name, description, expected) => {
+    expect(getSkillSearchScore({ searchTerm, name, description })).toBe(
+      expected
+    );
+  });
+
+  it("uses the best name or alias match and does not add weaker matches", () => {
+    expect(
+      getSkillSearchScore({
+        searchTerm: "deep dive",
+        name: "Go Deep",
+        aliases: ["Deep Dive"],
+        description: "Deep dive into research",
+      })
+    ).toBe(100);
+    const query = buildSkillMatchQuery("deep dive");
+    expect(query.dis_max?.tie_breaker).toBe(0);
+    expect(
+      query.dis_max?.queries.map((clause) => clause.constant_score?.boost)
+    ).toEqual([100, 80, 60, 40, 20, 10]);
+  });
+
+  it("handles long failing subsequences without regex backtracking", () => {
+    expect(
+      getSkillSearchScore({
+        searchTerm: `${"a".repeat(199)}b`,
+        name: "a".repeat(1000),
+        description: "a".repeat(10000),
+      })
+    ).toBe(0);
+  });
+
+  it("breaks ties in ES keyword byte order, including supplementary Unicode", () => {
+    const ranked = [
+      { score: 40, name: "same", sId: "b" },
+      { score: 40, name: "same", sId: "a" },
+      { score: 40, name: "😀", sId: "emoji" },
+      { score: 40, name: "\uE000", sId: "bmp" },
+      { score: 100, name: "Z", sId: "exact" },
+    ].sort(compareRankedSkills);
+    expect(ranked.map((item) => item.sId)).toEqual([
+      "exact",
+      "a",
+      "b",
+      "bmp",
+      "emoji",
+    ]);
+  });
+});

--- a/front/lib/skill_search/ranking.ts
+++ b/front/lib/skill_search/ranking.ts
@@ -1,0 +1,139 @@
+import type { estypes } from "@elastic/elasticsearch";
+
+// Fixed scores make indexed and code-defined skills comparable without corpus
+// statistics. Keep the predicates and normalization identical on both sides.
+const MATCH_SCORES = {
+  exact: 100,
+  prefix: 80,
+  substring: 60,
+  subsequence: 40,
+  descriptionSubstring: 20,
+  descriptionSubsequence: 10,
+};
+
+function escapeWildcard(value: string): string {
+  return value.replace(/[\\*?]/g, "\\$&");
+}
+
+export function buildSkillMatchQuery(
+  searchTerm: string
+): estypes.QueryDslQueryContainer {
+  const query = searchTerm.trim();
+  if (!query) {
+    return { constant_score: { filter: { match_all: {} }, boost: 1 } };
+  }
+  const literal = escapeWildcard(query);
+  const subsequence = `*${Array.from(query, escapeWildcard).join("*")}*`;
+  const matches = [
+    ["name.subsequence", literal, MATCH_SCORES.exact],
+    ["name.subsequence", `${literal}*`, MATCH_SCORES.prefix],
+    ["name.subsequence", `*${literal}*`, MATCH_SCORES.substring],
+    ["name.subsequence", subsequence, MATCH_SCORES.subsequence],
+    [
+      "user_facing_description.subsequence",
+      `*${literal}*`,
+      MATCH_SCORES.descriptionSubstring,
+    ],
+    [
+      "user_facing_description.subsequence",
+      subsequence,
+      MATCH_SCORES.descriptionSubsequence,
+    ],
+  ] as const;
+
+  return {
+    dis_max: {
+      tie_breaker: 0,
+      queries: matches.map(([field, value, boost]) => ({
+        constant_score: {
+          filter: { wildcard: { [field]: { value, case_insensitive: true } } },
+          boost,
+        },
+      })),
+    },
+  };
+}
+
+export function getSkillSearchScore({
+  searchTerm,
+  name,
+  description = "",
+  aliases = [],
+}: {
+  searchTerm: string;
+  name: string;
+  description?: string;
+  aliases?: readonly string[];
+}): number {
+  // ES wildcard case_insensitive folds ASCII only (including on wildcard fields).
+  const normalize = (value: string) =>
+    value.replace(/[A-Z]/g, (character) => character.toLowerCase());
+  const query = normalize(searchTerm.trim());
+  if (!query) {
+    return 1;
+  }
+  // Each scan moves forward, so repeated characters cannot cause backtracking.
+  const isSubsequence = (value: string) => {
+    let offset = 0;
+    for (const character of query) {
+      const found = value.indexOf(character, offset);
+      if (found < 0) {
+        return false;
+      }
+      offset = found + character.length;
+    }
+    return true;
+  };
+
+  let score = 0;
+  for (const value of [name, ...aliases]) {
+    const candidate = normalize(value);
+    const candidateScore =
+      candidate === query
+        ? MATCH_SCORES.exact
+        : candidate.startsWith(query)
+          ? MATCH_SCORES.prefix
+          : candidate.includes(query)
+            ? MATCH_SCORES.substring
+            : isSubsequence(candidate)
+              ? MATCH_SCORES.subsequence
+              : 0;
+    score = Math.max(score, candidateScore);
+  }
+  return Math.max(
+    score,
+    normalize(description).includes(query)
+      ? MATCH_SCORES.descriptionSubstring
+      : isSubsequence(normalize(description))
+        ? MATCH_SCORES.descriptionSubsequence
+        : 0
+  );
+}
+
+export interface RankedSkill {
+  score: number;
+  name: string;
+  sId: string;
+}
+
+const encoder = new TextEncoder();
+
+function compareUtf8Strings(a: string, b: string): number {
+  const left = encoder.encode(a);
+  const right = encoder.encode(b);
+  for (let i = 0; i < Math.min(left.length, right.length); i++) {
+    if (left[i] !== right[i]) {
+      return left[i] - right[i];
+    }
+  }
+  return left.length - right.length;
+}
+
+export function compareRankedSkills(a: RankedSkill, b: RankedSkill): number {
+  // Keyword fields sort by UTF-8 bytes, not locale collation or UTF-16 units.
+  return (
+    b.score - a.score ||
+    compareUtf8Strings(a.name, b.name) ||
+    compareUtf8Strings(a.sId, b.sId)
+  );
+}

--- a/front/lib/skill_search/search.test.ts
+++ b/front/lib/skill_search/search.test.ts
@@ -1,0 +1,440 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockClientSearch = vi.hoisted(() => vi.fn());
+
+vi.mock("@app/lib/api/elasticsearch", async () => {
+  const { Ok } = await import("@app/types/shared/result");
+
+  return {
+    SKILL_SEARCH_ALIAS_NAME: "front.skill_search",
+    withEs: async (
+      fn: (client: { search: typeof mockClientSearch }) => Promise<unknown>
+    ) => new Ok(await fn({ search: mockClientSearch })),
+  };
+});
+
+import { SkillSearchDocumentResource } from "@app/lib/resources/skill/skill_search_document_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { makeSId } from "@app/lib/resources/string_ids";
+import { searchSkillDocuments } from "@app/lib/skill_search/search";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { SkillSearchDocument } from "@app/types/skill_search/skill_search";
+
+function makeSkillDocument(
+  overrides: Partial<SkillSearchDocument> = {}
+): SkillSearchDocument {
+  return {
+    workspace_id: "workspace",
+    skill_id: "skill",
+    status: "active",
+    availability: "workspace_users",
+    name: "Skill",
+    user_facing_description: "Description",
+    icon: null,
+    edited_by: null,
+    editor_user_ids: [],
+    requested_space_ids: [],
+    non_pod_space_ids: [],
+    non_pod_space_count: 0,
+    pod_space_id: null,
+    updated_at: "2026-08-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function mockHits(documents: SkillSearchDocument[]) {
+  mockClientSearch.mockResolvedValueOnce({
+    hits: {
+      hits: documents.map((document) => ({ _source: document })),
+    },
+  });
+}
+
+describe("skill_search/search", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockClientSearch.mockReset();
+  });
+
+  it("requires every skill non-pod space to match a readable user space", async () => {
+    const { auth, workspace, user, globalSpace } =
+      await createPrivateApiMockRequest({ role: "user" });
+    mockHits([]);
+
+    const result = await searchSkillDocuments(auth, {
+      searchTerm: "summarize",
+      limit: 10,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockClientSearch).toHaveBeenCalledOnce();
+    const request = mockClientSearch.mock.calls[0][0];
+    expect(request).toMatchObject({
+      index: "front.skill_search",
+      size: 50,
+      sort: [
+        { _score: { order: "desc" } },
+        { "name.keyword": { order: "asc" } },
+        { skill_id: { order: "asc" } },
+      ],
+    });
+    expect(request.query.bool).toMatchObject({
+      minimum_should_match: 1,
+      should: [
+        {
+          multi_match: {
+            query: "summarize",
+            fields: ["name^4", "user_facing_description^2"],
+            type: "bool_prefix",
+          },
+        },
+        {
+          wildcard: {
+            "name.subsequence": {
+              value: "*s*u*m*m*a*r*i*z*e*",
+              case_insensitive: true,
+              boost: 4,
+            },
+          },
+        },
+        {
+          wildcard: {
+            "user_facing_description.subsequence": {
+              value: "*s*u*m*m*a*r*i*z*e*",
+              case_insensitive: true,
+              boost: 2,
+            },
+          },
+        },
+      ],
+    });
+
+    const filters = request.query.bool.filter;
+    expect(filters).toEqual(
+      expect.arrayContaining([
+        { term: { workspace_id: workspace.sId } },
+        { term: { status: "active" } },
+      ])
+    );
+    expect(filters[2]).toEqual({
+      bool: {
+        should: [
+          {
+            terms: {
+              availability: ["workspace_users", "users_and_agents"],
+            },
+          },
+          {
+            bool: {
+              filter: [
+                { term: { availability: "editors" } },
+                { term: { editor_user_ids: user.id } },
+              ],
+            },
+          },
+        ],
+        minimum_should_match: 1,
+      },
+    });
+    expect(filters[3]).toMatchObject({
+      bool: {
+        minimum_should_match: 1,
+        should: [
+          { term: { non_pod_space_count: 0 } },
+          {
+            terms_set: {
+              non_pod_space_ids: {
+                minimum_should_match_field: "non_pod_space_count",
+              },
+            },
+          },
+        ],
+      },
+    });
+    expect(
+      filters[3].bool.should[1].terms_set.non_pod_space_ids.terms
+    ).toContain(globalSpace.sId);
+  });
+
+  it("only accepts skills with no non-pod spaces when the user has none", async () => {
+    const { auth } = await createPrivateApiMockRequest({ role: "user" });
+    vi.spyOn(SpaceResource, "listWorkspaceSpaces").mockResolvedValue([]);
+    mockHits([]);
+
+    await searchSkillDocuments(auth, { searchTerm: "   ", limit: 10 });
+
+    const request = mockClientSearch.mock.calls[0][0];
+    expect(request.query.bool.filter[3]).toEqual({
+      term: { non_pod_space_count: 0 },
+    });
+    expect(request.query.bool.should).toBeUndefined();
+    expect(request.sort).toEqual([
+      { "name.keyword": { order: "asc" } },
+      { skill_id: { order: "asc" } },
+    ]);
+  });
+
+  it("only allows published skills when a non-key authenticator has no user", async () => {
+    const { auth } = await createPrivateApiMockRequest({ role: "user" });
+    vi.spyOn(auth, "user").mockReturnValue(null);
+    mockHits([]);
+
+    await searchSkillDocuments(auth, { searchTerm: "skill", limit: 10 });
+
+    const request = mockClientSearch.mock.calls[0][0];
+    expect(request.query.bool.filter[2]).toEqual({
+      bool: {
+        should: [
+          {
+            terms: {
+              availability: ["workspace_users", "users_and_agents"],
+            },
+          },
+        ],
+        minimum_should_match: 1,
+      },
+    });
+  });
+
+  it.each([
+    ["sand", "*s*a*n*d*"],
+    ["*", "*\\**"],
+    ["?", "*\\?*"],
+    ["\\", "*\\\\*"],
+    ["a*b?c\\d", "*a*\\**b*\\?*c*\\\\*d*"],
+    ["a.b", "*a*.*b*"],
+  ])("builds a literal subsequence pattern for %s", async (query, pattern) => {
+    const { auth } = await createPrivateApiMockRequest({ role: "user" });
+    mockHits([]);
+
+    await searchSkillDocuments(auth, { searchTerm: query, limit: 10 });
+
+    const should = mockClientSearch.mock.calls[0][0].query.bool.should;
+    expect(should[1].wildcard["name.subsequence"].value).toBe(pattern);
+    expect(
+      should[2].wildcard["user_facing_description.subsequence"].value
+    ).toBe(pattern);
+  });
+
+  it("checks only candidate pod access after Elasticsearch", async () => {
+    const { auth, workspace, user, globalGroup } =
+      await createPrivateApiMockRequest({ role: "user" });
+    const readablePod = await SpaceFactory.project(workspace, user.id);
+    const openPod = await SpaceFactory.project(workspace);
+    await SpaceFactory.attachGroup(openPod, globalGroup, "project_viewer");
+    const unreadablePod = await SpaceFactory.project(workspace);
+    await auth.refresh();
+    const missingPodId = SpaceResource.modelIdToSId({
+      id: 999_999_999,
+      workspaceId: workspace.id,
+    });
+
+    const documents = [
+      makeSkillDocument({
+        skill_id: "unreadable-pod",
+        pod_space_id: unreadablePod.sId,
+      }),
+      makeSkillDocument({ skill_id: "no-pod" }),
+      makeSkillDocument({
+        skill_id: "readable-pod",
+        pod_space_id: readablePod.sId,
+      }),
+      makeSkillDocument({
+        skill_id: "open-pod",
+        pod_space_id: openPod.sId,
+      }),
+      makeSkillDocument({
+        skill_id: "missing-pod",
+        pod_space_id: missingPodId,
+      }),
+    ];
+    const visibleDocuments = documents.filter((document) =>
+      ["no-pod", "readable-pod", "open-pod"].includes(document.skill_id)
+    );
+    mockHits(documents);
+    vi.spyOn(
+      SkillSearchDocumentResource,
+      "filterSearchDocumentsByCurrentState"
+    ).mockImplementation(async (_auth, candidates) => [...candidates]);
+    const fetchByIdsSpy = vi.spyOn(SpaceResource, "fetchByIds");
+
+    const result = await searchSkillDocuments(auth, {
+      searchTerm: "skill",
+      limit: 2,
+    });
+
+    expect(fetchByIdsSpy).toHaveBeenCalledOnce();
+    const [fetchAuth, fetchedPodIds] = fetchByIdsSpy.mock.calls[0];
+    expect(fetchAuth).toBe(auth);
+    expect(new Set(fetchedPodIds)).toEqual(
+      new Set([readablePod.sId, openPod.sId, unreadablePod.sId, missingPodId])
+    );
+    expect(mockClientSearch).toHaveBeenCalledOnce();
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(
+      SkillSearchDocumentResource.filterSearchDocumentsByCurrentState
+    ).toHaveBeenCalledOnce();
+    expect(
+      SkillSearchDocumentResource.filterSearchDocumentsByCurrentState
+    ).toHaveBeenCalledWith(auth, visibleDocuments);
+    expect(result.value.map((document) => document.skill_id)).toEqual([
+      "no-pod",
+      "readable-pod",
+    ]);
+  });
+
+  it("rejects an editors-only hit when the caller is not an editor", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      role: "user",
+    });
+    const editorsOnlySkill = makeSkillDocument({
+      workspace_id: workspace.sId,
+      skill_id: makeSId("skill", {
+        id: 999_999_999,
+        workspaceId: workspace.id,
+      }),
+      availability: "editors",
+      editor_user_ids: [auth.getNonNullableUser().id],
+    });
+    mockHits([editorsOnlySkill]);
+    const currentStateSpy = vi
+      .spyOn(SkillSearchDocumentResource, "filterSearchDocumentsByCurrentState")
+      .mockImplementation(async (_auth, candidates) => [...candidates]);
+
+    const result = await searchSkillDocuments(auth, {
+      searchTerm: "skill",
+      limit: 10,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual([]);
+    }
+    expect(currentStateSpy).toHaveBeenCalledWith(auth, []);
+  });
+
+  it("fails closed when an editors-only hit has malformed editor IDs", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      role: "user",
+    });
+    const malformedSkill = {
+      ...makeSkillDocument({
+        workspace_id: workspace.sId,
+        skill_id: makeSId("skill", {
+          id: 999_999_999,
+          workspaceId: workspace.id,
+        }),
+        availability: "editors",
+      }),
+      editor_user_ids: auth.getNonNullableUser().id,
+    } as unknown as SkillSearchDocument;
+    mockHits([malformedSkill]);
+
+    const result = await searchSkillDocuments(auth, {
+      searchTerm: "skill",
+      limit: 10,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual([]);
+    }
+  });
+
+  it.each([
+    ["skill ID", { skill_id: 123 }],
+    ["pod space ID", { pod_space_id: 123 }],
+  ])("fails closed when a hit has a malformed %s", async (_field, overrides) => {
+    const { auth } = await createPrivateApiMockRequest({ role: "user" });
+    const malformedSkill = {
+      ...makeSkillDocument(),
+      ...overrides,
+    } as unknown as SkillSearchDocument;
+    mockHits([malformedSkill]);
+    const fetchByIdsSpy = vi.spyOn(SpaceResource, "fetchByIds");
+
+    const result = await searchSkillDocuments(auth, {
+      searchTerm: "skill",
+      limit: 10,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual([]);
+    }
+    expect(fetchByIdsSpy).not.toHaveBeenCalled();
+  });
+
+  it("allows an editors-only hit when the caller is an editor", async () => {
+    const { auth } = await createPrivateApiMockRequest({ role: "user" });
+    const skill = await SkillFactory.create(auth, {
+      availability: "editors",
+      name: "My editors-only search skill",
+    });
+    await auth.refresh();
+    const document = await SkillSearchDocumentResource.fetchSearchDocument(
+      auth,
+      skill.sId
+    );
+    expect(document).not.toBeNull();
+    if (!document) {
+      return;
+    }
+    mockHits([document]);
+
+    const result = await searchSkillDocuments(auth, {
+      searchTerm: "skill",
+      limit: 10,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual([document]);
+    }
+  });
+
+  it("allows editors-only skills for API keys", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      role: "user",
+    });
+    vi.spyOn(auth, "isKey").mockReturnValue(true);
+    const editorsOnlySkill = makeSkillDocument({
+      skill_id: "editors-only",
+      availability: "editors",
+      editor_user_ids: [999_999_999],
+    });
+    mockHits([editorsOnlySkill]);
+    vi.spyOn(
+      SkillSearchDocumentResource,
+      "filterSearchDocumentsByCurrentState"
+    ).mockImplementation(async (_auth, candidates) => [...candidates]);
+
+    const result = await searchSkillDocuments(auth, {
+      searchTerm: "skill",
+      limit: 10,
+    });
+
+    expect(mockClientSearch).toHaveBeenCalledOnce();
+    expect(mockClientSearch.mock.calls[0][0].query.bool.filter).toEqual(
+      expect.arrayContaining([
+        { term: { workspace_id: workspace.sId } },
+        { term: { status: "active" } },
+      ])
+    );
+    expect(mockClientSearch.mock.calls[0][0].query.bool.filter).toHaveLength(3);
+    expect(
+      SkillSearchDocumentResource.filterSearchDocumentsByCurrentState
+    ).toHaveBeenCalledWith(auth, [editorsOnlySkill]);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.map((document) => document.skill_id)).toEqual([
+        "editors-only",
+      ]);
+    }
+  });
+});

--- a/front/lib/skill_search/search.test.ts
+++ b/front/lib/skill_search/search.test.ts
@@ -85,7 +85,7 @@ async function searchSkillDocuments(
   }
   return new Ok(
     removeNulls(
-      result.value.candidates.map((candidate) => candidate.document)
+      result.value.candidates.map((candidate) => candidate.skill)
     ).slice(0, limit)
   );
 }
@@ -212,9 +212,7 @@ describe("skill_search/search", () => {
       limit: MAX_SKILL_SEARCH_RESULTS,
     });
     assert(result.isOk());
-    expect(result.value.map((document) => document.skill_id)).toEqual(
-      expectedSkillIds
-    );
+    expect(result.value.map((skill) => skill.sId)).toEqual(expectedSkillIds);
     expect(mockClientSearch).toHaveBeenCalledOnce();
     expect(mockClientSearch.mock.calls[0][0].query.bool.must[0]).toEqual({
       bool: {
@@ -328,9 +326,7 @@ describe("skill_search/search", () => {
       limit: 10,
     });
     assert(result.isOk());
-    expect(result.value.map((document) => document.skill_id)).toEqual(
-      expectedSkillIds
-    );
+    expect(result.value.map((skill) => skill.sId)).toEqual(expectedSkillIds);
   });
 
   it.each([
@@ -356,7 +352,9 @@ describe("skill_search/search", () => {
       limit: 10,
     });
     assert(before.isOk());
-    expect(before.value).toEqual([document]);
+    expect(before.value).toEqual([
+      SkillSearchDocumentResource.toSearchJSON(document, 1),
+    ]);
 
     if (access === "pod") {
       await pod.writeGroupPermissions(auth, { members: [], editors: [] });
@@ -579,7 +577,7 @@ describe("skill_search/search", () => {
     expect(
       SkillSearchDocumentResource.filterSearchDocumentsByCurrentState
     ).toHaveBeenCalledWith(auth, visibleDocuments);
-    expect(result.value.map((document) => document.skill_id)).toEqual([
+    expect(result.value.map((skill) => skill.sId)).toEqual([
       "no-pod",
       "readable-pod",
     ]);
@@ -691,7 +689,9 @@ describe("skill_search/search", () => {
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value).toEqual([document]);
+      expect(result.value).toEqual([
+        SkillSearchDocumentResource.toSearchJSON(document, 1),
+      ]);
     }
   });
 
@@ -733,9 +733,7 @@ describe("skill_search/search", () => {
     ).toHaveBeenCalledWith(auth, [editorsOnlySkill]);
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value.map((document) => document.skill_id)).toEqual([
-        "editors-only",
-      ]);
+      expect(result.value.map((skill) => skill.sId)).toEqual(["editors-only"]);
     }
   });
 });

--- a/front/lib/skill_search/search.test.ts
+++ b/front/lib/skill_search/search.test.ts
@@ -13,14 +13,23 @@ vi.mock("@app/lib/api/elasticsearch", async () => {
   };
 });
 
+import { Authenticator } from "@app/lib/auth";
 import { SkillSearchDocumentResource } from "@app/lib/resources/skill/skill_search_document_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { makeSId } from "@app/lib/resources/string_ids";
-import { searchSkillDocuments } from "@app/lib/skill_search/search";
+import {
+  MAX_SKILL_SEARCH_RESULTS,
+  searchSkillDocuments,
+} from "@app/lib/skill_search/search";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { SKILL_AVAILABILITIES } from "@app/types/assistant/skill_configuration_constants";
 import type { SkillSearchDocument } from "@app/types/skill_search/skill_search";
+import assert from "assert";
 
 function makeSkillDocument(
   overrides: Partial<SkillSearchDocument> = {}
@@ -56,6 +65,283 @@ describe("skill_search/search", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     mockClientSearch.mockReset();
+  });
+
+  it.each([
+    { role: "user", keyFactory: null, label: "user" },
+    { role: "builder", keyFactory: null, label: "builder" },
+    { role: "manager", keyFactory: null, label: "manager" },
+    { role: "admin", keyFactory: null, label: "admin" },
+    { role: "user", keyFactory: KeyFactory.readOnly, label: "read-only key" },
+    { role: "builder", keyFactory: KeyFactory.regular, label: "builder key" },
+    { role: "admin", keyFactory: KeyFactory.admin, label: "admin key" },
+  ] as const)("enforces the space × pod × availability × editor matrix for $label", async ({
+    role,
+    keyFactory,
+  }) => {
+    const {
+      authenticator: authorAuth,
+      workspace,
+      user,
+      globalGroup,
+      globalSpace,
+      conversationsSpace,
+    } = await createResourceTest({ role });
+    const readableSpace = await SpaceFactory.regular(workspace);
+    const spaceMemberGroup =
+      await readableSpace.fetchManualMemberGroup(authorAuth);
+    assert(spaceMemberGroup);
+    await GroupFactory.withMembers(authorAuth, spaceMemberGroup, [user]);
+    const deniedSpace = await SpaceFactory.regular(workspace);
+    const readablePod = await SpaceFactory.project(workspace);
+    const podMemberGroup = await readablePod.fetchManualMemberGroup(authorAuth);
+    assert(podMemberGroup);
+    await GroupFactory.withMembers(authorAuth, podMemberGroup, [user]);
+    const deniedPod = await SpaceFactory.project(workspace);
+    // An unrelated readable space catches reversing the subset predicate.
+    const extraSpace = await SpaceFactory.regular(workspace);
+    await SpaceFactory.attachGroup(extraSpace, globalGroup);
+
+    const spaceCases = [
+      { label: "no spaces", spaces: [], readable: true },
+      { label: "all spaces", spaces: [readableSpace], readable: true },
+      {
+        label: "two readable spaces",
+        spaces: [readableSpace, extraSpace],
+        readable: true,
+      },
+      { label: "no space access", spaces: [deniedSpace], readable: false },
+      {
+        label: "partial space access",
+        spaces: [readableSpace, deniedSpace],
+        readable: false,
+      },
+    ];
+    const podCases = [
+      { label: "no pod", spaces: [], readable: true },
+      { label: "readable pod", spaces: [readablePod], readable: true },
+      { label: "denied pod", spaces: [deniedPod], readable: false },
+    ];
+    const esCandidateIds = new Set<string>();
+    const expectedSkillIds: string[] = [];
+    const skillIds: string[] = [];
+
+    // Bounded Cartesian product: 5 space cases × 3 pod cases × 3 availabilities × 2 editor states.
+    // Fixtures and auth/grant hydration stay real; only the ES boundary is mocked.
+    for (const spaceCase of spaceCases) {
+      for (const podCase of podCases) {
+        for (const availability of SKILL_AVAILABILITIES) {
+          for (const isEditor of [false, true]) {
+            const skill = await SkillFactory.create(authorAuth, {
+              name: `${spaceCase.label}, ${podCase.label}, ${availability}, editor=${isEditor}`,
+              availability,
+              addCurrentUserAsEditor: isEditor,
+              requestedSpaceIds: [...spaceCase.spaces, ...podCase.spaces].map(
+                (space) => space.id
+              ),
+            });
+            skillIds.push(skill.sId);
+            const visibleByAvailability =
+              availability !== "editors" || isEditor || keyFactory !== null;
+            if (spaceCase.readable && visibleByAvailability) {
+              esCandidateIds.add(skill.sId);
+              if (podCase.readable) {
+                expectedSkillIds.push(skill.sId);
+              }
+            }
+          }
+        }
+      }
+    }
+    const documents = await SkillSearchDocumentResource.fetchSearchDocuments(
+      authorAuth,
+      skillIds
+    );
+    expect(documents).toHaveLength(skillIds.length);
+    let auth = authorAuth;
+    if (keyFactory) {
+      const key = await keyFactory([
+        globalGroup,
+        spaceMemberGroup,
+        podMemberGroup,
+      ]);
+      auth = await Authenticator.fromKey(key, workspace.sId);
+    }
+    await auth.refresh();
+    expect(auth.can("read", readableSpace)).toBe(true);
+    expect(auth.can("read", deniedSpace)).toBe(false);
+    expect(auth.can("read", readablePod)).toBe(true);
+    expect(auth.can("read", deniedPod)).toBe(false);
+
+    // ES is not executed here: assert its full ACL contract below, then supply its expected
+    // candidates, including unreadable pods that the real post-filter must reject.
+    mockHits(
+      documents.filter((document) => esCandidateIds.has(document.skill_id))
+    );
+    const result = await searchSkillDocuments(auth, {
+      searchTerm: "",
+      limit: MAX_SKILL_SEARCH_RESULTS,
+    });
+    assert(result.isOk());
+    expect(result.value.map((document) => document.skill_id)).toEqual(
+      expectedSkillIds
+    );
+    expect(mockClientSearch).toHaveBeenCalledOnce();
+    expect(mockClientSearch.mock.calls[0][0].query).toEqual({
+      bool: {
+        filter: [
+          { term: { workspace_id: workspace.sId } },
+          { term: { status: "active" } },
+          ...(keyFactory
+            ? []
+            : [
+                {
+                  bool: {
+                    should: [
+                      {
+                        terms: {
+                          availability: ["workspace_users", "users_and_agents"],
+                        },
+                      },
+                      {
+                        bool: {
+                          filter: [
+                            { term: { availability: "editors" } },
+                            { term: { editor_user_ids: user.id } },
+                          ],
+                        },
+                      },
+                    ],
+                    minimum_should_match: 1,
+                  },
+                },
+              ]),
+          {
+            bool: {
+              should: [
+                { term: { non_pod_space_count: 0 } },
+                {
+                  terms_set: {
+                    non_pod_space_ids: {
+                      terms: expect.arrayContaining([
+                        globalSpace.sId,
+                        conversationsSpace.sId,
+                        readableSpace.sId,
+                        extraSpace.sId,
+                      ]),
+                      minimum_should_match_field: "non_pod_space_count",
+                    },
+                  },
+                },
+              ],
+              minimum_should_match: 1,
+            },
+          },
+        ],
+      },
+    });
+    const filters = mockClientSearch.mock.calls[0][0].query.bool.filter;
+    const spaceTerms =
+      filters.at(-1).bool.should[1].terms_set.non_pod_space_ids.terms;
+    expect(spaceTerms).toHaveLength(4);
+  }, 30_000);
+
+  it.each([
+    "open",
+    "member",
+    "editor",
+    "denied",
+  ] as const)("combines %s pod access with skill editorship and availability", async (access) => {
+    const { auth, workspace, user, globalGroup } =
+      await createPrivateApiMockRequest({ role: "user" });
+    const pod = await SpaceFactory.project(
+      workspace,
+      access === "editor" ? user.id : undefined
+    );
+    if (access === "open") {
+      await SpaceFactory.attachGroup(pod, globalGroup, "project_viewer");
+    }
+    if (access === "member") {
+      const members = await pod.fetchManualMemberGroup(auth);
+      assert(members);
+      await GroupFactory.withMembers(auth, members, [user]);
+    }
+    const skillIds: string[] = [];
+    const expectedSkillIds: string[] = [];
+    for (const availability of SKILL_AVAILABILITIES) {
+      for (const isEditor of [false, true]) {
+        const skill = await SkillFactory.create(auth, {
+          name: `${availability}, editor=${isEditor}`,
+          availability,
+          addCurrentUserAsEditor: isEditor,
+          requestedSpaceIds: [pod.id],
+        });
+        skillIds.push(skill.sId);
+        if (access !== "denied" && (availability !== "editors" || isEditor)) {
+          expectedSkillIds.push(skill.sId);
+        }
+      }
+    }
+    await auth.refresh();
+    expect(auth.can("read", pod)).toBe(access !== "denied");
+    expect(pod.isMember(auth)).toBe(access === "member" || access === "editor");
+    const documents = await SkillSearchDocumentResource.fetchSearchDocuments(
+      auth,
+      skillIds
+    );
+    expect(documents).toHaveLength(skillIds.length);
+    // Deliberately include non-editor hits: the live editor guard must also fail closed.
+    mockHits(documents);
+    const result = await searchSkillDocuments(auth, {
+      searchTerm: "",
+      limit: 10,
+    });
+    assert(result.isOk());
+    expect(result.value.map((document) => document.skill_id)).toEqual(
+      expectedSkillIds
+    );
+  });
+
+  it.each([
+    "pod",
+    "editor",
+  ] as const)("rejects a previously visible hit after revoking %s access without reindexing", async (access) => {
+    const { auth, workspace, user } = await createPrivateApiMockRequest({
+      role: "user",
+    });
+    const pod = await SpaceFactory.project(workspace, user.id);
+    const skill = await SkillFactory.create(auth, {
+      availability: "editors",
+      requestedSpaceIds: [pod.id],
+    });
+    const document = await SkillSearchDocumentResource.fetchSearchDocument(
+      auth,
+      skill.sId
+    );
+    assert(document);
+    mockHits([document]);
+    const before = await searchSkillDocuments(auth, {
+      searchTerm: "",
+      limit: 10,
+    });
+    assert(before.isOk());
+    expect(before.value).toEqual([document]);
+
+    if (access === "pod") {
+      await pod.writeGroupPermissions(auth, { members: [], editors: [] });
+    } else {
+      const removeResult = await skill.removeEditors(auth, [user]);
+      expect(removeResult.isOk()).toBe(true);
+    }
+    await auth.refresh();
+    mockHits([document]);
+    const after = await searchSkillDocuments(auth, {
+      searchTerm: "",
+      limit: 10,
+    });
+    assert(after.isOk());
+    expect(after.value).toEqual([]);
+    expect(mockClientSearch).toHaveBeenCalledTimes(2);
   });
 
   it("requires every skill non-pod space to match a readable user space", async () => {

--- a/front/lib/skill_search/search.test.ts
+++ b/front/lib/skill_search/search.test.ts
@@ -19,7 +19,8 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { makeSId } from "@app/lib/resources/string_ids";
 import {
   MAX_SKILL_SEARCH_RESULTS,
-  searchSkillDocuments,
+  prepareSkillSearchQuery,
+  searchSkillDocumentCandidates,
 } from "@app/lib/skill_search/search";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
@@ -28,6 +29,8 @@ import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { SKILL_AVAILABILITIES } from "@app/types/assistant/skill_configuration_constants";
+import { Ok } from "@app/types/shared/result";
+import { removeNulls } from "@app/types/shared/utils/general";
 import type { SkillSearchDocument } from "@app/types/skill_search/skill_search";
 import assert from "assert";
 
@@ -56,9 +59,35 @@ function makeSkillDocument(
 function mockHits(documents: SkillSearchDocument[]) {
   mockClientSearch.mockResolvedValueOnce({
     hits: {
-      hits: documents.map((document) => ({ _source: document })),
+      hits: documents.map((document, index) => ({
+        _source: document,
+        sort: [1, document.name, String(document.skill_id), index],
+      })),
     },
   });
+}
+
+// Exercise one candidate batch with the real authorization path. The API tests
+// cover the cross-batch merge and cursor behavior.
+async function searchSkillDocuments(
+  auth: Authenticator,
+  { searchTerm, limit }: { searchTerm: string; limit: number }
+) {
+  const query = await prepareSkillSearchQuery(auth, searchTerm);
+  const result = await searchSkillDocumentCandidates(auth, {
+    query,
+    pitId: "test-pit",
+    searchAfter: null,
+    limit: Math.min(200, Math.max(50, limit * 3)),
+  });
+  if (result.isErr()) {
+    return result;
+  }
+  return new Ok(
+    removeNulls(
+      result.value.candidates.map((candidate) => candidate.document)
+    ).slice(0, limit)
+  );
 }
 
 describe("skill_search/search", () => {
@@ -187,8 +216,9 @@ describe("skill_search/search", () => {
       expectedSkillIds
     );
     expect(mockClientSearch).toHaveBeenCalledOnce();
-    expect(mockClientSearch.mock.calls[0][0].query).toEqual({
+    expect(mockClientSearch.mock.calls[0][0].query.bool.must[0]).toEqual({
       bool: {
+        must: [{ constant_score: { filter: { match_all: {} }, boost: 1 } }],
         filter: [
           { term: { workspace_id: workspace.sId } },
           { term: { status: "active" } },
@@ -240,7 +270,8 @@ describe("skill_search/search", () => {
         ],
       },
     });
-    const filters = mockClientSearch.mock.calls[0][0].query.bool.filter;
+    const filters =
+      mockClientSearch.mock.calls[0][0].query.bool.must[0].bool.filter;
     const spaceTerms =
       filters.at(-1).bool.should[1].terms_set.non_pod_space_ids.terms;
     expect(spaceTerms).toHaveLength(4);
@@ -358,7 +389,7 @@ describe("skill_search/search", () => {
     expect(mockClientSearch).toHaveBeenCalledOnce();
     const request = mockClientSearch.mock.calls[0][0];
     expect(request).toMatchObject({
-      index: "front.skill_search",
+      pit: { id: "test-pit", keep_alive: "300s" },
       size: 50,
       sort: [
         { _score: { order: "desc" } },
@@ -366,38 +397,11 @@ describe("skill_search/search", () => {
         { skill_id: { order: "asc" } },
       ],
     });
-    expect(request.query.bool).toMatchObject({
-      minimum_should_match: 1,
-      should: [
-        {
-          multi_match: {
-            query: "summarize",
-            fields: ["name^4", "user_facing_description^2"],
-            type: "bool_prefix",
-          },
-        },
-        {
-          wildcard: {
-            "name.subsequence": {
-              value: "*s*u*m*m*a*r*i*z*e*",
-              case_insensitive: true,
-              boost: 4,
-            },
-          },
-        },
-        {
-          wildcard: {
-            "user_facing_description.subsequence": {
-              value: "*s*u*m*m*a*r*i*z*e*",
-              case_insensitive: true,
-              boost: 2,
-            },
-          },
-        },
-      ],
-    });
+    expect(
+      request.query.bool.must[0].bool.must[0].dis_max.queries
+    ).toHaveLength(6);
 
-    const filters = request.query.bool.filter;
+    const filters = request.query.bool.must[0].bool.filter;
     expect(filters).toEqual(
       expect.arrayContaining([
         { term: { workspace_id: workspace.sId } },
@@ -452,11 +456,12 @@ describe("skill_search/search", () => {
     await searchSkillDocuments(auth, { searchTerm: "   ", limit: 10 });
 
     const request = mockClientSearch.mock.calls[0][0];
-    expect(request.query.bool.filter[3]).toEqual({
+    expect(request.query.bool.must[0].bool.filter[3]).toEqual({
       term: { non_pod_space_count: 0 },
     });
-    expect(request.query.bool.should).toBeUndefined();
+    expect(request.query.bool.must[0].bool.should).toBeUndefined();
     expect(request.sort).toEqual([
+      { _score: { order: "desc" } },
       { "name.keyword": { order: "asc" } },
       { skill_id: { order: "asc" } },
     ]);
@@ -470,7 +475,7 @@ describe("skill_search/search", () => {
     await searchSkillDocuments(auth, { searchTerm: "skill", limit: 10 });
 
     const request = mockClientSearch.mock.calls[0][0];
-    expect(request.query.bool.filter[2]).toEqual({
+    expect(request.query.bool.must[0].bool.filter[2]).toEqual({
       bool: {
         should: [
           {
@@ -497,10 +502,16 @@ describe("skill_search/search", () => {
 
     await searchSkillDocuments(auth, { searchTerm: query, limit: 10 });
 
-    const should = mockClientSearch.mock.calls[0][0].query.bool.should;
-    expect(should[1].wildcard["name.subsequence"].value).toBe(pattern);
+    const matches =
+      mockClientSearch.mock.calls[0][0].query.bool.must[0].bool.must[0].dis_max
+        .queries;
     expect(
-      should[2].wildcard["user_facing_description.subsequence"].value
+      matches[3].constant_score.filter.wildcard["name.subsequence"].value
+    ).toBe(pattern);
+    expect(
+      matches[5].constant_score.filter.wildcard[
+        "user_facing_description.subsequence"
+      ].value
     ).toBe(pattern);
   });
 
@@ -706,13 +717,17 @@ describe("skill_search/search", () => {
     });
 
     expect(mockClientSearch).toHaveBeenCalledOnce();
-    expect(mockClientSearch.mock.calls[0][0].query.bool.filter).toEqual(
+    expect(
+      mockClientSearch.mock.calls[0][0].query.bool.must[0].bool.filter
+    ).toEqual(
       expect.arrayContaining([
         { term: { workspace_id: workspace.sId } },
         { term: { status: "active" } },
       ])
     );
-    expect(mockClientSearch.mock.calls[0][0].query.bool.filter).toHaveLength(3);
+    expect(
+      mockClientSearch.mock.calls[0][0].query.bool.must[0].bool.filter
+    ).toHaveLength(3);
     expect(
       SkillSearchDocumentResource.filterSearchDocumentsByCurrentState
     ).toHaveBeenCalledWith(auth, [editorsOnlySkill]);

--- a/front/lib/skill_search/search.ts
+++ b/front/lib/skill_search/search.ts
@@ -1,0 +1,281 @@
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import { SKILL_SEARCH_ALIAS_NAME, withEs } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { SkillSearchDocumentResource } from "@app/lib/resources/skill/skill_search_document_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { removeNulls } from "@app/types/shared/utils/general";
+import type { SkillSearchDocument } from "@app/types/skill_search/skill_search";
+import type { estypes } from "@elastic/elasticsearch";
+import assert from "assert";
+
+export const MAX_SKILL_SEARCH_RESULTS = 150;
+const MAX_SKILL_SEARCH_CANDIDATES = 200;
+const MIN_SKILL_SEARCH_CANDIDATES = 50;
+
+function buildNonPodAccessFilter(
+  readableNonPodSpaceIds: string[]
+): estypes.QueryDslQueryContainer {
+  if (readableNonPodSpaceIds.length === 0) {
+    return { term: { non_pod_space_count: 0 } };
+  }
+
+  return {
+    bool: {
+      should: [
+        { term: { non_pod_space_count: 0 } },
+        {
+          terms_set: {
+            non_pod_space_ids: {
+              terms: readableNonPodSpaceIds,
+              minimum_should_match_field: "non_pod_space_count",
+            },
+          },
+        },
+      ],
+      minimum_should_match: 1,
+    },
+  };
+}
+
+function buildAvailabilityFilter(
+  editorUserId: ModelId | null
+): estypes.QueryDslQueryContainer {
+  const should: estypes.QueryDslQueryContainer[] = [
+    { terms: { availability: ["workspace_users", "users_and_agents"] } },
+  ];
+  if (editorUserId !== null) {
+    should.push({
+      bool: {
+        filter: [
+          { term: { availability: "editors" } },
+          { term: { editor_user_ids: editorUserId } },
+        ],
+      },
+    });
+  }
+
+  return {
+    bool: {
+      should,
+      minimum_should_match: 1,
+    },
+  };
+}
+
+function canReadEditorsOnlyCandidate(
+  auth: Authenticator,
+  candidate: SkillSearchDocument
+): boolean {
+  if (candidate.availability !== "editors" || auth.isKey()) {
+    return true;
+  }
+
+  const user = auth.user();
+  const parsedSkillId = getResourceNameAndIdFromSId(candidate.skill_id);
+
+  return (
+    user !== null &&
+    Array.isArray(candidate.editor_user_ids) &&
+    candidate.editor_user_ids.includes(user.id) &&
+    parsedSkillId?.resourceName === "skill" &&
+    parsedSkillId.workspaceModelId === auth.getNonNullableWorkspace().id &&
+    auth
+      .getGrantedVerbs("skill", parsedSkillId.resourceModelId)
+      .includes("write")
+  );
+}
+
+function escapeWildcardCharacter(character: string): string {
+  return character === "\\" || character === "*" || character === "?"
+    ? `\\${character}`
+    : character;
+}
+
+function buildSubsequencePattern(searchTerm: string): string {
+  return `*${Array.from(searchTerm, escapeWildcardCharacter).join("*")}*`;
+}
+
+function buildSkillSearchQuery({
+  workspaceId,
+  searchTerm,
+  readableNonPodSpaceIds,
+  editorUserId,
+  canReadAllEditorsOnly,
+}: {
+  workspaceId: string;
+  searchTerm: string;
+  readableNonPodSpaceIds: string[];
+  editorUserId: ModelId | null;
+  canReadAllEditorsOnly: boolean;
+}): estypes.QueryDslQueryContainer {
+  const trimmedSearchTerm = searchTerm.trim();
+
+  return {
+    bool: {
+      filter: [
+        { term: { workspace_id: workspaceId } },
+        { term: { status: "active" } },
+        ...(canReadAllEditorsOnly
+          ? []
+          : [buildAvailabilityFilter(editorUserId)]),
+        buildNonPodAccessFilter(readableNonPodSpaceIds),
+      ],
+      ...(trimmedSearchTerm
+        ? {
+            should: [
+              {
+                multi_match: {
+                  query: trimmedSearchTerm,
+                  fields: ["name^4", "user_facing_description^2"],
+                  type: "bool_prefix",
+                },
+              },
+              {
+                wildcard: {
+                  "name.subsequence": {
+                    value: buildSubsequencePattern(trimmedSearchTerm),
+                    case_insensitive: true,
+                    boost: 4,
+                  },
+                },
+              },
+              {
+                wildcard: {
+                  "user_facing_description.subsequence": {
+                    value: buildSubsequencePattern(trimmedSearchTerm),
+                    case_insensitive: true,
+                    boost: 2,
+                  },
+                },
+              },
+            ],
+            minimum_should_match: 1,
+          }
+        : {}),
+    },
+  };
+}
+
+function buildSkillSearchSort(hasSearchTerm: boolean): estypes.Sort {
+  return hasSearchTerm
+    ? [
+        { _score: { order: "desc" } },
+        { "name.keyword": { order: "asc" } },
+        { skill_id: { order: "asc" } },
+      ]
+    : [{ "name.keyword": { order: "asc" } }, { skill_id: { order: "asc" } }];
+}
+
+function getSkillSearchHitSources(
+  hits: estypes.SearchHit<SkillSearchDocument>[]
+): SkillSearchDocument[] {
+  return removeNulls(
+    hits.map((hit) => {
+      const source = hit._source;
+      if (
+        !source ||
+        typeof source.skill_id !== "string" ||
+        (source.pod_space_id !== null &&
+          typeof source.pod_space_id !== "string")
+      ) {
+        return null;
+      }
+
+      return source;
+    })
+  );
+}
+
+/**
+ * Searches a bounded custom-skill candidate window.
+ *
+ * Non-pod spaces and editors-only visibility are filtered directly in
+ * Elasticsearch. Projects/pods are authorized from only the IDs present in
+ * the candidate window, so a user's potentially unbounded memberships are
+ * never sent to Elasticsearch.
+ */
+export async function searchSkillDocuments(
+  auth: Authenticator,
+  {
+    searchTerm,
+    limit,
+  }: {
+    searchTerm: string;
+    limit: number;
+  }
+): Promise<Result<SkillSearchDocument[], ElasticsearchError>> {
+  assert(
+    Number.isInteger(limit) && limit > 0 && limit <= MAX_SKILL_SEARCH_RESULTS,
+    `limit must be between 1 and ${MAX_SKILL_SEARCH_RESULTS}`
+  );
+
+  const workspace = auth.getNonNullableWorkspace();
+  const workspaceSpaces = await SpaceResource.listWorkspaceSpaces(auth, {
+    includeConversationsSpace: true,
+  });
+  const readableNonPodSpaceIds = [
+    ...new Set(
+      workspaceSpaces
+        .filter((space) => auth.can("read", space))
+        .map((s) => s.sId)
+    ),
+  ];
+  const candidateLimit = Math.min(
+    MAX_SKILL_SEARCH_CANDIDATES,
+    Math.max(MIN_SKILL_SEARCH_CANDIDATES, limit * 3)
+  );
+
+  const candidateSearchResult = await withEs((client) =>
+    client.search<SkillSearchDocument>({
+      index: SKILL_SEARCH_ALIAS_NAME,
+      query: buildSkillSearchQuery({
+        workspaceId: workspace.sId,
+        searchTerm,
+        readableNonPodSpaceIds,
+        editorUserId: auth.user()?.id ?? null,
+        canReadAllEditorsOnly: auth.isKey(),
+      }),
+      size: candidateLimit,
+      sort: buildSkillSearchSort(searchTerm.trim().length > 0),
+    })
+  );
+  if (candidateSearchResult.isErr()) {
+    return new Err(candidateSearchResult.error);
+  }
+
+  const candidates = getSkillSearchHitSources(
+    candidateSearchResult.value.hits.hits
+  );
+  if (candidates.length === 0) {
+    return new Ok([]);
+  }
+  const candidatePodIds = [
+    ...new Set(
+      removeNulls(candidates.map((candidate) => candidate.pod_space_id))
+    ),
+  ];
+  const candidatePods = await SpaceResource.fetchByIds(auth, candidatePodIds);
+  const readableCandidatePodIds = new Set(
+    candidatePods
+      .filter((space) => space.isProject() && auth.can("read", space))
+      .map((space) => space.sId)
+  );
+  const accessFilteredCandidates = candidates
+    .filter(
+      (candidate) =>
+        candidate.pod_space_id === null ||
+        readableCandidatePodIds.has(candidate.pod_space_id)
+    )
+    .filter((candidate) => canReadEditorsOnlyCandidate(auth, candidate));
+  const visibleCandidates =
+    await SkillSearchDocumentResource.filterSearchDocumentsByCurrentState(
+      auth,
+      accessFilteredCandidates
+    );
+
+  return new Ok(visibleCandidates.slice(0, limit));
+}

--- a/front/lib/skill_search/search.ts
+++ b/front/lib/skill_search/search.ts
@@ -1,15 +1,21 @@
 import { ElasticsearchError, withEs } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SkillSearchDocumentResource } from "@app/lib/resources/skill/skill_search_document_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
 import { buildSkillMatchQuery } from "@app/lib/skill_search/ranking";
+import type {
+  SkillSearchPermissionFiltering,
+  SkillSearchResult,
+} from "@app/types/api/skills";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { SkillSearchDocument } from "@app/types/skill_search/skill_search";
 import type { estypes } from "@elastic/elasticsearch";
+import assert from "assert";
 import { z } from "zod";
 
 export const MAX_SKILL_SEARCH_RESULTS = 150;
@@ -24,7 +30,7 @@ export type SkillSearchSort = z.infer<typeof SkillSearchSortSchema>;
 
 export interface SkillSearchCandidate {
   // Rejected hits retain their position so a page of denied hits can advance.
-  document: SkillSearchDocument | null;
+  skill: SkillSearchResult | null;
   sort: SkillSearchSort;
 }
 
@@ -158,8 +164,22 @@ function getSkillSearchHitSources(
 // Prepare once per API request, not once per candidate batch.
 export async function prepareSkillSearchQuery(
   auth: Authenticator,
-  searchTerm: string
+  searchTerm: string,
+  permissionFiltering: SkillSearchPermissionFiltering = "strict"
 ): Promise<estypes.QueryDslQueryContainer> {
+  if (permissionFiltering === "redact_unreadable") {
+    assert(auth.isAdmin(), "Only admins can search unreadable skills.");
+    // Admin listing metadata remains visible under the resource's redaction policy.
+    return {
+      bool: {
+        filter: [
+          { term: { workspace_id: auth.getNonNullableWorkspace().sId } },
+          { term: { status: "active" } },
+        ],
+        must: [buildSkillMatchQuery(searchTerm)],
+      },
+    };
+  }
   const workspaceSpaces = await SpaceResource.listWorkspaceSpaces(auth, {
     includeConversationsSpace: true,
   });
@@ -213,6 +233,11 @@ async function filterSkillSearchCandidates(
   return visibleCandidates;
 }
 
+/**
+ * @cc [owner:aubin-tchoi,label:security] admin-redaction-authority
+ * redact_unreadable requires an admin and rehydrates candidates through the canonical
+ * resource redaction path; strict search continues to exclude inaccessible skills.
+ */
 export async function searchSkillDocumentCandidates(
   auth: Authenticator,
   {
@@ -220,11 +245,13 @@ export async function searchSkillDocumentCandidates(
     pitId,
     searchAfter,
     limit,
+    permissionFiltering = "strict",
   }: {
     query: estypes.QueryDslQueryContainer;
     pitId: string;
     searchAfter: SkillSearchSort | null;
     limit: number;
+    permissionFiltering?: SkillSearchPermissionFiltering;
   }
 ): Promise<
   Result<
@@ -236,6 +263,10 @@ export async function searchSkillDocumentCandidates(
     ElasticsearchError
   >
 > {
+  assert(
+    permissionFiltering !== "redact_unreadable" || auth.isAdmin(),
+    "Only admins can search unreadable skills."
+  );
   const result = await withEs((client) =>
     client.search<SkillSearchDocument>({
       pit: { id: pitId, keep_alive: `${SKILL_SEARCH_KEEP_ALIVE_SECONDS}s` },
@@ -264,9 +295,33 @@ export async function searchSkillDocumentCandidates(
     );
   }
   const hits = result.value.hits.hits;
-  const visible = await filterSkillSearchCandidates(
-    auth,
-    getSkillSearchHitSources(hits)
+  const sources = getSkillSearchHitSources(hits);
+  let redactedResources: SkillResource[] = [];
+  let visible: SkillSearchDocument[] = [];
+  if (permissionFiltering === "redact_unreadable") {
+    const workspace = auth.getNonNullableWorkspace();
+    const skillIds = sources
+      .filter((document) => {
+        const parsed = getResourceNameAndIdFromSId(document.skill_id);
+        return (
+          document.workspace_id === workspace.sId &&
+          parsed?.resourceName === "skill" &&
+          parsed.workspaceModelId === workspace.id
+        );
+      })
+      .map((document) => document.skill_id);
+    redactedResources = await SkillResource.fetchByIds(auth, skillIds, {
+      onlyActive: true,
+      permissionFiltering: "redact_unreadable",
+      withInstructions: false,
+      withTools: false,
+      withFileAttachments: false,
+    });
+  } else {
+    visible = await filterSkillSearchCandidates(auth, sources);
+  }
+  const resourceById = new Map(
+    redactedResources.map((skill) => [skill.sId, skill])
   );
   const visibleById = new Map(
     visible.map((document) => [document.skill_id, document])
@@ -282,11 +337,19 @@ export async function searchSkillDocumentCandidates(
         )
       );
     }
+    const resource = hit._source
+      ? resourceById.get(hit._source.skill_id)
+      : undefined;
+    const document = hit._source
+      ? visibleById.get(hit._source.skill_id)
+      : undefined;
     candidates.push({
       sort: sort.data,
-      document: hit._source
-        ? (visibleById.get(hit._source.skill_id) ?? null)
-        : null,
+      skill: resource
+        ? resource.toSearchJSON(auth, sort.data[0])
+        : document
+          ? SkillSearchDocumentResource.toSearchJSON(document, sort.data[0])
+          : null,
     });
   }
   return new Ok({

--- a/front/lib/skill_search/search.ts
+++ b/front/lib/skill_search/search.ts
@@ -1,20 +1,32 @@
-import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
-import { SKILL_SEARCH_ALIAS_NAME, withEs } from "@app/lib/api/elasticsearch";
+import { ElasticsearchError, withEs } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import { SkillSearchDocumentResource } from "@app/lib/resources/skill/skill_search_document_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
+import { buildSkillMatchQuery } from "@app/lib/skill_search/ranking";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { SkillSearchDocument } from "@app/types/skill_search/skill_search";
 import type { estypes } from "@elastic/elasticsearch";
-import assert from "assert";
+import { z } from "zod";
 
 export const MAX_SKILL_SEARCH_RESULTS = 150;
-const MAX_SKILL_SEARCH_CANDIDATES = 200;
-const MIN_SKILL_SEARCH_CANDIDATES = 50;
+export const SKILL_SEARCH_KEEP_ALIVE_SECONDS = 300;
+export const SkillSearchSortSchema = z.tuple([
+  z.number().finite(),
+  z.string(),
+  z.string(),
+  z.number().int(),
+]);
+export type SkillSearchSort = z.infer<typeof SkillSearchSortSchema>;
+
+export interface SkillSearchCandidate {
+  // Rejected hits retain their position so a page of denied hits can advance.
+  document: SkillSearchDocument | null;
+  sort: SkillSearchSort;
+}
 
 function buildNonPodAccessFilter(
   readableNonPodSpaceIds: string[]
@@ -89,16 +101,6 @@ function canReadEditorsOnlyCandidate(
   );
 }
 
-function escapeWildcardCharacter(character: string): string {
-  return character === "\\" || character === "*" || character === "?"
-    ? `\\${character}`
-    : character;
-}
-
-function buildSubsequencePattern(searchTerm: string): string {
-  return `*${Array.from(searchTerm, escapeWildcardCharacter).join("*")}*`;
-}
-
 function buildSkillSearchQuery({
   workspaceId,
   searchTerm,
@@ -112,8 +114,6 @@ function buildSkillSearchQuery({
   editorUserId: ModelId | null;
   canReadAllEditorsOnly: boolean;
 }): estypes.QueryDslQueryContainer {
-  const trimmedSearchTerm = searchTerm.trim();
-
   return {
     bool: {
       filter: [
@@ -124,51 +124,16 @@ function buildSkillSearchQuery({
           : [buildAvailabilityFilter(editorUserId)]),
         buildNonPodAccessFilter(readableNonPodSpaceIds),
       ],
-      ...(trimmedSearchTerm
-        ? {
-            should: [
-              {
-                multi_match: {
-                  query: trimmedSearchTerm,
-                  fields: ["name^4", "user_facing_description^2"],
-                  type: "bool_prefix",
-                },
-              },
-              {
-                wildcard: {
-                  "name.subsequence": {
-                    value: buildSubsequencePattern(trimmedSearchTerm),
-                    case_insensitive: true,
-                    boost: 4,
-                  },
-                },
-              },
-              {
-                wildcard: {
-                  "user_facing_description.subsequence": {
-                    value: buildSubsequencePattern(trimmedSearchTerm),
-                    case_insensitive: true,
-                    boost: 2,
-                  },
-                },
-              },
-            ],
-            minimum_should_match: 1,
-          }
-        : {}),
+      must: [buildSkillMatchQuery(searchTerm)],
     },
   };
 }
 
-function buildSkillSearchSort(hasSearchTerm: boolean): estypes.Sort {
-  return hasSearchTerm
-    ? [
-        { _score: { order: "desc" } },
-        { "name.keyword": { order: "asc" } },
-        { skill_id: { order: "asc" } },
-      ]
-    : [{ "name.keyword": { order: "asc" } }, { skill_id: { order: "asc" } }];
-}
+const SKILL_SEARCH_SORT: estypes.Sort = [
+  { _score: { order: "desc" } },
+  { "name.keyword": { order: "asc" } },
+  { skill_id: { order: "asc" } },
+];
 
 function getSkillSearchHitSources(
   hits: estypes.SearchHit<SkillSearchDocument>[]
@@ -190,30 +155,11 @@ function getSkillSearchHitSources(
   );
 }
 
-/**
- * Searches a bounded custom-skill candidate window.
- *
- * Non-pod spaces and editors-only visibility are filtered directly in
- * Elasticsearch. Projects/pods are authorized from only the IDs present in
- * the candidate window, so a user's potentially unbounded memberships are
- * never sent to Elasticsearch.
- */
-export async function searchSkillDocuments(
+// Prepare once per API request, not once per candidate batch.
+export async function prepareSkillSearchQuery(
   auth: Authenticator,
-  {
-    searchTerm,
-    limit,
-  }: {
-    searchTerm: string;
-    limit: number;
-  }
-): Promise<Result<SkillSearchDocument[], ElasticsearchError>> {
-  assert(
-    Number.isInteger(limit) && limit > 0 && limit <= MAX_SKILL_SEARCH_RESULTS,
-    `limit must be between 1 and ${MAX_SKILL_SEARCH_RESULTS}`
-  );
-
-  const workspace = auth.getNonNullableWorkspace();
+  searchTerm: string
+): Promise<estypes.QueryDslQueryContainer> {
   const workspaceSpaces = await SpaceResource.listWorkspaceSpaces(auth, {
     includeConversationsSpace: true,
   });
@@ -224,34 +170,21 @@ export async function searchSkillDocuments(
         .map((s) => s.sId)
     ),
   ];
-  const candidateLimit = Math.min(
-    MAX_SKILL_SEARCH_CANDIDATES,
-    Math.max(MIN_SKILL_SEARCH_CANDIDATES, limit * 3)
-  );
+  return buildSkillSearchQuery({
+    workspaceId: auth.getNonNullableWorkspace().sId,
+    searchTerm,
+    readableNonPodSpaceIds: readableNonPodSpaceIds.sort(),
+    editorUserId: auth.user()?.id ?? null,
+    canReadAllEditorsOnly: auth.isKey(),
+  });
+}
 
-  const candidateSearchResult = await withEs((client) =>
-    client.search<SkillSearchDocument>({
-      index: SKILL_SEARCH_ALIAS_NAME,
-      query: buildSkillSearchQuery({
-        workspaceId: workspace.sId,
-        searchTerm,
-        readableNonPodSpaceIds,
-        editorUserId: auth.user()?.id ?? null,
-        canReadAllEditorsOnly: auth.isKey(),
-      }),
-      size: candidateLimit,
-      sort: buildSkillSearchSort(searchTerm.trim().length > 0),
-    })
-  );
-  if (candidateSearchResult.isErr()) {
-    return new Err(candidateSearchResult.error);
-  }
-
-  const candidates = getSkillSearchHitSources(
-    candidateSearchResult.value.hits.hits
-  );
+async function filterSkillSearchCandidates(
+  auth: Authenticator,
+  candidates: SkillSearchDocument[]
+): Promise<SkillSearchDocument[]> {
   if (candidates.length === 0) {
-    return new Ok([]);
+    return [];
   }
   const candidatePodIds = [
     ...new Set(
@@ -277,5 +210,88 @@ export async function searchSkillDocuments(
       accessFilteredCandidates
     );
 
-  return new Ok(visibleCandidates.slice(0, limit));
+  return visibleCandidates;
+}
+
+export async function searchSkillDocumentCandidates(
+  auth: Authenticator,
+  {
+    query,
+    pitId,
+    searchAfter,
+    limit,
+  }: {
+    query: estypes.QueryDslQueryContainer;
+    pitId: string;
+    searchAfter: SkillSearchSort | null;
+    limit: number;
+  }
+): Promise<
+  Result<
+    {
+      candidates: SkillSearchCandidate[];
+      pitId: string;
+      exhausted: boolean;
+    },
+    ElasticsearchError
+  >
+> {
+  const result = await withEs((client) =>
+    client.search<SkillSearchDocument>({
+      pit: { id: pitId, keep_alive: `${SKILL_SEARCH_KEEP_ALIVE_SECONDS}s` },
+      // A PIT replaces the index parameter, never the workspace/ACL filters.
+      query: {
+        bool: {
+          filter: [
+            { term: { workspace_id: auth.getNonNullableWorkspace().sId } },
+          ],
+          must: [query],
+        },
+      },
+      size: limit,
+      sort: SKILL_SEARCH_SORT,
+      ...(searchAfter ? { search_after: searchAfter } : {}),
+      track_total_hits: false,
+      allow_partial_search_results: false,
+    })
+  );
+  if (result.isErr()) {
+    return result;
+  }
+  if (result.value.timed_out) {
+    return new Err(
+      new ElasticsearchError("query_error", "Skill search timed out")
+    );
+  }
+  const hits = result.value.hits.hits;
+  const visible = await filterSkillSearchCandidates(
+    auth,
+    getSkillSearchHitSources(hits)
+  );
+  const visibleById = new Map(
+    visible.map((document) => [document.skill_id, document])
+  );
+  const candidates: SkillSearchCandidate[] = [];
+  for (const hit of hits) {
+    const sort = SkillSearchSortSchema.safeParse(hit.sort);
+    if (!sort.success) {
+      return new Err(
+        new ElasticsearchError(
+          "query_error",
+          "Missing skill search sort values"
+        )
+      );
+    }
+    candidates.push({
+      sort: sort.data,
+      document: hit._source
+        ? (visibleById.get(hit._source.skill_id) ?? null)
+        : null,
+    });
+  }
+  return new Ok({
+    candidates,
+    pitId: result.value.pit_id ?? pitId,
+    exhausted: hits.length < limit,
+  });
 }

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -16,6 +16,7 @@ import type {
   GetSkillsResponseBody,
   GetSkillsWithRelationsResponseBody,
   GetSkillWithRelationsResponseBody,
+  SearchSkillsResponseBody,
 } from "@app/types/api/skills";
 import type { GetSimilarSkillsResponseBody } from "@app/types/api/skills/existing_skill_checker";
 import type {
@@ -30,12 +31,13 @@ import { isAPIErrorResponse } from "@app/types/error";
 import { Ok } from "@app/types/shared/result";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { Fetcher, SWRConfiguration } from "swr";
 import type { SWRMutationConfiguration } from "swr/mutation";
 import useSWRMutation from "swr/mutation";
 
 const DETECT_SKILLS_DEBOUNCE_MS = 1_000;
+const SEARCH_SKILLS_DEBOUNCE_MS = 250;
 
 export function useSkill(options: {
   workspaceId: string;
@@ -157,6 +159,53 @@ export function useSkills({
     isSkillsError: !!error,
     isSkillsLoading: isLoading,
     mutateSkills: mutate,
+  };
+}
+
+export function useSearchSkills({
+  owner,
+  searchTerm,
+  disabled,
+  swrOptions,
+}: {
+  owner: LightWorkspaceType;
+  searchTerm: string;
+  disabled?: boolean;
+  swrOptions?: SWRConfiguration;
+}) {
+  const { fetcher } = useFetcher();
+  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState(searchTerm);
+
+  // The delayed value controls the external network request; search-result
+  // filtering and ordering remain derived synchronously by the caller.
+  useEffect(() => {
+    const timeout = setTimeout(
+      () => setDebouncedSearchTerm(searchTerm),
+      SEARCH_SKILLS_DEBOUNCE_MS
+    );
+    return () => clearTimeout(timeout);
+  }, [searchTerm]);
+
+  const queryParams = new URLSearchParams({
+    query: debouncedSearchTerm.slice(0, 200),
+  });
+  const skillsFetcher: Fetcher<SearchSkillsResponseBody> = fetcher;
+  const { data, error, isValidating } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/skills/search?${queryParams.toString()}`,
+    skillsFetcher,
+    {
+      ...swrOptions,
+      disabled,
+      keepPreviousData: true,
+    }
+  );
+
+  return {
+    skills:
+      data?.skills ?? emptyArray<SearchSkillsResponseBody["skills"][number]>(),
+    isSkillsError: !!error,
+    isSkillsLoading:
+      searchTerm !== debouncedSearchTerm || (!error && (!data || isValidating)),
   };
 }
 

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -17,6 +17,7 @@ import type {
   GetSkillsWithRelationsResponseBody,
   GetSkillWithRelationsResponseBody,
   SearchSkillsResponseBody,
+  SkillSearchPermissionFiltering,
 } from "@app/types/api/skills";
 import type { GetSimilarSkillsResponseBody } from "@app/types/api/skills/existing_skill_checker";
 import type {
@@ -167,6 +168,7 @@ export function useSearchSkills({
   searchTerm,
   cursor,
   limit,
+  permissionFiltering,
   disabled,
   swrOptions,
 }: {
@@ -174,6 +176,7 @@ export function useSearchSkills({
   searchTerm: string;
   cursor?: string;
   limit?: number;
+  permissionFiltering?: SkillSearchPermissionFiltering;
   disabled?: boolean;
   swrOptions?: SWRConfiguration;
 }) {
@@ -198,6 +201,9 @@ export function useSearchSkills({
   }
   if (limit !== undefined) {
     queryParams.set("limit", String(limit));
+  }
+  if (permissionFiltering) {
+    queryParams.set("permissionFiltering", permissionFiltering);
   }
   const skillsFetcher: Fetcher<SearchSkillsResponseBody> = fetcher;
   const { data, error, isValidating } = useSWRWithDefaults(

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -165,19 +165,23 @@ export function useSkills({
 export function useSearchSkills({
   owner,
   searchTerm,
+  cursor,
+  limit,
   disabled,
   swrOptions,
 }: {
   owner: LightWorkspaceType;
   searchTerm: string;
+  cursor?: string;
+  limit?: number;
   disabled?: boolean;
   swrOptions?: SWRConfiguration;
 }) {
   const { fetcher } = useFetcher();
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState(searchTerm);
 
-  // The delayed value controls the external network request; search-result
-  // filtering and ordering remain derived synchronously by the caller.
+  // Debounce the external request. Never mix scores from the previous query
+  // with current-query tool scores while this timer or the request is pending.
   useEffect(() => {
     const timeout = setTimeout(
       () => setDebouncedSearchTerm(searchTerm),
@@ -189,6 +193,12 @@ export function useSearchSkills({
   const queryParams = new URLSearchParams({
     query: debouncedSearchTerm.slice(0, 200),
   });
+  if (cursor) {
+    queryParams.set("cursor", cursor);
+  }
+  if (limit !== undefined) {
+    queryParams.set("limit", String(limit));
+  }
   const skillsFetcher: Fetcher<SearchSkillsResponseBody> = fetcher;
   const { data, error, isValidating } = useSWRWithDefaults(
     `/api/w/${owner.sId}/skills/search?${queryParams.toString()}`,
@@ -196,16 +206,23 @@ export function useSearchSkills({
     {
       ...swrOptions,
       disabled,
-      keepPreviousData: true,
+      keepPreviousData: false,
     }
   );
 
   return {
     skills:
-      data?.skills ?? emptyArray<SearchSkillsResponseBody["skills"][number]>(),
+      searchTerm === debouncedSearchTerm && !disabled
+        ? (data?.skills ??
+          emptyArray<SearchSkillsResponseBody["skills"][number]>())
+        : emptyArray<SearchSkillsResponseBody["skills"][number]>(),
+    nextCursor:
+      searchTerm === debouncedSearchTerm ? (data?.nextCursor ?? null) : null,
     isSkillsError: !!error,
     isSkillsLoading:
-      searchTerm !== debouncedSearchTerm || (!error && (!data || isValidating)),
+      !disabled &&
+      (searchTerm !== debouncedSearchTerm ||
+        (!error && (!data || isValidating))),
   };
 }
 

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -87,6 +87,7 @@ import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_v
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
 import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspace_verification_attempt_resource";
+import { launchWorkspaceSkillSearchDeletion } from "@app/lib/skill_search/indexation";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
@@ -657,6 +658,7 @@ export async function deleteSkillsActivity({
   const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
 
   await SkillResource.deleteAllForWorkspace(auth);
+  await launchWorkspaceSkillSearchDeletion({ workspaceId });
 
   hardDeleteLogger.info({ workspaceId }, "Deleted all skills");
 }

--- a/front/scripts/backfill_skill_search.ts
+++ b/front/scripts/backfill_skill_search.ts
@@ -1,0 +1,215 @@
+import { Authenticator } from "@app/lib/auth";
+import { SkillSearchDocumentResource } from "@app/lib/resources/skill/skill_search_document_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import { launchIndexSkillSearchWorkflow } from "@app/temporal/es_indexation/client";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { LightWorkspaceType } from "@app/types/user";
+import assert from "assert";
+
+const DEFAULT_BATCH_SIZE = 500;
+const DEFAULT_CONCURRENCY = 10;
+
+interface BackfillCounts {
+  candidates: number;
+  enqueued: number;
+  failed: number;
+}
+
+async function enqueueSkillSearchBatch({
+  concurrency,
+  logger,
+  skills,
+  workspaceId,
+}: {
+  concurrency: number;
+  logger: Logger;
+  skills: readonly { skillId: string }[];
+  workspaceId: string;
+}): Promise<Pick<BackfillCounts, "enqueued" | "failed">> {
+  const results = await concurrentExecutor(
+    skills,
+    async ({ skillId }) => {
+      const result = await launchIndexSkillSearchWorkflow({
+        workspaceId,
+        skillId,
+      });
+      if (result.isErr()) {
+        logger.error(
+          { error: result.error, skillId, workspaceId },
+          "[SkillSearchBackfill] Failed to enqueue workflow"
+        );
+        return false;
+      }
+
+      return true;
+    },
+    { concurrency }
+  );
+  const enqueued = results.filter(Boolean).length;
+
+  return { enqueued, failed: results.length - enqueued };
+}
+
+async function backfillWorkspace({
+  batchSize,
+  concurrency,
+  execute,
+  initialSkillModelId,
+  logger,
+  workspace,
+}: {
+  batchSize: number;
+  concurrency: number;
+  execute: boolean;
+  initialSkillModelId: ModelId | null;
+  logger: Logger;
+  workspace: LightWorkspaceType;
+}): Promise<BackfillCounts> {
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  let lastSkillModelId = initialSkillModelId;
+  const counts: BackfillCounts = {
+    candidates: 0,
+    enqueued: 0,
+    failed: 0,
+  };
+
+  while (true) {
+    const skills =
+      await SkillSearchDocumentResource.listActiveSearchIndexSkillIds(auth, {
+        afterSkillModelId: lastSkillModelId,
+        limit: batchSize,
+      });
+    if (skills.length === 0) {
+      break;
+    }
+
+    lastSkillModelId = skills[skills.length - 1].skillModelId;
+    counts.candidates += skills.length;
+
+    if (execute) {
+      const batchCounts = await enqueueSkillSearchBatch({
+        concurrency,
+        logger,
+        skills,
+        workspaceId: workspace.sId,
+      });
+      counts.enqueued += batchCounts.enqueued;
+      counts.failed += batchCounts.failed;
+    }
+
+    logger.info(
+      {
+        execute,
+        lastSkillModelId,
+        workspaceCandidates: counts.candidates,
+        workspaceEnqueued: counts.enqueued,
+        workspaceFailed: counts.failed,
+        workspaceId: workspace.sId,
+      },
+      "[SkillSearchBackfill] Batch complete"
+    );
+  }
+
+  logger.info(
+    {
+      execute,
+      lastSkillModelId,
+      workspaceCandidates: counts.candidates,
+      workspaceEnqueued: counts.enqueued,
+      workspaceFailed: counts.failed,
+      workspaceId: workspace.sId,
+    },
+    "[SkillSearchBackfill] Workspace complete"
+  );
+
+  return counts;
+}
+
+makeScript(
+  {
+    wId: {
+      type: "string",
+      describe: "Workspace sId to backfill (omit to run on all workspaces).",
+    },
+    fromWorkspaceModelId: {
+      type: "number",
+      describe:
+        "Skip workspaces with model id below this value (for resuming).",
+    },
+    fromSkillModelId: {
+      type: "number",
+      describe:
+        "Skip skills through this model id in the selected or first workspace.",
+    },
+    batchSize: {
+      type: "number",
+      default: DEFAULT_BATCH_SIZE,
+      describe: "Number of skills to fetch per database query.",
+    },
+    concurrency: {
+      type: "number",
+      default: DEFAULT_CONCURRENCY,
+      describe: "Concurrent Temporal workflow launches per batch.",
+    },
+  },
+  async (
+    {
+      batchSize,
+      concurrency,
+      execute,
+      fromSkillModelId,
+      fromWorkspaceModelId,
+      wId,
+    },
+    logger
+  ) => {
+    assert(batchSize > 0, "--batchSize must be positive");
+    assert(concurrency > 0, "--concurrency must be positive");
+    assert(
+      fromSkillModelId === undefined ||
+        wId !== undefined ||
+        fromWorkspaceModelId !== undefined,
+      "--fromSkillModelId requires --wId or --fromWorkspaceModelId"
+    );
+
+    let totalCandidates = 0;
+    let totalEnqueued = 0;
+    let totalFailed = 0;
+
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        const initialSkillModelId =
+          wId !== undefined || workspace.id === fromWorkspaceModelId
+            ? (fromSkillModelId ?? null)
+            : null;
+        const counts = await backfillWorkspace({
+          batchSize,
+          concurrency,
+          execute,
+          initialSkillModelId,
+          logger,
+          workspace,
+        });
+
+        totalCandidates += counts.candidates;
+        totalEnqueued += counts.enqueued;
+        totalFailed += counts.failed;
+      },
+      { wId, fromWorkspaceId: fromWorkspaceModelId }
+    );
+
+    logger.info(
+      { execute, totalCandidates, totalEnqueued, totalFailed },
+      execute
+        ? "[SkillSearchBackfill] Enqueue complete"
+        : "[SkillSearchBackfill] Dry run complete"
+    );
+
+    if (totalFailed > 0) {
+      throw new Error(`${totalFailed} skill search workflow launches failed`);
+    }
+  }
+);

--- a/front/temporal/es_indexation/activities.test.ts
+++ b/front/temporal/es_indexation/activities.test.ts
@@ -1,0 +1,37 @@
+import { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import { Authenticator } from "@app/lib/auth";
+import { SkillSearchDocumentResource } from "@app/lib/resources/skill/skill_search_document_resource";
+import { deleteSkillDocument } from "@app/lib/skill_search";
+import { indexSkillSearchActivity } from "@app/temporal/es_indexation/activities";
+import { Err } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/skill_search", async (importActual) => {
+  const actual = await importActual<typeof import("@app/lib/skill_search")>();
+  return { ...actual, deleteSkillDocument: vi.fn() };
+});
+
+describe("indexSkillSearchActivity", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("propagates deletion errors so Temporal retries", async () => {
+    vi.spyOn(Authenticator, "internalAdminForWorkspace").mockResolvedValue(
+      {} as Authenticator
+    );
+    vi.spyOn(
+      SkillSearchDocumentResource,
+      "fetchSearchDocument"
+    ).mockResolvedValue(null);
+    const error = new ElasticsearchError("query_error", "index missing", 404);
+    vi.mocked(deleteSkillDocument).mockResolvedValue(new Err(error));
+
+    await expect(
+      indexSkillSearchActivity({
+        workspaceId: "workspace-1",
+        skillId: "skill-1",
+      })
+    ).rejects.toBe(error);
+  });
+});

--- a/front/temporal/es_indexation/activities.ts
+++ b/front/temporal/es_indexation/activities.ts
@@ -1,6 +1,13 @@
+import { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { SkillSearchDocumentResource } from "@app/lib/resources/skill/skill_search_document_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import {
+  deleteSkillDocument,
+  deleteWorkspaceSkillDocuments,
+  indexSkillDocument,
+} from "@app/lib/skill_search";
 import { deleteUserDocument, indexUserDocument } from "@app/lib/user_search";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
@@ -75,5 +82,43 @@ export async function indexUserSearchActivity({
         );
       }
     }
+  }
+}
+
+export async function indexSkillSearchActivity({
+  workspaceId,
+  skillId,
+}: {
+  workspaceId: string;
+  skillId: string;
+}): Promise<void> {
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  const document = await SkillSearchDocumentResource.fetchSearchDocument(
+    auth,
+    skillId
+  );
+
+  if (!document) {
+    const deleteResult = await deleteSkillDocument({ workspaceId, skillId });
+    if (deleteResult.isErr()) {
+      throw deleteResult.error;
+    }
+    return;
+  }
+
+  const indexResult = await indexSkillDocument(document);
+  if (indexResult.isErr()) {
+    throw indexResult.error;
+  }
+}
+
+export async function deleteWorkspaceSkillSearchActivity({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<void> {
+  const deleteResult = await deleteWorkspaceSkillDocuments({ workspaceId });
+  if (deleteResult.isErr()) {
+    throw deleteResult.error;
   }
 }

--- a/front/temporal/es_indexation/client.ts
+++ b/front/temporal/es_indexation/client.ts
@@ -1,13 +1,21 @@
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { QUEUE_NAME } from "@app/temporal/es_indexation/config";
-import { makeIndexUserSearchWorkflowId } from "@app/temporal/es_indexation/helpers";
+import {
+  makeDeleteWorkspaceSkillSearchWorkflowId,
+  makeIndexSkillSearchWorkflowId,
+  makeIndexUserSearchWorkflowId,
+} from "@app/temporal/es_indexation/helpers";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
-import { indexUserSearchSignal } from "./signals";
-import { indexUserSearchWorkflow } from "./workflows";
+import { indexSkillSearchSignal, indexUserSearchSignal } from "./signals";
+import {
+  deleteWorkspaceSkillSearchWorkflow,
+  indexSkillSearchWorkflow,
+  indexUserSearchWorkflow,
+} from "./workflows";
 
 export async function launchIndexUserSearchWorkflow({
   userId,
@@ -38,6 +46,65 @@ export async function launchIndexUserSearchWorkflow({
         error: e,
       },
       "Failed starting index user workflow"
+    );
+
+    return new Err(normalizeError(e));
+  }
+}
+
+export async function launchIndexSkillSearchWorkflow({
+  workspaceId,
+  skillId,
+}: {
+  workspaceId: string;
+  skillId: string;
+}): Promise<Result<undefined, Error>> {
+  const client = await getTemporalClientForFrontNamespace();
+  const workflowId = makeIndexSkillSearchWorkflowId({ workspaceId, skillId });
+
+  try {
+    await client.workflow.signalWithStart(indexSkillSearchWorkflow, {
+      args: [{ workspaceId, skillId }],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      signal: indexSkillSearchSignal,
+      signalArgs: undefined,
+      memo: {
+        workspaceId,
+        skillId,
+      },
+    });
+    return new Ok(undefined);
+  } catch (e) {
+    logger.error(
+      { workflowId, workspaceId, skillId, error: e },
+      "Failed starting index skill workflow"
+    );
+
+    return new Err(normalizeError(e));
+  }
+}
+
+export async function launchDeleteWorkspaceSkillSearchWorkflow({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<Result<undefined, Error>> {
+  const client = await getTemporalClientForFrontNamespace();
+  const workflowId = makeDeleteWorkspaceSkillSearchWorkflowId({ workspaceId });
+
+  try {
+    await client.workflow.start(deleteWorkspaceSkillSearchWorkflow, {
+      args: [{ workspaceId }],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      memo: { workspaceId },
+    });
+    return new Ok(undefined);
+  } catch (e) {
+    logger.error(
+      { workflowId, workspaceId, error: e },
+      "Failed starting workspace skill index deletion workflow"
     );
 
     return new Err(normalizeError(e));

--- a/front/temporal/es_indexation/helpers.ts
+++ b/front/temporal/es_indexation/helpers.ts
@@ -5,3 +5,21 @@ export function makeIndexUserSearchWorkflowId({
 }): string {
   return `es-indexation-user-search-${userId}`;
 }
+
+export function makeIndexSkillSearchWorkflowId({
+  workspaceId,
+  skillId,
+}: {
+  workspaceId: string;
+  skillId: string;
+}): string {
+  return `es-indexation-skill-search-${workspaceId}-${skillId}`;
+}
+
+export function makeDeleteWorkspaceSkillSearchWorkflowId({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): string {
+  return `es-indexation-delete-workspace-skill-search-${workspaceId}`;
+}

--- a/front/temporal/es_indexation/signals.ts
+++ b/front/temporal/es_indexation/signals.ts
@@ -4,6 +4,10 @@ export const indexUserSearchSignal = defineSignal<[void]>(
   "index_user_search_signal"
 );
 
+export const indexSkillSearchSignal = defineSignal<[void]>(
+  "index_skill_search_signal"
+);
+
 export const indexConversationEsSignal = defineSignal<[void]>(
   "index_conversation_es_signal"
 );

--- a/front/temporal/es_indexation/workflows.ts
+++ b/front/temporal/es_indexation/workflows.ts
@@ -1,11 +1,15 @@
 import type * as activities from "@app/temporal/es_indexation/activities";
 import { proxyActivities, setHandler, sleep } from "@temporalio/workflow";
 
-import { indexUserSearchSignal } from "./signals";
+import { indexSkillSearchSignal, indexUserSearchSignal } from "./signals";
 
 const DEBOUNCE_DELAY_MS = 1_000;
 
-const { indexUserSearchActivity } = proxyActivities<typeof activities>({
+const {
+  deleteWorkspaceSkillSearchActivity,
+  indexSkillSearchActivity,
+  indexUserSearchActivity,
+} = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
 });
 
@@ -32,4 +36,39 @@ export async function indexUserSearchWorkflow({
 
   // /!\ Any signal received outside of the while loop will be lost, so don't make any async call
   // here, which will allow the signal handler to be executed by the nodejs event loop.
+}
+
+export async function indexSkillSearchWorkflow({
+  workspaceId,
+  skillId,
+}: {
+  workspaceId: string;
+  skillId: string;
+}): Promise<void> {
+  let signaled = false;
+
+  setHandler(indexSkillSearchSignal, async () => {
+    signaled = true;
+  });
+
+  while (signaled) {
+    signaled = false;
+    await sleep(DEBOUNCE_DELAY_MS);
+    if (signaled) {
+      continue;
+    }
+
+    await indexSkillSearchActivity({ workspaceId, skillId });
+  }
+
+  // /!\ Any signal received outside of the while loop will be lost, so don't make any async call
+  // here, which will allow the signal handler to be executed by the nodejs event loop.
+}
+
+export async function deleteWorkspaceSkillSearchWorkflow({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<void> {
+  await deleteWorkspaceSkillSearchActivity({ workspaceId });
 }

--- a/front/temporal/relocation/activities/destination_region/front/es_indexation.test.ts
+++ b/front/temporal/relocation/activities/destination_region/front/es_indexation.test.ts
@@ -1,0 +1,74 @@
+import { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import {
+  deleteWorkspaceSkillDocuments,
+  indexSkillDocument,
+} from "@app/lib/skill_search";
+import { recreateSkillSearchIndex } from "@app/temporal/relocation/activities/destination_region/front/es_indexation";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/skill_search", () => ({
+  deleteWorkspaceSkillDocuments: vi.fn(),
+  indexSkillDocument: vi.fn(),
+}));
+
+describe("recreateSkillSearchIndex", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(deleteWorkspaceSkillDocuments).mockResolvedValue(
+      new Ok(undefined)
+    );
+    vi.mocked(indexSkillDocument).mockResolvedValue(new Ok(undefined));
+  });
+
+  it("clears and rebuilds active skill documents", async () => {
+    const { authenticator, user, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const regularSpace = await SpaceFactory.regular(workspace);
+    const pod = await SpaceFactory.project(workspace, user.id);
+    const activeSkill = await SkillFactory.create(authenticator, {
+      requestedSpaceIds: [regularSpace.id, pod.id],
+    });
+    await SkillFactory.create(authenticator, { status: "archived" });
+
+    await recreateSkillSearchIndex({ workspaceId: workspace.sId });
+
+    expect(deleteWorkspaceSkillDocuments).toHaveBeenCalledOnce();
+    expect(deleteWorkspaceSkillDocuments).toHaveBeenCalledWith({
+      workspaceId: workspace.sId,
+    });
+    expect(indexSkillDocument).toHaveBeenCalledOnce();
+    expect(indexSkillDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skill_id: activeSkill.sId,
+        requested_space_ids: [regularSpace.sId, pod.sId],
+        non_pod_space_ids: [regularSpace.sId],
+        non_pod_space_count: 1,
+        pod_space_id: pod.sId,
+      })
+    );
+    expect(
+      vi.mocked(deleteWorkspaceSkillDocuments).mock.invocationCallOrder[0]
+    ).toBeLessThan(vi.mocked(indexSkillDocument).mock.invocationCallOrder[0]);
+  });
+
+  it("throws after an indexing failure so Temporal retries", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    await SkillFactory.create(authenticator);
+    vi.mocked(indexSkillDocument).mockResolvedValue(
+      new Err(new ElasticsearchError("query_error", "write failed"))
+    );
+
+    await expect(
+      recreateSkillSearchIndex({ workspaceId: workspace.sId })
+    ).rejects.toThrow(
+      `Failed to index 1 skills for workspace ${workspace.sId}`
+    );
+  });
+});

--- a/front/temporal/relocation/activities/destination_region/front/es_indexation.ts
+++ b/front/temporal/relocation/activities/destination_region/front/es_indexation.ts
@@ -1,10 +1,20 @@
+import { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { SkillSearchDocumentResource } from "@app/lib/resources/skill/skill_search_document_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import {
+  deleteWorkspaceSkillDocuments,
+  indexSkillDocument,
+} from "@app/lib/skill_search";
 import { indexUserDocument } from "@app/lib/user_search";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
+import type { ModelId } from "@app/types/shared/model_id";
+
+const SKILL_SEARCH_BATCH_SIZE = 500;
+const SKILL_SEARCH_INDEX_CONCURRENCY = 10;
 
 export async function recreateUserSearchIndex({
   workspaceId,
@@ -94,6 +104,94 @@ export async function recreateUserSearchIndex({
   if (errorCount > 0) {
     throw new Error(
       `Failed to index ${errorCount} users for workspace ${workspaceId}`
+    );
+  }
+}
+
+export async function recreateSkillSearchIndex({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<void> {
+  const localLogger = logger.child({ workspaceId });
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+
+  localLogger.info(
+    "[Skill Search] Recreating skill search index for workspace."
+  );
+
+  const deleteResult = await deleteWorkspaceSkillDocuments({ workspaceId });
+  if (deleteResult.isErr()) {
+    throw deleteResult.error;
+  }
+
+  let afterSkillModelId: ModelId | null = null;
+  let indexedCount = 0;
+  let skippedCount = 0;
+  let errorCount = 0;
+
+  while (true) {
+    const skills =
+      await SkillSearchDocumentResource.listActiveSearchIndexSkillIds(auth, {
+        afterSkillModelId,
+        limit: SKILL_SEARCH_BATCH_SIZE,
+      });
+    if (skills.length === 0) {
+      break;
+    }
+
+    afterSkillModelId = skills[skills.length - 1].skillModelId;
+    const documents = await SkillSearchDocumentResource.fetchSearchDocuments(
+      auth,
+      skills.map(({ skillId }) => skillId)
+    );
+    const documentBySkillId = new Map(
+      documents.map((document) => [document.skill_id, document])
+    );
+    const results = await concurrentExecutor(
+      skills,
+      async ({ skillId }) => {
+        const document = documentBySkillId.get(skillId);
+        if (!document) {
+          localLogger.warn(
+            { skillId },
+            "[Skill Search] Skipping skill that is no longer active"
+          );
+          return "skipped" as const;
+        }
+
+        const indexResult = await indexSkillDocument(document);
+        if (indexResult.isErr()) {
+          localLogger.error(
+            { error: indexResult.error, skillId },
+            "[Skill Search] Failed to index skill document"
+          );
+          return "failed" as const;
+        }
+
+        return "indexed" as const;
+      },
+      { concurrency: SKILL_SEARCH_INDEX_CONCURRENCY }
+    );
+
+    indexedCount += results.filter((result) => result === "indexed").length;
+    skippedCount += results.filter((result) => result === "skipped").length;
+    errorCount += results.filter((result) => result === "failed").length;
+
+    localLogger.info(
+      { afterSkillModelId, errorCount, indexedCount, skippedCount },
+      "[Skill Search] Recreated skill search index batch"
+    );
+  }
+
+  localLogger.info(
+    { errorCount, indexedCount, skippedCount },
+    "[Skill Search] Completed skill search index recreation for workspace"
+  );
+
+  if (errorCount > 0) {
+    throw new Error(
+      `Failed to index ${errorCount} skills for workspace ${workspaceId}`
     );
   }
 }

--- a/front/temporal/relocation/workflows.ts
+++ b/front/temporal/relocation/workflows.ts
@@ -19,6 +19,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import {
   continueAsNew,
   executeChild,
+  patched,
   proxyActivities,
   sleep,
   workflowInfo,
@@ -320,6 +321,10 @@ export async function workspaceRelocateFrontEsIndexationWorkflow({
 
   // Recreate user search index.
   await destinationRegionActivities.recreateUserSearchIndex({ workspaceId });
+
+  if (patched("relocation-recreate-skill-search-index")) {
+    await destinationRegionActivities.recreateSkillSearchIndex({ workspaceId });
+  }
 }
 
 /**

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -37,6 +37,7 @@ import { TakeawaysResource } from "@app/lib/resources/takeaways_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { launchWorkspaceSkillSearchDeletion } from "@app/lib/skill_search/indexation";
 import { CustomerioServerSideTracking } from "@app/lib/tracking/customerio/server";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
@@ -293,6 +294,9 @@ async function deleteAgentMemories(auth: Authenticator) {
 
 async function deleteSkills(auth: Authenticator) {
   await SkillResource.deleteAllForWorkspace(auth);
+  await launchWorkspaceSkillSearchDeletion({
+    workspaceId: auth.getNonNullableWorkspace().sId,
+  });
 }
 
 async function deleteOnboardingTasks(auth: Authenticator) {

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -34,6 +34,7 @@ import {
 import { isSCIMEnabled } from "@app/lib/plans/scim";
 import {
   ADMIN_GROUP_NAME,
+  GROUP_MEMBERSHIP_RESTORE_TOLERANCE_MS,
   GroupResource,
   MANAGER_GROUP_NAME,
 } from "@app/lib/resources/group_resource";
@@ -42,6 +43,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { launchSkillsSearchIndexationForGroups } from "@app/lib/skill_search/indexation";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import mainLogger from "@app/logger/logger";
 import { GROUP_KINDS } from "@app/types/groups";
@@ -1172,12 +1174,13 @@ async function handleCreateOrUpdateWorkOSUser(
       );
     }
 
-    await revokeWorkOSUserMembership(
+    await revokeWorkOSUserMembership({
       workspace,
-      inactiveUser,
-      eventData.directoryId,
-      false
-    );
+      user: inactiveUser,
+      directoryId: eventData.directoryId,
+      eventCreatedAt: new Date(event.createdAt),
+      triggersDeleted: false,
+    });
     return;
   }
 
@@ -1229,6 +1232,21 @@ async function handleCreateOrUpdateWorkOSUser(
       workspace,
       newOrigin: "provisioned",
       author: createdOrUpdatedUser.toJSON(),
+    });
+    // A retry can arrive after createAndTrackMembership restored editor-group
+    // rows but before their indexation launch completed. Re-reading current
+    // grants makes that retry converge.
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const currentGrantGroups =
+      await GroupResource.dangerouslyListAllUserGroupsInWorkspace({
+        auth,
+        user: createdOrUpdatedUser,
+        groupKinds: ["regular_auto"],
+        dangerouslySkipMembershipCheck: true,
+      });
+    await launchSkillsSearchIndexationForGroups({
+      workspace,
+      groupModelIds: currentGrantGroups.map((group) => group.id),
     });
 
     void emitAuditLogEventDirect({
@@ -1315,20 +1333,62 @@ async function handleCreateOrUpdateWorkOSUser(
   });
 }
 
-async function revokeWorkOSUserMembership(
-  workspace: LightWorkspaceType,
-  user: UserResource,
-  directoryId: string | null | undefined,
-  triggersDeleted: boolean
-) {
+async function revokeWorkOSUserMembership({
+  workspace,
+  user,
+  directoryId,
+  eventCreatedAt,
+  triggersDeleted,
+}: {
+  workspace: LightWorkspaceType;
+  user: UserResource;
+  directoryId: string | null | undefined;
+  eventCreatedAt: Date;
+  triggersDeleted: boolean;
+}) {
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-  const groups = await GroupResource.dangerouslyListAllUserGroupsInWorkspace({
-    auth,
-    user,
-    groupKinds: GROUP_KINDS.filter((k) => k !== "system" && k !== "global"),
-  });
+  const groupKinds = GROUP_KINDS.filter(
+    (kind) => kind !== "system" && kind !== "global"
+  );
+  const latestMembership =
+    await MembershipResource.getLatestMembershipOfUserInWorkspace({
+      user,
+      workspace,
+    });
+  const revokedAt = latestMembership?.isRevoked()
+    ? latestMembership.endAt
+    : null;
+  const activeGroups =
+    await GroupResource.dangerouslyListAllUserGroupsInWorkspace({
+      auth,
+      user,
+      groupKinds,
+      dangerouslySkipMembershipCheck: true,
+    });
+  const historicalLookupAt = revokedAt
+    ? new Date(revokedAt.getTime() - GROUP_MEMBERSHIP_RESTORE_TOLERANCE_MS)
+    : eventCreatedAt;
+  // Keep the event-time view as well as the current one. If an earlier attempt
+  // ended group rows before failing, a retry can still recover the affected
+  // editor grants and enqueue their skills.
+  const recentlyActiveGroups =
+    await GroupResource.dangerouslyListAllUserGroupsInWorkspace({
+      auth,
+      user,
+      groupKinds,
+      at: historicalLookupAt,
+      dangerouslySkipMembershipCheck: true,
+    });
+  const affectedGroups = [
+    ...new Map(
+      [...activeGroups, ...recentlyActiveGroups].map((group) => [
+        group.id,
+        group,
+      ])
+    ).values(),
+  ];
 
-  for (const group of groups) {
+  for (const group of activeGroups) {
     // No canWrite guard here — see handleUserRemovedFromGroup. `auth` is
     // internalAdminForWorkspace, and canWrite is false for agent_editors
     // groups, which would wrongly abort deprovisioning of editor users.
@@ -1357,15 +1417,25 @@ async function revokeWorkOSUserMembership(
     },
   });
 
-  if (membershipRevokeResult.isErr()) {
-    if (membershipRevokeResult.error.type === "already_revoked") {
-      logger.info(
-        { userId: user.sId, workspaceId: workspace.sId },
-        "User membership already revoked, skipping"
-      );
-      return;
-    }
+  if (
+    membershipRevokeResult.isErr() &&
+    membershipRevokeResult.error.type !== "already_revoked"
+  ) {
     throw membershipRevokeResult.error;
+  }
+
+  await launchSkillsSearchIndexationForGroups({
+    workspace,
+    groupModelIds: affectedGroups
+      .filter((group) => group.isRegularAuto())
+      .map((group) => group.id),
+  });
+  if (membershipRevokeResult.isErr()) {
+    logger.info(
+      { userId: user.sId, workspaceId: workspace.sId },
+      "User membership already revoked, skipping"
+    );
+    return;
   }
 
   // Emit SCIM-specific audit event in addition to the generic membership.revoked.
@@ -1427,12 +1497,13 @@ async function handleDeleteWorkOSUser(
   // Clear WorkOS custom attributes before revoking membership.
   await clearCustomAttributesFromUserMetadata(user, workspace);
 
-  await revokeWorkOSUserMembership(
+  await revokeWorkOSUserMembership({
     workspace,
     user,
-    eventData.directoryId,
-    true
-  );
+    directoryId: eventData.directoryId,
+    eventCreatedAt: new Date(event.createdAt),
+    triggersDeleted: true,
+  });
 }
 
 async function handleGroupDelete(

--- a/front/types/api/skills/index.ts
+++ b/front/types/api/skills/index.ts
@@ -11,6 +11,20 @@ export type GetSkillsResponseBody = {
   })[];
 };
 
+export type SkillSearchResult = Pick<
+  SkillWithoutInstructionsAndToolsType,
+  | "editedBy"
+  | "icon"
+  | "name"
+  | "requestedSpaceIds"
+  | "sId"
+  | "userFacingDescription"
+>;
+
+export type SearchSkillsResponseBody = {
+  skills: SkillSearchResult[];
+};
+
 export type GetSkillsWithRelationsResponseBody = {
   skills: (SkillWithoutInstructionsAndToolsWithRelationsType & {
     isFavorite?: boolean;

--- a/front/types/api/skills/index.ts
+++ b/front/types/api/skills/index.ts
@@ -1,3 +1,4 @@
+import type { SkillPermissionFilteringMode } from "@app/lib/resources/skill/skill_resource";
 import type {
   SkillType,
   SkillWithoutInstructionsAndToolsType,
@@ -22,7 +23,14 @@ export type SkillSearchResult = Pick<
 > & {
   // Fixed relevance score shared with code-defined skills. Older clients may ignore it.
   score?: number;
+  // False for an unreadable result retained by admin-only redact_unreadable search.
+  canRead?: boolean;
 };
+
+export type SkillSearchPermissionFiltering = Exclude<
+  SkillPermissionFilteringMode,
+  "dangerously_skip"
+>;
 
 export type SearchSkillsResponseBody = {
   skills: SkillSearchResult[];

--- a/front/types/api/skills/index.ts
+++ b/front/types/api/skills/index.ts
@@ -19,10 +19,15 @@ export type SkillSearchResult = Pick<
   | "requestedSpaceIds"
   | "sId"
   | "userFacingDescription"
->;
+> & {
+  // Fixed relevance score shared with code-defined skills. Older clients may ignore it.
+  score?: number;
+};
 
 export type SearchSkillsResponseBody = {
   skills: SkillSearchResult[];
+  // Null means exhausted; optional for clients talking to an older server.
+  nextCursor?: string | null;
 };
 
 export type GetSkillsWithRelationsResponseBody = {

--- a/front/types/skill_search/skill_search.ts
+++ b/front/types/skill_search/skill_search.ts
@@ -1,0 +1,22 @@
+import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
+import type {
+  SkillAvailability,
+  SkillStatus,
+} from "@app/types/assistant/skill_configuration";
+import type { ModelId } from "@app/types/shared/model_id";
+
+export interface SkillSearchDocument extends ElasticsearchBaseDocument {
+  skill_id: string;
+  status: SkillStatus;
+  availability: SkillAvailability;
+  name: string;
+  user_facing_description: string | null;
+  icon: string | null;
+  edited_by: number | null;
+  editor_user_ids: ModelId[];
+  requested_space_ids: string[];
+  non_pod_space_ids: string[];
+  non_pod_space_count: number;
+  pod_space_id: string | null;
+  updated_at: string;
+}

--- a/front/vite.setup.ts
+++ b/front/vite.setup.ts
@@ -123,6 +123,14 @@ vi.mock("@app/temporal/es_indexation/client", async (importOriginal) => {
   const mod = (await importOriginal()) as Record<string, unknown>;
   return {
     ...mod,
+    launchDeleteWorkspaceSkillSearchWorkflow: vi.fn(async () => {
+      const { Ok } = await import("@app/types/shared/result");
+      return new Ok(undefined);
+    }),
+    launchIndexSkillSearchWorkflow: vi.fn(async () => {
+      const { Ok } = await import("@app/types/shared/result");
+      return new Ok(undefined);
+    }),
     launchIndexUserSearchWorkflow: vi.fn(async () => {
       const { Ok } = await import("@app/types/shared/result");
       return new Ok(undefined);

--- a/init_dev_container.sh
+++ b/init_dev_container.sh
@@ -45,6 +45,7 @@ cd -
 cd front/
 npm install
 npx tsx ./scripts/create_elasticsearch_index.ts --index-name agent_message_analytics --index-version 2 --skip-confirmation --execute
+npx tsx ./scripts/create_elasticsearch_index.ts --index-name skill_search --index-version 1 --skip-confirmation --execute
 npx tsx ./scripts/create_elasticsearch_index.ts --index-name user_search --index-version 1 --skip-confirmation --execute
 cd -
 

--- a/x/henry/dust-hive/src/lib/init.ts
+++ b/x/henry/dust-hive/src/lib/init.ts
@@ -209,6 +209,7 @@ async function initElasticsearchTS(
     { name: "agent_document_outputs", version: "1" },
     { name: "agent_message_analytics", version: "2" },
     { name: "agent_message_consumption_analytics", version: "1" },
+    { name: "skill_search", version: "1" },
     { name: "user_search", version: "1" },
   ];
 


### PR DESCRIPTION
## Description

Admin search needs to include skills they cannot read without exposing their private fields. Add an opt-in `permissionFiltering=redact_unreadable` mode using the existing resource authorization and metadata-only serialization, with `canRead` on each result.

Strict filtering remains the default for slash search. Redacted searches retain workspace isolation and bind pagination cursors to the permission mode. No mapping change or backfill is required.

## Tests

- Added coverage for admin-only access, canonical redaction, cross-workspace/stale hits, and permission changes during pagination.
- Verified both modes locally against the ten space, pod, and editor ACL fixtures.

## Risk

- Medium. Permission-sensitive search change; redacted results require an explicit admin opt-in.

## Deploy Plan

- Deploy front.
