### PR TITLE
Fix Stripe cancellation for schedule-managed subscriptions

### DIFF
--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -786,6 +786,12 @@ export async function cancelSubscriptionAtPeriodEnd({
  * the Stripe sub stops at the new Metronome contract's start time, so the two
  * rails don't double-bill. Prorations at cancellation follow the subscription's
  * existing proration settings (default: a credit for the unused portion).
+ *
+ * @cc [owner:tdraier,label:backend] cancels-schedule-managed-subscriptions
+ * `scheduleSubscriptionCancellation` schedules the subscription to cancel at `cancelAt`, including
+ * when the subscription is managed by a subscription schedule: it releases the schedule before
+ * setting `cancel_at`, since Stripe rejects direct cancelation edits on schedule-managed
+ * subscriptions.
  */
 export async function scheduleSubscriptionCancellation({
   stripeSubscriptionId,
@@ -795,6 +801,22 @@ export async function scheduleSubscriptionCancellation({
   cancelAt: Date;
 }) {
   const stripe = getStripeClient();
+
+  // A subscription driven by a subscription schedule rejects direct `cancel_at`
+  // edits ("updating any cancelation behavior directly is not allowed"). Release
+  // the schedule so the subscription becomes standalone before scheduling the
+  // cancellation. Releasing keeps the subscription running with its current items
+  // and discards future scheduled phases, which is the intended outcome here: the
+  // subscription is being wound down.
+  const subscription =
+    await stripe.subscriptions.retrieve(stripeSubscriptionId);
+  const scheduleId = isString(subscription.schedule)
+    ? subscription.schedule
+    : subscription.schedule?.id;
+  if (scheduleId) {
+    await stripe.subscriptionSchedules.release(scheduleId);
+  }
+
   await stripe.subscriptions.update(stripeSubscriptionId, {
     cancel_at: Math.floor(cancelAt.getTime() / 1000),
   });


### PR DESCRIPTION
## Description

When switching a Stripe-billed workspace to a Metronome contract in Poke, the post-provision step that schedules the old Stripe subscription to cancel could fail with:

> The subscription is managed by the subscription schedule `sub_sched_...`, and updating any cancelation behavior directly is not allowed. Please update the schedule instead.

`scheduleSubscriptionCancellation` (`front/lib/plans/stripe.ts`) set `cancel_at` directly via `stripe.subscriptions.update`, which Stripe rejects for subscriptions driven by a subscription schedule. 

Adds a `@cc` code contract documenting the schedule-managed behavior.

## Tests

## Risk

Low

## Deploy Plan

Standard `front` deploy. No migration, no config, no ordering constraints.
