### PR TITLE
[Agent Loop] Clean up unfinished runs after conversation deletion

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1,3 +1,4 @@
+import { getConversationRankVersionLock } from "@app/lib/api/assistant/conversation/lock";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationMCPServerViewModel } from "@app/lib/models/agent/actions/conversation_mcp_server_view";
 import {
@@ -3000,6 +3001,72 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     );
 
     return new Ok(updated[0]);
+  }
+
+  /**
+   * @cc [owner:philipperolet,label:backend;concurrency] cancel-unavailable-agent-message
+   * After an agent loop loses access to its data, cancel only its workspace-scoped message
+   * version if still created; under the conversation lock, clear the running flag only if
+   * that transition applied and no current agent message is running.
+   */
+  static async cancelUnavailableAgentMessage(
+    auth: Authenticator,
+    {
+      conversationId,
+      agentMessageId,
+      agentMessageVersion,
+    }: {
+      conversationId: string;
+      agentMessageId: string;
+      agentMessageVersion: number;
+    }
+  ): Promise<void> {
+    // Deletion or a permissions change may remove the loop's original access. This internal
+    // cleanup stays scoped to its workspace and message; it never returns conversation content.
+    const conversation = await this.fetchById(auth, conversationId, {
+      includeDeleted: true,
+      dangerouslySkipPermissionFiltering: true,
+    });
+    if (!conversation) {
+      return;
+    }
+
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    await withTransaction(async (transaction) => {
+      await getConversationRankVersionLock(auth, conversation, transaction);
+      const message = await MessageModel.findOne({
+        where: {
+          workspaceId,
+          conversationId: conversation.id,
+          sId: agentMessageId,
+          version: agentMessageVersion,
+        },
+        transaction,
+      });
+      if (!message?.agentMessageId) {
+        return;
+      }
+
+      const [updatedCount] = await AgentMessageModel.update(
+        { status: "cancelled", completedAt: new Date() },
+        {
+          where: { id: message.agentMessageId, workspaceId, status: "created" },
+          transaction,
+        }
+      );
+      if (
+        updatedCount === 0 ||
+        (await conversation.getRunningAgentMessage(auth, { transaction }))
+      ) {
+        return;
+      }
+
+      await this.setIsRunningAgentLoop(auth, {
+        conversation: conversation.toJSON(),
+        isRunningAgentLoop: false,
+        transaction,
+      });
+    });
   }
 
   static async markAsReadForAuthUser(

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -512,6 +512,22 @@ async function withContentView(
 const DEFAULT_WORKFLOW_ERROR_MESSAGE =
   "An unexpected error occurred while generating the agent response. Please try again.";
 
+/**
+ * @cc [owner:philipperolet,label:backend] finalize-unavailable-loop
+ * Call only after the loop's conversation or message becomes unavailable; cancel its unfinished
+ * message before exiting, without publishing terminal events or starting another run.
+ */
+export async function finalizeUnavailableAgentLoop(
+  authType: AuthenticatorType,
+  agentLoopArgs: Pick<
+    AgentLoopArgs,
+    "conversationId" | "agentMessageId" | "agentMessageVersion"
+  >
+): Promise<void> {
+  const auth = await AuthenticatorClass.fromJsonWithRefrehedGroups(authType);
+  await ConversationResource.cancelUnavailableAgentMessage(auth, agentLoopArgs);
+}
+
 function toUserFriendlyMessage(error: {
   message: string;
   name: string;
@@ -543,6 +559,11 @@ export async function notifyWorkflowError(
     conversationId
   );
   if (!conversation) {
+    await finalizeUnavailableAgentLoop(authType, {
+      conversationId,
+      agentMessageId,
+      agentMessageVersion,
+    });
     return null;
   }
 
@@ -643,6 +664,7 @@ export async function finalizeCancellation(
   );
   if (runAgentDataRes.isErr()) {
     if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
+      await finalizeUnavailableAgentLoop(authType, agentLoopArgs);
       logger.info(
         {
           conversationId: agentLoopArgs.conversationId,
@@ -721,6 +743,7 @@ export async function finalizeInterruption(
   );
   if (runAgentDataRes.isErr()) {
     if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
+      await finalizeUnavailableAgentLoop(authType, agentLoopArgs);
       logger.info(
         {
           conversationId: agentLoopArgs.conversationId,
@@ -808,6 +831,7 @@ export async function finalizeGracefulStop(
   );
   if (runAgentDataRes.isErr()) {
     if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
+      await finalizeUnavailableAgentLoop(authType, agentLoopArgs);
       logger.info(
         {
           conversationId: agentLoopArgs.conversationId,
@@ -872,6 +896,7 @@ export async function finalizeCreditStop(
   );
   if (runAgentDataRes.isErr()) {
     if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
+      await finalizeUnavailableAgentLoop(authType, agentLoopArgs);
       logger.info(
         {
           conversationId: agentLoopArgs.conversationId,

--- a/front/temporal/agent_loop/activities/deletion.test.ts
+++ b/front/temporal/agent_loop/activities/deletion.test.ts
@@ -1,0 +1,157 @@
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { finalizeCancellation } from "@app/temporal/agent_loop/activities/common";
+import { runModelAndCreateActionsActivity } from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { assert, describe, expect, it, vi } from "vitest";
+
+vi.mock("@temporalio/activity", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@temporalio/activity")>()),
+  Context: {
+    current: () => ({ info: { attempt: 1, startToCloseTimeoutMs: 60_000 } }),
+  },
+  heartbeat: vi.fn(),
+}));
+
+async function createRunningLoop() {
+  const { authenticator: auth, workspace } = await createResourceTest({});
+  const agentConfig = await AgentConfigurationFactory.createTestAgent(auth);
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: agentConfig.sId,
+    messagesCreatedAt: [],
+  });
+  const { userMessage, messageRow } =
+    await ConversationFactory.createUserMessage({
+      auth,
+      workspace,
+      conversation,
+      content: "Hello",
+    });
+  const { agentMessage } = await ConversationFactory.createAgentMessage(auth, {
+    workspace,
+    conversation,
+    agentConfig,
+    parentMessageModelId: messageRow.id,
+    rank: 1,
+  });
+  await ConversationResource.setIsRunningAgentLoop(auth, {
+    conversation,
+    isRunningAgentLoop: true,
+  });
+  const resource = await ConversationResource.fetchById(auth, conversation.sId);
+  assert(resource);
+  return {
+    auth,
+    workspace,
+    agentConfig,
+    conversation: resource,
+    agentLoopArgs: {
+      conversationId: conversation.sId,
+      conversationTitle: conversation.title,
+      agentMessageId: agentMessage.sId,
+      agentMessageVersion: agentMessage.version,
+      userMessageId: userMessage.sId,
+      userMessageVersion: userMessage.version,
+      userMessageOrigin: userMessage.context.origin,
+    },
+  };
+}
+
+describe("agent loop deletion cleanup", () => {
+  it.each([
+    "next step",
+    "cancellation",
+  ] as const)("finalizes the message when %s encounters a deleted conversation", async (exit) => {
+    const { auth, conversation, agentLoopArgs } = await createRunningLoop();
+    await conversation.updateVisibilityToDeleted(auth);
+
+    if (exit === "next step") {
+      expect(
+        await runModelAndCreateActionsActivity({
+          authType: auth.toJSON(),
+          runAgentArgs: { ...agentLoopArgs, initialStartTime: Date.now() },
+          runIds: [],
+          step: 0,
+        })
+      ).toBeNull();
+    } else {
+      await finalizeCancellation(auth.toJSON(), agentLoopArgs);
+    }
+
+    const message = await conversation.getMessageById(
+      auth,
+      agentLoopArgs.agentMessageId
+    );
+    assert(message.isOk());
+    expect(message.value.agentMessage?.status).toBe("cancelled");
+    expect(message.value.agentMessage?.completedAt).toBeInstanceOf(Date);
+    const updated = await ConversationResource.fetchById(
+      auth,
+      conversation.sId,
+      {
+        includeDeleted: true,
+      }
+    );
+    expect(updated?.isRunningAgentLoop).toBe(false);
+  });
+
+  it("preserves another running message and ignores repeated cleanup", async () => {
+    const { auth, workspace, agentConfig, conversation, agentLoopArgs } =
+      await createRunningLoop();
+    const { agentMessage: nextMessage } =
+      await ConversationFactory.createAgentMessage(auth, {
+        workspace,
+        conversation,
+        agentConfig,
+        rank: 2,
+      });
+    await conversation.updateVisibilityToDeleted(auth);
+
+    await finalizeCancellation(auth.toJSON(), agentLoopArgs);
+    const first = await conversation.getMessageById(
+      auth,
+      agentLoopArgs.agentMessageId
+    );
+    assert(first.isOk());
+    expect(first.value.agentMessage?.status).toBe("cancelled");
+    const completedAt = first.value.agentMessage?.completedAt;
+
+    await finalizeCancellation(auth.toJSON(), agentLoopArgs);
+    const repeated = await conversation.getMessageById(
+      auth,
+      agentLoopArgs.agentMessageId
+    );
+    assert(repeated.isOk());
+    expect(repeated.value.agentMessage?.completedAt).toEqual(completedAt);
+    const updated = await ConversationResource.fetchById(
+      auth,
+      conversation.sId,
+      {
+        includeDeleted: true,
+      }
+    );
+    expect(updated?.isRunningAgentLoop).toBe(true);
+    expect((await conversation.getRunningAgentMessage(auth))?.sId).toBe(
+      nextMessage.sId
+    );
+  });
+
+  it("cannot cancel a message in another workspace", async () => {
+    const { auth, conversation, agentLoopArgs } = await createRunningLoop();
+    const { authenticator: otherAuth } = await createResourceTest({});
+    await conversation.updateVisibilityToDeleted(auth);
+
+    await ConversationResource.cancelUnavailableAgentMessage(
+      otherAuth,
+      agentLoopArgs
+    );
+
+    const message = await conversation.getMessageById(
+      auth,
+      agentLoopArgs.agentMessageId
+    );
+    assert(message.isOk());
+    expect(message.value.agentMessage?.status).toBe("created");
+  });
+});

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -10,7 +10,10 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { withPeriodicHeartbeat } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
-import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
+import {
+  finalizeUnavailableAgentLoop,
+  updateResourceAndPublishEvent,
+} from "@app/temporal/agent_loop/activities/common";
 import {
   AGENT_LOOP_COST_HARD_CAP_USD,
   AGENT_LOOP_SUBAGENT_HARD_CAP,
@@ -136,6 +139,7 @@ async function _runModelAndCreateActionsActivity({
   );
   if (contextProviderRes.isErr()) {
     if (isAgentLoopDataSoftDeleteError(contextProviderRes.error)) {
+      await finalizeUnavailableAgentLoop(authType, runAgentArgs);
       logger.info(
         {
           conversationId: runAgentArgs.conversationId,


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8402.

If a user deletes a conversation while an agent is answering, the agent can notice the deletion and exit, while its saved message still says `created` and the conversation is still marked as running. The code previously just logged the deletion and returned.

This change marks that unfinished message as cancelled and clears the conversation's running flag when no other agent message is running. It covers both deletion noticed between steps and deletion noticed while stopping or handling an error. Repeated cleanup leaves finished messages and other running agents alone. The same cleanup applies when the loop loses access to its conversation.

The separate bug where deleting a message made later messages stay queued was fixed by https://github.com/dust-tt/dust/pull/29418. This PR addresses the remaining cleanup gap discussed in the closed https://github.com/dust-tt/dust/pull/26241. It does not sweep historical messages.

Context: [original Slack thread](https://dust4ai.slack.com/archives/C09GELMTTRT/p1779872037151629).

## Risks

Blast radius: agent loops exiting after their conversation or message becomes unavailable.
Risk: low. Cleanup targets the original message version and uses the conversation lock to preserve other running messages.

## Deploy Plan

- Deploy front

## Tests

- [x] Existing agent message finalization tests and new deletion regression tests: 29 tests passed.
- [x] Deletion noticed between steps and during cancellation finalizes the unfinished message.
- [x] Repeated cleanup preserves the completion time and another running message.
- [x] Cleanup cannot change a message in another workspace.
