### PR TITLE
company space: give Company Data its own member group

### DIFF
--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -3019,4 +3019,121 @@ describe("SpaceResource group_permissions enforcement", () => {
     // read on a space the caller just opened, in the same request.
     expect(adminAuth.getGrantedVerbs("space", space.id)).toContain("read");
   });
+
+  // The global space (Company Data): everyone reads it, and write comes from the admin/manager
+  // roles plus the members of its member group (see `spaceRoleGrants` / `spaceGroupRoles`).
+  describe("global space member group", () => {
+    it("is created with exactly one member group holding a `member` grant", async () => {
+      const globalSpace =
+        await SpaceResource.fetchWorkspaceGlobalSpace(adminAuth);
+
+      const autoGroups = await globalSpace.fetchRegularAutoGroups(adminAuth);
+      expect(autoGroups).toHaveLength(1);
+
+      const memberGroup = await globalSpace.fetchManualMemberGroup(adminAuth);
+      expect(memberGroup.sId).toBe(autoGroups[0].sId);
+
+      const globalGroupRes =
+        await GroupResource.fetchWorkspaceGlobalGroup(adminAuth);
+      expect(globalGroupRes.isOk()).toBe(true);
+      if (globalGroupRes.isErr()) {
+        return;
+      }
+
+      // The workspace global group reads (everyone can see Company Data); the member group reads
+      // and writes.
+      const grants = await globalSpace.fetchGrantReferences();
+      expect(
+        grants
+          .map((grant) => ({
+            groupId: grant.groupId,
+            grantType: grant.grantType,
+          }))
+          .sort((a, b) => a.groupId - b.groupId)
+      ).toEqual(
+        [
+          { groupId: globalGroupRes.value.id, grantType: "reader" },
+          { groupId: memberGroup.id, grantType: "member" },
+        ].sort((a, b) => a.groupId - b.groupId)
+      );
+    });
+
+    it("gives write to the users in its member group, and read-only to everyone else", async () => {
+      const globalSpace =
+        await SpaceResource.fetchWorkspaceGlobalSpace(adminAuth);
+      const memberGroup = await globalSpace.fetchManualMemberGroup(adminAuth);
+      await memberGroup.dangerouslyAddMember(adminAuth, {
+        user: memberUser.toJSON(),
+      });
+
+      const nonMemberUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, nonMemberUser, {
+        role: "user",
+      });
+
+      // Built after the membership exists so their snapshots include its grants.
+      const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        memberUser.sId,
+        workspace.sId
+      );
+      const nonMemberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        nonMemberUser.sId,
+        workspace.sId
+      );
+
+      expect(memberAuth.can("read", globalSpace)).toBe(true);
+      expect(memberAuth.can("write", globalSpace)).toBe(true);
+
+      expect(nonMemberAuth.can("read", globalSpace)).toBe(true);
+      expect(nonMemberAuth.can("write", globalSpace)).toBe(false);
+    });
+
+    it("creates the member group on a workspace that predates it, keeping workspace-wide read", async () => {
+      const globalSpace =
+        await SpaceResource.fetchWorkspaceGlobalSpace(adminAuth);
+      const globalGroupRes =
+        await GroupResource.fetchWorkspaceGlobalGroup(adminAuth);
+      expect(globalGroupRes.isOk()).toBe(true);
+      if (globalGroupRes.isErr()) {
+        return;
+      }
+
+      // Back to the pre-feature shape: only the workspace global group is attached.
+      const memberGroup = await globalSpace.fetchManualMemberGroup(adminAuth);
+      await globalSpace.writeGroupPermissions(adminAuth, {
+        members: [globalGroupRes.value],
+        editors: [],
+      });
+      const deleteRes = await memberGroup.delete(adminAuth);
+      expect(deleteRes.isOk()).toBe(true);
+      expect(await globalSpace.fetchRegularAutoGroups(adminAuth)).toEqual([]);
+
+      // What the backfill runs, twice: the second call is a no-op.
+      await globalSpace.ensureGlobalSpaceMemberGroup(adminAuth);
+      await globalSpace.ensureGlobalSpaceMemberGroup(adminAuth);
+
+      const repairedGroups =
+        await globalSpace.fetchRegularAutoGroups(adminAuth);
+      expect(repairedGroups).toHaveLength(1);
+
+      await repairedGroups[0].dangerouslyAddMember(adminAuth, {
+        user: memberUser.toJSON(),
+      });
+      const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        memberUser.sId,
+        workspace.sId
+      );
+      expect(memberAuth.can("write", globalSpace)).toBe(true);
+
+      // The workspace global group kept its `reader` grant through the rewrite.
+      const otherUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+      const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherUser.sId,
+        workspace.sId
+      );
+      expect(otherAuth.can("read", globalSpace)).toBe(true);
+      expect(otherAuth.can("write", globalSpace)).toBe(false);
+    });
+  });
 });

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -261,19 +261,28 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         transaction
       ));
 
