### PR TITLE
[front] enh: add method on Authenticator to list readable space IDs

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1648,6 +1648,15 @@ export class Authenticator {
   }
 
   /**
+   * @cc [owner:aubin-tchoi,label:security;performance] readable-spaces-from-permissions
+   * Returns the readable space model IDs from the current permission snapshot without fetching;
+   * a type-wide read grant returns `{ kind: "all" }` because it contains no enumerable ID list.
+   */
+  getReadableSpaceModelIds(): ResourcesWithVerb {
+    return this.getResourceIdsWithVerb("space", "read");
+  }
+
+  /**
    * Whether the caller holds `verb` on `target` — i.e. on EVERY access-control list the target
    * declares (a resource may declare multiple ACLs that must all hold). `verb` is a grant verb
    * (instance verbs like read/write/admin, or type-level capabilities like "create").


### PR DESCRIPTION
## Description

Expose the spaces an authenticator can read without additional fetches. `getReadableSpaceModelIds()` reuses the existing permission snapshot and returns model IDs, or `{ kind: "all" }` for type-wide read grants.

Will be useful to port our existing permission system to a different system that only stores requested space IDs, namely ES.

## Tests

- Covered by existing permission tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
