### PR TITLE
feat: add read-only public API for agent triggers

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -6244,31 +6244,6 @@
           },
           {
             "in": "query",
-            "name": "status",
-            "required": false,
-            "description": "Filter by trigger status (defaults to `enabled` only)",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "enabled",
-                "disabled",
-                "disabled_by_manager",
-                "relocating",
-                "downgraded"
-              ]
-            }
-          },
-          {
-            "in": "query",
-            "name": "agentConfigurationId",
-            "required": false,
-            "description": "Filter to triggers configured on this agent",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
             "name": "limit",
             "required": false,
             "description": "Maximum number of triggers to return (default 50, max 100)",

--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -6097,6 +6097,66 @@
         }
       }
     },
+    "/api/v1/w/{wId}/triggers/{tId}": {
+      "get": {
+        "summary": "Get a trigger",
+        "description": "Get one agent trigger (scheduled run or webhook) by id. Requires a workspace admin API\nkey.\n",
+        "tags": [
+          "Triggers"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "tId",
+            "required": true,
+            "description": "ID of the trigger",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The trigger",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "trigger": {
+                      "$ref": "#/components/schemas/Trigger"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized. Invalid or missing authentication token."
+          },
+          "403": {
+            "description": "Forbidden. Requires a workspace admin API key."
+          },
+          "404": {
+            "description": "Workspace or trigger not found."
+          }
+        }
+      }
+    },
     "/api/v1/w/{wId}/triggers/hooks/{webhookSourceId}": {
       "post": {
         "summary": "Receive external webhook to trigger flows",
@@ -6148,6 +6208,119 @@
           },
           "404": {
             "description": "Workspace or webhook source not found"
+          }
+        }
+      }
+    },
+    "/api/v1/w/{wId}/triggers": {
+      "get": {
+        "summary": "List triggers",
+        "description": "List the agent triggers (scheduled runs and webhooks) configured across the workspace\nidentified by {wId}. Requires a workspace admin API key.\n",
+        "tags": [
+          "Triggers"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "kind",
+            "required": false,
+            "description": "Filter by trigger kind",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "schedule",
+                "webhook"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "description": "Filter by trigger status (defaults to `enabled` only)",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "enabled",
+                "disabled",
+                "disabled_by_manager",
+                "relocating",
+                "downgraded"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "agentConfigurationId",
+            "required": false,
+            "description": "Filter to triggers configured on this agent",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "description": "Maximum number of triggers to return (default 50, max 100)",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "description": "Number of triggers to skip, for pagination",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The workspace's triggers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "triggers": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Trigger"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request. Invalid query parameters."
+          },
+          "401": {
+            "description": "Unauthorized. Invalid or missing authentication token."
+          },
+          "403": {
+            "description": "Forbidden. Requires a workspace admin API key."
+          },
+          "404": {
+            "description": "Workspace not found."
           }
         }
       }
@@ -15612,6 +15785,94 @@
                 "nullable": true,
                 "description": "Profile image URL of the editor",
                 "example": "https://example.com/profile/johndoe.jpg"
+              }
+            }
+          }
+        }
+      },
+      "Trigger": {
+        "type": "object",
+        "required": [
+          "id",
+          "sId",
+          "name",
+          "agentConfigurationId",
+          "kind",
+          "status",
+          "createdAt",
+          "executionMode",
+          "configuration"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 12345
+          },
+          "sId": {
+            "type": "string",
+            "description": "Unique string identifier for the trigger",
+            "example": "0ec9852c2f"
+          },
+          "name": {
+            "type": "string",
+            "example": "Daily summary"
+          },
+          "agentConfigurationId": {
+            "type": "string",
+            "description": "sId of the agent this trigger runs",
+            "example": "8f3a1c2d9e"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "schedule",
+              "webhook"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "enabled",
+              "disabled",
+              "disabled_by_manager",
+              "relocating",
+              "downgraded"
+            ]
+          },
+          "createdAt": {
+            "type": "integer",
+            "example": 1625097600
+          },
+          "customPrompt": {
+            "type": "string",
+            "nullable": true
+          },
+          "naturalLanguageDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "executionMode": {
+            "type": "string",
+            "enum": [
+              "user_pool",
+              "workspace_pool"
+            ]
+          },
+          "configuration": {
+            "type": "object",
+            "description": "For `kind: schedule`, either a cron config (`cron`, `timezone`) or an interval\nconfig (`intervalDays`, `dayOfWeek`, `hour`, `minute`, `timezone`). For\n`kind: webhook`, `{ includePayload, event?, filter? }`.\n"
+          },
+          "webhookSource": {
+            "type": "object",
+            "nullable": true,
+            "description": "Present only for `kind: webhook` triggers",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "provider": {
+                "type": "string",
+                "example": "github"
               }
             }
           }

