### PR TITLE
[front] feat: add optional You.com web search provider

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/set_web_providers.ts
+++ b/front/lib/api/poke/plugins/workspaces/set_web_providers.ts
@@ -21,6 +21,7 @@ export const setWebProvidersPlugin = createPlugin({
         values: [
           { label: "Firecrawl", value: "firecrawl" },
           { label: "Exa", value: "exa" },
+          { label: "You.com", value: "you_com" },
         ],
         multiple: false,
       },

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -540,7 +540,7 @@ type WorkspaceKillSwitchValue =
   | typeof WorkspaceResource.FULL_WORKSPACE_KILL_SWITCH_VALUE
   | WorkspaceConversationKillSwitchValue;
 
-export const WEB_SEARCH_PROVIDERS = ["exa", "firecrawl"] as const;
+export const WEB_SEARCH_PROVIDERS = ["exa", "firecrawl", "you_com"] as const;
 export type WebSearchProvider = (typeof WEB_SEARCH_PROVIDERS)[number];
 
 export const WEB_BROWSE_PROVIDERS = ["exa", "firecrawl", "spider"] as const;

--- a/front/lib/utils/websearch.ts
+++ b/front/lib/utils/websearch.ts
@@ -44,6 +44,11 @@ type ExaParams = {
   api_key?: string;
 };
 
+type YouComParams = {
+  provider: "you_com";
+  api_key?: string;
+};
+
 const serpapiDefaultOptions = {
   provider: "serpapi",
   engine: "google",
@@ -52,7 +57,7 @@ const serpapiDefaultOptions = {
 } satisfies Omit<BaseWebSearchParams & SerpapiParams, "query">;
 
 export type SearchParams = BaseWebSearchParams &
-  (SerpapiParams | SerperParams | FirecrawlParams | ExaParams);
+  (SerpapiParams | SerperParams | FirecrawlParams | ExaParams | YouComParams);
 
 export type SearchResultItem = {
   title: string;
@@ -261,8 +266,72 @@ const exaSearch = async ({
   return new Ok(results);
 };
 
+const YOU_COM_BASE_URL = "https://ydc-index.io";
+
+const youComSearch = async ({
+  query,
+  num,
+  api_key,
+}: BaseWebSearchParams & YouComParams): Promise<
+  Result<SearchResponse, Error>
+> => {
+  const youComApiKey = api_key ?? credentials.YDC_API_KEY;
+
+  if (!youComApiKey) {
+    return new Err(
+      new Error("utils/websearch: a DUST_MANAGED_YDC_API_KEY is required")
+    );
+  }
+
+  // eslint-disable-next-line no-restricted-globals
+  const res = await fetch(`${YOU_COM_BASE_URL}/v1/search`, {
+    method: "POST",
+    headers: {
+      "X-API-Key": youComApiKey,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      query,
+      count: num ?? 10,
+    }),
+  });
+
+  logger.debug({ ok: res.ok, statusCode: res.status }, "post you.com search");
+
+  if (res.ok) {
+    const json = await res.json();
+
+    if ("results" in json && Array.isArray(json.results?.web)) {
+      const results = json.results.web.reduce(
+        (acc: SearchResultItem[], item: any) => {
+          if (item.url) {
+            acc.push({
+              title: item.title ?? item.url,
+              link: item.url,
+              snippet: item.description ?? item.snippets?.[0] ?? "",
+            });
+          }
+          return acc;
+        },
+        [] as SearchResultItem[]
+      );
+
+      return new Ok(results);
+    }
+
+    return new Ok([]);
+  }
+
+  logger.error(
+    { statusCode: res.status, statusText: res.statusText },
+    "Bad request on You.com search"
+  );
+
+  return new Err(new Error(`Bad request on You.com: ${res.statusText}`));
+};
+
 /**
- * Make a web search using SerpAPI, Serper, Firecrawl or Exa
+ * Make a web search using SerpAPI, Serper, Firecrawl, Exa or You.com
  * @param {SearchParams} params
  */
 export const webSearch = async (
@@ -284,6 +353,9 @@ export const webSearch = async (
     }
     case "exa": {
       return exaSearch(params);
+    }
+    case "you_com": {
+      return youComSearch(params);
     }
     default:
       assertNever(provider);

--- a/front/types/api/credentials.ts
+++ b/front/types/api/credentials.ts
@@ -11,6 +11,7 @@ const {
   DUST_MANAGED_ELEVENLABS_API_KEY = "",
   DUST_MANAGED_SPIDER_API_KEY = "",
   DUST_MANAGED_EXA_API_KEY = "",
+  DUST_MANAGED_YDC_API_KEY = "",
 } = process.env;
 
 export const credentialsFromProviders = (
@@ -90,5 +91,6 @@ export const dustManagedServiceCredentials = (): DustManagedCredentialsType => {
     ELEVENLABS_API_KEY: DUST_MANAGED_ELEVENLABS_API_KEY,
     SPIDER_API_KEY: DUST_MANAGED_SPIDER_API_KEY,
     EXA_API_KEY: DUST_MANAGED_EXA_API_KEY,
+    YDC_API_KEY: DUST_MANAGED_YDC_API_KEY,
   };
 };

--- a/front/types/provider.ts
+++ b/front/types/provider.ts
@@ -13,6 +13,7 @@ export type DustManagedCredentialsType = {
   SPIDER_API_KEY?: string;
   SERPER_API_KEY?: string;
   EXA_API_KEY?: string;
+  YDC_API_KEY?: string;
 };
 
 export type CredentialsType = DustManagedCredentialsType & LLMCredentialsType;


### PR DESCRIPTION
## Description

This adds [You.com](https://you.com) as an optional web search provider, following the existing provider pattern in `front/lib/utils/websearch.ts` (SerpAPI / Serper / Firecrawl / Exa). I noticed the `webSearch()` switch already had a clean per-provider shape, so this reuses it rather than introducing anything new:

- `YouComParams { provider: "you_com"; api_key?: string }` added to the `SearchParams` union
- `youComSearch()` — plain `fetch` POST to `https://ydc-index.io/v1/search` with the `X-API-Key` header, mapping `results.web[]` to `SearchResultItem` (`title` / `link` / `snippet`). No new dependency, same style as `serpapiSearch` / `serperSearch`.
- `"you_com"` added to `WEB_SEARCH_PROVIDERS`, so a workspace can select it through the existing `webSearchProvider` metadata, and to the `set-web-providers` poke plugin enum
- `YDC_API_KEY` credential + `DUST_MANAGED_YDC_API_KEY` env var, mirroring the `EXA_API_KEY` / `DUST_MANAGED_EXA_API_KEY` pattern

Fully opt-in: the default provider is unchanged (`firecrawl` fallback in the websearch tool stays as-is); You.com is only used when a workspace explicitly sets `webSearchProvider: "you_com"` or a caller passes `provider: "you_com"`. A missing key fails closed with the same error shape as the other providers. No secrets are exposed; the key only ever comes from the dust-managed credentials or an explicit `api_key` param.

For context on where You.com also ships agent-side: the You.com MCP server is available at `https://api.you.com/mcp` (and a keyless `?profile=free` variant), packaged in [youdotcom-oss/agent-skills](https://github.com/youdotcom-oss/agent-skills) — not needed for this PR, just noting the ecosystem in case it's useful for docs elsewhere.

## Tests

- `biome check --error-on-warnings` on all 5 touched files: clean
- `tsgo --noEmit -p front/tsconfig.json`: 421 errors on this branch vs 421 on unmodified `main` (pre-existing, mostly `@dust-tt/sparkle` build artifacts and unrelated type noise); zero errors reference the touched files. Verified by stashing the change and re-running.
- Runtime sanity check of the `results.web` → `SearchResultItem` mapping (normal payload, missing `results`, non-array `results.web`, result without `url` dropped, missing title/snippet fallbacks): 3/3 cases pass
- Live API validation requires a key: `curl -X POST https://ydc-index.io/v1/search -H "X-API-Key: $YDC_API_KEY" -H 'Content-Type: application/json' -d '{"query":"...","count":5}'` with a key from https://you.com/platform/api-keys

## Risk

Low — purely additive union member + switch case + enum entries. Default behavior for existing providers is untouched; a workspace that never selects `you_com` sees no difference. Rollback is a plain revert.

## Deploy Plan

Standard front deploy. Self-hosted instances that want to use the provider set `DUST_MANAGED_YDC_API_KEY`; nothing else changes.