### PR TITLE
feat: show progress during conversation compaction

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -171,10 +171,15 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     .filter(isCompactionMessage)
     .findLast((message) => message.status === "created");
   const lastMessage = allMessages.at(-1);
-  const latestCompactionMessage =
-    lastMessage && isCompactionMessage(lastMessage) ? lastMessage : undefined;
+  // Keep the terminal state docked until the next message moves it into the transcript.
+  const latestTerminalCompactionMessage =
+    lastMessage &&
+    isCompactionMessage(lastMessage) &&
+    lastMessage.status !== "created"
+      ? lastMessage
+      : undefined;
   const dockedCompactionMessage =
-    activeCompactionMessage ?? latestCompactionMessage;
+    activeCompactionMessage ?? latestTerminalCompactionMessage;
   const isCompactionInProgress = activeCompactionMessage !== undefined;
   const { compact: retryCompaction, isCompacting: isRetryingCompaction } =
     useCompactConversation({

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -1,4 +1,5 @@
 import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
+import { CompactionProgress } from "@app/components/assistant/conversation/CompactionProgress";
 import { ContextUsageWarningBanner } from "@app/components/assistant/conversation/ContextUsageWarningBanner";
 import { useGenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
@@ -21,6 +22,7 @@ import { WakeUpBanner } from "@app/components/assistant/conversation/WakeUpBanne
 import { PodJoinCTA } from "@app/components/pod/conversation/PodJoinCTA";
 import {
   useCancelMessage,
+  useCompactConversation,
   useConversation,
   useConversationContextUsage,
 } from "@app/hooks/conversations";
@@ -165,11 +167,27 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     options: { disabled: !context.conversation },
   });
 
-  const isCompactionInProgress = allMessages.some(
-    (message) => isCompactionMessage(message) && message.status === "created"
-  );
+  const activeCompactionMessage = allMessages
+    .filter(isCompactionMessage)
+    .findLast((message) => message.status === "created");
+  const lastMessage = allMessages.at(-1);
+  const latestCompactionMessage =
+    lastMessage && isCompactionMessage(lastMessage) ? lastMessage : undefined;
+  const dockedCompactionMessage =
+    activeCompactionMessage ?? latestCompactionMessage;
+  const isCompactionInProgress = activeCompactionMessage !== undefined;
+  const { compact: retryCompaction, isCompacting: isRetryingCompaction } =
+    useCompactConversation({
+      owner: context.owner,
+      conversationId: context.conversation?.sId,
+    });
+  const handleRetryCompaction = () => {
+    if (contextUsage?.model) {
+      void retryCompaction(contextUsage.model);
+    }
+  };
   const compactionBlockMessage = isCompactionInProgress
-    ? "Wait for compaction to finish."
+    ? "Compaction in progress. Sending resumes when it finishes."
     : contextUsagePercentage >=
         CONTEXT_USAGE_PERCENT_THRESHOLDS["force_compaction"]
       ? "Context is full, compact to continue."
@@ -651,6 +669,15 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
           isOwner={isActiveWakeUpOwner}
         />
       )}