--- a/front-api/routes/v1/w/[wId]/swagger_schemas.ts
+++ b/front-api/routes/v1/w/[wId]/swagger_schemas.ts
@@ -1034,4 +1034,65 @@
  *               nullable: true
  *               description: Profile image URL of the editor
  *               example: "https://example.com/profile/johndoe.jpg"
+ *     Trigger:
+ *       type: object
+ *       required:
+ *         - id
+ *         - sId
+ *         - name
+ *         - agentConfigurationId
+ *         - kind
+ *         - status
+ *         - createdAt
+ *         - executionMode
+ *         - configuration
+ *       properties:
+ *         id:
+ *           type: integer
+ *           example: 12345
+ *         sId:
+ *           type: string
+ *           description: Unique string identifier for the trigger
+ *           example: "0ec9852c2f"
+ *         name:
+ *           type: string
+ *           example: "Daily summary"
+ *         agentConfigurationId:
+ *           type: string
+ *           description: sId of the agent this trigger runs
+ *           example: "8f3a1c2d9e"
+ *         kind:
+ *           type: string
+ *           enum: [schedule, webhook]
+ *         status:
+ *           type: string
+ *           enum: [enabled, disabled, disabled_by_manager, relocating, downgraded]
+ *         createdAt:
+ *           type: integer
+ *           example: 1625097600
+ *         customPrompt:
+ *           type: string
+ *           nullable: true
+ *         naturalLanguageDescription:
+ *           type: string
+ *           nullable: true
+ *         executionMode:
+ *           type: string
+ *           enum: [user_pool, workspace_pool]
+ *         configuration:
+ *           type: object
+ *           description: |
+ *             For `kind: schedule`, either a cron config (`cron`, `timezone`) or an interval
+ *             config (`intervalDays`, `dayOfWeek`, `hour`, `minute`, `timezone`). For
+ *             `kind: webhook`, `{ includePayload, event?, filter? }`.
+ *         webhookSource:
+ *           type: object
+ *           nullable: true
+ *           description: "Present only for `kind: webhook` triggers"
+ *           properties:
+ *             name:
+ *               type: string
+ *             provider:
+ *               type: string
+ *               example: "github"
  */

--- a/front-api/routes/v1/w/[wId]/triggers/[tId]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/[tId]/index.test.ts
@@ -1,0 +1,73 @@
+import { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { WorkspaceType } from "@app/types/user";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+// `TriggerResource.makeNew` requires a user editor, not the internal-admin auth.
+async function userAuthForWorkspace(workspace: WorkspaceType) {
+  const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
+  await SpaceFactory.defaults(internalAdminAuth);
+
+  const owner = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, owner, { role: "admin" });
+  return Authenticator.fromUserIdAndWorkspaceId(owner.sId, workspace.sId);
+}
+
+function getTrigger(
+  workspace: { sId: string },
+  key: { secret: string },
+  tId: string
+) {
+  return honoApp.request(`/api/v1/w/${workspace.sId}/triggers/${tId}`, {
+    headers: { authorization: `Bearer ${key.secret}` },
+  });
+}
+
+describe("GET /api/v1/w/:wId/triggers/:tId", () => {
+  it("returns 403 for a non-admin key", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "builder",
+    });
+
+    const response = await getTrigger(workspace, key, "trigger-0");
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 404 for an unknown trigger", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+
+    const response = await getTrigger(workspace, key, "trigger-unknown");
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns the trigger for an admin key", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+    const auth = await userAuthForWorkspace(workspace);
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await TriggerFactory.schedule(auth, {
+      agentConfigurationId: agent.sId,
+      configuration: { type: "cron", cron: "0 9 * * *", timezone: "UTC" },
+    });
+
+    const response = await getTrigger(workspace, key, trigger.sId);
+    expect(response.status).toBe(200);
+
+    const { trigger: serialized } = await response.json();
+    expect(serialized.sId).toBe(trigger.sId);
+    expect(serialized.kind).toBe("schedule");
+  });
+});