-    const globalSpace =
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      existingSpaces.find((s) => s.isGlobal()) ||
-      (await SpaceResource.makeNew(
+    let globalSpace = existingSpaces.find((s) => s.isGlobal());
+    if (!globalSpace) {
+      // The global space is created with its own member group: that group's `member` grant is the
+      // only source of write on Company Data outside the admin/manager roles (see
+      // `spaceGroupRoles`).
+      const memberGroup = await SpaceResource.makeGlobalSpaceMemberGroup({
+        workspaceId: auth.getNonNullableWorkspace().id,
+        spaceName: GLOBAL_SPACE_NAME,
+        transaction,
+      });
+
+      globalSpace = await SpaceResource.makeNew(
         auth,
         {
           name: GLOBAL_SPACE_NAME,
           kind: "global",
           workspaceId: auth.getNonNullableWorkspace().id,
         },
-        { members: [globalGroup] },
+        { members: [globalGroup, memberGroup] },
         transaction
-      ));
+      );
+    }
 
     const conversationsSpace =
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -294,6 +303,31 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       globalSpace,
       conversationsSpace,
     };
+  }
+
+  /**
+   * @cc [owner:fabiencelier,label:security] global-space-member-group
+   * A workspace's global space must be created with exactly one `regular_auto` member group,
+   * created by this method: that group's `member` grant is the global space's only source of
+   * `write` outside the `admin` and `manager` (and legacy `builder`) workspace roles.
+   */
+  static async makeGlobalSpaceMemberGroup({
+    workspaceId,
+    spaceName,
+    transaction,
+  }: {
+    workspaceId: ModelId;
+    spaceName: string;
+    transaction?: Transaction;
+  }): Promise<GroupResource> {
+    return GroupResource.makeNew(
+      {
+        name: `${SPACE_GROUP_PREFIX} ${spaceName}`,
+        kind: "regular_auto",
+        workspaceId,
+      },
+      { transaction }
+    );
   }
 
   get sId(): string {
@@ -1953,6 +1987,49 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return memberGroups[0];
   }
 
+  // New workspaces get the group at creation (`makeDefaultsForWorkspace`); this is how the
+  // `20260908_backfill_global_space_member_group` migration gives it to the workspaces that
+  // predate it.
+  /**
+   * @cc [owner:fabiencelier,label:backend] ensure-global-space-member-group
+   * Idempotently gives the global space its `regular_auto` member group and that group's `member`
+   * grant, preserving the grants of the groups already attached to the space.
+   */
+  async ensureGlobalSpaceMemberGroup(
+    auth: Authenticator,
+    transaction?: Transaction
+  ): Promise<void> {
+    assert(this.isGlobal(), "Only the global space has a member group to fix.");
+
+    // One transaction for the whole repair: `writeGroupPermissions` clears the space's grants
+    // before re-inserting them, so a failure halfway through an autocommitted repair would leave
+    // Company Data with no `reader` grant (unreadable workspace-wide) and a committed, unusable
+    // group whose name makes every retry collide.
+    await withTransaction(async (t: Transaction) => {
+      const autoGroups = await this.fetchRegularAutoGroups(auth, t);
+      if (autoGroups.length > 0) {
+        return;
+      }
+
+      // The groups already granted on the space (the workspace global group), re-passed so their
+      // grants survive the rewrite.
+      const existingGroups = await this.fetchGroupResources(auth, {
+        transaction: t,
+      });
+      const memberGroup = await SpaceResource.makeGlobalSpaceMemberGroup({
+        workspaceId: this.workspaceId,
+        spaceName: this.name,
+        transaction: t,
+      });
+
+      await this.writeGroupPermissions(auth, {
+        members: [...existingGroups, memberGroup],
+        editors: [],
+        transaction: t,
+      });
+    }, transaction);
+  }
+
   /**
    * Check if the auth is a member of this space.
    */
