### PR TITLE
[front] fix: keep generated text visible during inline activity

### DIFF
--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.test.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.test.tsx
@@ -74,6 +74,35 @@ const mockAgentMessage: LightAgentMessageType = {
 };
 
 describe("InlineActivitySteps", () => {
+  it.each([
+    "thinking",
+    "acting",
+  ] as const)("keeps the latest generated text visible while %s", (agentState) => {
+    render(
+      <InlineActivitySteps
+        agentMessage={mockAgentMessage}
+        lastAgentStateClassification={agentState}
+        completedSteps={[
+          {
+            type: "thinking",
+            content: "Historical reasoning step",
+            id: "thinking-1",
+          },
+        ]}
+        pendingToolCalls={[]}
+        owner={mockOwner}
+        isLastMessage
+      />
+    );
+
+    expect(screen.getByText("Live final answer")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: /Thinking/i }));
+
+    expect(screen.getByText("Historical reasoning step")).not.toBeVisible();
+    expect(screen.getByText("Live final answer")).toBeVisible();
+  });
+
   it("keeps the live answer visible when collapsing during writing", () => {
     render(
       <InlineActivitySteps

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -59,11 +59,6 @@ function getTerminalLabel(status: LightAgentMessageType["status"]): string {
  *
  * Steps are accumulated by useAgentMessageStream — this component is a pure render.
  */
-/**
- * @cc [owner:aubin-tchoi,label:product] preserve-active-message-content
- * Before completion, non-empty message content must remain visible outside the
- * collapsible activity section, including while thinking or executing tools.
- */
 export function InlineActivitySteps({
   agentMessage,
   lastAgentStateClassification,

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -159,7 +159,6 @@ export function InlineActivitySteps({
 
   const hasContent =
     completedSteps.length > 0 ||
-    !!agentMessage.content ||
     showActiveThinking ||
     showActiveWriting ||
     activeActions.length > 0 ||
@@ -209,7 +208,7 @@ export function InlineActivitySteps({
         <AgentMessageMarkdown
           content={agentMessage.content}
           owner={owner}
-          streamingState={isWriting ? "streaming" : "none"}
+          streamingState="streaming"
           isLastMessage={false}
         />
       </div>

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -59,6 +59,11 @@ function getTerminalLabel(status: LightAgentMessageType["status"]): string {
  *
  * Steps are accumulated by useAgentMessageStream — this component is a pure render.
  */
+/**
+ * @cc [owner:aubin-tchoi,label:product] preserve-active-message-content
+ * Before completion, non-empty message content must remain visible outside the
+ * collapsible activity section, including while thinking or executing tools.
+ */
 export function InlineActivitySteps({
   agentMessage,
   lastAgentStateClassification,
@@ -159,6 +164,7 @@ export function InlineActivitySteps({
 
   const hasContent =
     completedSteps.length > 0 ||
+    !!agentMessage.content ||
     showActiveThinking ||
     showActiveWriting ||
     activeActions.length > 0 ||
@@ -203,12 +209,12 @@ export function InlineActivitySteps({
       : undefined;
 
   const extraBelowCollapse =
-    showActiveWriting && agentMessage.content ? (
+    !isDone && agentMessage.content ? (
       <div className="mt-3">
         <AgentMessageMarkdown
           content={agentMessage.content}
           owner={owner}
-          streamingState="streaming"
+          streamingState={isWriting ? "streaming" : "none"}
           isLastMessage={false}
         />
       </div>


### PR DESCRIPTION
## Description

Context [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1788869543248569), trace [here](https://langfuse.dust.tt/project/cmi4ft2qm00061707q4a9azyc/traces?filter=metadata%3BstringObject%3BconversationId%3B%3D%3Bmw37Htt2hW&peek=93db2d263f53eb99fee408a4b7853aec&timestamp=2026-09-08T06%3A02%3A40.959Z&observation=40a51bfa22ed85ea).

We have an example where the final generation tokens just before a tool call (actually part of the same LLM output to be precise) are not displayed in a conversation where the agent is waiting for the user to answer a question.

This PR fixes that by keeping available content visible in that case.

## Tests

- Added a test.
- Tested locally + preview on the problematic convo

## Risk

- Low.

## Deploy Plan

- Deploy front.