--- a/front-api/routes/v1/w/[wId]/triggers/[tId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/[tId]/index.ts
@@ -1,0 +1,88 @@
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import type { GetTriggerResponseType } from "@dust-tt/client";
+import { publicApiApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { publicApiAuth } from "@front-api/middlewares/public_api_auth";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+import { serializeTriggersForPublicApi } from "../serialize";
+
+const ParamsSchema = z.object({
+  tId: z.string(),
+});
+
+// Auth applied per-handler, not at the parent, so sibling `/hooks` doesn't inherit it.
+const app = publicApiApp();
+
+/**
+ * @swagger
+ * /api/v1/w/{wId}/triggers/{tId}:
+ *   get:
+ *     summary: Get a trigger
+ *     description: |
+ *       Get one agent trigger (scheduled run or webhook) by id. Requires a workspace admin API
+ *       key.
+ *     tags:
+ *       - Triggers
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: tId
+ *         required: true
+ *         description: ID of the trigger
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: The trigger
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 trigger:
+ *                   $ref: '#/components/schemas/Trigger'
+ *       401:
+ *         description: Unauthorized. Invalid or missing authentication token.
+ *       403:
+ *         description: Forbidden. Requires a workspace admin API key.
+ *       404:
+ *         description: Workspace or trigger not found.
+ */
+app.get(
+  "/",
+  publicApiAuth,
+  ensureIsAdmin(),
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetTriggerResponseType> => {
+    const auth = ctx.get("auth");
+    const { tId } = ctx.req.valid("param");
+
+    const trigger = await TriggerResource.fetchById(auth, tId);
+    if (!trigger) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "trigger_not_found",
+          message: `Trigger ${tId} not found.`,
+        },
+      });
+    }
+
+    const [serialized] = await serializeTriggersForPublicApi(auth, [trigger]);
+
+    return ctx.json({ trigger: serialized });
+  }
+);
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/triggers/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/index.test.ts
@@ -1,0 +1,114 @@
+import { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WebhookSourceViewFactory } from "@app/tests/utils/WebhookSourceViewFactory";
+import type { WorkspaceType } from "@app/types/user";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+// `TriggerResource.makeNew` requires a user editor, not the internal-admin auth.
+async function userAuthForWorkspace(workspace: WorkspaceType) {
+  const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
+  const { systemSpace } = await SpaceFactory.defaults(internalAdminAuth);
+
+  const owner = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, owner, { role: "admin" });
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    owner.sId,
+    workspace.sId
+  );
+
+  return { auth, systemSpace };
+}
+
+function listTriggers(
+  workspace: { sId: string },
+  key: { secret: string },
+  query: Record<string, string> = {}
+) {
+  const qs = new URLSearchParams(query).toString();
+  return honoApp.request(
+    `/api/v1/w/${workspace.sId}/triggers${qs ? `?${qs}` : ""}`,
+    { headers: { authorization: `Bearer ${key.secret}` } }
+  );
+}
+
+describe("GET /api/v1/w/:wId/triggers", () => {
+  it("returns 403 for a non-admin key", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "builder",
+    });
+
+    const response = await listTriggers(workspace, key);
+
+    expect(response.status).toBe(403);
+  });
+
+  it("only returns enabled triggers by default, across agents", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+    const { auth } = await userAuthForWorkspace(workspace);
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const disabledTrigger = await TriggerFactory.schedule(auth, {
+      agentConfigurationId: agent.sId,
+      configuration: { type: "cron", cron: "0 9 * * *", timezone: "UTC" },
+    });
+
+    const defaultResponse = await listTriggers(workspace, key);
+    expect(defaultResponse.status).toBe(200);
+    expect((await defaultResponse.json()).triggers).toHaveLength(0);
+
+    const disabledResponse = await listTriggers(workspace, key, {
+      status: "disabled",
+    });
+    expect(disabledResponse.status).toBe(200);
+    const { triggers } = await disabledResponse.json();
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0].sId).toBe(disabledTrigger.sId);
+    expect(triggers[0].kind).toBe("schedule");
+  });
+
+  it("filters by kind and includes a webhookSource label for webhook triggers", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+    const { auth, systemSpace } = await userAuthForWorkspace(workspace);
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const view = await new WebhookSourceViewFactory(workspace).create(
+      systemSpace
+    );
+
+    await TriggerFactory.schedule(auth, {
+      agentConfigurationId: agent.sId,
+      configuration: { type: "cron", cron: "0 9 * * *", timezone: "UTC" },
+    });
+    const webhookTrigger = await TriggerFactory.webhook(auth, {
+      agentConfigurationId: agent.sId,
+      webhookSourceViewId: view.id,
+    });
+
+    const response = await listTriggers(workspace, key, {
+      kind: "webhook",
+      status: "disabled",
+    });
+    expect(response.status).toBe(200);
+
+    const { triggers } = await response.json();
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0].sId).toBe(webhookTrigger.sId);
+    expect(triggers[0].webhookSource).toEqual({
+      name: view.name,
+      provider: "custom",
+    });
+    expect(triggers[0].editor).toBeUndefined();
+    expect(triggers[0].webhookSourceViewId).toBeUndefined();
+  });
+});

