### PR TITLE
company space: space settings sheet for Company Data

### DIFF
--- a/front/components/pages/spaces/SpacePage.tsx
+++ b/front/components/pages/spaces/SpacePage.tsx
@@ -1,4 +1,5 @@
 import { CreateOrEditSpaceModal } from "@app/components/spaces/CreateOrEditSpaceModal";
+import { GlobalSpaceSettingsModal } from "@app/components/spaces/GlobalSpaceSettingsModal";
 import { SpaceCategoriesList } from "@app/components/spaces/SpaceCategoriesList";
 import { SpaceSearchInput } from "@app/components/spaces/SpaceSearchLayout";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
@@ -76,13 +77,26 @@ export function SpacePage() {
           isAdmin={isAdmin}
           onButtonClick={() => setShowSpaceEditionModal(true)}
         />
-        <CreateOrEditSpaceModal
-          owner={owner}
-          isOpen={showSpaceEditionModal}
-          onClose={() => setShowSpaceEditionModal(false)}
-          space={space}
-          isAdmin={isAdmin}
-        />
+        {/* The global space's settings are admin-only, and it is the admin-only "Space settings"
+            button that opens them, so the panel is not mounted for anyone else. */}
+        {space.kind === "global" ? (
+          isAdmin && (
+            <GlobalSpaceSettingsModal
+              owner={owner}
+              isOpen={showSpaceEditionModal}
+              onClose={() => setShowSpaceEditionModal(false)}
+              space={space}
+            />
+          )
+        ) : (
+          <CreateOrEditSpaceModal
+            owner={owner}
+            isOpen={showSpaceEditionModal}
+            onClose={() => setShowSpaceEditionModal(false)}
+            space={space}
+            isAdmin={isAdmin}
+          />
+        )}
       </Page.Vertical>
     </SpaceSearchInput>
   );

