### PR TITLE
Pods: alllow groups for members and editors of pods

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -9890,6 +9890,31 @@
                                 "type": "object"
                               }
                             },
+                            "groups": {
+                              "type": "array",
+                              "description": "The groups given access to the space, with the role their grant confers.",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "sId": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string",
+                                    "enum": [
+                                      "member",
+                                      "editor"
+                                    ]
+                                  }
+                                }
+                              }
+                            },
                             "description": {
                               "type": "string",
                               "nullable": true

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/index.test.ts
@@ -1,6 +1,7 @@
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentMCPServerConfigurationFactory } from "@app/tests/utils/AgentMCPServerConfigurationFactory";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
@@ -67,6 +68,47 @@ describe("GET /api/w/:wId/spaces/:spaceId", () => {
     expect(
       space.categories.actions.usage.agents.map((a: { sId: string }) => a.sId)
     ).toEqual([agent.sId]);
+  });
+
+  it("lists the groups given access to the space, with their role", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    await SpaceFactory.defaults(auth);
+    const pod = await SpaceFactory.project(workspace, user.id);
+
+    const memberGroup = await GroupFactory.provisioned(workspace, "Dev team");
+    const editorGroup = await GroupFactory.regularManual(workspace, "Leads");
+    await GroupFactory.withMembers(auth, editorGroup, [user]);
+
+    const updateRes = await pod.updatePermissions(auth, {
+      name: pod.name,
+      isRestricted: true,
+      editorIds: [user.sId],
+      groupIds: [memberGroup.sId],
+      editorGroupIds: [editorGroup.sId],
+    });
+    assert(updateRes.isOk(), "Failed to attach the groups to the Pod.");
+
+    const response = await getSpace(workspace, pod.sId);
+    expect(response.status).toBe(200);
+    const { space } = await response.json();
+
+    // A group brings members to the space, so its name, kind and role are all listed.
+    expect(
+      space.groups
+        .map(({ name, kind, role }: Record<string, unknown>) => ({
+          name,
+          kind,
+          role,
+        }))
+        .sort((a: { name: string }, b: { name: string }) =>
+          a.name.localeCompare(b.name)
+        )
+    ).toEqual([
+      { name: "Dev team", kind: "provisioned", role: "member" },
+      { name: "Leads", kind: "regular_manual", role: "editor" },
+    ]);
   });
 
   it("excludes auto-provisioned tools from the Tools usage row, even in the global space", async () => {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
@@ -130,6 +130,21 @@ const app = workspaceApp();
  *                           type: array
  *                           items:
  *                             type: object
+ *                         groups:
+ *                           type: array
+ *                           description: The groups given access to the space, with the role their grant confers.
+ *                           items:
+ *                             type: object
+ *                             properties:
+ *                               sId:
+ *                                 type: string
+ *                               name:
+ *                                 type: string
+ *                               kind:
+ *                                 type: string
+ *                               role:
+ *                                 type: string
+ *                                 enum: [member, editor]
  *                         description:
  *                           type: string
  *                           nullable: true
@@ -310,6 +325,10 @@ app.get(
       "sId"
     );
 
+    // The groups given access to the space, alongside its individual members: a space's members
+    // are the two put together.
+    const groups = await space.toGroupAccessesJSON(auth);
+
     const meta = space.isProject()
       ? await ProjectMetadataResource.fetchBySpace(auth, space)
       : undefined;
@@ -327,6 +346,7 @@ app.get(
         isMember: space.isMember(auth),
         isEditor: auth.can("admin", space),
         members: currentMembers,
+        groups,
         description: meta?.description ?? null,
         archivedAt: meta?.archivedAt?.getTime() ?? null,
         // Automated task generation removed; keep fields hardcoded for API compat.

--- a/front/components/assistant/conversation/space/ManageUsersPanel.tsx
+++ b/front/components/assistant/conversation/space/ManageUsersPanel.tsx
@@ -4,7 +4,7 @@ import type {
 } from "@app/components/members/MemberSelectionTable";
 import { MemberSelectionTable } from "@app/components/members/MemberSelectionTable";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { spaceMembershipDimensions } from "@app/lib/spaces_utils";
+import { spaceMembershipProperties } from "@app/lib/spaces_utils";
 import { useUpdateSpace } from "@app/lib/swr/spaces";
 import type { RichSpaceType } from "@app/types/api/spaces";
 import type { LightWorkspaceType, SpaceUserType } from "@app/types/user";
@@ -118,7 +118,7 @@ export function ManageUsersPanel(props: ManageUsersPanelProps) {
         {
           isRestricted: props.space.isRestricted,
           // Only the individual members change here; the space's groups are passed through.
-          ...spaceMembershipDimensions(props.space),
+          ...spaceMembershipProperties(props.space),
           memberIds,
           editorIds,
           name: props.space.name,

--- a/front/components/assistant/conversation/space/ManageUsersPanel.tsx
+++ b/front/components/assistant/conversation/space/ManageUsersPanel.tsx
@@ -4,6 +4,7 @@ import type {
 } from "@app/components/members/MemberSelectionTable";
 import { MemberSelectionTable } from "@app/components/members/MemberSelectionTable";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { spaceMembershipDimensions } from "@app/lib/spaces_utils";
 import { useUpdateSpace } from "@app/lib/swr/spaces";
 import type { RichSpaceType } from "@app/types/api/spaces";
 import type { LightWorkspaceType, SpaceUserType } from "@app/types/user";
@@ -98,6 +99,9 @@ export function ManageUsersPanel(props: ManageUsersPanelProps) {
       );
       const editorIds = Array.from(currentEditors);
 
+      // A Pod keeps at least one individual editor even when a group is attached to it as an
+      // editor: a group's membership can drop to zero — in its IdP, for a provisioned one —
+      // leaving the Pod with nobody able to administrate it.
       if (!isAdminControlled && editorIds.length === 0) {
         setIsOpen(false);
         sendNotification({
@@ -113,6 +117,8 @@ export function ManageUsersPanel(props: ManageUsersPanelProps) {
         props.space,
         {
           isRestricted: props.space.isRestricted,
+          // Only the individual members change here; the space's groups are passed through.
+          ...spaceMembershipDimensions(props.space),
           memberIds,
           editorIds,
           name: props.space.name,

--- a/front/components/groups/GroupSelectionTable.tsx
+++ b/front/components/groups/GroupSelectionTable.tsx
@@ -19,7 +19,7 @@ import type {
 } from "@tanstack/react-table";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-interface GroupRowData {
+export interface GroupRowData {
   sId: string;
   name: string;
   kind: GroupKind;
@@ -40,12 +40,16 @@ interface GroupSelectionTableProps {
   owner: LightWorkspaceType;
   selectedGroupIds: Set<string>;
   onSelectionChange: (ids: Set<string>, groups: GroupType[]) => void;
+  // Appended after the group columns, as `MemberSelectionTable` does — used to pick the role a
+  // selected group gets.
+  extraColumns?: ColumnDef<GroupRowData>[];
 }
 
 export function GroupSelectionTable({
   owner,
   selectedGroupIds,
   onSelectionChange,
+  extraColumns,
 }: GroupSelectionTableProps) {
   const [searchText, setSearchText] = useState("");
   const [pagination, setPagination] = useState<PaginationState>({
@@ -146,8 +150,9 @@ export function GroupSelectionTable({
           );
         },
       },
+      ...(extraColumns ?? []),
     ],
-    []
+    [extraColumns]
   );
 
   return (

--- a/front/components/pod/settings/ManagePodGroupsPanel.tsx
+++ b/front/components/pod/settings/ManagePodGroupsPanel.tsx
@@ -1,6 +1,6 @@
 import type { GroupRowData } from "@app/components/groups/GroupSelectionTable";
 import { GroupSelectionTable } from "@app/components/groups/GroupSelectionTable";
-import { spaceMembershipDimensions } from "@app/lib/spaces_utils";
+import { spaceMembershipProperties } from "@app/lib/spaces_utils";
 import { useUpdateSpace } from "@app/lib/swr/spaces";
 import type { RichSpaceType } from "@app/types/api/spaces";
 import type { GroupType } from "@app/types/groups";
@@ -130,13 +130,13 @@ export function ManagePodGroupsPanel({
   const handleSave = async () => {
     setIsSaving(true);
 
-    const dimensions = spaceMembershipDimensions(pod);
+    const properties = spaceMembershipProperties(pod);
     const updatedSpace = await doUpdateSpace(
       pod,
       {
         isRestricted: pod.isRestricted,
         name: pod.name,
-        ...dimensions,
+        ...properties,
         groupIds: Array.from(selectedGroupIds).filter(
           (id) => !editorGroupIds.has(id)
         ),

--- a/front/components/pod/settings/ManagePodGroupsPanel.tsx
+++ b/front/components/pod/settings/ManagePodGroupsPanel.tsx
@@ -1,0 +1,190 @@
+import type { GroupRowData } from "@app/components/groups/GroupSelectionTable";
+import { GroupSelectionTable } from "@app/components/groups/GroupSelectionTable";
+import { spaceMembershipDimensions } from "@app/lib/spaces_utils";
+import { useUpdateSpace } from "@app/lib/swr/spaces";
+import type { RichSpaceType } from "@app/types/api/spaces";
+import type { GroupType } from "@app/types/groups";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  Check,
+  DataTable,
+  Sheet,
+  SheetContainer,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@dust-tt/sparkle";
+import type { CellContext, ColumnDef } from "@tanstack/react-table";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+interface ManagePodGroupsPanelProps {
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+  owner: LightWorkspaceType;
+  pod: RichSpaceType;
+  onSuccess?: () => void | Promise<void>;
+}
+
+/**
+ * Picks the groups given access to a Pod, and whether each is an editor — the counterpart of
+ * `ManageUsersPanel` for the Pod's group members. Saving sends the Pod's whole membership, with
+ * the individual members passed through untouched.
+ */
+export function ManagePodGroupsPanel({
+  isOpen,
+  setIsOpen,
+  owner,
+  pod,
+  onSuccess,
+}: ManagePodGroupsPanelProps) {
+  const [isSaving, setIsSaving] = useState(false);
+  const doUpdateSpace = useUpdateSpace({ owner });
+
+  const [selectedGroupIds, setSelectedGroupIds] = useState<Set<string>>(
+    new Set()
+  );
+  const [editorGroupIds, setEditorGroupIds] = useState<Set<string>>(new Set());
+
+  // The Pod's current groups are the starting point every time the panel opens, so a cancelled
+  // edit leaves nothing behind. Keyed on `isOpen` only: `pod.groups` is a new array on every SWR
+  // revalidation, and re-running then would wipe the selection being edited.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset state when the panel opens
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedGroupIds(new Set(pod.groups.map((group) => group.sId)));
+      setEditorGroupIds(
+        new Set(
+          pod.groups
+            .filter((group) => group.role === "editor")
+            .map((group) => group.sId)
+        )
+      );
+    }
+  }, [isOpen]);
+
+  const handleSelectionChange = useCallback(
+    (ids: Set<string>, _groups: GroupType[]) => {
+      setSelectedGroupIds(ids);
+      // A group that is no longer selected cannot stay an editor.
+      setEditorGroupIds((previous) => {
+        const next = new Set(previous);
+        for (const id of previous) {
+          if (!ids.has(id)) {
+            next.delete(id);
+          }
+        }
+        return next;
+      });
+    },
+    []
+  );
+
+  const toggleEditor = useCallback((groupId: string) => {
+    setEditorGroupIds((previous) => {
+      const next = new Set(previous);
+      if (next.has(groupId)) {
+        next.delete(groupId);
+      } else {
+        next.add(groupId);
+      }
+      return next;
+    });
+  }, []);
+
+  const editorColumn: ColumnDef<GroupRowData>[] = useMemo(() => {
+    if (pod.isAdminControlled) {
+      return [];
+    }
+    return [
+      {
+        id: "editor",
+        header: "",
+        meta: { className: "w-28" },
+        cell: (info: CellContext<GroupRowData, unknown>) => {
+          const { sId } = info.row.original;
+          if (!selectedGroupIds.has(sId)) {
+            return null;
+          }
+          const isEditor = editorGroupIds.has(sId);
+          return (
+            <DataTable.CellContent>
+              <Button
+                size="xs"
+                variant={isEditor ? "highlight" : "outline"}
+                label={isEditor ? "Editor" : "Set as editor"}
+                icon={isEditor ? Check : undefined}
+                onClick={(e) => {
+                  toggleEditor(sId);
+                  e.stopPropagation();
+                }}
+              />
+            </DataTable.CellContent>
+          );
+        },
+      },
+    ];
+  }, [pod.isAdminControlled, selectedGroupIds, editorGroupIds, toggleEditor]);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+
+    const dimensions = spaceMembershipDimensions(pod);
+    const updatedSpace = await doUpdateSpace(
+      pod,
+      {
+        isRestricted: pod.isRestricted,
+        name: pod.name,
+        ...dimensions,
+        groupIds: Array.from(selectedGroupIds).filter(
+          (id) => !editorGroupIds.has(id)
+        ),
+        editorGroupIds: Array.from(editorGroupIds),
+      },
+      {
+        title: "Successfully updated Pod groups",
+        description: "The groups with access to this Pod were updated.",
+      }
+    );
+
+    if (updatedSpace) {
+      await onSuccess?.();
+      setIsOpen(false);
+    }
+
+    setIsSaving(false);
+  };
+
+  return (
+    <Sheet open={isOpen} onOpenChange={(open) => !open && setIsOpen(false)}>
+      <SheetContent size="lg" side="right">
+        <SheetHeader>
+          <SheetTitle>{`Manage Groups of ${pod.name}`}</SheetTitle>
+        </SheetHeader>
+        <SheetContainer>
+          <GroupSelectionTable
+            owner={owner}
+            selectedGroupIds={selectedGroupIds}
+            onSelectionChange={handleSelectionChange}
+            extraColumns={editorColumn}
+          />
+        </SheetContainer>
+        <SheetFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: () => setIsOpen(false),
+          }}
+          rightButtonProps={{
+            label: "Save",
+            variant: "highlight",
+            onClick: handleSave,
+            disabled: isSaving,
+            isLoading: isSaving,
+          }}
+        />
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/front/components/pod/settings/PodGroupMembersTable.tsx
+++ b/front/components/pod/settings/PodGroupMembersTable.tsx
@@ -1,6 +1,6 @@
 import { ConfirmContext } from "@app/components/Confirm";
 import { getGroupKindChip } from "@app/components/groups/GroupKinds";
-import { spaceMembershipDimensions } from "@app/lib/spaces_utils";
+import { spaceMembershipProperties } from "@app/lib/spaces_utils";
 import { useUpdateSpace } from "@app/lib/swr/spaces";
 import type {
   RichSpaceType,
@@ -43,17 +43,17 @@ export function PodGroupMembersTable({
 
   const removeGroup = useCallback(
     async (groupId: string) => {
-      const dimensions = spaceMembershipDimensions(pod);
+      const properties = spaceMembershipProperties(pod);
 
-      // Only the group dimensions change; the individual members are passed through.
+      // Only the group properties change; the individual members are passed through.
       const updated = await doUpdate(
         pod,
         {
           isRestricted: pod.isRestricted,
           name: pod.name,
-          ...dimensions,
-          groupIds: dimensions.groupIds.filter((sId) => sId !== groupId),
-          editorGroupIds: dimensions.editorGroupIds.filter(
+          ...properties,
+          groupIds: properties.groupIds.filter((sId) => sId !== groupId),
+          editorGroupIds: properties.editorGroupIds.filter(
             (sId) => sId !== groupId
           ),
         },

--- a/front/components/pod/settings/PodGroupMembersTable.tsx
+++ b/front/components/pod/settings/PodGroupMembersTable.tsx
@@ -1,0 +1,166 @@
+import { ConfirmContext } from "@app/components/Confirm";
+import { getGroupKindChip } from "@app/components/groups/GroupKinds";
+import { spaceMembershipDimensions } from "@app/lib/spaces_utils";
+import { useUpdateSpace } from "@app/lib/swr/spaces";
+import type {
+  RichSpaceType,
+  SpaceGroupAccessType,
+} from "@app/types/api/spaces";
+import type { GroupKind } from "@app/types/groups";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { MenuItem } from "@dust-tt/sparkle";
+import { Chip, DataTable, Trash01, Users01 } from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useCallback, useContext, useMemo } from "react";
+
+interface PodGroupMembersTableProps {
+  owner: LightWorkspaceType;
+  pod: RichSpaceType;
+  groups: SpaceGroupAccessType[];
+  isEditor?: boolean;
+  mutatePodInfo: () => Promise<void>;
+}
+
+type GroupRowData = {
+  groupId: string;
+  name: string;
+  kind: GroupKind;
+  role: SpaceGroupAccessType["role"];
+  onClick?: () => void;
+};
+
+type GroupRowInfo = { row: { original: GroupRowData } };
+
+export function PodGroupMembersTable({
+  owner,
+  pod,
+  groups,
+  isEditor,
+  mutatePodInfo,
+}: PodGroupMembersTableProps) {
+  const doUpdate = useUpdateSpace({ owner });
+  const confirm = useContext(ConfirmContext);
+
+  const removeGroup = useCallback(
+    async (groupId: string) => {
+      const dimensions = spaceMembershipDimensions(pod);
+
+      // Only the group dimensions change; the individual members are passed through.
+      const updated = await doUpdate(
+        pod,
+        {
+          isRestricted: pod.isRestricted,
+          name: pod.name,
+          ...dimensions,
+          groupIds: dimensions.groupIds.filter((sId) => sId !== groupId),
+          editorGroupIds: dimensions.editorGroupIds.filter(
+            (sId) => sId !== groupId
+          ),
+        },
+        {
+          title: "Successfully removed group",
+          description: "The group no longer has access to this Pod.",
+        }
+      );
+      if (updated) {
+        await mutatePodInfo();
+      }
+    },
+    [doUpdate, mutatePodInfo, pod]
+  );
+
+  const rows: GroupRowData[] = useMemo(
+    () =>
+      groups.map((group) => ({
+        groupId: group.sId,
+        name: group.name,
+        kind: group.kind,
+        role: group.role,
+      })),
+    [groups]
+  );
+
+  const columns: ColumnDef<GroupRowData>[] = useMemo(
+    () => [
+      {
+        accessorKey: "name",
+        header: "Group name",
+        id: "name",
+        sortingFn: "text",
+        meta: { className: "w-[250px]" },
+        cell: (info: GroupRowInfo) => (
+          <DataTable.CellContent icon={Users01}>
+            {info.row.original.name}
+          </DataTable.CellContent>
+        ),
+      },
+      {
+        id: "kind",
+        header: "Group type",
+        meta: { className: "w-[250px]" },
+        cell: (info: GroupRowInfo) => {
+          const { label, color } = getGroupKindChip(info.row.original.kind);
+          return (
+            <DataTable.CellContent>
+              <Chip size="xs" color={color} label={label} />
+            </DataTable.CellContent>
+          );
+        },
+      },
+      {
+        id: "role",
+        header: "Role",
+        meta: { className: "w-20" },
+        cell: (info: GroupRowInfo) => (
+          <DataTable.CellContent>
+            {info.row.original.role === "editor" && (
+              <Chip color="success" size="xs" label="Editor" />
+            )}
+          </DataTable.CellContent>
+        ),
+      },
+      ...(isEditor
+        ? [
+            {
+              id: "actions",
+              header: "",
+              meta: { className: "w-12" },
+              cell: (info: GroupRowInfo) => {
+                const { name, groupId } = info.row.original;
+                const menuItems: MenuItem[] = [
+                  {
+                    kind: "item",
+                    label: "Remove from Pod",
+                    icon: Trash01,
+                    variant: "warning",
+                    onClick: async () => {
+                      const confirmed = await confirm({
+                        title: "Remove group",
+                        message: `Are you sure you want to remove "${name}" from this Pod? Its members will lose access, unless they are members of the Pod some other way.`,
+                        validateLabel: "Remove",
+                        validateVariant: "warning",
+                      });
+                      if (confirmed) {
+                        await removeGroup(groupId);
+                      }
+                    },
+                  },
+                ];
+                return <DataTable.MoreButton menuItems={menuItems} />;
+              },
+            },
+          ]
+        : []),
+    ],
+    [confirm, isEditor, removeGroup]
+  );
+
+  return (
+    <DataTable
+      data={rows}
+      columns={columns}
+      className="relative w-full"
+      sorting={[{ id: "name", desc: false }]}
+    />
+  );
+}

--- a/front/components/pod/settings/PodMembersTable.tsx
+++ b/front/components/pod/settings/PodMembersTable.tsx
@@ -1,6 +1,6 @@
 import { ConfirmContext } from "@app/components/Confirm";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { spaceMembershipDimensions } from "@app/lib/spaces_utils";
+import { spaceMembershipProperties } from "@app/lib/spaces_utils";
 import { useUpdateSpace } from "@app/lib/swr/spaces";
 import type { RichSpaceType } from "@app/types/api/spaces";
 import type { LightWorkspaceType, SpaceUserType } from "@app/types/user";
@@ -84,7 +84,7 @@ export function PodMembersTable({
         pod,
         {
           isRestricted: pod.isRestricted,
-          ...spaceMembershipDimensions(pod),
+          ...spaceMembershipProperties(pod),
           memberIds: updatedMembers
             .filter((member) => !member.isEditor)
             .map((member) => member.sId),
@@ -136,7 +136,7 @@ export function PodMembersTable({
         pod,
         {
           isRestricted: pod.isRestricted,
-          ...spaceMembershipDimensions(pod),
+          ...spaceMembershipProperties(pod),
           memberIds: updatedMembers
             .filter((member) => !member.isEditor)
             .map((member) => member.sId),

--- a/front/components/pod/settings/PodMembersTable.tsx
+++ b/front/components/pod/settings/PodMembersTable.tsx
@@ -1,5 +1,6 @@
 import { ConfirmContext } from "@app/components/Confirm";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { spaceMembershipDimensions } from "@app/lib/spaces_utils";
 import { useUpdateSpace } from "@app/lib/swr/spaces";
 import type { RichSpaceType } from "@app/types/api/spaces";
 import type { LightWorkspaceType, SpaceUserType } from "@app/types/user";
@@ -63,6 +64,9 @@ export function PodMembersTable({
   const removeMember = useCallback(
     async (userId: string) => {
       const updatedMembers = selectedMembers.filter((m) => m.sId !== userId);
+      // The individual editor list must not be emptied, even when a group is attached to the Pod
+      // as an editor: a group's membership can drop to zero — in its IdP, for a provisioned one —
+      // leaving the Pod with nobody able to administrate it.
       if (
         !pod.isAdminControlled &&
         selectedMembers.some((m) => m.isEditor) &&
@@ -80,6 +84,7 @@ export function PodMembersTable({
         pod,
         {
           isRestricted: pod.isRestricted,
+          ...spaceMembershipDimensions(pod),
           memberIds: updatedMembers
             .filter((member) => !member.isEditor)
             .map((member) => member.sId),
@@ -131,6 +136,7 @@ export function PodMembersTable({
         pod,
         {
           isRestricted: pod.isRestricted,
+          ...spaceMembershipDimensions(pod),
           memberIds: updatedMembers
             .filter((member) => !member.isEditor)
             .map((member) => member.sId),

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -4,6 +4,8 @@ import { ConfirmContext } from "@app/components/Confirm";
 import { MarkdownFileEditor } from "@app/components/editor/MarkdownFileEditor";
 import { AdminControlledPodTile } from "@app/components/pod/settings/AdminControlledPodTile";
 import { DeletePodDialog } from "@app/components/pod/settings/DeletePodDialog";
+import { ManagePodGroupsPanel } from "@app/components/pod/settings/ManagePodGroupsPanel";
+import { PodGroupMembersTable } from "@app/components/pod/settings/PodGroupMembersTable";
 import { PodMembersTable } from "@app/components/pod/settings/PodMembersTable";
 import { PodNetworkSection } from "@app/components/pod/settings/PodNetworkSection";
 import { PodSettingsOptionLabel } from "@app/components/pod/settings/PodSettingsOptionLabel";
@@ -17,6 +19,7 @@ import {
 } from "@app/lib/api/projects/constants";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { getSkillAvatarIcon } from "@app/lib/skill";
+import { spaceMembershipDimensions } from "@app/lib/spaces_utils";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import {
   useCheckPodName,
@@ -25,7 +28,6 @@ import {
   useUpdatePodMetadata,
 } from "@app/lib/swr/pods";
 import { useSkills } from "@app/lib/swr/skill_configurations";
-import { spaceMembershipDimensions } from "@app/lib/spaces_utils";
 import { useSpaceInfo, useUpdateSpace } from "@app/lib/swr/spaces";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { areOpenPodsAllowed } from "@app/lib/workspace_policies";
@@ -87,7 +89,12 @@ export function PodSettingsTab({
   pod: pod,
   onOpenMembersPanel,
 }: PodSettingsTabProps) {
-  const { members: podMembers, isEditor: isPodEditor, isRestricted } = pod;
+  const {
+    members: podMembers,
+    groups: podGroups,
+    isEditor: isPodEditor,
+    isRestricted,
+  } = pod;
   const isOpen = !isRestricted;
   const areWorkspaceOpenPodsAllowed = areOpenPodsAllowed(owner);
   const isPrivatePodAndOpenPodsDisallowed =
@@ -95,6 +102,7 @@ export function PodSettingsTab({
   const isVisibilityToggleDisabled =
     !isPodEditor || isPrivatePodAndOpenPodsDisallowed;
   const [searchSelectedMembers, setSearchSelectedMembers] = useState("");
+  const [isGroupsPanelOpen, setIsGroupsPanelOpen] = useState(false);
 
   const confirm = useContext(ConfirmContext);
   const { hasFeature } = useFeatureFlags();
@@ -781,7 +789,7 @@ export function PodSettingsTab({
 
         <div className="flex flex-col gap-3">
           <div className="flex items-center gap-2">
-            <h3 className="heading-lg flex-1">Members</h3>
+            <h3 className="heading-lg flex-1">Individual members</h3>
             {isPodEditor && onOpenMembersPanel && (
               <Button
                 label="Manage"
@@ -812,6 +820,40 @@ export function PodSettingsTab({
             </>
           )}
         </div>
+
+        {/* The Pod's members are the individual list above plus the members of these groups. */}
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-2">
+            <h3 className="heading-lg flex-1">Group members</h3>
+            {isPodEditor && (
+              <Button
+                label="Manage"
+                variant="outline"
+                icon={Users01}
+                onClick={() => setIsGroupsPanelOpen(true)}
+              />
+            )}
+          </div>
+          {podGroups.length > 0 && (
+            <ScrollArea className="h-full" orientation="horizontal">
+              <PodGroupMembersTable
+                owner={owner}
+                pod={pod}
+                groups={podGroups}
+                isEditor={isPodEditor}
+                mutatePodInfo={() => mutatePodInfo()}
+              />
+            </ScrollArea>
+          )}
+        </div>
+
+        <ManagePodGroupsPanel
+          isOpen={isGroupsPanelOpen}
+          setIsOpen={setIsGroupsPanelOpen}
+          owner={owner}
+          pod={pod}
+          onSuccess={() => mutatePodInfo()}
+        />
 
         {canViewPodNetwork && (
           <PodNetworkSection

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -19,7 +19,7 @@ import {
 } from "@app/lib/api/projects/constants";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { getSkillAvatarIcon } from "@app/lib/skill";
-import { spaceMembershipDimensions } from "@app/lib/spaces_utils";
+import { spaceMembershipProperties } from "@app/lib/spaces_utils";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import {
   useCheckPodName,
@@ -382,7 +382,7 @@ export function PodSettingsTab({
       pod,
       {
         isRestricted,
-        ...spaceMembershipDimensions(pod),
+        ...spaceMembershipProperties(pod),
         name: newPodName,
       },
       {
@@ -474,7 +474,7 @@ export function PodSettingsTab({
       pod,
       {
         isRestricted: !newIsOpen,
-        ...spaceMembershipDimensions(pod),
+        ...spaceMembershipProperties(pod),
         name: pod.name,
       },
       {

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -25,6 +25,7 @@ import {
   useUpdatePodMetadata,
 } from "@app/lib/swr/pods";
 import { useSkills } from "@app/lib/swr/skill_configurations";
+import { spaceMembershipDimensions } from "@app/lib/spaces_utils";
 import { useSpaceInfo, useUpdateSpace } from "@app/lib/swr/spaces";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { areOpenPodsAllowed } from "@app/lib/workspace_policies";
@@ -373,8 +374,7 @@ export function PodSettingsTab({
       pod,
       {
         isRestricted,
-        memberIds: podMembers.filter((m) => !m.isEditor).map((m) => m.sId),
-        editorIds: podMembers.filter((m) => m.isEditor).map((m) => m.sId),
+        ...spaceMembershipDimensions(pod),
         name: newPodName,
       },
       {
@@ -466,8 +466,7 @@ export function PodSettingsTab({
       pod,
       {
         isRestricted: !newIsOpen,
-        memberIds: podMembers.filter((m) => !m.isEditor).map((m) => m.sId),
-        editorIds: podMembers.filter((m) => m.isEditor).map((m) => m.sId),
+        ...spaceMembershipDimensions(pod),
         name: pod.name,
       },
       {
@@ -484,7 +483,6 @@ export function PodSettingsTab({
     doUpdate,
     isOpen,
     mutateRestrictionImpact,
-    podMembers,
     pod,
     mutatePodInfo,
     restrictionImpact,

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1772,6 +1772,86 @@ describe("SpaceResource", () => {
     });
   });
 
+  describe("fetchAttachedGroupAccesses", () => {
+    let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+    let adminAuth: Authenticator;
+    let adminUser: UserResource;
+
+    beforeEach(async () => {
+      workspace = await WorkspaceFactory.basic();
+      adminUser = await UserFactory.basic();
+      const { globalGroup, systemGroup } =
+        await GroupFactory.defaults(workspace);
+      await MembershipFactory.associate(workspace, adminUser, {
+        role: "admin",
+      });
+      const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      await SpaceResource.makeDefaultsForWorkspace(internalAdminAuth, {
+        globalGroup,
+        systemGroup,
+      });
+      adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        adminUser.sId,
+        workspace.sId
+      );
+    });
+
+    it("returns the attached groups with the role their grant confers", async () => {
+      const pod = await SpaceFactory.project(workspace, adminUser.id);
+      const memberGroup = await GroupFactory.provisioned(workspace, "Dev team");
+      const editorGroup = await GroupFactory.regularManual(workspace, "Leads");
+
+      const res = await pod.updatePermissions(adminAuth, {
+        name: pod.name,
+        isRestricted: true,
+        editorIds: [adminUser.sId],
+        groupIds: [memberGroup.sId],
+        editorGroupIds: [editorGroup.sId],
+      });
+      expect(res.isOk()).toBe(true);
+
+      const accesses = await pod.fetchAttachedGroupAccesses(adminAuth);
+      expect(
+        accesses
+          .map(({ group, role }) => ({ sId: group.sId, role }))
+          .sort((a, b) => a.sId.localeCompare(b.sId))
+      ).toEqual(
+        [
+          { sId: memberGroup.sId, role: "member" },
+          { sId: editorGroup.sId, role: "editor" },
+        ].sort((a, b) => a.sId.localeCompare(b.sId))
+      );
+    });
+
+    it("excludes the space's own groups and the workspace global group", async () => {
+      // An open space attaches the global group as a viewer, and every space has its own
+      // regular_auto member group — neither is a group an admin picked.
+      const space = await SpaceFactory.regular(workspace);
+      const attachedGroup = await GroupFactory.provisioned(workspace, "Dev");
+
+      const res = await space.updatePermissions(adminAuth, {
+        name: space.name,
+        isRestricted: false,
+        memberIds: [adminUser.sId],
+        groupIds: [attachedGroup.sId],
+      });
+      expect(res.isOk()).toBe(true);
+
+      const accesses = await space.fetchAttachedGroupAccesses(adminAuth);
+      expect(accesses.map(({ group }) => group.sId)).toEqual([
+        attachedGroup.sId,
+      ]);
+    });
+
+    it("returns nothing for a space no group is attached to", async () => {
+      const space = await SpaceFactory.regular(workspace);
+
+      expect(await space.fetchAttachedGroupAccesses(adminAuth)).toEqual([]);
+    });
+  });
+
   describe("isRestricted", () => {
     let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
     let adminAuth: Authenticator;

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -24,6 +24,7 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import tracer from "@app/logger/tracer";
+import type { SpaceGroupAccessType } from "@app/types/api/spaces";
 import type {
   GrantSpec,
   GrantType,
@@ -108,6 +109,12 @@ export class SpaceGroupReference {
     return this.grantType === "reader";
   }
 }
+
+// A group attached to a space, with the role its grant confers.
+export type SpaceGroupAccess = {
+  group: GroupResource;
+  role: "member" | "editor";
+};
 
 // Space membership resolved from the caller's governance grants (see `SpaceResource.isMember`). The
 // membership verb differs by space kind:
@@ -1094,11 +1101,11 @@ export class SpaceResource extends BaseResource<SpaceModel> {
    * whole desired state — a dimension it leaves out is emptied, not kept — so a client that only
    * knows about members clears the groups, and the other way around, which is what switching a
    * space from one to the other has always done.
-   *
-   * The two used to be exclusive, selected by `managementMode`: a space's members were either its
-   * manual list or the members of its groups. They are now merged, and a space's members are its
-   * manual list plus the members of every group attached to it. `managementMode` is still accepted
-   * (and ignored) so that clients sending it are not broken.
+   */
+  /**
+   * @cc [owner:fabiencelier,label:product] membership-update-is-whole-state
+   * `params` is the space's whole desired membership: `memberIds`, `editorIds`, `groupIds` and
+   * `editorGroupIds` are each overwritten, and a dimension `params` leaves out is emptied.
    */
   async updatePermissions(
     auth: Authenticator,
@@ -1926,6 +1933,53 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return { memberGroups, editorGroups };
   }
 
+  /**
+   * @cc [owner:fabiencelier,label:backend] attached-manageable-groups-only
+   * Returns exactly one entry per `provisioned` or `regular_manual` group holding a grant on the
+   * space, and never one for the space's own `regular_auto` groups or the workspace global group.
+   */
+  async fetchAttachedGroupAccesses(
+    auth: Authenticator,
+    transaction?: Transaction
+  ): Promise<SpaceGroupAccess[]> {
+    const references = await this.fetchGrantReferences(transaction);
+    const groups = await this.fetchGroupResources(auth, {
+      groupReferences: references,
+      transaction,
+    });
+
+    // `fetchGroupResources` preserves the order of the references it is given.
+    return removeNulls(
+      references.map((reference, index) => {
+        const group = groups[index];
+        if (!isManageableGroupKind(group.kind)) {
+          return null;
+        }
+        return {
+          group,
+          role:
+            reference.grantType === SPACE_EDITOR_GRANT_TYPE
+              ? ("editor" as const)
+              : ("member" as const),
+        };
+      })
+    );
+  }
+
+  // The space's attached groups as the API returns them.
+  async toGroupAccessesJSON(
+    auth: Authenticator
+  ): Promise<SpaceGroupAccessType[]> {
+    const accesses = await this.fetchAttachedGroupAccesses(auth);
+
+    return accesses.map(({ group, role }) => ({
+      sId: group.sId,
+      name: group.name,
+      kind: group.kind,
+      role,
+    }));
+  }
+
   // Whether any group is attached to this space, i.e. part of its access comes from a group's
   // membership rather than from the space's own member list.
   async hasAttachedGroups(auth: Authenticator): Promise<boolean> {
@@ -2236,15 +2290,23 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     }));
   }
 
-  // Writes this space's `group_permissions` rows from the roles its groups confer (see
-  // `spaceGroupRoles`). The space mutation paths call this to keep the table in sync as the source of
-  // truth. Idempotent — it clears the space's instance grants then re-inserts the desired set in one
-  // transaction.
-  //
-  // The caller passes the space's groups split into `members` and `editors` (the workspace global
-  // group, attached to unrestricted spaces, goes in `members`) rather than this method loading them:
-  // callers mutate the group set in-transaction so a fetch would be stale anyway. `editors` only
-  // applies to projects.
+  /**
+   * Writes this space's `group_permissions` rows from the roles its groups confer (see
+   * `spaceGroupRoles`). The space mutation paths call this to keep the table in sync as the source
+   * of truth. Idempotent — it clears the space's instance grants then re-inserts the desired set
+   * in one transaction.
+   *
+   * The caller passes the space's groups split into `members` and `editors` (the workspace global
+   * group, attached to unrestricted spaces, goes in `members`) rather than this method loading
+   * them: callers mutate the group set in-transaction so a fetch would be stale anyway. `editors`
+   * only applies to projects.
+   */
+  /**
+   * @cc [owner:fabiencelier,label:backend] grants-rewritten-wholesale
+   * Replaces the space's instance grants with the ones `members` and `editors` confer: every grant
+   * row is deleted and re-inserted, so no grant row survives a call and `createdAt` is the time of
+   * the last call rather than when the group was first given access.
+   */
   async writeGroupPermissions(
     auth: Authenticator,
     {

--- a/front/lib/spaces_utils.ts
+++ b/front/lib/spaces_utils.ts
@@ -65,11 +65,11 @@ export const isPrivateSpacesLimitReached = (
     plan.limits.vaults.maxVaults;
 
 /**
- * @cc [owner:fabiencelier,label:product] membership-dimensions-mirror-space
- * Returns the space's four membership dimensions as the update endpoint takes them, so a caller
- * that spreads the result and overrides only the dimensions it edits leaves the others unchanged.
+ * @cc [owner:fabiencelier,label:product] membership-properties-mirror-space
+ * Returns the space's four membership properties as the update endpoint takes them, so a caller
+ * that spreads the result and overrides only the properties it edits leaves the others unchanged.
  */
-export const spaceMembershipDimensions = (space: RichSpaceType) => ({
+export const spaceMembershipProperties = (space: RichSpaceType) => ({
   memberIds: space.members.filter((m) => !m.isEditor).map((m) => m.sId),
   editorIds: space.members.filter((m) => m.isEditor).map((m) => m.sId),
   groupIds: space.groups.filter((g) => g.role === "member").map((g) => g.sId),

--- a/front/lib/spaces_utils.ts
+++ b/front/lib/spaces_utils.ts
@@ -1,3 +1,4 @@
+import type { RichSpaceType } from "@app/types/api/spaces";
 import { GLOBAL_SPACE_NAME } from "@app/types/groups";
 import type { PlanType } from "@app/types/plan";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -62,3 +63,17 @@ export const isPrivateSpacesLimitReached = (
   plan.limits.vaults.maxVaults !== -1 &&
   spaces.filter((s) => s.kind === "regular").length >=
     plan.limits.vaults.maxVaults;
+
+/**
+ * @cc [owner:fabiencelier,label:product] membership-dimensions-mirror-space
+ * Returns the space's four membership dimensions as the update endpoint takes them, so a caller
+ * that spreads the result and overrides only the dimensions it edits leaves the others unchanged.
+ */
+export const spaceMembershipDimensions = (space: RichSpaceType) => ({
+  memberIds: space.members.filter((m) => !m.isEditor).map((m) => m.sId),
+  editorIds: space.members.filter((m) => m.isEditor).map((m) => m.sId),
+  groupIds: space.groups.filter((g) => g.role === "member").map((g) => g.sId),
+  editorGroupIds: space.groups
+    .filter((g) => g.role === "editor")
+    .map((g) => g.sId),
+});

--- a/front/types/api/spaces.ts
+++ b/front/types/api/spaces.ts
@@ -1,4 +1,5 @@
 import type { AgentsAndSkillsUsageType } from "@app/types/data_source";
+import type { GroupKind } from "@app/types/groups";
 import type { PodFileTab } from "@app/types/pod_file_tab";
 import { PodFileTabsSchema, PodTabsOrderSchema } from "@app/types/pod_file_tab";
 import type { EnrichedSpaceType, PodType, SpaceType } from "@app/types/space";
@@ -82,12 +83,24 @@ export type SpaceCategoryInfo = {
   count: number;
 };
 
+/**
+ * A group given access to a space: who it is, what it confers, and since when. The space's members
+ * are its individual members plus the members of these groups.
+ */
+export type SpaceGroupAccessType = {
+  sId: string;
+  name: string;
+  kind: GroupKind;
+  role: "member" | "editor";
+};
+
 export type RichSpaceType = EnrichedSpaceType & {
   categories: { [key: string]: SpaceCategoryInfo };
   canWrite: boolean;
   canRead: boolean;
   isMember: boolean;
   members: SpaceUserType[];
+  groups: SpaceGroupAccessType[];
   isEditor: boolean;
   // Useful in case of projects
   description: string | null;


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/10299

Add groups to the way members can be manage in pods. Old section has been renamed "Individual members" and a new "Group members" section has been added.
Managed the same way as individual members: groups can be either a member or an editor of the pod.

<img width="3184" height="1654" alt="image" src="https://github.com/user-attachments/assets/0411c525-f6da-4e8c-b0ff-3b89d383737f" />

<img width="3196" height="1682" alt="image" src="https://github.com/user-attachments/assets/ddc7686f-5681-4430-b13c-ba3a23f6e363" />


## Tests

 - updated unit tests
 - tested locally

## Risk

blast radius: accessing and administrating skills
this work with the same mecanism as spaces, so risk is limited 

## Deploy Plan

deploy front
