### PR TITLE
Fix poke coupon creation 500 under Cloudflare Access auth

### DIFF
--- a/front/lib/resources/coupon_resource.ts
+++ b/front/lib/resources/coupon_resource.ts
@@ -66,11 +66,11 @@ export class CouponResource extends BaseResource<CouponModel> {
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<CouponResource, Error>> {
     try {
-      const user = auth.getNonNullableUser();
+      const user = auth.user();
       const coupon = await CouponModel.create(
         {
           ...body,
-          createdByUserId: user.id,
+          createdByUserId: user?.id ?? null,
         },
         { transaction }
       );


### PR DESCRIPTION
## Description

Creating a coupon from Poke in production fails with:

```
500 {"error":{"type":"internal_server_error","message":"Failed to create coupon: Unexpected unauthenticated call to `getNonNullableUser`."}}
```

Root cause: since #32041 ("Remove poke workOS fallback outside of dev"), Poke
requests in prod authenticate exclusively via the Cloudflare Access path, which
builds the `Authenticator` with a `pokePrincipal` (email/name) but **no Dust
`UserResource`** attached. `CouponResource.makeNew` called
`auth.getNonNullableUser()` to populate `createdByUserId`, which throws when no
user is attached. It worked in dev only because the dev-only WorkOS fallback
attaches a real user.

The `coupons.createdByUserId` column is already nullable, so the fix records the
user id when one is present and `null` otherwise (Cloudflare Access operators).

## Tests

Existing `front-api/routes/poke/coupons/index.test.ts` covers creation. No new
behavior beyond allowing a null author when the authenticator carries only a
poke principal.

## Risk

Low. Single-line change on a nullable column. Attribution (`createdByUserId`) is
now null for Cloudflare-Access-authenticated operators, which is acceptable
given the column already allows null. Other poke write paths calling
`getNonNullableUser()` may have the same latent issue and are out of scope here.

## Deploy Plan

Standard deploy. No migration required (column already nullable).