+      {dockedCompactionMessage && (
+        <CompactionProgress
+          key={dockedCompactionMessage.sId}
+          message={dockedCompactionMessage}
+          canRetry={!!contextUsage?.model}
+          isRetrying={isRetryingCompaction}
+          onRetry={handleRetryCompaction}
+        />
+      )}
       <div
         className={classNames(
           "relative w-full",
@@ -723,6 +750,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
                 actions={agentBuilderContext?.actionsToShow}
                 isSubmitting={agentBuilderContext?.isSubmitting === true}
                 isAgentBuilder={!!agentBuilderContext}
+                disableInput={isCompactionInProgress}
                 submitBlockMessage={
                   forkBlockMessage ??
                   wakeUpBlockMessage ??

--- a/front/components/assistant/conversation/CompactionMessage.tsx
+++ b/front/components/assistant/conversation/CompactionMessage.tsx
@@ -1,19 +1,11 @@
-import {
-  getCompactionInProgressLabel,
-  getCompactionSuccessLabel,
-} from "@app/components/assistant/conversation/utils";
+import { getCompactionSuccessLabel } from "@app/components/assistant/conversation/utils";
 import { formatTimestring } from "@app/lib/utils/timestamps";
 import type {
   CompactionMessageType,
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
-import {
-  AlertCircle,
-  AnimatedText,
-  ContentMessage,
-  Spinner,
-} from "@dust-tt/sparkle";
+import { AlertCircle, ContentMessage } from "@dust-tt/sparkle";
 
 interface CompactionMessageProps {
   message: CompactionMessageType;
@@ -47,18 +39,8 @@ export function CompactionMessage({
           </span>
         </div>
       );
-    case "created": {
-      const label = getCompactionInProgressLabel(message, conversation);
-
-      return (
-        <div className="flex items-center justify-center gap-1.5">
-          <Spinner size="xs" />
-          <AnimatedText variant="muted" className="text-sm">
-            {label}
-          </AnimatedText>
-        </div>
-      );
-    }
+    case "created":
+      return null;
     default:
       assertNeverAndIgnore(message.status);
       return null;

--- a/front/components/assistant/conversation/CompactionProgress.test.ts
+++ b/front/components/assistant/conversation/CompactionProgress.test.ts
@@ -22,12 +22,16 @@ describe("getCompactionFill", () => {
 
 describe("getCompactionProgressTier", () => {
   it("changes tiers at the expected durations", () => {
-    expect(getCompactionProgressTier(89)).toBe("normal");
-    expect(getCompactionProgressTier(90)).toBe("past-typical");
-    expect(getCompactionProgressTier(149)).toBe("past-typical");
-    expect(getCompactionProgressTier(150)).toBe("slow");
-    expect(getCompactionProgressTier(269)).toBe("slow");
-    expect(getCompactionProgressTier(270)).toBe("tail");
+    expect(getCompactionProgressTier({ elapsedSeconds: 89 })).toBe("normal");
+    expect(getCompactionProgressTier({ elapsedSeconds: 90 })).toBe(
+      "past-typical"
+    );
+    expect(getCompactionProgressTier({ elapsedSeconds: 149 })).toBe(
+      "past-typical"
+    );
+    expect(getCompactionProgressTier({ elapsedSeconds: 150 })).toBe("slow");
+    expect(getCompactionProgressTier({ elapsedSeconds: 269 })).toBe("slow");
+    expect(getCompactionProgressTier({ elapsedSeconds: 270 })).toBe("tail");
   });
 });
 
@@ -43,9 +47,12 @@ describe("CompactionProgress", () => {
     );
 
     expect(screen.getByText("100%")).toBeDefined();
-    expect(screen.getByRole("progressbar").getAttribute("aria-valuenow")).toBe(
-      "100"
-    );
+    const progressBar = screen.getByRole("progressbar");
+    expect(progressBar.getAttribute("aria-valuenow")).toBe("100");
+    expect(progressBar.classList.contains("bg-success-100")).toBe(true);
+    expect(
+      progressBar.firstElementChild?.classList.contains("bg-success-700")
+    ).toBe(true);
     expect(
       screen.getByText("The conversation is compacted. You can keep going.")
     ).toBeDefined();

--- a/front/components/assistant/conversation/CompactionProgress.test.ts
+++ b/front/components/assistant/conversation/CompactionProgress.test.ts
@@ -47,7 +47,7 @@ describe("CompactionProgress", () => {
       "100"
     );
     expect(
-      screen.getByText("This conversation is compacted. You can keep going.")
+      screen.getByText("The conversation is compacted. You can keep going.")
     ).toBeDefined();
   });
 });

--- a/front/components/assistant/conversation/CompactionProgress.test.ts
+++ b/front/components/assistant/conversation/CompactionProgress.test.ts
@@ -1,0 +1,53 @@
+import {
+  CompactionProgress,
+  getCompactionFill,
+  getCompactionProgressTier,
+} from "@app/components/assistant/conversation/CompactionProgress";
+import { render, screen } from "@testing-library/react";
+import { createElement } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+describe("getCompactionFill", () => {
+  it("fits the typical and rare durations", () => {
+    expect(getCompactionFill(90)).toBeCloseTo(85);
+    expect(getCompactionFill(270)).toBeCloseTo(97);
+  });
+
+  it("approaches 99 without reaching it", () => {
+    expect(getCompactionFill(0)).toBe(0);
+    expect(getCompactionFill(10_000)).toBeLessThan(99);
+    expect(getCompactionFill(10_000)).toBeGreaterThan(98);
+  });
+});
+
+describe("getCompactionProgressTier", () => {
+  it("changes tiers at the expected durations", () => {
+    expect(getCompactionProgressTier(89)).toBe("normal");
+    expect(getCompactionProgressTier(90)).toBe("past-typical");
+    expect(getCompactionProgressTier(149)).toBe("past-typical");
+    expect(getCompactionProgressTier(150)).toBe("slow");
+    expect(getCompactionProgressTier(269)).toBe("slow");
+    expect(getCompactionProgressTier(270)).toBe("tail");
+  });
+});
+
+describe("CompactionProgress", () => {
+  it("shows 100% when a compaction succeeds", () => {
+    render(
+      createElement(CompactionProgress, {
+        message: { created: Date.now(), status: "succeeded" },
+        canRetry: true,
+        isRetrying: false,
+        onRetry: vi.fn(),
+      })
+    );
+
+    expect(screen.getByText("100%")).toBeDefined();
+    expect(screen.getByRole("progressbar").getAttribute("aria-valuenow")).toBe(
+      "100"
+    );
+    expect(
+      screen.getByText("This conversation is compacted. You can keep going.")
+    ).toBeDefined();
+  });
+});

--- a/front/components/assistant/conversation/CompactionProgress.tsx
+++ b/front/components/assistant/conversation/CompactionProgress.tsx
@@ -1,0 +1,224 @@
+import { classNames } from "@app/lib/utils";
+import type { CompactionMessageType } from "@app/types/assistant/conversation";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { Button, ProgressBar } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+
+const TYPICAL_SECONDS = 90;
+const RARE_SECONDS = 270;
+const SLOW_THRESHOLD_SECONDS = 150;
+const AT_TYPICAL_PERCENT = 85;
+const AT_RARE_PERCENT = 97;
+const CEILING_PERCENT = 99;
+const UPDATE_INTERVAL_MS = 1000;
+
+const TYPICAL_RATIO =
+  AT_TYPICAL_PERCENT / (CEILING_PERCENT - AT_TYPICAL_PERCENT);
+const RARE_RATIO = AT_RARE_PERCENT / (CEILING_PERCENT - AT_RARE_PERCENT);
+const CURVE_POWER =
+  Math.log(RARE_RATIO / TYPICAL_RATIO) /
+  Math.log(RARE_SECONDS / TYPICAL_SECONDS);
+const CURVE_SCALE_SECONDS =
+  TYPICAL_SECONDS / Math.pow(TYPICAL_RATIO, 1 / CURVE_POWER);
+
+export type CompactionProgressTier =
+  | "normal"
+  | "past-typical"
+  | "slow"
+  | "tail";
+
+const STAGE_BY_TIER = {
+  normal: "Writing the summary",
+  "past-typical": "This conversation is longer than most. Still compacting.",
+  slow: "Still running, just slower than usual. Your messages are safe.",
+  tail: "This is taking unusually long. We'll keep going, and your conversation stays intact either way.",
+} satisfies Record<CompactionProgressTier, string>;
+
+export function getCompactionFill(elapsedSeconds: number): number {
+  const curvePosition = Math.pow(
+    elapsedSeconds / CURVE_SCALE_SECONDS,
+    CURVE_POWER
+  );
+  return (CEILING_PERCENT * curvePosition) / (1 + curvePosition);
+}
+
+export function getCompactionProgressTier(
+  elapsedSeconds: number,
+  slowThresholdSeconds = SLOW_THRESHOLD_SECONDS
+): CompactionProgressTier {
+  if (elapsedSeconds < TYPICAL_SECONDS) {
+    return "normal";
+  }
+  if (elapsedSeconds < slowThresholdSeconds) {
+    return "past-typical";
+  }
+  if (elapsedSeconds < RARE_SECONDS) {
+    return "slow";
+  }
+  return "tail";
+}
+
+function useElapsedSeconds(startedAtMs: number, isRunning: boolean): number {
+  const [elapsedSeconds, setElapsedSeconds] = useState(() =>
+    Math.max(0, Math.floor((Date.now() - startedAtMs) / 1000))
+  );
+
+  useEffect(() => {
+    const updateElapsedSeconds = () => {
+      setElapsedSeconds(
+        Math.max(0, Math.floor((Date.now() - startedAtMs) / 1000))
+      );
+    };
+
+    updateElapsedSeconds();
+    if (!isRunning) {
+      return;
+    }
+
+    const intervalId = window.setInterval(
+      updateElapsedSeconds,
+      UPDATE_INTERVAL_MS
+    );
+    return () => window.clearInterval(intervalId);
+  }, [isRunning, startedAtMs]);
+
+  return elapsedSeconds;
+}
+
+interface CompactionProgressProps {
+  message: Pick<CompactionMessageType, "created" | "status">;
+  canRetry: boolean;
+  isRetrying: boolean;
+  onRetry: () => void;
+}
+
+type CompactionProgressTone = "default" | "success" | "warning";
+
+const PROGRESS_CLASSES = {
+  default: "bg-muted-background [&>div]:bg-foreground",
+  success: "bg-success-100 [&>div]:bg-success-700",
+  warning: "bg-warning-100 [&>div]:bg-warning-700",
+} satisfies Record<CompactionProgressTone, string>;
+
+const STAGE_CLASSES = {
+  default: "text-muted-foreground",
+  success: "text-success-700",
+  warning: "text-warning-700",
+} satisfies Record<CompactionProgressTone, string>;
+
+function CompactionProgressCard({
+  fillPercentage,
+  displayPercentage,
+  stage,
+  stageAction,
+  footer,
+  tone,
+}: {
+  fillPercentage: number;
+  displayPercentage?: number;
+  stage: string;
+  stageAction?: ReactNode;
+  footer?: string;
+  tone: CompactionProgressTone;
+}) {
+  return (
+    <section className="mb-2 rounded-2xl border border-border bg-background px-4 py-3 md:px-5 md:py-4">
+      <div className="mb-2 flex items-baseline justify-between gap-3">
+        <h2 className="text-base font-semibold text-foreground">
+          Compacting this conversation
+        </h2>
+        {displayPercentage !== undefined && (
+          <span className="shrink-0 text-sm tabular-nums text-muted-foreground">
+            {displayPercentage}%
+          </span>
+        )}
+      </div>
+      <ProgressBar
+        label="Conversation compaction progress"
+        percentage={fillPercentage}
+        className={classNames(
+          "h-1 w-full [&>div]:transition-[width] [&>div]:duration-1000 [&>div]:ease-linear motion-reduce:[&>div]:transition-none",
+          PROGRESS_CLASSES[tone]
+        )}
+      />
+      <div
+        className={classNames(
+          "mt-2 flex items-start gap-2 text-sm",
+          STAGE_CLASSES[tone]
+        )}
+        aria-live="polite"
+      >
+        <span
+          aria-hidden
+          className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-current opacity-40"
+        />
+        <span className="grow">{stage}</span>
+        {stageAction}
+      </div>
+      {footer && (
+        <p className="mt-2 text-right text-xs text-muted-foreground">
+          {footer}
+        </p>
+      )}
+    </section>
+  );
+}
+
+export function CompactionProgress({
+  message,
+  canRetry,
+  isRetrying,
+  onRetry,
+}: CompactionProgressProps) {
+  const isRunning = message.status === "created";
+  const elapsedSeconds = useElapsedSeconds(message.created, isRunning);
+  const fillPercentage = getCompactionFill(elapsedSeconds);
+  const displayPercentage = Math.floor(fillPercentage);
+  const tier = getCompactionProgressTier(elapsedSeconds);
+  const isSlow = tier === "slow" || tier === "tail";
+
+  switch (message.status) {
+    case "created":
+      return (
+        <CompactionProgressCard
+          fillPercentage={fillPercentage}
+          displayPercentage={displayPercentage}
+          stage={STAGE_BY_TIER[tier]}
+          footer={isSlow ? "This keeps running if you leave." : undefined}
+          tone={isSlow ? "warning" : "default"}
+        />
+      );
+    case "succeeded":
+      return (
+        <CompactionProgressCard
+          fillPercentage={100}
+          displayPercentage={100}
+          stage="This conversation is compacted. You can keep going."
+          tone="success"
+        />
+      );
+    case "failed":
+      return (
+        <CompactionProgressCard
+          fillPercentage={fillPercentage}
+          stage="Compaction didn't finish. Your conversation is unchanged."
+          stageAction={
+            <Button
+              label="Try again"
+              variant="ghost"
+              size="xs"
+              className="-mr-2 shrink-0"
+              disabled={!canRetry || isRetrying}
+              isLoading={isRetrying}
+              onClick={onRetry}
+            />
+          }
+          tone="warning"
+        />
+      );
+    default:
+      assertNeverAndIgnore(message.status);
+      return null;
+  }
+}

--- a/front/components/assistant/conversation/CompactionProgress.tsx
+++ b/front/components/assistant/conversation/CompactionProgress.tsx
@@ -51,10 +51,13 @@ export function getCompactionFill(elapsedSeconds: number): number {
   return (CEILING_PERCENT * curvePosition) / (1 + curvePosition);
 }
 
-export function getCompactionProgressTier(
-  elapsedSeconds: number,
-  slowThresholdSeconds = SLOW_THRESHOLD_SECONDS
-): CompactionProgressTier {
+export function getCompactionProgressTier({
+  elapsedSeconds,
+  slowThresholdSeconds = SLOW_THRESHOLD_SECONDS,
+}: {
+  elapsedSeconds: number;
+  slowThresholdSeconds?: number;
+}): CompactionProgressTier {
   if (elapsedSeconds < TYPICAL_SECONDS) {
     return "normal";
   }
@@ -103,10 +106,16 @@ interface CompactionProgressProps {
 
 type CompactionProgressTone = "default" | "success" | "warning";
 
-const PROGRESS_CLASSES = {
-  default: "bg-muted-background [&>div]:bg-foreground",
-  success: "bg-success-100 [&>div]:bg-success-700",
-  warning: "bg-warning-100 [&>div]:bg-warning-700",
+const PROGRESS_TRACK_CLASSES = {
+  default: "bg-muted-background",
+  success: "bg-success-100",
+  warning: "bg-warning-100",
+} satisfies Record<CompactionProgressTone, string>;
+
+const PROGRESS_FILL_CLASSES = {
+  default: "bg-foreground",
+  success: "bg-success-700",
+  warning: "bg-warning-700",
 } satisfies Record<CompactionProgressTone, string>;
 
 const STAGE_CLASSES = {
@@ -131,8 +140,8 @@ function CompactionProgressCard({
   tone: CompactionProgressTone;
 }) {
   return (
-    <section className="mb-2 rounded-2xl border border-border bg-background px-4 py-3 md:px-5 md:py-4">
-      <div className="mb-2 flex items-baseline justify-between gap-3">
+    <section className="mb-2 flex flex-col gap-2 rounded-2xl border border-border bg-background p-4">
+      <div className="flex items-baseline justify-between gap-3">
         <h2 className="text-base font-semibold text-foreground">Compacting</h2>
         {displayPercentage !== undefined && (
           <span className="shrink-0 text-sm tabular-nums text-muted-foreground">
@@ -143,14 +152,15 @@ function CompactionProgressCard({
       <ProgressBar
         label="Conversation compaction progress"
         percentage={fillPercentage}
-        className={classNames(
-          "h-1 w-full [&>div]:transition-[width] [&>div]:duration-1000 [&>div]:ease-linear motion-reduce:[&>div]:transition-none",
-          PROGRESS_CLASSES[tone]
+        className={classNames("h-1 w-full", PROGRESS_TRACK_CLASSES[tone])}
+        fillClassName={classNames(
+          "transition-[width] duration-1000 ease-linear motion-reduce:transition-none",
+          PROGRESS_FILL_CLASSES[tone]
         )}
       />
       <div
         className={classNames(
-          "mt-2 flex items-start gap-2 text-sm",
+          "flex items-start gap-2 text-sm",
           STAGE_CLASSES[tone]
         )}
         aria-live="polite"
@@ -163,9 +173,7 @@ function CompactionProgressCard({
         {stageAction}
       </div>
       {footer && (
-        <p className="mt-2 text-right text-xs text-muted-foreground">
-          {footer}
-        </p>
+        <p className="text-right text-xs text-muted-foreground">{footer}</p>
       )}
     </section>
   );
@@ -181,7 +189,7 @@ export function CompactionProgress({
   const elapsedSeconds = useElapsedSeconds(message.created, isRunning);
   const fillPercentage = getCompactionFill(elapsedSeconds);
   const displayPercentage = Math.floor(fillPercentage);
-  const tier = getCompactionProgressTier(elapsedSeconds);
+  const tier = getCompactionProgressTier({ elapsedSeconds });
   const isSlow = tier === "slow" || tier === "tail";
 
   switch (message.status) {
@@ -214,7 +222,7 @@ export function CompactionProgress({
               label="Try again"
               variant="ghost"
               size="xs"
-              className="-mr-2 shrink-0"
+              className="shrink-0"
               disabled={!canRetry || isRetrying}
               isLoading={isRetrying}
               onClick={onRetry}

--- a/front/components/assistant/conversation/CompactionProgress.tsx
+++ b/front/components/assistant/conversation/CompactionProgress.tsx
@@ -5,14 +5,22 @@ import { Button, ProgressBar } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 
+// The estimate reaches 85% at the typical 90-second duration and 97% at the
+// rare 270-second duration. It approaches 99%. Only completion reaches 100%.
 const TYPICAL_SECONDS = 90;
 const RARE_SECONDS = 270;
-const SLOW_THRESHOLD_SECONDS = 150;
 const AT_TYPICAL_PERCENT = 85;
 const AT_RARE_PERCENT = 97;
 const CEILING_PERCENT = 99;
+
+// Start the long-run reassurance after 150 seconds.
+const SLOW_THRESHOLD_SECONDS = 150;
+
+// Update once per second so the displayed whole percentage stays current.
 const UPDATE_INTERVAL_MS = 1000;
 
+// Solve the curve's power and time scale from the two anchors above. The curve
+// uses u = (elapsed / scale)^power and fill = ceiling * u / (1 + u).
 const TYPICAL_RATIO =
   AT_TYPICAL_PERCENT / (CEILING_PERCENT - AT_TYPICAL_PERCENT);
 const RARE_RATIO = AT_RARE_PERCENT / (CEILING_PERCENT - AT_RARE_PERCENT);
@@ -30,9 +38,9 @@ export type CompactionProgressTier =
 
 const STAGE_BY_TIER = {
   normal: "Writing the summary",
-  "past-typical": "This conversation is longer than most. Still compacting.",
-  slow: "Still running, just slower than usual. Your messages are safe.",
-  tail: "This is taking unusually long. We'll keep going, and your conversation stays intact either way.",
+  "past-typical": "The conversation is longer than most. Still compacting.",
+  slow: "Compaction is taking longer than usual. Your messages are safe.",
+  tail: "Compaction is taking much longer than usual. The conversation stays intact even if compaction fails.",
 } satisfies Record<CompactionProgressTier, string>;
 
 export function getCompactionFill(elapsedSeconds: number): number {
@@ -125,9 +133,7 @@ function CompactionProgressCard({
   return (
     <section className="mb-2 rounded-2xl border border-border bg-background px-4 py-3 md:px-5 md:py-4">
       <div className="mb-2 flex items-baseline justify-between gap-3">
-        <h2 className="text-base font-semibold text-foreground">
-          Compacting this conversation
-        </h2>
+        <h2 className="text-base font-semibold text-foreground">Compacting</h2>
         {displayPercentage !== undefined && (
           <span className="shrink-0 text-sm tabular-nums text-muted-foreground">
             {displayPercentage}%
@@ -185,7 +191,7 @@ export function CompactionProgress({
           fillPercentage={fillPercentage}
           displayPercentage={displayPercentage}
           stage={STAGE_BY_TIER[tier]}
-          footer={isSlow ? "This keeps running if you leave." : undefined}
+          footer={isSlow ? "Compaction continues if you leave." : undefined}
           tone={isSlow ? "warning" : "default"}
         />
       );
@@ -194,7 +200,7 @@ export function CompactionProgress({
         <CompactionProgressCard
           fillPercentage={100}
           displayPercentage={100}
-          stage="This conversation is compacted. You can keep going."
+          stage="The conversation is compacted. You can keep going."
           tone="success"
         />
       );
@@ -202,7 +208,7 @@ export function CompactionProgress({
       return (
         <CompactionProgressCard
           fillPercentage={fillPercentage}
-          stage="Compaction didn't finish. Your conversation is unchanged."
+          stage="Compaction didn't finish. The conversation is unchanged."
           stageAction={
             <Button
               label="Try again"

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -71,6 +71,7 @@ import type {
   ConversationListItemType,
 } from "@app/types/assistant/conversation";
 import {
+  isCompactionMessageType,
   isLightAgentMessageType,
   isUserMessageTypeWithContentFragments,
 } from "@app/types/assistant/conversation";
@@ -558,6 +559,37 @@ export const ConversationViewer = ({
     const minRank = Math.min(...ranks);
 
     const messagesFromBackend = messages.flatMap((m) => m.messages);
+
+    const refreshedCompactionsById = new Map(
+      messagesFromBackend
+        .filter(isCompactionMessageType)
+        .map((message) => [message.sId, message])
+    );
+
+    if (
+      virtuosoMessageListRef.current.data.get().some((message) => {
+        if (!isCompactionMessage(message) || message.status !== "created") {
+          return false;
+        }
+
+        const refreshedMessage = refreshedCompactionsById.get(message.sId);
+        return (
+          refreshedMessage?.status !== undefined &&
+          refreshedMessage.status !== "created"
+        );
+      })
+    ) {
+      virtuosoMessageListRef.current.data.map((message) => {
+        if (!isCompactionMessage(message) || message.status !== "created") {
+          return message;
+        }
+
+        const refreshedMessage = refreshedCompactionsById.get(message.sId);
+        return refreshedMessage && refreshedMessage.status !== "created"
+          ? refreshedMessage
+          : message;
+      });
+    }
 
     const olderMessagesFromBackend = messagesFromBackend.filter(
       (m) => m.rank < minRank
@@ -1051,6 +1083,19 @@ export const ConversationViewer = ({
                   : m
               );
             }
+            void mutateMessages(
+              (pages) =>
+                pages?.map((page) => ({
+                  ...page,
+                  messages: page.messages.map((message) =>
+                    isCompactionMessageType(message) &&
+                    message.sId === event.messageId
+                      ? event.message
+                      : message
+                  ),
+                })),
+              { revalidate: false }
+            );
             void mutateContextUsage();
             window.dispatchEvent(new CompactionCompletedEvent());
             break;

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -396,6 +396,11 @@ export const ConversationViewer = ({
     options: { disabled: true },
   });
 
+  const notifyCompactionCompleted = useCallback(() => {
+    void mutateContextUsage();
+    window.dispatchEvent(new CompactionCompletedEvent());
+  }, [mutateContextUsage]);
+
   const submitMessage = useSubmitMessage({
     owner,
     user,
@@ -566,6 +571,7 @@ export const ConversationViewer = ({
         .map((message) => [message.sId, message])
     );
 
+    // The refresh has already updated SWR. Reconcile Virtuoso and notify local listeners.
     if (
       virtuosoMessageListRef.current.data.get().some((message) => {
         if (!isCompactionMessage(message) || message.status !== "created") {
@@ -589,6 +595,7 @@ export const ConversationViewer = ({
           ? refreshedMessage
           : message;
       });
+      notifyCompactionCompleted();
     }
 
     const olderMessagesFromBackend = messagesFromBackend.filter(
@@ -624,7 +631,11 @@ export const ConversationViewer = ({
         )
       );
     }
-  }, [conversation?.forkingData?.forkedChildren, messages]);
+  }, [
+    conversation?.forkingData?.forkedChildren,
+    messages,
+    notifyCompactionCompleted,
+  ]);
 
   useEffect(() => {
     if (
@@ -1096,8 +1107,7 @@ export const ConversationViewer = ({
                 })),
               { revalidate: false }
             );
-            void mutateContextUsage();
-            window.dispatchEvent(new CompactionCompletedEvent());
+            notifyCompactionCompleted();
             break;
           case "plan_updated": {
             // The acting client already updates via the per-message plan tool action; this handles
@@ -1156,6 +1166,7 @@ export const ConversationViewer = ({
       mutateConversations,
       mutateMessages,
       mutateWakeUps,
+      notifyCompactionCompleted,
       owner.sId,
       user.sId,
     ]

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -275,6 +275,10 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
     }
 
     if (isCompactionMessage(data)) {
+      if (data.status === "created" || !nextData) {
+        return null;
+      }
+
       return (
         <div
           ref={ref}

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -276,7 +276,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
 
     if (isCompactionMessage(data)) {
       if (data.status === "created" || !nextData) {
-        return null;
+        return <div ref={ref} className="h-px" />;
       }
 
       return (

--- a/front/components/assistant/conversation/utils.ts
+++ b/front/components/assistant/conversation/utils.ts
@@ -331,29 +331,6 @@ function getCompactionParentConversation(
   return parentConversation;
 }
 
-export function getCompactionInProgressLabel(
-  message: CompactionMessageType,
-  conversation: CompactionConversationInput
-): string {
-  const parentConversation = getCompactionParentConversation(
-    message,
-    conversation
-  );
-
-  if (!parentConversation) {
-    return "Compacting context, this may take a moment…";
-  }
-
-  const parentConversationTitle =
-    getParentConversationTitleLabel(parentConversation);
-  const truncatedParentConversationTitle = truncate(
-    parentConversationTitle,
-    MAX_SOURCE_CONVERSATION_TITLE_LENGTH
-  );
-
-  return `Summarizing '${truncatedParentConversationTitle}', this may take a moment…`;
-}
-
 export function getCompactionSuccessLabel(
   message: CompactionMessageType,
   conversation: CompactionConversationInput

--- a/front/hooks/conversations/useConversationMessages.ts
+++ b/front/hooks/conversations/useConversationMessages.ts
@@ -8,8 +8,11 @@ import type {
   FetchConversationMessageResponse,
   FetchConversationMessagesResponse,
 } from "@app/types/api/assistant/messages";
+import { isCompactionMessageType } from "@app/types/assistant/conversation";
 import { useMemo } from "react";
 import type { Fetcher } from "swr";
+
+const COMPACTION_REFRESH_INTERVAL_MS = 5_000;
 
 export function useConversationMessages({
   conversationId,
@@ -48,6 +51,17 @@ export function useConversationMessages({
       },
       messagesFetcher,
       {
+        refreshInterval: (pages) =>
+          pages?.some((page) =>
+            page.messages.some(
+              (
+                message: FetchConversationMessagesResponse["messages"][number]
+              ) =>
+                isCompactionMessageType(message) && message.status === "created"
+            )
+          )
+            ? COMPACTION_REFRESH_INTERVAL_MS
+            : 0,
         revalidateAll: false,
         revalidateOnFocus: false,
       }

--- a/sparkle/src/components/ProgressBar.tsx
+++ b/sparkle/src/components/ProgressBar.tsx
@@ -46,6 +46,8 @@ export type ProgressBarProps = Omit<
      * Name what is progressing (e.g. "Upload progress").
      */
     label?: string;
+    /** Class names applied to every fill before each value's className. */
+    fillClassName?: string;
   } & (
     | { percentage: number; values?: never }
     | {
@@ -72,6 +74,7 @@ export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
       radius = "full",
       variant = "default",
       className,
+      fillClassName,
       ...props
     },
     ref
@@ -118,6 +121,7 @@ export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
               key={index}
               className={cn(
                 progressBarFillVariants({ radius, variant }),
+                fillClassName,
                 segment.className
               )}
               style={

--- a/sparkle/src/stories/ProgressBar.stories.tsx
+++ b/sparkle/src/stories/ProgressBar.stories.tsx
@@ -18,6 +18,7 @@ const meta = {
 - Pass a \`percentage\` between 0 and 100; out-of-range values are clamped.
 - Pass an array to \`values\` to render adjacent segments separated by a 2px gap. Each entry pairs its \`value\` with an optional \`className\`; values are normalized to total 100.
 - Use \`radius\` to switch between square, extra-small, and fully rounded corners.
+- Control the track via \`className\` and every filled segment via \`fillClassName\`. A segmented value's \`className\` can override the shared fill style.
 - Control the bar's width via \`className\` (e.g. \`w-24\`, \`w-full\`).`,
       },
     },
@@ -60,6 +61,19 @@ export const Percentages: Story = {
       ))}
     </div>
   ),
+};
+
+/**
+ * `className` styles the track while `fillClassName` styles the filled area.
+ *
+ * @summary Custom track and fill colors.
+ */
+export const CustomFill: Story = {
+  args: {
+    percentage: 68,
+    className: "w-48 bg-warning-100",
+    fillClassName: "bg-warning-700",
+  },
 };
 
 export const Segmented: Story = {


### PR DESCRIPTION
## Description

Replace the static compaction spinner with a progress card docked above the composer. The card uses a fitted time curve, changes its status text for long runs, and shows success or retry states when the run ends.

Disable the composer while compaction runs so the control matches the blocked state. Keep completion state in the message cache and poll active compactions every five seconds. This lets a reloaded conversation recover when the completion event was missed.

Sometimes the bar is gonna end at 25%, sometimes it's gonna stay for long at 99%, but this is better than a bland "compacting..." message i believe.

## Tests

Locally, over a 25% full convo, triggered with /compact

<img width="1380" height="1506" alt="Screenshot 2026-09-08 at 15 42 16" src="https://github.com/user-attachments/assets/3a6509bb-e0cc-4d5c-8a2b-b8c5bea195eb" />

<img width="816" height="539" alt="Screenshot 2026-09-08 at 15 42 28" src="https://github.com/user-attachments/assets/e2200b1a-4d05-4780-aac0-46c239940b35" />

<img width="816" height="539" alt="Screenshot 2026-09-08 at 15 42 54" src="https://github.com/user-attachments/assets/6f189af8-e87e-4bc7-bb62-bc047a063349" />


## Risk

The percentage estimates elapsed time rather than backend work. It stays below 100% until the backend reports completion. Polling runs only while a loaded compaction has `created` status, and reconciliation only advances that status to `succeeded` or `failed`.

## Deploy Plan

Deploy through the standard frontend release process. No migration or configuration change is required.