--- a/front-api/routes/v1/w/[wId]/triggers/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/index.test.ts
@@ -50,29 +50,23 @@ describe("GET /api/v1/w/:wId/triggers", () => {
     expect(response.status).toBe(403);
   });
 
-  it("only returns enabled triggers by default, across agents", async () => {
+  it("returns the workspace's triggers across agents", async () => {
     const { workspace, key } = await createPublicApiMockRequest({
       role: "admin",
     });
     const { auth } = await userAuthForWorkspace(workspace);
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
 
-    const disabledTrigger = await TriggerFactory.schedule(auth, {
+    const trigger = await TriggerFactory.schedule(auth, {
       agentConfigurationId: agent.sId,
       configuration: { type: "cron", cron: "0 9 * * *", timezone: "UTC" },
     });
 
-    const defaultResponse = await listTriggers(workspace, key);
-    expect(defaultResponse.status).toBe(200);
-    expect((await defaultResponse.json()).triggers).toHaveLength(0);
-
-    const disabledResponse = await listTriggers(workspace, key, {
-      status: "disabled",
-    });
-    expect(disabledResponse.status).toBe(200);
-    const { triggers } = await disabledResponse.json();
+    const response = await listTriggers(workspace, key);
+    expect(response.status).toBe(200);
+    const { triggers } = await response.json();
     expect(triggers).toHaveLength(1);
-    expect(triggers[0].sId).toBe(disabledTrigger.sId);
+    expect(triggers[0].sId).toBe(trigger.sId);
     expect(triggers[0].kind).toBe("schedule");
   });
 
@@ -97,7 +91,6 @@ describe("GET /api/v1/w/:wId/triggers", () => {
 
     const response = await listTriggers(workspace, key, {
       kind: "webhook",
-      status: "disabled",
     });
     expect(response.status).toBe(200);
 

--- a/front-api/routes/v1/w/[wId]/triggers/index.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/index.ts
@@ -1,5 +1,5 @@
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
-import { TRIGGER_KINDS, TRIGGER_STATUSES } from "@app/types/assistant/triggers";
+import { TRIGGER_KINDS } from "@app/types/assistant/triggers";
 import type { GetTriggersResponseType } from "@dust-tt/client";
 import { publicApiApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
@@ -17,8 +17,6 @@ const MAX_LIMIT = 100;
 
 const GetTriggersQuerySchema = z.object({
   kind: z.enum(TRIGGER_KINDS).optional(),
-  status: z.enum(TRIGGER_STATUSES).optional(),
-  agentConfigurationId: z.string().optional(),
   limit: z.coerce.number().int().positive().max(MAX_LIMIT).optional(),
   offset: z.coerce.number().int().nonnegative().optional(),
 });
@@ -52,19 +50,6 @@ app.route("/hooks", hooks);
  *         schema:
  *           type: string
  *           enum: [schedule, webhook]
- *       - in: query
- *         name: status
- *         required: false
- *         description: Filter by trigger status (defaults to `enabled` only)
- *         schema:
- *           type: string
- *           enum: [enabled, disabled, disabled_by_manager, relocating, downgraded]
- *       - in: query
- *         name: agentConfigurationId
- *         required: false
- *         description: Filter to triggers configured on this agent
- *         schema:
- *           type: string
  *       - in: query
  *         name: limit
  *         required: false
@@ -107,14 +92,11 @@ app.get(
   validate("query", GetTriggersQuerySchema),
   async (ctx): HandlerResult<GetTriggersResponseType> => {
     const auth = ctx.get("auth");
-    const { kind, status, agentConfigurationId, limit, offset } =
-      ctx.req.valid("query");
+    const { kind, limit, offset } = ctx.req.valid("query");
 
     const triggers =
       await TriggerResource.listByWorkspaceAndKindsAndExecutionModes(auth, {
         kinds: kind ? [kind] : undefined,
-        statuses: [status ?? "enabled"],
-        agentConfigurationId,
         limit: limit ?? DEFAULT_LIMIT,
         offset: offset ?? 0,
       });

--- a/front-api/routes/v1/w/[wId]/triggers/index.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/index.ts
@@ -110,7 +110,7 @@ app.get(
     const { kind, status, agentConfigurationId, limit, offset } =
       ctx.req.valid("query");
 
-    const triggers = await TriggerResource.listByWorkspaceForPublicApi(auth, {
+    const triggers = await TriggerResource.listByWorkspaceAndFilters(auth, {
       kind,
       status: status ?? "enabled",
       agentConfigurationId,

--- a/front-api/routes/v1/w/[wId]/triggers/index.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/index.ts
@@ -1,13 +1,129 @@
-import { createHono } from "@front-api/lib/hono";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { TRIGGER_KINDS, TRIGGER_STATUSES } from "@app/types/assistant/triggers";
+import type { GetTriggersResponseType } from "@dust-tt/client";
+import { publicApiApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { publicApiAuth } from "@front-api/middlewares/public_api_auth";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
+import tId from "./[tId]";
 import hooks from "./hooks";
+import { serializeTriggersForPublicApi } from "./serialize";
 
-// Mounted at /api/v1/w/:wId/triggers. This sub-tree is mounted before
-// `publicWorkspaceApp` in `routes/v1/index.ts` so it does not inherit
-// `publicApiAuth` — the webhook endpoint uses its own URL secret-based
-// authentication.
-const app = createHono();
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+const GetTriggersQuerySchema = z.object({
+  kind: z.enum(TRIGGER_KINDS).optional(),
+  status: z.enum(TRIGGER_STATUSES).optional(),
+  agentConfigurationId: z.string().optional(),
+  limit: z.coerce.number().int().positive().max(MAX_LIMIT).optional(),
+  offset: z.coerce.number().int().nonnegative().optional(),
+});
+
+// No sub-app-wide `publicApiAuth`: /hooks (mounted below) uses its own URL-secret auth instead.
+const app = publicApiApp();
 
 app.route("/hooks", hooks);
+
+/**
+ * @swagger
+ * /api/v1/w/{wId}/triggers:
+ *   get:
+ *     summary: List triggers
+ *     description: |
+ *       List the agent triggers (scheduled runs and webhooks) configured across the workspace
+ *       identified by {wId}. Requires a workspace admin API key.
+ *     tags:
+ *       - Triggers
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: kind
+ *         required: false
+ *         description: Filter by trigger kind
+ *         schema:
+ *           type: string
+ *           enum: [schedule, webhook]
+ *       - in: query
+ *         name: status
+ *         required: false
+ *         description: Filter by trigger status (defaults to `enabled` only)
+ *         schema:
+ *           type: string
+ *           enum: [enabled, disabled, disabled_by_manager, relocating, downgraded]
+ *       - in: query
+ *         name: agentConfigurationId
+ *         required: false
+ *         description: Filter to triggers configured on this agent
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: limit
+ *         required: false
+ *         description: Maximum number of triggers to return (default 50, max 100)
+ *         schema:
+ *           type: integer
+ *       - in: query
+ *         name: offset
+ *         required: false
+ *         description: Number of triggers to skip, for pagination
+ *         schema:
+ *           type: integer
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: The workspace's triggers
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 triggers:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Trigger'
+ *       400:
+ *         description: Bad Request. Invalid query parameters.
+ *       401:
+ *         description: Unauthorized. Invalid or missing authentication token.
+ *       403:
+ *         description: Forbidden. Requires a workspace admin API key.
+ *       404:
+ *         description: Workspace not found.
+ */
+app.get(
+  "/",
+  publicApiAuth,
+  ensureIsAdmin(),
+  validate("query", GetTriggersQuerySchema),
+  async (ctx): HandlerResult<GetTriggersResponseType> => {
+    const auth = ctx.get("auth");
+    const { kind, status, agentConfigurationId, limit, offset } =
+      ctx.req.valid("query");
+
+    const triggers = await TriggerResource.listByWorkspaceForPublicApi(auth, {
+      kind,
+      status: status ?? "enabled",
+      agentConfigurationId,
+      limit: limit ?? DEFAULT_LIMIT,
+      offset: offset ?? 0,
+    });
+
+    return ctx.json({
+      triggers: await serializeTriggersForPublicApi(auth, triggers),
+    });
+  }
+);
+
+app.route("/:tId", tId);
 
 export default app;

--- a/front-api/routes/v1/w/[wId]/triggers/index.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/index.ts
@@ -110,13 +110,14 @@ app.get(
     const { kind, status, agentConfigurationId, limit, offset } =
       ctx.req.valid("query");
 
-    const triggers = await TriggerResource.listByWorkspaceAndFilters(auth, {
-      kind,
-      status: status ?? "enabled",
-      agentConfigurationId,
-      limit: limit ?? DEFAULT_LIMIT,
-      offset: offset ?? 0,
-    });
+    const triggers =
+      await TriggerResource.listByWorkspaceAndKindsAndExecutionModes(auth, {
+        kinds: kind ? [kind] : undefined,
+        statuses: [status ?? "enabled"],
+        agentConfigurationId,
+        limit: limit ?? DEFAULT_LIMIT,
+        offset: offset ?? 0,
+      });
 
     return ctx.json({
       triggers: await serializeTriggersForPublicApi(auth, triggers),

--- a/front-api/routes/v1/w/[wId]/triggers/serialize.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/serialize.ts
@@ -1,0 +1,65 @@
+import type { Authenticator } from "@app/lib/auth";
+import type { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
+import { removeNulls } from "@app/types/shared/utils/general";
+import type { TriggerType as PublicTriggerType } from "@dust-tt/client";
+
+/**
+ * @cc [owner:adrien,label:api] public-api-trigger-serialization
+ * Serializes a workspace-wide `TriggerResource` list for the read-only public API: internal
+ * fields with no meaning outside the workspace (`editor`, `origin`, `spaceId`,
+ * `webhookSourceViewId`) are dropped, and webhook triggers get a `webhookSource` label
+ * (`name`/`provider`) resolved from their view instead of the raw internal view id.
+ */
+export async function serializeTriggersForPublicApi(
+  auth: Authenticator,
+  triggers: TriggerResource[]
+): Promise<PublicTriggerType[]> {
+  const webhookSourceViewIds = [
+    ...new Set(removeNulls(triggers.map((t) => t.webhookSourceViewId))),
+  ];
+  const views =
+    webhookSourceViewIds.length > 0
+      ? await WebhookSourcesViewResource.fetchByModelIds(
+          auth,
+          webhookSourceViewIds
+        )
+      : [];
+  const viewsById = new Map(views.map((view) => [view.id, view]));
+
+  return triggers.map((trigger) => {
+    const triggerJSON = trigger.toJSON();
+    const base = {
+      id: triggerJSON.id,
+      sId: triggerJSON.sId,
+      name: triggerJSON.name,
+      agentConfigurationId: triggerJSON.agentConfigurationId,
+      customPrompt: triggerJSON.customPrompt,
+      status: triggerJSON.status,
+      createdAt: triggerJSON.createdAt,
+      naturalLanguageDescription: triggerJSON.naturalLanguageDescription,
+      executionMode: triggerJSON.executionMode,
+    };
+
+    if (triggerJSON.kind !== "webhook") {
+      return {
+        ...base,
+        kind: "schedule" as const,
+        configuration: triggerJSON.configuration,
+      };
+    }
+
+    const view = trigger.webhookSourceViewId
+      ? viewsById.get(trigger.webhookSourceViewId)
+      : undefined;
+
+    return {
+      ...base,
+      kind: "webhook" as const,
+      configuration: triggerJSON.configuration,
+      webhookSource: view
+        ? { name: view.name, provider: view.webhookSource.provider ?? "custom" }
+        : null,
+    };
+  });
+}

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -374,7 +374,18 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     {
       kinds,
       executionModes,
-    }: { kinds?: TriggerKind[]; executionModes?: TriggerExecutionMode[] }
+      statuses,
+      agentConfigurationId,
+      limit,
+      offset,
+    }: {
+      kinds?: TriggerKind[];
+      executionModes?: TriggerExecutionMode[];
+      statuses?: TriggerStatus[];
+      agentConfigurationId?: string;
+      limit?: number;
+      offset?: number;
+    }
   ): Promise<TriggerResource[]> {
     return this.baseFetch(auth, {
       where: {
@@ -382,30 +393,7 @@ export class TriggerResource extends BaseResource<TriggerModel> {
         ...(executionModes?.length
           ? { executionMode: { [Op.in]: executionModes } }
           : {}),
-      },
-    });
-  }
-
-  static async listByWorkspaceAndFilters(
-    auth: Authenticator,
-    {
-      kind,
-      status,
-      agentConfigurationId,
-      limit,
-      offset,
-    }: {
-      kind?: TriggerKind;
-      status?: TriggerStatus;
-      agentConfigurationId?: string;
-      limit: number;
-      offset: number;
-    }
-  ): Promise<TriggerResource[]> {
-    return this.baseFetch(auth, {
-      where: {
-        ...(kind ? { kind } : {}),
-        ...(status ? { status } : {}),
+        ...(statuses?.length ? { status: { [Op.in]: statuses } } : {}),
         ...(agentConfigurationId ? { agentConfigurationId } : {}),
       },
       order: [["id", "ASC"]],

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -374,15 +374,11 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     {
       kinds,
       executionModes,
-      statuses,
-      agentConfigurationId,
       limit,
       offset,
     }: {
       kinds?: TriggerKind[];
       executionModes?: TriggerExecutionMode[];
-      statuses?: TriggerStatus[];
-      agentConfigurationId?: string;
       limit?: number;
       offset?: number;
     }
@@ -393,8 +389,6 @@ export class TriggerResource extends BaseResource<TriggerModel> {
         ...(executionModes?.length
           ? { executionMode: { [Op.in]: executionModes } }
           : {}),
-        ...(statuses?.length ? { status: { [Op.in]: statuses } } : {}),
-        ...(agentConfigurationId ? { agentConfigurationId } : {}),
       },
       order: [["id", "ASC"]],
       limit,

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -234,6 +234,8 @@ export class TriggerResource extends BaseResource<TriggerModel> {
         workspaceId: workspace.id,
       },
       limit: options.limit,
+      offset: options.offset,
+      order: options.order,
     });
 
     return res.map((c) => new this(this.model, c.get()));
@@ -381,6 +383,41 @@ export class TriggerResource extends BaseResource<TriggerModel> {
           ? { executionMode: { [Op.in]: executionModes } }
           : {}),
       },
+    });
+  }
+
+  /**
+   * @cc [owner:adrien,label:api;security] public-api-workspace-wide-unrestricted
+   * Returns triggers across every agent in the workspace, unfiltered by editor or
+   * agent-level read permissions. Callers must enforce their own access gate (e.g.
+   * `ensureIsAdmin()`) before calling this — the resource layer performs no
+   * authorization check beyond workspace scoping.
+   */
+  static async listByWorkspaceForPublicApi(
+    auth: Authenticator,
+    {
+      kind,
+      status,
+      agentConfigurationId,
+      limit,
+      offset,
+    }: {
+      kind?: TriggerKind;
+      status?: TriggerStatus;
+      agentConfigurationId?: string;
+      limit: number;
+      offset: number;
+    }
+  ): Promise<TriggerResource[]> {
+    return this.baseFetch(auth, {
+      where: {
+        ...(kind ? { kind } : {}),
+        ...(status ? { status } : {}),
+        ...(agentConfigurationId ? { agentConfigurationId } : {}),
+      },
+      order: [["id", "ASC"]],
+      limit,
+      offset,
     });
   }
 

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -386,14 +386,7 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     });
   }
 
-  /**
-   * @cc [owner:adrien,label:api;security] public-api-workspace-wide-unrestricted
-   * Returns triggers across every agent in the workspace, unfiltered by editor or
-   * agent-level read permissions. Callers must enforce their own access gate (e.g.
-   * `ensureIsAdmin()`) before calling this — the resource layer performs no
-   * authorization check beyond workspace scoping.
-   */
-  static async listByWorkspaceForPublicApi(
+  static async listByWorkspaceAndFilters(
     auth: Authenticator,
     {
       kind,

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -296,6 +296,89 @@ export type PostWebhookTriggerResponseType = z.infer<
   typeof PostWebhookTriggerResponseSchema
 >;
 
+export const TriggerKindSchema = z.enum(["schedule", "webhook"]);
+export type TriggerKindType = z.infer<typeof TriggerKindSchema>;
+
+export const TriggerStatusSchema = z.enum([
+  "enabled",
+  "disabled",
+  "disabled_by_manager",
+  "relocating",
+  "downgraded",
+]);
+export type TriggerStatusType = z.infer<typeof TriggerStatusSchema>;
+
+export const TriggerExecutionModeSchema = z.enum([
+  "user_pool",
+  "workspace_pool",
+]);
+export type TriggerExecutionModeType = z.infer<
+  typeof TriggerExecutionModeSchema
+>;
+
+export const CronScheduleConfigSchema = z.object({
+  type: z.literal("cron").optional(),
+  cron: z.string(),
+  timezone: z.string(),
+});
+
+export const IntervalScheduleConfigSchema = z.object({
+  type: z.literal("interval"),
+  intervalDays: z.number(),
+  dayOfWeek: z.number().nullable(),
+  hour: z.number(),
+  minute: z.number(),
+  timezone: z.string(),
+});
+
+export const ScheduleConfigSchema = z.union([
+  CronScheduleConfigSchema,
+  IntervalScheduleConfigSchema,
+]);
+
+export const WebhookConfigSchema = z.object({
+  includePayload: z.boolean(),
+  event: z.string().optional(),
+  filter: z.string().optional(),
+});
+
+const TriggerBaseSchema = z.object({
+  id: z.number(),
+  sId: z.string(),
+  name: z.string(),
+  agentConfigurationId: z.string(),
+  customPrompt: z.string().nullable(),
+  status: TriggerStatusSchema,
+  createdAt: z.number(),
+  naturalLanguageDescription: z.string().nullable(),
+  executionMode: TriggerExecutionModeSchema,
+});
+
+export const TriggerSchema = z.discriminatedUnion("kind", [
+  TriggerBaseSchema.extend({
+    kind: z.literal("schedule"),
+    configuration: ScheduleConfigSchema,
+  }),
+  TriggerBaseSchema.extend({
+    kind: z.literal("webhook"),
+    configuration: WebhookConfigSchema,
+    webhookSource: z
+      .object({ name: z.string(), provider: z.string() })
+      .nullable(),
+  }),
+]);
+export type TriggerType = z.infer<typeof TriggerSchema>;
+
+export const GetTriggersResponseSchema = z.object({
+  triggers: z.array(TriggerSchema),
+});
+export type GetTriggersResponseType = z.infer<typeof GetTriggersResponseSchema>;
+
+export const GetTriggerResponseSchema = z.object({
+  trigger: TriggerSchema,
+});
+export type GetTriggerResponseType = z.infer<typeof GetTriggerResponseSchema>;
+
 type OtherContentType = keyof typeof supportedOtherFileFormats;
 type ImageContentType = keyof typeof supportedImageFileFormats;
 type AudioContentType = keyof typeof supportedAudioFileFormats;


### PR DESCRIPTION
## Description

People asked for public API access to agent triggers. Adds admin-only, read-only `GET /w/{wId}/triggers` (list, filterable by kind/status/agent) and `GET /w/{wId}/triggers/{tId}`, mirroring the read access already granted on the automations page.

## Tests

Route tests cover the 403 for non-admin keys, default enabled-only filtering, kind filtering, and the webhookSource label enrichment.

## Risk

Low. New endpoints only, admin-gated, no writes.

## Deploy Plan

Deploy front-api.