### PR TITLE
company space: let admins pick who can write to Company Data

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/members.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/members.test.ts
@@ -334,3 +334,131 @@ describe("PATCH /api/w/:wId/spaces/:spaceId/members", () => {
     );
   });
 });
+
+// The global space (Company Data) is readable by the whole workspace; its member list is the set of
+// people who may modify its content, on top of admins and managers.
+describe("global space members", () => {
+  // Whether `userId` may write to `space`, resolved from a freshly built Authenticator so the
+  // grants the request wrote are visible.
+  async function canWrite(
+    workspace: { sId: string },
+    space: SpaceResource,
+    userId: string
+  ): Promise<boolean> {
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      userId,
+      workspace.sId
+    );
+    const refreshed = await SpaceResource.fetchById(auth, space.sId);
+    expect(refreshed).not.toBeNull();
+    return auth.can("write", refreshed!);
+  }
+
+  it("adds an individual member through PATCH and gives them write", async () => {
+    const { workspace, globalSpace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const { agentOwner: member } = await setupAgentOwner(workspace, "user");
+
+    expect(await canWrite(workspace, globalSpace, member.sId)).toBe(false);
+
+    const response = await patchMembers(workspace, globalSpace.sId, {
+      isRestricted: false,
+      memberIds: [member.sId],
+    });
+
+    expect(response.status).toBe(200);
+    expect(await canWrite(workspace, globalSpace, member.sId)).toBe(true);
+  });
+
+  it("adds members by group through PATCH and gives them write", async () => {
+    const { workspace, auth, globalSpace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const { agentOwner: member } = await setupAgentOwner(workspace, "user");
+    const group = await GroupFactory.provisioned(workspace, "Data owners");
+    await GroupFactory.withMembers(auth, group, [member]);
+
+    const response = await patchMembers(workspace, globalSpace.sId, {
+      isRestricted: false,
+      groupIds: [group.sId],
+    });
+
+    expect(response.status).toBe(200);
+    expect(await canWrite(workspace, globalSpace, member.sId)).toBe(true);
+  });
+
+  it("takes individual members and groups in the same PATCH", async () => {
+    const { workspace, auth, globalSpace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const { agentOwner: member } = await setupAgentOwner(workspace, "user");
+    const { agentOwner: groupMember } = await setupAgentOwner(
+      workspace,
+      "user"
+    );
+    const group = await GroupFactory.provisioned(workspace, "Data owners");
+    await GroupFactory.withMembers(auth, group, [groupMember]);
+
+    const response = await patchMembers(workspace, globalSpace.sId, {
+      isRestricted: false,
+      memberIds: [member.sId],
+      groupIds: [group.sId],
+    });
+
+    expect(response.status).toBe(200);
+    expect(await canWrite(workspace, globalSpace, member.sId)).toBe(true);
+    expect(await canWrite(workspace, globalSpace, groupMember.sId)).toBe(true);
+  });
+
+  it("adds an individual member through POST without replacing the list", async () => {
+    const { workspace, auth, globalSpace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const { agentOwner: existingMember } = await setupAgentOwner(
+      workspace,
+      "user"
+    );
+    const { agentOwner: newMember } = await setupAgentOwner(workspace, "user");
+    await globalSpace.addMembers(auth, { userIds: [existingMember.sId] });
+
+    const response = await postMembers(workspace, globalSpace.sId, {
+      memberIds: [newMember.sId],
+    });
+
+    expect(response.status).toBe(200);
+
+    const members =
+      await globalSpace.fetchDistinctActiveManualGroupMembers(auth);
+    expect(new Set(members.map((m) => m.sId))).toEqual(
+      new Set([existingMember.sId, newMember.sId])
+    );
+    expect(await canWrite(workspace, globalSpace, newMember.sId)).toBe(true);
+  });
+
+  it("rejects restricting the global space", async () => {
+    const { workspace, globalSpace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+
+    const response = await patchMembers(workspace, globalSpace.sId, {
+      isRestricted: true,
+      memberIds: [],
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects non-admins", async () => {
+    const { workspace, user, globalSpace } = await createPrivateApiMockRequest({
+      role: "builder",
+    });
+
+    const response = await patchMembers(workspace, globalSpace.sId, {
+      isRestricted: false,
+      memberIds: [user.sId],
+    });
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/members.ts
@@ -28,18 +28,21 @@ export type {
 // Mounted at /api/w/:wId/spaces/:spaceId/members.
 const app = workspaceApp();
 
-// Members can only be administrated on regular spaces and projects, by their administrators.
+// Members can only be administrated on regular spaces, projects and the global space, by their
+// administrators. On the global space the member list is the write list: everyone reads it, and its
+// members are the people allowed to modify its content (see `SpaceResource.spaceRoleGrants`).
 function membersAdministrationError(
   ctx: Context,
   auth: Authenticator,
   space: SpaceResource
 ) {
-  if (!space.isRegular() && !space.isProject()) {
+  if (!space.isRegular() && !space.isProject() && !space.isGlobal()) {
     return apiError(ctx, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Only projects and regular spaces can have members.",
+        message:
+          "Only projects, regular spaces and the global space can have members.",
       },
     });
   }
@@ -66,7 +69,8 @@ type MembersMutationErrorCode =
   | "invalid_id"
   | "group_requirements_not_met"
   | "invalid_group_kind"
-  | "system_or_global_group";
+  | "system_or_global_group"
+  | "invalid_request_error";
 
 // Maps the error codes of the space membership mutations to API errors. POST only produces a
 // subset of PATCH's codes; both go through the same mapping.
@@ -146,6 +150,14 @@ function membersMutationError(ctx: Context, code: MembersMutationErrorCode) {
           type: "invalid_request_error",
           message:
             "Users cannot be added to or removed from system or global groups.",
+        },
+      });
+    case "invalid_request_error":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "The requested space permissions are not supported.",
         },
       });
     default:

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -2824,6 +2824,155 @@ describe("SpaceResource group_permissions enforcement", () => {
     expect(adminAuth.getGrantedVerbs("space", space.id)).toContain("read");
   });
 
+  // The company space's member list is administrated like any other space's, except that it can
+  // never be restricted: everyone reads Company Data, and its members are the people allowed to
+  // modify it.
+  describe("global space administration", () => {
+    const fetchGlobalSpace = async (auth: Authenticator) =>
+      SpaceResource.fetchWorkspaceGlobalSpace(auth);
+
+    // Whether `user` may write to the global space, from a freshly built Authenticator so the
+    // grants the update wrote are visible.
+    const canWrite = async (user: UserResource) => {
+      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+      return userAuth.can("write", await fetchGlobalSpace(adminAuth));
+    };
+
+    it("gives write to its members and read-only to everyone else", async () => {
+      const nonMemberUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, nonMemberUser, {
+        role: "user",
+      });
+
+      const globalSpace = await fetchGlobalSpace(adminAuth);
+      const res = await globalSpace.updatePermissions(adminAuth, {
+        isRestricted: false,
+        memberIds: [memberUser.sId],
+      });
+      expect(res.isOk()).toBe(true);
+
+      expect(await canWrite(memberUser)).toBe(true);
+      expect(await canWrite(nonMemberUser)).toBe(false);
+
+      const nonMemberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        nonMemberUser.sId,
+        workspace.sId
+      );
+      const refreshed = await fetchGlobalSpace(adminAuth);
+      expect(nonMemberAuth.can("read", refreshed)).toBe(true);
+      expect(await refreshed.isRestricted(adminAuth)).toBe(false);
+    });
+
+    it("takes individual members and groups at once", async () => {
+      const groupUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, groupUser, { role: "user" });
+      const provisionedGroup = await GroupFactory.provisioned(
+        workspace,
+        "Company Data editors"
+      );
+      await GroupFactory.withMembers(adminAuth, provisionedGroup, [groupUser]);
+
+      const globalSpace = await fetchGlobalSpace(adminAuth);
+      const res = await globalSpace.updatePermissions(adminAuth, {
+        isRestricted: false,
+        memberIds: [memberUser.sId],
+        groupIds: [provisionedGroup.sId],
+      });
+      expect(res.isOk()).toBe(true);
+
+      expect(await canWrite(memberUser)).toBe(true);
+      expect(await canWrite(groupUser)).toBe(true);
+
+      // Both dimensions are cleared by an update that leaves them out; read survives.
+      const clearRes = await (
+        await fetchGlobalSpace(adminAuth)
+      ).updatePermissions(adminAuth, { isRestricted: false });
+      expect(clearRes.isOk()).toBe(true);
+
+      expect(await canWrite(memberUser)).toBe(false);
+      expect(await canWrite(groupUser)).toBe(false);
+
+      const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        memberUser.sId,
+        workspace.sId
+      );
+      expect(memberAuth.can("read", await fetchGlobalSpace(adminAuth))).toBe(
+        true
+      );
+    });
+
+    it("adds and removes members without replacing the whole list", async () => {
+      const otherUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+
+      const globalSpace = await fetchGlobalSpace(adminAuth);
+      expect(
+        (
+          await globalSpace.addMembers(adminAuth, { userIds: [memberUser.sId] })
+        ).isOk()
+      ).toBe(true);
+      expect(
+        (
+          await globalSpace.addMembers(adminAuth, { userIds: [otherUser.sId] })
+        ).isOk()
+      ).toBe(true);
+
+      const members =
+        await globalSpace.fetchDistinctActiveManualGroupMembers(adminAuth);
+      expect(new Set(members.map((member) => member.sId))).toEqual(
+        new Set([memberUser.sId, otherUser.sId])
+      );
+      expect(await canWrite(otherUser)).toBe(true);
+
+      const removeRes = await globalSpace.removeMembers(adminAuth, {
+        userIds: [otherUser.sId],
+      });
+      expect(removeRes.isOk()).toBe(true);
+
+      const remaining =
+        await globalSpace.fetchDistinctActiveManualGroupMembers(adminAuth);
+      expect(remaining.map((member) => member.sId)).toEqual([memberUser.sId]);
+      expect(await canWrite(otherUser)).toBe(false);
+    });
+
+    it("cannot be restricted", async () => {
+      const globalSpace = await fetchGlobalSpace(adminAuth);
+      const res = await globalSpace.updatePermissions(adminAuth, {
+        isRestricted: true,
+        memberIds: [memberUser.sId],
+      });
+      expect(res.isErr()).toBe(true);
+      if (res.isErr()) {
+        expect(res.error.code).toBe("invalid_request_error");
+      }
+
+      // Still readable workspace-wide: the global group kept its `reader` grant.
+      const refreshed = await fetchGlobalSpace(adminAuth);
+      expect(await refreshed.isRestricted(adminAuth)).toBe(false);
+      const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        memberUser.sId,
+        workspace.sId
+      );
+      expect(memberAuth.can("read", refreshed)).toBe(true);
+    });
+
+    it("keeps write for admins whatever its member list holds", async () => {
+      const globalSpace = await fetchGlobalSpace(adminAuth);
+      const res = await globalSpace.updatePermissions(adminAuth, {
+        isRestricted: false,
+        memberIds: [],
+      });
+      expect(res.isOk()).toBe(true);
+
+      const refreshed = await fetchGlobalSpace(adminAuth);
+      expect(adminAuth.can("write", refreshed)).toBe(true);
+      expect(adminAuth.can("admin", refreshed)).toBe(true);
+    });
+  });
+
   // The global space (Company Data): everyone reads it, and write comes from the admin/manager
   // roles plus the members of its member group (see `spaceRoleGrants` / `spaceGroupRoles`).
   describe("global space member group", () => {

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1112,6 +1112,12 @@ export class SpaceResource extends BaseResource<SpaceModel> {
    * `params` is the space's whole desired membership: `memberIds`, `editorIds`, `groupIds` and
    * `editorGroupIds` are each overwritten, and a dimension `params` leaves out is emptied.
    */
+  /**
+   * @cc [owner:fabiencelier,label:security] global-space-permissions-update
+   * On the global space, this must reject `isRestricted: true` with `invalid_request_error` and
+   * keep the workspace global group's `reader` grant: Company Data is always readable by the whole
+   * workspace, and only the selected members and groups gain `write`.
+   */
   async updatePermissions(
     auth: Authenticator,
     params: {
@@ -1130,6 +1136,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         | "invalid_group_kind"
         | "system_or_global_group"
         | "invalid_id"
+        | "invalid_request_error"
       >
     >
   > {
@@ -1142,17 +1149,28 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       );
     }
 
-    if (!this.isRegular() && !this.isProject()) {
+    if (!this.isRegular() && !this.isProject() && !this.isGlobal()) {
       return new Err(
         new DustError(
           "unauthorized",
-          "Only projects and regular spaces can have members."
+          "Only projects, regular spaces and the global space can have members."
         )
       );
     }
 
     // The request is the space's whole desired membership: a dimension it leaves out is emptied.
     const { isRestricted, memberIds = [], editorIds = [] } = params;
+
+    // The global space is readable by the whole workspace by construction: its members are the
+    // people allowed to write to it, not the people allowed to see it.
+    if (this.isGlobal() && isRestricted) {
+      return new Err(
+        new DustError(
+          "invalid_request_error",
+          "The global space cannot be restricted."
+        )
+      );
+    }
 
     const groupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
     if (groupRes.isErr()) {
@@ -1178,8 +1196,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       const { memberGroups, editorGroups } = requestedGroupsRes.value;
 
       // The space is open (unrestricted) exactly when the workspace global group is one of its
-      // groups: it is simply included in `members` iff the space is (becoming) open.
-      const willBeOpen = !isRestricted;
+      // groups: it is simply included in `members` iff the space is (becoming) open. The global
+      // space is always open — that grant is what makes Company Data readable workspace-wide.
+      const willBeOpen = this.isGlobal() || !isRestricted;
 
       // The space's own groups always hold its manual members, alongside the attached groups.
       const memberGroup = await this.fetchManualMemberGroup(auth, t);
@@ -1325,8 +1344,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     }
 
     assert(
-      this.isRegular() || this.isProject(),
-      "Only regular spaces and projects can have manual members."
+      this.isRegular() || this.isProject() || this.isGlobal(),
+      "Only regular spaces, projects and the global space can have manual members."
     );
 
     const users = await UserResource.fetchByIds(userIds);


### PR DESCRIPTION
## Description

Backend change to allow admin to pick members of the global space.

Company Data now has a member list, administrated like any other open space's: the people picked individually plus the members of the groups given access can modify its content (upload files, delete documents, connect data sources) on top of admins and managers.

- `updatePermissions`, `addMembers` and `removeMembers` accept the global space, and the members endpoint administrates it.
- `isRestricted: true` on the global space is refused (`invalid_request_error` → 400): read on Company Data is workspace-wide by construction, and the supported way to lock company data down is `move_company_space_to_restricted.ts`, which demotes the old global space to a restricted regular space and swaps in a fresh, empty Company Data.

## Tests
 - new test on endpoints and resource

## Risk

**High: it is a permission path.**
What it opens is narrow: a workspace admin can grant `write` (never `admin`) on the global space, to people who could already read it, and it reuses the grant model of open regular spaces rather than adding one. Read on Company Data cannot be revoked through this path: the global group's `reader` grant is always kept, and restricting it is refused. Easy to revert (the grants are rewritten from the space's group set on the next update).

## Deploy Plan

- Deploy front