### PR TITLE
[front] fix: cap Poke message breakdown height

### DIFF
--- a/front/components/poke/conversation/message_consumption_inspector.tsx
+++ b/front/components/poke/conversation/message_consumption_inspector.tsx
@@ -337,11 +337,6 @@ interface PokeMessageConsumptionInspectorProps {
   workspaceId: string;
 }
 
-/**
- * @cc [owner:aubin-tchoi,label:react] bounded-message-consumption-panel
- * The panel height must stay below the viewport height, with a scrollable breakdown
- * and an always-visible header and close button.
- */
 export function PokeMessageConsumptionInspector({
   billedCredits,
   conversationId,

--- a/front/components/poke/conversation/message_consumption_inspector.tsx
+++ b/front/components/poke/conversation/message_consumption_inspector.tsx
@@ -337,6 +337,11 @@ interface PokeMessageConsumptionInspectorProps {
   workspaceId: string;
 }
 
+/**
+ * @cc [owner:aubin-tchoi,label:react] bounded-message-consumption-panel
+ * The panel height must stay below the viewport height, with a scrollable breakdown
+ * and an always-visible header and close button.
+ */
 export function PokeMessageConsumptionInspector({
   billedCredits,
   conversationId,
@@ -442,7 +447,7 @@ export function PokeMessageConsumptionInspector({
             role="region"
             aria-labelledby={triggerId}
             className={cn(
-              "z-10 overflow-clip rounded-xl border border-border bg-background",
+              "z-10 flex max-h-[calc(100dvh-2rem)] flex-col overflow-clip rounded-xl border border-border bg-background",
               "will-change-transform",
               "xl:absolute xl:left-[calc(100%+1.5rem)] xl:top-0 xl:w-[var(--poke-inspector-width)]"
             )}
@@ -452,10 +457,13 @@ export function PokeMessageConsumptionInspector({
             animate="open"
             exit={shouldReduceMotion ? undefined : "closed"}
           >
-            <div ref={handlePanelContentRef} className="rounded-[inherit]">
+            <div
+              ref={handlePanelContentRef}
+              className="flex min-h-0 flex-col rounded-[inherit]"
+            >
               <div
                 className={cn(
-                  "sticky top-0 z-10 flex min-h-14 items-center justify-between gap-3",
+                  "flex min-h-14 shrink-0 items-center justify-between gap-3",
                   "border-b border-border bg-background px-4 py-3"
                 )}
               >
@@ -485,7 +493,10 @@ export function PokeMessageConsumptionInspector({
                   <Icon visual={XClose} size="xs" />
                 </button>
               </div>
-              <div className="bg-muted-background">
+              <div
+                tabIndex={0}
+                className="min-h-0 overflow-y-auto overscroll-contain bg-muted-background"
+              >
                 {isConsumptionError ? (
                   <div className="flex flex-col gap-1 p-4">
                     <p


### PR DESCRIPTION
## Description

Long message consumption breakdowns in Poke can exceed the viewport (for instance when a large number of different tools were used within the same agent message), making some of the content not readable.

This PR caps the panel at the viewport height (minus some space) and scroll the breakdown.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
