### PR TITLE
Add CIMD support for remote MCP OAuth

### DIFF
--- a/front/lib/api/mcp_server/urls.ts
+++ b/front/lib/api/mcp_server/urls.ts
@@ -6,6 +6,23 @@ import { EnvironmentConfig } from "@app/types/shared/utils/config";
 const MCP_OAUTH_PROXY_ENABLED = true;
 
 /**
+ * @cc [owner:tdraier,label:security;mcp] cimd-client-id-matches-document
+ * `MCP_CLIENT_ID_METADATA_DOCUMENT_URL` must be byte-for-byte identical to the
+ * `client_id` field of the document served at
+ * `front/public/.well-known/oauth-client.json`, and that document must remain
+ * reachable at this exact URL. Authorization servers fetch the URL and reject a
+ * document whose `client_id` differs from the URL it was fetched from, so any
+ * divergence silently breaks every CIMD-based MCP connection.
+ *
+ * The value is a single global constant (not derived from per-region config)
+ * because CIMD requires one stable client identity across all regions and
+ * cells; the redirect URI a given region sends is validated against the
+ * document's `redirect_uris`, which lists every region's finalize callback.
+ */
+export const MCP_CLIENT_ID_METADATA_DOCUMENT_URL =
+  "https://app.dust.tt/.well-known/oauth-client.json";
+
+/**
  * Whether MCP OAuth metadata/token/registration should be proxied through the
  * Dust MCP host. Enabled in development only; never active in production.
  * Toggle via `MCP_OAUTH_PROXY_ENABLED` in this file.

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -6,6 +6,7 @@ import type {
 import { DEFAULT_MCP_ACTION_DESCRIPTION } from "@app/lib/actions/constants";
 import { remoteMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { MCPToolType, RemoteMCPServerType } from "@app/lib/api/mcp";
+import { MCP_CLIENT_ID_METADATA_DOCUMENT_URL } from "@app/lib/api/mcp_server/urls";
 import type { Authenticator } from "@app/lib/auth";
 import { toGlobalResponse, untrustedFetch } from "@app/lib/egress/server";
 import { DustError } from "@app/lib/error";
@@ -24,6 +25,7 @@ import { mcpToolsRequireConfiguration } from "@app/lib/utils/json_schemas";
 import logger from "@app/logger/logger";
 import type { MCPOAuthConnectionMetadataType } from "@app/types/api/oauth/providers/mcp";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
+import { isDevelopment } from "@app/types/shared/env";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -647,6 +649,16 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     this.heavyAttributes = { ...this.heavyAttributes, lastError };
   }
 
+  /**
+   * @cc [owner:tdraier,label:mcp] oauth-client-registration-precedence
+   * Resolves the OAuth client identity in this order and returns the first that
+   * applies: (1) outside development, when the authorization-server metadata
+   * advertises `client_id_metadata_document_supported`, returns a public-client
+   * metadata (`token_endpoint_auth_method: "none"`, no `client_secret`) whose
+   * `client_id` is `MCP_CLIENT_ID_METADATA_DOCUMENT_URL`; else (2) attempts
+   * Dynamic Client Registration; else (3) fails with a `DustError` directing the
+   * caller to Static OAuth. It never performs DCR when CIMD applies.
+   */
   static async discoverOAuthMetadata({
     serverUrl,
     provider,
@@ -747,6 +759,27 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       resourceScopes: resourceMetadata?.scopes_supported,
       authorizationServerScopes: metadata.scopes_supported,
     });