--- a/front/components/spaces/GlobalSpaceSettingsModal.tsx
+++ b/front/components/spaces/GlobalSpaceSettingsModal.tsx
@@ -1,0 +1,206 @@
+import { RestrictedAccessBody } from "@app/components/spaces/RestrictedAccessBody";
+import { getSpaceName } from "@app/lib/spaces";
+import { useGroups } from "@app/lib/swr/groups";
+import { useSpaceInfo, useUpdateSpace } from "@app/lib/swr/spaces";
+import type { GroupType } from "@app/types/groups";
+import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
+import type { SpaceType } from "@app/types/space";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  ContentMessage,
+  Page,
+  Sheet,
+  SheetContainer,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface GlobalSpaceSettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  owner: LightWorkspaceType;
+  space: SpaceType;
+}
+
+/**
+ * Settings of the company space (the `global` space): its name is fixed and it cannot be deleted,
+ * so the only thing to configure is who may write to it. Everyone in the workspace reads it; its
+ * members — the people picked here plus the members of the groups picked here — are the ones
+ * allowed to modify its content, on top of admins and managers.
+ */
+export function GlobalSpaceSettingsModal({
+  isOpen,
+  onClose,
+  owner,
+  space,
+}: GlobalSpaceSettingsModalProps) {
+  // The member selection is held as ids, not as user objects: the ids are what the save sends, so
+  // a member can never drop out of the space because the UI failed to resolve their user object.
+  const [selectedMemberIds, setSelectedMemberIds] = useState<Set<string>>(
+    () => new Set()
+  );
+  const [selectedGroups, setSelectedGroups] = useState<GroupType[]>([]);
+  const [isDirty, setIsDirty] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const doUpdate = useUpdateSpace({ owner });
+
+  // Both hooks are held back while the panel is closed: it stays mounted on the space page, and
+  // neither the member list nor the workspace groups are needed until an admin opens it.
+  const { spaceInfo, mutateSpaceInfo, isSpaceInfoLoading, isSpaceInfoError } =
+    useSpaceInfo({
+      workspaceId: owner.sId,
+      spaceId: space.sId,
+      includeAllMembers: true, // Include members whose membership is not active yet.
+      disabled: !isOpen,
+    });
+
+  const { groups, isGroupsLoading, isGroupsError } = useGroups({
+    owner,
+    kinds: MANAGEABLE_GROUP_KINDS,
+    disabled: !isOpen,
+  });
+
+  // A save carries the space's whole membership, both lists at once, so the sheet must not open on
+  // half of it: `useSpaceInfo` seeds the selected members and groups, and `useGroups` names the
+  // groups that can be picked. Either one still loading and a save would write an empty list.
+  const isAccessLoading = isSpaceInfoLoading || isGroupsLoading;
+
+  // Either one failing blocks the save outright, for the same reason: the sheet cannot send a
+  // membership it does not know.
+  const isAccessUnavailable = !!isSpaceInfoError || isGroupsError;
+
+  // Seeded once per opening: `spaceInfo` is revalidated by SWR while the panel is open, and
+  // re-seeding on every revalidation would discard the admin's pending edits.
+  const hasSeededRef = useRef(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      hasSeededRef.current = false;
+      return;
+    }
+    // Nothing is seeded until the space's current access is known: seeding an empty selection from
+    // a failed or pending fetch would let a save replace the whole member list with a partial one.
+    if (hasSeededRef.current || isAccessLoading || !spaceInfo) {
+      return;
+    }
+    hasSeededRef.current = true;
+
+    setSelectedMemberIds(
+      new Set(spaceInfo.members.map((member) => member.sId))
+    );
+    setSelectedGroups(
+      groups.filter((group) => spaceInfo.groupIds.includes(group.sId))
+    );
+    setIsDirty(false);
+  }, [groups, isAccessLoading, isOpen, spaceInfo]);
+
+  const handleClose = useCallback(() => {
+    onClose();
+    setIsDirty(false);
+    setIsSaving(false);
+  }, [onClose]);
+
+  const onSave = useCallback(async () => {
+    setIsSaving(true);
+
+    // Both lists are always sent: the space's members are the manual list plus the members of the
+    // groups given access to it, and the request describes the whole membership.
+    await doUpdate(space, {
+      // The company space is readable by the whole workspace and can never be restricted.
+      isRestricted: false,
+      memberIds: Array.from(selectedMemberIds),
+      groupIds: selectedGroups.map((group) => group.sId),
+    });
+
+    await mutateSpaceInfo();
+    handleClose();
+  }, [
+    doUpdate,
+    handleClose,
+    mutateSpaceInfo,
+    selectedGroups,
+    selectedMemberIds,
+    space,
+  ]);
+
+  const spaceName = getSpaceName(space);
+
+  return (
+    <Sheet open={isOpen} onOpenChange={handleClose}>
+      <SheetContent trapFocusScope={false} size="lg">
+        <SheetHeader>
+          <SheetTitle>Space Settings - {spaceName}</SheetTitle>
+        </SheetHeader>
+        <SheetContainer>
+          <div className="flex w-full flex-col gap-y-4">
+            <Page.SectionHeader title="Access" />
+            {/* Separate lines rather than one `description`: read access, write access and where
+                the members come from are three statements, as in `RestrictedAccessHeader`. */}
+            <div className="flex flex-col gap-y-1">
+              <span>
+                {spaceName} is the space where you upload and connect the data
+                the whole company has access to, so anyone in the workspace can
+                read this data.
+              </span>
+              <span>
+                Only admins, managers and the people selected here can modify
+                the data (upload files, delete documents, connect data
+                sources...).
+              </span>
+              <span>
+                They are the people picked below, plus everyone in the groups
+                given access to the space.
+              </span>
+            </div>
+
+            {isAccessLoading ? (
+              <div className="flex justify-center p-8">
+                <Spinner />
+              </div>
+            ) : isAccessUnavailable ? (
+              <ContentMessage
+                variant="warning"
+                title="Access settings unavailable"
+              >
+                Failed to load group members, please reload the page.
+              </ContentMessage>
+            ) : (
+              <RestrictedAccessBody
+                owner={owner}
+                selectedMemberIds={selectedMemberIds}
+                selectedGroups={selectedGroups}
+                onMemberIdsUpdated={(memberIds) => {
+                  setSelectedMemberIds(memberIds);
+                  setIsDirty(true);
+                }}
+                onGroupsUpdated={(updatedGroups) => {
+                  setSelectedGroups(updatedGroups);
+                  setIsDirty(true);
+                }}
+                initialMembers={spaceInfo?.members}
+              />
+            )}
+          </div>
+        </SheetContainer>
+        <SheetFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            label: isSaving ? "Saving..." : "Save",
+            onClick: onSave,
+            disabled:
+              !isDirty || isSaving || isAccessLoading || isAccessUnavailable,
+          }}
+        />
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/front/components/spaces/SpaceCategoriesList.tsx
+++ b/front/components/spaces/SpaceCategoriesList.tsx
@@ -152,14 +152,16 @@ export const SpaceCategoriesList = ({
 
   const actionButtons = (
     <>
-      {isAdmin && onButtonClick && space.kind === "regular" && (
-        <Button
-          label="Space settings"
-          icon={Settings01}
-          onClick={onButtonClick}
-          variant="outline"
-        />
-      )}
+      {isAdmin &&
+        onButtonClick &&
+        (space.kind === "regular" || space.kind === "global") && (
+          <Button
+            label="Space settings"
+            icon={Settings01}
+            onClick={onButtonClick}
+            variant="outline"
+          />
+        )}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button label="Add data" icon={Plus} />


### PR DESCRIPTION
## Description

Adds the "Space settings" button and sheet to the company space, so an admin can pick who may modify its content.

The sheet reuses the members/groups tables of the regular space sheet and drops what does not apply to Company Data — no name field and no delete button (it cannot be renamed or deleted), no restricted-access toggle (everyone reads it).

A save sends the whole membership (`memberIds` + `groupIds`, `isRestricted: false`) and no name.

<img width="3204" height="1002" alt="image" src="https://github.com/user-attachments/assets/9d5653af-d485-4149-8e86-9008ac3ddd75" />

<img width="3188" height="1856" alt="image" src="https://github.com/user-attachments/assets/fad2f5a6-0bc7-40c0-8047-bf3774836bd7" />


## Tests

 - tested manually

## Risk

Low. Admin-only UI, no new endpoint, easy to revert.

## Deploy Plan

- Deploy front