@@ -2109,7 +2186,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
    *
    * 2. Global spaces:
    * - Read: All workspace members
-   * - Write: Workspace admins and builders
+   * - Write: Workspace admins and managers (legacy: builders), plus the members of the space's
+   *   member groups
    *
    * 3. Open spaces:
    * - Read: All workspace members
@@ -2184,8 +2262,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       }));
     }
 
-    // Global Workspace space and Conversations space: write comes from the role grants.
-    if (this.isGlobal() || this.isConversations()) {
+    // Conversations space: write comes from the role grants.
+    if (this.isConversations()) {
       return associatedGroups.map((group) => ({
         groupId: group.id,
         grantType: "reader",
@@ -2200,11 +2278,13 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     // A space is open when the workspace global group is one of its groups.
     const isOpen = associatedGroups.some((group) => group.isGlobal());
 
-    // Open regular space: the workspace global group is attached as a viewer, so it must only read
-    // — conferring write would hand write on every open space to every workspace member. Every
-    // other group is a member group and reads and writes, exactly as on a restricted space; that is
-    // what makes a space's member list meaningful even when the space is open.
-    if (this.isRegular() && isOpen) {
+    // The global space (Company Data), and an open regular space: the workspace global group is
+    // attached as a viewer, so it must only read — conferring write would hand write on every such
+    // space to every workspace member. Every other group is a member group and reads and writes,
+    // exactly as on a restricted space; that is what makes the space's member list meaningful even
+    // though everyone can read it, and on Company Data it is what lets an admin grant write to
+    // people who are neither admins nor managers.
+    if (this.isGlobal() || (this.isRegular() && isOpen)) {
       return groups.map((group) => ({
         groupId: group.id,
         grantType: group.isGlobal() ? "reader" : "member",

--- a/front/migrations/20260908_backfill_global_space_member_group.ts
+++ b/front/migrations/20260908_backfill_global_space_member_group.ts
@@ -1,0 +1,91 @@
+import { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+
+// Creates the missing member group of each workspace's global space (Company Data), so admins can
+// grant write on it to people who are neither admins nor managers (see
+// `SpaceResource.spaceGroupRoles`). Global spaces created before this feature only carry the
+// workspace global group's `reader` grant.
+//
+// The group is created empty: nobody gains write from the backfill, since write already comes from
+// the `admin` / `manager` / legacy `builder` roles.
+//
+// Idempotent: a global space that already has a `regular_auto` group is left untouched.
+async function backfillWorkspaceGlobalSpaceMemberGroup(
+  execute: boolean,
+  logger: Logger,
+  workspace: LightWorkspaceType
+): Promise<void> {
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  // A workspace with no global space at all is a pre-existing inconsistency this backfill must not
+  // turn into a failed run (`fetchWorkspaceGlobalSpace` throws).
+  let globalSpace: SpaceResource;
+  try {
+    globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+  } catch (err) {
+    logger.error(
+      { workspaceId: workspace.sId, error: normalizeError(err).message },
+      "Skipping workspace: no global space"
+    );
+    return;
+  }
+
+  const context = {
+    workspaceId: workspace.sId,
+    spaceId: globalSpace.sId,
+    spaceName: globalSpace.name,
+  };
+
+  const autoGroups = await globalSpace.fetchRegularAutoGroups(auth);
+  if (autoGroups.length > 0) {
+    logger.info(
+      { ...context, groupIds: autoGroups.map((group) => group.sId) },
+      "Global space already has a member group, skipping"
+    );
+    return;
+  }
+
+  if (!execute) {
+    logger.info(context, "Dry run: would create the global space member group");
+    return;
+  }
+
+  try {
+    await globalSpace.ensureGlobalSpaceMemberGroup(auth);
+    logger.info(context, "Created the global space member group");
+  } catch (err) {
+    // A name collision (a leftover group already named after the global space) is the one failure
+    // an operator has to resolve by hand; it is reported per workspace rather than aborting the run.
+    logger.error(
+      { ...context, error: normalizeError(err).message },
+      "Failed to create the global space member group"
+    );
+  }
+}
+
+makeScript(
+  {
+    wId: { type: "string", required: false },
+  },
+  async ({ wId, execute }, logger) => {
+    logger.info("Starting global space member group backfill");
+
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        await backfillWorkspaceGlobalSpaceMemberGroup(
+          execute,
+          logger,
+          workspace
+        );
+      },
+      { concurrency: 4, wId }
+    );
+
+    logger.info("Global space member group backfill completed");
+  }
+);

--- a/front/scripts/move_company_space_to_restricted.ts
+++ b/front/scripts/move_company_space_to_restricted.ts
@@ -86,6 +86,17 @@ makeScript(
     }
     const globalGroup = globalGroupRes.value;
 
+    // The global space's own member group, if it has one (see the member-group resolution in the
+    // transaction below).
+    const existingAutoGroups = await globalSpace.fetchRegularAutoGroups(auth);
+    if (existingAutoGroups.length > 1) {
+      scriptLogger.error(
+        { groupIds: existingAutoGroups.map((group) => group.sId) },
+        "The global space has more than one member group; resolve by hand."
+      );
+      return;
+    }
+
     // Count data source views in the current global space for summary.
     const dataSourceViews = await DataSourceViewModel.findAll({
       where: {
@@ -112,7 +123,9 @@ makeScript(
             `Rename global space "${globalSpace.name}" to "${spaceName}"`,
             `Change space kind from "global" to "regular"`,
             `Remove global group from the space`,
-            `Create member group "${SPACE_GROUP_PREFIX} ${spaceName}"`,
+            existingAutoGroups.length > 0
+              ? `Rename member group "${existingAutoGroups[0].name}" to "${SPACE_GROUP_PREFIX} ${spaceName}"`
+              : `Create member group "${SPACE_GROUP_PREFIX} ${spaceName}"`,
             `Link member group to the space`,
             ...(managementMode === "group" && groupIds
               ? [
@@ -120,7 +133,7 @@ makeScript(
                   `Set managementMode to "group"`,
                 ]
               : []),
-            `Create new empty global space "${GLOBAL_SPACE_NAME}"`,
+            `Create new empty global space "${GLOBAL_SPACE_NAME}" with its member group "${SPACE_GROUP_PREFIX} ${GLOBAL_SPACE_NAME}"`,
           ],
         },
         "DRY RUN — planned actions"
@@ -146,18 +159,37 @@ makeScript(
         "Renamed space / changed kind to 'regular'"
       );
 
-      // Create a member group for the restricted space.
-      const memberGroup = await GroupResource.makeNew(
-        {
-          name: `${SPACE_GROUP_PREFIX} ${spaceName}`,
-          kind: "regular_auto",
-          workspaceId: workspace.id,
-        },
-        { transaction: t }
-      );
+      // The member group of the restricted space. The old global space already owns one (created
+      // with the space, or by the `20260908_backfill_global_space_member_group` migration), named
+      // after the global space; it is renamed and reused rather than left behind, because creating
+      // a second `${SPACE_GROUP_PREFIX} ${GLOBAL_SPACE_NAME}` group for the new global space below
+      // would collide with it on the unique (workspaceId, name) group index.
+      const [existingMemberGroup] = existingAutoGroups;
+      const memberGroup =
+        existingMemberGroup ??
+        (await GroupResource.makeNew(
+          {
+            name: `${SPACE_GROUP_PREFIX} ${spaceName}`,
+            kind: "regular_auto",
+            workspaceId: workspace.id,
+          },
+          { transaction: t }
+        ));
+      if (existingMemberGroup) {
+        const renameRes = await memberGroup.dangerouslyUpdateName(
+          `${SPACE_GROUP_PREFIX} ${spaceName}`
+        );
+        if (renameRes.isErr()) {
+          throw renameRes.error;
+        }
+      }
       scriptLogger.info(
-        { groupId: memberGroup.sId, groupName: memberGroup.name },
-        "Created member group"
+        {
+          groupId: memberGroup.sId,
+          groupName: memberGroup.name,
+          reused: !!existingMemberGroup,
+        },
+        "Resolved member group"
       );
 
       const memberGroups: GroupResource[] = [memberGroup];
@@ -207,7 +239,14 @@ makeScript(
         "Rewrote space group_permissions for restricted access"
       );
 
-      // Create a new global space.
+      // Create a new global space, with its own member group (whose `member` grant is what confers
+      // write on the global space outside the admin/manager roles).
+      const newGlobalSpaceMemberGroup =
+        await SpaceResource.makeGlobalSpaceMemberGroup({
+          workspaceId: workspace.id,
+          spaceName: GLOBAL_SPACE_NAME,
+          transaction: t,
+        });
       const newGlobalSpace = await SpaceResource.makeNew(
         auth,
         {
@@ -215,7 +254,7 @@ makeScript(
           kind: "global",
           workspaceId: workspace.id,
         },
-        { members: [globalGroup] },
+        { members: [globalGroup, newGlobalSpaceMemberGroup] },
         t
       );
       scriptLogger.info(

--- a/front/tests/utils/SpaceFactory.ts
+++ b/front/tests/utils/SpaceFactory.ts
@@ -50,14 +50,22 @@ export class SpaceFactory {
     const group =
       globalGroup ?? (await GroupFactory.defaults(workspace)).globalGroup;
 
+    const name = "space " + faker.string.alphanumeric(8);
+    // Production also creates the global space's own member group, whose `member` grant is what
+    // confers write on it outside the admin/manager roles.
+    const memberGroup = await SpaceResource.makeGlobalSpaceMemberGroup({
+      workspaceId: workspace.id,
+      spaceName: name,
+    });
+
     return SpaceResource.makeNew(
       await this.internalAuth(workspace),
       {
-        name: "space " + faker.string.alphanumeric(8),
+        name,
         kind: "global",
         workspaceId: workspace.id,
       },
-      { members: [group] }
+      { members: [group, memberGroup] }
     );
   }
 


### PR DESCRIPTION
## Description

Give the company space (`Company Data`, the `global` space) a member list that decides who can modify its content. Today write on it comes only from the `admin` / `manager` / legacy `builder` workspace roles, because `spaceGroupRoles` grants `reader` to every group attached to the global space.

This PR makes room for that list, and nothing else:

- The global space is now granted like an open regular space: the workspace global group stays a viewer (`reader`, so everyone keeps reading Company Data) and every other attached group holds `member` (read + write).
- Every global space gets its own `regular_auto` member group: `makeDefaultsForWorkspace` creates it with the space, `ensureGlobalSpaceMemberGroup` is the idempotent repair the backfill uses for existing workspaces, and `SpaceFactory.global` matches production.

Nobody gains access: the group is created empty, and nothing can add members to it yet: `updatePermissions` / `addMembers` still reject the global space (that comes in PR 3).

## Tests

 - new unit tests

## Risk

Medium. Touches how the global space's grants are computed, which is the read path for every workspace's company data — but the only behavioral change is that a group attached to the global space would confer write, and the sole such group is created empty.

## Deploy Plan

- Deploy front
- Run the post-deploy migration `front/migrations/20260908_backfill_global_space_member_group.ts` (dry-run first, then `--execute`; `--wId` for a single workspace)