+
+    // CIMD (Client ID Metadata Documents): when a server advertises support, we
+    // present our hosted metadata-document URL as `client_id` instead of
+    // registering a client. This sidesteps both DCR (which enterprise servers
+    // such as ServiceNow refuse) and the manual per-instance Static OAuth setup.
+    // Skipped in development, where the finalize redirect URI is localhost and
+    // therefore absent from the published document's `redirect_uris`, so the
+    // authorization server would reject it — DCR remains the dev path.
+    if (metadata.client_id_metadata_document_supported && !isDevelopment()) {
+      const connectionMetadata: MCPOAuthConnectionMetadataType = {
+        authorization_endpoint: metadata.authorization_endpoint,
+        token_endpoint: metadata.token_endpoint,
+        token_endpoint_auth_method: "none",
+        client_id: MCP_CLIENT_ID_METADATA_DOCUMENT_URL,
+        resource: resource
+          ? url.format(resource, { fragment: false })
+          : undefined,
+        scope: clientMetadata.scope,
+      };
+      return new Ok(connectionMetadata);
+    }
 
     try {
       // Try DCR.

--- a/front/public/.well-known/oauth-client.json
+++ b/front/public/.well-known/oauth-client.json
@@ -1,0 +1,18 @@
+{
+  "client_id": "https://app.dust.tt/.well-known/oauth-client.json",
+  "client_name": "Dust",
+  "client_uri": "https://dust.tt",
+  "logo_uri": "https://dust.tt/static/AppIcon.png",
+  "tos_uri": "https://dust.tt/terms",
+  "policy_uri": "https://dust.tt/privacy",
+  "contacts": ["support@dust.com"],
+  "software_id": "dust",
+  "redirect_uris": [
+    "https://app.dust.tt/oauth/mcp/finalize",
+    "https://dust.tt/oauth/mcp/finalize",
+    "https://eu.dust.tt/oauth/mcp/finalize"
+  ],
+  "token_endpoint_auth_method": "none",
+  "grant_types": ["authorization_code", "refresh_token"],
+  "response_types": ["code"]
+}


### PR DESCRIPTION
## Description

fixes: https://github.com/dust-tt/tasks/issues/9873

Enterprise MCP servers that refuse Dynamic Client Registration (ServiceNow, Azure DevOps, Meta Ads, ZoomInfo) currently fail Dust's automatic OAuth and force every customer into per-instance Static OAuth setup (create an OAuth app, whitelist Dust's callback, paste client id/secret). 

This adds support for **CIMD (Client ID Metadata Documents)**, the MCP 2025-11-25 auth mechanism. When a server advertises `client_id_metadata_document_supported`, the client presents an HTTPS URL as its `client_id`; the server fetches that URL, reads the client metadata, and validates the redirect URI against it — no registration, no secret, no admin app. Servers like ServiceNow (Zurich P7+) accept CIMD where they reject DCR.

Changes:
- **New static document** `front/public/.well-known/oauth-client.json`, served as a static asset at `https://app.dust.tt/.well-known/oauth-client.json` (same path mechanism as `security.txt`; `.json` yields `application/json`). Its `client_id` is self-referential; `redirect_uris` lists the go-forward `app.dust.tt/oauth/mcp/finalize` plus the two legacy override hosts (`dust.tt`, `eu.dust.tt`).
- **`MCP_CLIENT_ID_METADATA_DOCUMENT_URL`** constant (one global value — CIMD requires a single stable client identity across all regions/cells, so it is deliberately not derived from per-region config), guarded by a `security;mcp` code contract requiring it to equal the served document's `client_id`.
- **`discoverOAuthMetadata()`** gains a CIMD branch that runs *before* DCR when the flag is advertised (and outside development, where the finalize redirect is localhost and absent from the published document): it returns a public-client metadata (`token_endpoint_auth_method: "none"`, no `client_secret`) with `client_id` set to the document URL and skips registration. DCR and the existing Static OAuth error remain the fallbacks. A `mcp` code contract documents this precedence.
- **No core change**: the Rust token exchange already forwards `client_id`.

The SDK (`@modelcontextprotocol/sdk@^1.29.0`) already parses `client_id_metadata_document_supported`, so no SDK bump and no raw metadata re-fetch are needed.

## Tests

- `cc-check format`/`list` pass for both new code contracts.
- JSON document validated.
- ⚠️ Typecheck/unit tests were not run in the authoring worktree (deps not installed there) — needs `npx tsgo --noEmit` (front) and MCP OAuth tests in a fully-installed env before merge.
- Post-deploy: verify end-to-end against the official ServiceNow MCP server (document fetch content-type + `redirect_uri` match).

## Risk

Low. The CIMD branch only triggers for servers that explicitly advertise the flag; all other servers keep the exact current DCR → Static OAuth behavior. No changes to `core` or to the Static OAuth path. The one correctness invariant (constant must equal the served document's `client_id`) is captured by a code contract.

## Deploy Plan

Standard. The static document ships with `front` and is served by front-spa at `app.dust.tt`. Follow-up (non-blocking): when PR #31913's legacy redirect-URI override is removed, trim `redirect_uris` in the document down to just `app.dust.tt`.