### PR TITLE
[Admin Governance] Report system-key agent edit access

### DIFF
--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -24,21 +24,123 @@ import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_me
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
+import logger from "@app/logger/logger";
 import * as scheduleClient from "@app/temporal/triggers/schedule_client";
 import * as wakeUpClient from "@app/temporal/triggers/wakeup_client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentSuggestionFactory } from "@app/tests/utils/AgentSuggestionFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WakeUpFactory } from "@app/tests/utils/WakeUpFactory";
 import { Err, Ok } from "@app/types/shared/result";
+import assert from "assert";
 import { describe, expect, it, vi } from "vitest";
 
 describe("getAgentConfigurations", () => {
+  it("reports system-key edit access without a permission shadow mismatch", async () => {
+    const { authenticator, workspace, systemGroup } = await createResourceTest({
+      role: "admin",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      {
+        scope: "hidden",
+      }
+    );
+    await FeatureFlagFactory.basic(authenticator, "group_permissions_shadow");
+    const key = await KeyFactory.system(systemGroup);
+    const auth = await Authenticator.fromKey(key, workspace.sId);
+    const warn = vi.spyOn(logger, "warn");
+    try {
+      const configuration = await getAgentConfiguration(auth, {
+        agentId: agent.sId,
+        variant: "light",
+      });
+
+      expect(configuration).toMatchObject({ canRead: true, canEdit: true });
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.objectContaining({ check: "agent_permissions" }),
+        "group_permissions_shadow_mismatch"
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("respects the agent grants of a scoped system key", async () => {
+    const { authenticator, workspace, systemGroup } = await createResourceTest({
+      role: "admin",
+    });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const otherAgent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      {
+        name: "Other agent",
+      }
+    );
+    const group = await GroupFactory.regularManual(workspace, "Agent editors");
+    const resource = await AgentResource.fetchByAgentConfiguration(
+      authenticator,
+      agent
+    );
+    assert(resource.id !== null);
+    await GroupPermissionResource.grant(authenticator, {
+      group,
+      grantType: "editor",
+      resourceType: "agent",
+      resourceId: resource.id,
+    });
+    const key = await KeyFactory.system(systemGroup);
+    const auth = await Authenticator.fromKey(key, workspace.sId, [group.sId]);
+    const agents = await getAgentConfigurations(auth, {
+      agentIds: [agent.sId, otherAgent.sId],
+      variant: "light",
+    });
+
+    expect(
+      Object.fromEntries(agents.map((agent) => [agent.sId, agent.canEdit]))
+    ).toEqual({
+      [agent.sId]: true,
+      [otherAgent.sId]: false,
+    });
+  });
+
+  it("does not give human or impersonated admins implicit edit access", async () => {
+    const { authenticator, workspace, systemGroup } = await createResourceTest({
+      role: "admin",
+    });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const admin = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, admin, { role: "admin" });
+    const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      admin.sId,
+      workspace.sId
+    );
+    const key = await KeyFactory.system(systemGroup);
+    const systemAuth = await Authenticator.fromKey(key, workspace.sId);
+    const impersonatedAuth =
+      await systemAuth.exchangeSystemKeyForUserAuthByEmail(systemAuth, {
+        userEmail: admin.email,
+        requestedRole: "admin",
+      });
+    assert(impersonatedAuth);
+    for (const auth of [adminAuth, impersonatedAuth]) {
+      const configuration = await getAgentConfiguration(auth, {
+        agentId: agent.sId,
+        variant: "light",
+      });
+      expect(configuration?.canEdit).toBe(false);
+    }
+  });
+
   it("returns only the latest version of each requested agent", async () => {
     const { authenticator } = await createResourceTest({ role: "admin" });
     const firstAgent =

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -123,6 +123,9 @@ async function shadowAgentPermissions(
     context: {
       check: "agent_permissions",
       workspaceId: auth.getNonNullableWorkspace().sId,
+      authMethod: auth.authMethod(),
+      hasUser: auth.user() !== null,
+      isSystemKey: auth.isSystemKey(),
     },
     equals: (legacy, candidate) =>
       legacy.length === candidate.length &&
@@ -142,6 +145,11 @@ async function shadowAgentPermissions(
 
 /**
  * Enrich agent configurations with additional data (actions, tags, favorites).
+ */
+/**
+ * @cc [owner:philipperolet,label:security] agent-editability
+ * `canEdit` allows legacy authors/editors or user-less system-key callers with agent write
+ * permission; workspace admin role alone does not grant it.
  */
 export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
   auth: Authenticator,
@@ -194,9 +202,13 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
 
     const isAuthor = agent.authorId === auth.user()?.id;
     const isMember = editorIds.includes(agent.id);
+    const canEditAsSystem =
+      !user &&
+      auth.isSystemKey() &&
+      auth.can("write", AgentResource.fromAgentConfigurationModel(agent));
 
-    const canRead = isAuthor || isMember || agent.scope === "visible";
-    const canEdit = isAuthor || isMember;
+    const canEdit = isAuthor || isMember || canEditAsSystem;
+    const canRead = canEdit || agent.scope === "visible";
     const agentConfigurationType: AgentConfigurationType = {
       id: agent.id,
       sId: agent.sId,


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/31919.

Agent permission shadowing reports mismatches for system-key requests: the key has write permission, but `canEdit` is false because the legacy editor lookup requires a user.

For system keys without an impersonated user, derive editability from the key's agent write permission. Unscoped keys can edit all custom agents; scoped keys can edit only agents covered by their grants. Agents the key can edit also report `canRead: true`. Human admins and impersonated users keep the existing author/editor rules.

Include caller type in permission mismatch logs. Non-system internal authenticators are unchanged; their remaining mismatches require a separate policy decision before the grants read switch.

## Risks

Blast radius: Agent read/edit flags returned to system-key callers, including scoped keys.
Risk: standard

## Deploy Plan

- Deploy front-api and front workers. No migration required.

## Tests

- [x] Agent configuration, views, resource, auth permissions, and shadow suites: 72 tests passed.
- [x] Public agent GET/PATCH endpoint regression suite: 3 tests passed.
- [x] New system-key tests fail before the change and pass after it; human and impersonated admins remain non-editors.
