### PR TITLE
[front] enh: reveal truncated tool names in message breakdown

### DIFF
--- a/front/components/assistant/conversation/CreditCostPopover.test.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.test.tsx
@@ -2,7 +2,7 @@ import { CreditCostPopover } from "@app/components/assistant/conversation/Credit
 import type { AgentMessageConsumptionToolDetails } from "@app/types/assistant/agent_message_consumption";
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ComponentProps, ReactNode } from "react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockOpenPanel,
@@ -115,21 +115,10 @@ const defaultProps: ComponentProps<typeof CreditCostPopover> = {
 
 describe("CreditCostPopover", () => {
   beforeEach(() => {
-    vi.stubGlobal(
-      "ResizeObserver",
-      class {
-        observe() {}
-        disconnect() {}
-      }
-    );
     mockOpenPanel.mockReset();
     mockSidePanelContext.currentPanel = undefined;
     mockTrackEvent.mockReset();
     mockUseAgentMessageConsumption.mockReset();
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
   });
 
   it("shows the tool breakdown and opens credit usage", () => {

--- a/front/components/assistant/conversation/CreditCostPopover.test.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.test.tsx
@@ -2,7 +2,7 @@ import { CreditCostPopover } from "@app/components/assistant/conversation/Credit
 import type { AgentMessageConsumptionToolDetails } from "@app/types/assistant/agent_message_consumption";
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ComponentProps, ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockOpenPanel,
@@ -53,36 +53,40 @@ vi.mock("@app/components/resources/resources_icons", () => ({
   },
 }));
 
-vi.mock("@dust-tt/sparkle", () => ({
-  ShapesPlus: () => null,
-  Button: ({ label, onClick }: { label: string; onClick: () => void }) => (
-    <button type="button" onClick={onClick}>
-      {label}
-    </button>
-  ),
-  Chip: ({ label }: { label: string }) => <span>{label}</span>,
-  Icon: () => null,
-  Plus: () => null,
-  PopoverRoot: ({
-    children,
-    onOpenChange,
-  }: {
-    children: ReactNode;
-    onOpenChange?: (open: boolean) => void;
-  }) => (
-    <div>
-      <button type="button" onClick={() => onOpenChange?.(true)}>
-        Open credit details
+vi.mock("@dust-tt/sparkle", async (importOriginal) => {
+  const { cn } = await importOriginal<typeof import("@dust-tt/sparkle")>();
+  return {
+    cn,
+    ShapesPlus: () => null,
+    Button: ({ label, onClick }: { label: string; onClick: () => void }) => (
+      <button type="button" onClick={onClick}>
+        {label}
       </button>
-      {children}
-    </div>
-  ),
-  PopoverContent: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  PopoverTrigger: ({ children }: { children: ReactNode }) => children,
-  Tooltip: ({ trigger }: { trigger: ReactNode }) => trigger,
-}));
+    ),
+    Chip: ({ label }: { label: string }) => <span>{label}</span>,
+    Icon: () => null,
+    Plus: () => null,
+    PopoverRoot: ({
+      children,
+      onOpenChange,
+    }: {
+      children: ReactNode;
+      onOpenChange?: (open: boolean) => void;
+    }) => (
+      <div>
+        <button type="button" onClick={() => onOpenChange?.(true)}>
+          Open credit details
+        </button>
+        {children}
+      </div>
+    ),
+    PopoverContent: ({ children }: { children: ReactNode }) => (
+      <div>{children}</div>
+    ),
+    PopoverTrigger: ({ children }: { children: ReactNode }) => children,
+    Tooltip: ({ trigger }: { trigger: ReactNode }) => trigger,
+  };
+});
 
 const makeTool = (
   toolName: string,
@@ -111,10 +115,21 @@ const defaultProps: ComponentProps<typeof CreditCostPopover> = {
 
 describe("CreditCostPopover", () => {
   beforeEach(() => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      }
+    );
     mockOpenPanel.mockReset();
     mockSidePanelContext.currentPanel = undefined;
     mockTrackEvent.mockReset();
     mockUseAgentMessageConsumption.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("shows the tool breakdown and opens credit usage", () => {

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -65,10 +65,9 @@ function CreditDetailRow({
           labelElement &&
           labelElement.scrollWidth > labelElement.clientWidth
         ) {
-          const labelBounds = labelElement.getBoundingClientRect();
           labelElement.style.setProperty(
             "--credit-label-collapsed-width",
-            `${labelBounds.width}px`
+            `${labelElement.clientWidth}px`
           );
           setIsLabelExpanded(true);
         }

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -74,51 +74,54 @@ function CreditDetailRow({
       }}
       onPointerLeave={() => setIsLabelExpanded(false)}
     >
-      <dt className="col-start-1 row-start-1 flex min-w-0 items-center gap-2 font-medium text-foreground">
-        {icon && (
-          <Icon
-            visual={icon}
-            size="xs"
-            className="mt-0.5 shrink-0 self-start text-muted-foreground"
-          />
-        )}
-        <span
-          ref={labelRef}
-          className={classNames(
-            "truncate",
-            isLabelExpanded && "relative z-10 bg-overlay-background shadow-none"
+      <dt className="col-span-2 col-start-1 row-start-1 grid min-w-0 grid-cols-subgrid items-start font-medium text-foreground">
+        <span className="col-start-1 row-start-1 flex min-w-0 items-center gap-2">
+          {icon && (
+            <Icon
+              visual={icon}
+              size="xs"
+              className="mt-0.5 shrink-0 self-start text-muted-foreground"
+            />
           )}
-          style={{ textOverflow: isLabelExpanded ? "clip" : undefined }}
-        >
-          {label}
-        </span>
-        {description && (
           <span
-            aria-hidden={isLabelExpanded}
+            ref={labelRef}
             className={classNames(
-              "flex shrink-0",
-              isLabelExpanded && "invisible"
+              "truncate",
+              isLabelExpanded &&
+                "relative z-10 bg-overlay-background shadow-none"
+            )}
+            style={{ textOverflow: isLabelExpanded ? "clip" : undefined }}
+          >
+            {label}
+          </span>
+          {description && (
+            <span
+              aria-hidden={isLabelExpanded}
+              className={classNames(
+                "flex shrink-0",
+                isLabelExpanded && "invisible"
+              )}
+            >
+              <Chip
+                size="mini"
+                label={description}
+                className="shrink-0 font-normal"
+              />
+            </span>
+          )}
+        </span>
+        {isLabelExpanded && (
+          <span
+            aria-hidden
+            className={classNames(
+              "pointer-events-none col-span-2 col-start-1 row-start-1 min-w-0 justify-self-start break-all animate-credit-label-reveal select-none motion-reduce:animate-none",
+              icon ? "ml-6" : ""
             )}
           >
-            <Chip
-              size="mini"
-              label={description}
-              className="shrink-0 font-normal"
-            />
+            {label}
           </span>
         )}
       </dt>
-      {isLabelExpanded && (
-        <dt
-          aria-hidden
-          className={classNames(
-            "pointer-events-none col-span-2 col-start-1 row-start-1 min-w-0 justify-self-start break-all font-medium text-foreground animate-credit-label-reveal select-none motion-reduce:animate-none",
-            icon ? "ml-6" : ""
-          )}
-        >
-          {label}
-        </dt>
-      )}
       <dd
         aria-hidden={isLabelExpanded}
         className={classNames(

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -80,7 +80,7 @@ function CreditDetailRow({
             <Icon
               visual={icon}
               size="xs"
-              className="mt-0.5 shrink-0 self-start text-muted-foreground"
+              className="shrink-0 text-muted-foreground"
             />
           )}
           <span
@@ -88,26 +88,20 @@ function CreditDetailRow({
             className={classNames(
               "truncate",
               isLabelExpanded &&
-                "relative z-10 bg-overlay-background shadow-none"
+                "relative z-10 text-clip bg-overlay-background shadow-none"
             )}
-            style={{ textOverflow: isLabelExpanded ? "clip" : undefined }}
           >
             {label}
           </span>
           {description && (
-            <span
-              aria-hidden={isLabelExpanded}
+            <Chip
+              size="mini"
+              label={description}
               className={classNames(
-                "flex shrink-0",
+                "shrink-0 font-normal",
                 isLabelExpanded && "invisible"
               )}
-            >
-              <Chip
-                size="mini"
-                label={description}
-                className="shrink-0 font-normal"
-              />
-            </span>
+            />
           )}
         </span>
         {isLabelExpanded && (
@@ -123,7 +117,6 @@ function CreditDetailRow({
         )}
       </dt>
       <dd
-        aria-hidden={isLabelExpanded}
         className={classNames(
           "col-start-2 row-start-1 shrink-0 text-muted-foreground",
           isLabelExpanded && "invisible"

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -89,7 +89,7 @@ function CreditDetailRow({
       }}
       onPointerLeave={() => setIsLabelExpanded(false)}
     >
-      {/* Two spans keep the prefix fixed while the full name reveals underneath. */}
+      {/* Two spans keep the prefix fixed, then put the full name on top for selection. */}
       <dt
         className={cn(
           "col-span-2 col-start-1 row-start-1",
@@ -105,7 +105,9 @@ function CreditDetailRow({
             ref={labelRef}
             className={cn(
               "overflow-hidden whitespace-nowrap",
-              isLabelExpanded ? "z-10 bg-overlay-background" : "text-ellipsis"
+              isLabelExpanded
+                ? "pointer-events-none z-10 bg-overlay-background select-none"
+                : "text-ellipsis"
             )}
           >
             {label}
@@ -125,8 +127,8 @@ function CreditDetailRow({
           <span
             aria-hidden
             className={cn(
-              "col-span-2 col-start-1 row-start-1 justify-self-start",
-              "pointer-events-none break-all select-none",
+              "col-span-2 col-start-1 row-start-1 z-20",
+              "break-all bg-overlay-background select-text",
               "animate-credit-label-reveal motion-reduce:animate-none",
               icon && "ml-6"
             )}

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -49,6 +49,10 @@ interface CreditDetailRowProps {
  * When `expandLabelOnHover` is enabled, hovering a truncated label reveals its
  * full text in place of the description and value until the pointer leaves the row.
  */
+/**
+ * @cc [owner:aubin-tchoi,label:react] reduced-motion-label-reveal
+ * The label reveal animation is disabled when the user prefers reduced motion.
+ */
 function CreditDetailRow({
   description,
   expandLabelOnHover = false,
@@ -91,7 +95,11 @@ function CreditDetailRow({
         )}
         <span
           ref={labelRef}
-          className={isLabelExpanded ? "min-w-0 break-words" : "truncate"}
+          className={
+            isLabelExpanded
+              ? "min-w-0 break-words animate-in fade-in slide-in-from-left-1 duration-150 ease-enter motion-reduce:animate-none"
+              : "truncate"
+          }
         >
           {label}
         </span>

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -62,14 +62,10 @@ function CreditDetailRow({
       return;
     }
 
-    const observer = new ResizeObserver(() => {
-      rowElement.style.setProperty(
-        "--credit-label-collapsed-width",
-        `${labelElement.clientWidth}px`
-      );
-    });
-    observer.observe(labelElement);
-    return () => observer.disconnect();
+    rowElement.style.setProperty(
+      "--credit-label-collapsed-width",
+      `${labelElement.clientWidth}px`
+    );
   }, [expandLabelOnHover]);
 
   return (

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -83,6 +83,7 @@ function CreditDetailRow({
             ref={labelRef}
             className={classNames(
               "truncate",
+              // Keep the visible prefix above the animated copy throughout the reveal.
               isLabelExpanded && "z-10 text-clip bg-overlay-background"
             )}
           >

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -56,7 +56,7 @@ function CreditDetailRow({
 
   return (
     <div
-      className="grid min-h-9 grid-cols-[minmax(0,1fr)_auto] items-start gap-x-3 py-2 text-sm"
+      className="grid grid-cols-[minmax(0,1fr)_auto] gap-x-3 py-2 text-sm"
       onPointerEnter={(event) => {
         const labelElement = labelRef.current;
         if (
@@ -74,21 +74,16 @@ function CreditDetailRow({
       }}
       onPointerLeave={() => setIsLabelExpanded(false)}
     >
-      <dt className="col-span-2 col-start-1 row-start-1 grid min-w-0 grid-cols-subgrid items-start font-medium text-foreground">
-        <span className="col-start-1 row-start-1 flex min-w-0 items-center gap-2">
+      <dt className="col-span-2 col-start-1 row-start-1 grid grid-cols-subgrid items-start font-medium text-foreground">
+        <span className="col-start-1 row-start-1 flex items-center gap-2">
           {icon && (
-            <Icon
-              visual={icon}
-              size="xs"
-              className="shrink-0 text-muted-foreground"
-            />
+            <Icon visual={icon} size="xs" className="text-muted-foreground" />
           )}
           <span
             ref={labelRef}
             className={classNames(
               "truncate",
-              isLabelExpanded &&
-                "relative z-10 text-clip bg-overlay-background shadow-none"
+              isLabelExpanded && "z-10 text-clip bg-overlay-background"
             )}
           >
             {label}
@@ -108,7 +103,7 @@ function CreditDetailRow({
           <span
             aria-hidden
             className={classNames(
-              "pointer-events-none col-span-2 col-start-1 row-start-1 min-w-0 justify-self-start break-all animate-credit-label-reveal select-none motion-reduce:animate-none",
+              "pointer-events-none col-span-2 col-start-1 row-start-1 justify-self-start break-all animate-credit-label-reveal select-none motion-reduce:animate-none",
               icon ? "ml-6" : ""
             )}
           >
@@ -118,7 +113,7 @@ function CreditDetailRow({
       </dt>
       <dd
         className={classNames(
-          "col-start-2 row-start-1 shrink-0 text-muted-foreground",
+          "col-start-2 row-start-1 text-muted-foreground",
           isLabelExpanded && "invisible"
         )}
       >

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -8,6 +8,7 @@ import {
   TRACKING_AREAS,
   trackEvent,
 } from "@app/lib/tracking";
+import { classNames } from "@app/lib/utils";
 import type { AgentMessageConsumptionToolDetails } from "@app/types/assistant/agent_message_consumption";
 import {
   Button,
@@ -37,20 +38,50 @@ function toolDescription(tool: AgentMessageConsumptionToolDetails): string {
 
 interface CreditDetailRowProps {
   description?: string;
+  expandLabelOnHover?: boolean;
   icon?: ComponentType<{ className?: string }>;
   label: string;
   value: string;
 }
 
+/**
+ * @cc [owner:aubin-tchoi,label:product] reveal-truncated-tool-label
+ * When `expandLabelOnHover` is enabled, hovering a truncated label reveals its
+ * full text in place of the description and value until the pointer leaves the row.
+ */
 function CreditDetailRow({
   description,
+  expandLabelOnHover = false,
   icon,
   label,
   value,
 }: CreditDetailRowProps) {
+  const labelRef = useRef<HTMLSpanElement>(null);
+  const [isLabelExpanded, setIsLabelExpanded] = useState(false);
+
   return (
-    <div className="grid min-h-9 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 text-sm">
-      <dt className="flex min-w-0 items-center gap-2 font-medium text-foreground">
+    <div
+      className="grid min-h-9 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 text-sm"
+      onPointerEnter={(event) => {
+        const labelElement = labelRef.current;
+        if (
+          expandLabelOnHover &&
+          event.pointerType === "mouse" &&
+          labelElement
+        ) {
+          setIsLabelExpanded(
+            labelElement.scrollWidth > labelElement.clientWidth
+          );
+        }
+      }}
+      onPointerLeave={() => setIsLabelExpanded(false)}
+    >
+      <dt
+        className={classNames(
+          "flex min-w-0 items-center gap-2 font-medium text-foreground",
+          isLabelExpanded && "col-span-2"
+        )}
+      >
         {icon && (
           <Icon
             visual={icon}
@@ -58,8 +89,13 @@ function CreditDetailRow({
             className="shrink-0 text-muted-foreground"
           />
         )}
-        <span className="truncate">{label}</span>
-        {description && (
+        <span
+          ref={labelRef}
+          className={isLabelExpanded ? "min-w-0 break-words" : "truncate"}
+        >
+          {label}
+        </span>
+        {description && !isLabelExpanded && (
           <Chip
             size="mini"
             label={description}
@@ -67,7 +103,9 @@ function CreditDetailRow({
           />
         )}
       </dt>
-      <dd className="shrink-0 text-muted-foreground">{value}</dd>
+      <dd hidden={isLabelExpanded} className="shrink-0 text-muted-foreground">
+        {value}
+      </dd>
     </div>
   );
 }
@@ -210,6 +248,7 @@ export function CreditCostPopover({
                   key={`${tool.internalMCPServerName ?? "external"}:${tool.toolName}:${tool.label}`}
                   label={tool.label}
                   description={toolDescription(tool)}
+                  expandLabelOnHover
                   value={formatCreditValue(tool.attributedCredits)}
                   icon={getActionStepIcon(tool)}
                 />

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -65,7 +65,7 @@ function CreditDetailRow({
           labelElement &&
           labelElement.scrollWidth > labelElement.clientWidth
         ) {
-          labelElement.style.setProperty(
+          event.currentTarget.style.setProperty(
             "--credit-label-collapsed-width",
             `${labelElement.clientWidth}px`
           );
@@ -74,12 +74,7 @@ function CreditDetailRow({
       }}
       onPointerLeave={() => setIsLabelExpanded(false)}
     >
-      <dt
-        className={classNames(
-          "flex min-w-0 items-center gap-2 font-medium text-foreground",
-          isLabelExpanded && "col-span-2"
-        )}
-      >
+      <dt className="col-start-1 row-start-1 flex min-w-0 items-center gap-2 font-medium text-foreground">
         {icon && (
           <Icon
             visual={icon}
@@ -89,18 +84,21 @@ function CreditDetailRow({
         )}
         <span
           ref={labelRef}
-          className={
-            isLabelExpanded
-              ? "min-w-0 break-all animate-credit-label-reveal motion-reduce:animate-none"
-              : "truncate"
-          }
+          className={classNames(
+            "truncate",
+            isLabelExpanded && "relative z-10 bg-overlay-background shadow-none"
+          )}
+          style={{ textOverflow: isLabelExpanded ? "clip" : undefined }}
         >
           {label}
         </span>
         {description && (
           <span
             aria-hidden={isLabelExpanded}
-            className={isLabelExpanded ? "hidden" : "flex shrink-0"}
+            className={classNames(
+              "flex shrink-0",
+              isLabelExpanded && "invisible"
+            )}
           >
             <Chip
               size="mini"
@@ -110,11 +108,22 @@ function CreditDetailRow({
           </span>
         )}
       </dt>
+      {isLabelExpanded && (
+        <dt
+          aria-hidden
+          className={classNames(
+            "pointer-events-none col-span-2 col-start-1 row-start-1 min-w-0 justify-self-start break-all font-medium text-foreground animate-credit-label-reveal select-none motion-reduce:animate-none",
+            icon ? "ml-6" : ""
+          )}
+        >
+          {label}
+        </dt>
+      )}
       <dd
         aria-hidden={isLabelExpanded}
         className={classNames(
-          "shrink-0 text-muted-foreground",
-          isLabelExpanded && "hidden"
+          "col-start-2 row-start-1 shrink-0 text-muted-foreground",
+          isLabelExpanded && "invisible"
         )}
       >
         {value}

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -44,20 +44,6 @@ interface CreditDetailRowProps {
   value: string;
 }
 
-/**
- * @cc [owner:aubin-tchoi,label:product] reveal-truncated-tool-label
- * When `expandLabelOnHover` is enabled, hovering a truncated label reveals its
- * full text in place of the description and value until the pointer leaves the row.
- * The label reveal and detail wipe start together and share their duration and easing.
- */
-/**
- * @cc [owner:aubin-tchoi,label:product] stationary-visible-label-prefix
- * Text visible before the ellipsis retains its position and opacity throughout the reveal.
- */
-/**
- * @cc [owner:aubin-tchoi,label:react] reduced-motion-label-reveal
- * The label reveal and detail wipe animations are disabled when the user prefers reduced motion.
- */
 function CreditDetailRow({
   description,
   expandLabelOnHover = false,

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -74,6 +74,7 @@ function CreditDetailRow({
       }}
       onPointerLeave={() => setIsLabelExpanded(false)}
     >
+      {/* Span both columns without pushing the credit count onto another row. */}
       <dt className="col-span-2 col-start-1 row-start-1 grid grid-cols-subgrid items-start font-medium text-foreground">
         <span className="col-start-1 row-start-1 flex items-center gap-2">
           {icon && (
@@ -104,6 +105,7 @@ function CreditDetailRow({
           <span
             aria-hidden
             className={classNames(
+              // Overlay the original label and extend across the hidden credit column.
               "pointer-events-none col-span-2 col-start-1 row-start-1 justify-self-start break-all animate-credit-label-reveal select-none motion-reduce:animate-none",
               icon ? "ml-6" : ""
             )}

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -52,13 +52,11 @@ function CreditDetailRow({
   value,
 }: CreditDetailRowProps) {
   const labelRef = useRef<HTMLSpanElement>(null);
-  const descriptionRef = useRef<HTMLSpanElement>(null);
-  const valueRef = useRef<HTMLElement>(null);
   const [isLabelExpanded, setIsLabelExpanded] = useState(false);
 
   return (
     <div
-      className="relative grid min-h-9 grid-cols-[minmax(0,1fr)_auto] items-start gap-x-3 py-2 text-sm"
+      className="grid min-h-9 grid-cols-[minmax(0,1fr)_auto] items-start gap-x-3 py-2 text-sm"
       onPointerEnter={(event) => {
         const labelElement = labelRef.current;
         if (
@@ -67,32 +65,11 @@ function CreditDetailRow({
           labelElement &&
           labelElement.scrollWidth > labelElement.clientWidth
         ) {
-          const rowElement = event.currentTarget;
-          const rowBounds = rowElement.getBoundingClientRect();
           const labelBounds = labelElement.getBoundingClientRect();
           labelElement.style.setProperty(
             "--credit-label-collapsed-width",
             `${labelBounds.width}px`
           );
-          rowElement.style.setProperty(
-            "--credit-reveal-start",
-            `${labelBounds.right - rowBounds.left}px`
-          );
-          rowElement.style.setProperty(
-            "--credit-reveal-end",
-            `${rowBounds.width}px`
-          );
-          for (const detailElement of [
-            descriptionRef.current,
-            valueRef.current,
-          ]) {
-            if (detailElement) {
-              detailElement.style.setProperty(
-                "--credit-detail-left",
-                `${detailElement.getBoundingClientRect().left - rowBounds.left}px`
-              );
-            }
-          }
           setIsLabelExpanded(true);
         }
       }}
@@ -123,13 +100,8 @@ function CreditDetailRow({
         </span>
         {description && (
           <span
-            ref={descriptionRef}
             aria-hidden={isLabelExpanded}
-            className={classNames(
-              "flex shrink-0",
-              isLabelExpanded &&
-                "absolute top-2 left-(--credit-detail-left) animate-credit-details-hide motion-reduce:invisible motion-reduce:animate-none"
-            )}
+            className={isLabelExpanded ? "hidden" : "flex shrink-0"}
           >
             <Chip
               size="mini"
@@ -140,12 +112,10 @@ function CreditDetailRow({
         )}
       </dt>
       <dd
-        ref={valueRef}
         aria-hidden={isLabelExpanded}
         className={classNames(
           "shrink-0 text-muted-foreground",
-          isLabelExpanded &&
-            "absolute top-2 left-(--credit-detail-left) animate-credit-details-hide motion-reduce:invisible motion-reduce:animate-none"
+          isLabelExpanded && "hidden"
         )}
       >
         {value}

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -8,11 +8,11 @@ import {
   TRACKING_AREAS,
   trackEvent,
 } from "@app/lib/tracking";
-import { classNames } from "@app/lib/utils";
 import type { AgentMessageConsumptionToolDetails } from "@app/types/assistant/agent_message_consumption";
 import {
   Button,
   Chip,
+  cn,
   Icon,
   LoadingBlock,
   Plus,
@@ -74,18 +74,23 @@ function CreditDetailRow({
       }}
       onPointerLeave={() => setIsLabelExpanded(false)}
     >
-      {/* Span both columns without pushing the credit count onto another row. */}
-      <dt className="col-span-2 col-start-1 row-start-1 grid grid-cols-subgrid items-start font-medium text-foreground">
+      {/* Two spans keep the prefix fixed while the full name reveals underneath. */}
+      <dt
+        className={cn(
+          "col-span-2 col-start-1 row-start-1",
+          "grid grid-cols-subgrid items-start",
+          "font-medium text-foreground"
+        )}
+      >
         <span className="col-start-1 row-start-1 flex items-center gap-2">
           {icon && (
             <Icon visual={icon} size="xs" className="text-muted-foreground" />
           )}
           <span
             ref={labelRef}
-            className={classNames(
-              "truncate",
-              // Keep the visible prefix above the animated copy throughout the reveal.
-              isLabelExpanded && "z-10 text-clip bg-overlay-background"
+            className={cn(
+              "overflow-hidden whitespace-nowrap",
+              isLabelExpanded ? "z-10 bg-overlay-background" : "text-ellipsis"
             )}
           >
             {label}
@@ -94,7 +99,7 @@ function CreditDetailRow({
             <Chip
               size="mini"
               label={description}
-              className={classNames(
+              className={cn(
                 "shrink-0 font-normal",
                 isLabelExpanded && "invisible"
               )}
@@ -104,10 +109,11 @@ function CreditDetailRow({
         {isLabelExpanded && (
           <span
             aria-hidden
-            className={classNames(
-              // Overlay the original label and extend across the hidden credit column.
-              "pointer-events-none col-span-2 col-start-1 row-start-1 justify-self-start break-all animate-credit-label-reveal select-none motion-reduce:animate-none",
-              icon ? "ml-6" : ""
+            className={cn(
+              "col-span-2 col-start-1 row-start-1 justify-self-start",
+              "pointer-events-none break-all select-none",
+              "animate-credit-label-reveal motion-reduce:animate-none",
+              icon && "ml-6"
             )}
           >
             {label}
@@ -115,7 +121,7 @@ function CreditDetailRow({
         )}
       </dt>
       <dd
-        className={classNames(
+        className={cn(
           "col-start-2 row-start-1 text-muted-foreground",
           isLabelExpanded && "invisible"
         )}

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -22,7 +22,7 @@ import {
   Tooltip,
 } from "@dust-tt/sparkle";
 import type { ComponentType, ReactElement } from "react";
-import { useId, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 
 const MAX_VISIBLE_TOOLS = 3;
 
@@ -51,11 +51,30 @@ function CreditDetailRow({
   label,
   value,
 }: CreditDetailRowProps) {
+  const rowRef = useRef<HTMLDivElement>(null);
   const labelRef = useRef<HTMLSpanElement>(null);
   const [isLabelExpanded, setIsLabelExpanded] = useState(false);
 
+  useEffect(() => {
+    const rowElement = rowRef.current;
+    const labelElement = labelRef.current;
+    if (!expandLabelOnHover || !rowElement || !labelElement) {
+      return;
+    }
+
+    const observer = new ResizeObserver(() => {
+      rowElement.style.setProperty(
+        "--credit-label-collapsed-width",
+        `${labelElement.clientWidth}px`
+      );
+    });
+    observer.observe(labelElement);
+    return () => observer.disconnect();
+  }, [expandLabelOnHover]);
+
   return (
     <div
+      ref={rowRef}
       className="grid grid-cols-[minmax(0,1fr)_auto] gap-x-3 py-2 text-sm"
       onPointerEnter={(event) => {
         const labelElement = labelRef.current;
@@ -65,10 +84,6 @@ function CreditDetailRow({
           labelElement &&
           labelElement.scrollWidth > labelElement.clientWidth
         ) {
-          event.currentTarget.style.setProperty(
-            "--credit-label-collapsed-width",
-            `${labelElement.clientWidth}px`
-          );
           setIsLabelExpanded(true);
         }
       }}

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -50,6 +50,10 @@ interface CreditDetailRowProps {
  * full text in place of the description and value until the pointer leaves the row.
  */
 /**
+ * @cc [owner:aubin-tchoi,label:product] stationary-visible-label-prefix
+ * Text visible before the ellipsis retains its position and opacity throughout the reveal.
+ */
+/**
  * @cc [owner:aubin-tchoi,label:react] reduced-motion-label-reveal
  * The label reveal animation is disabled when the user prefers reduced motion.
  */
@@ -65,17 +69,20 @@ function CreditDetailRow({
 
   return (
     <div
-      className="grid min-h-9 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 text-sm"
+      className="grid min-h-9 grid-cols-[minmax(0,1fr)_auto] items-start gap-x-3 py-2 text-sm"
       onPointerEnter={(event) => {
         const labelElement = labelRef.current;
         if (
           expandLabelOnHover &&
           event.pointerType === "mouse" &&
-          labelElement
+          labelElement &&
+          labelElement.scrollWidth > labelElement.clientWidth
         ) {
-          setIsLabelExpanded(
-            labelElement.scrollWidth > labelElement.clientWidth
+          labelElement.style.setProperty(
+            "--credit-label-collapsed-width",
+            `${labelElement.clientWidth}px`
           );
+          setIsLabelExpanded(true);
         }
       }}
       onPointerLeave={() => setIsLabelExpanded(false)}
@@ -90,14 +97,14 @@ function CreditDetailRow({
           <Icon
             visual={icon}
             size="xs"
-            className="shrink-0 text-muted-foreground"
+            className="mt-0.5 shrink-0 self-start text-muted-foreground"
           />
         )}
         <span
           ref={labelRef}
           className={
             isLabelExpanded
-              ? "min-w-0 break-words animate-in fade-in slide-in-from-left-1 duration-150 ease-enter motion-reduce:animate-none"
+              ? "min-w-0 break-all animate-credit-label-reveal motion-reduce:animate-none"
               : "truncate"
           }
         >

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -48,6 +48,7 @@ interface CreditDetailRowProps {
  * @cc [owner:aubin-tchoi,label:product] reveal-truncated-tool-label
  * When `expandLabelOnHover` is enabled, hovering a truncated label reveals its
  * full text in place of the description and value until the pointer leaves the row.
+ * The description and value wipe away along the same edge that reveals the label.
  */
 /**
  * @cc [owner:aubin-tchoi,label:product] stationary-visible-label-prefix
@@ -55,7 +56,7 @@ interface CreditDetailRowProps {
  */
 /**
  * @cc [owner:aubin-tchoi,label:react] reduced-motion-label-reveal
- * The label reveal animation is disabled when the user prefers reduced motion.
+ * The label reveal and detail wipe animations are disabled when the user prefers reduced motion.
  */
 function CreditDetailRow({
   description,
@@ -65,11 +66,13 @@ function CreditDetailRow({
   value,
 }: CreditDetailRowProps) {
   const labelRef = useRef<HTMLSpanElement>(null);
+  const descriptionRef = useRef<HTMLSpanElement>(null);
+  const valueRef = useRef<HTMLElement>(null);
   const [isLabelExpanded, setIsLabelExpanded] = useState(false);
 
   return (
     <div
-      className="grid min-h-9 grid-cols-[minmax(0,1fr)_auto] items-start gap-x-3 py-2 text-sm"
+      className="relative grid min-h-9 grid-cols-[minmax(0,1fr)_auto] items-start gap-x-3 py-2 text-sm"
       onPointerEnter={(event) => {
         const labelElement = labelRef.current;
         if (
@@ -78,10 +81,32 @@ function CreditDetailRow({
           labelElement &&
           labelElement.scrollWidth > labelElement.clientWidth
         ) {
+          const rowElement = event.currentTarget;
+          const rowBounds = rowElement.getBoundingClientRect();
+          const labelBounds = labelElement.getBoundingClientRect();
           labelElement.style.setProperty(
             "--credit-label-collapsed-width",
-            `${labelElement.clientWidth}px`
+            `${labelBounds.width}px`
           );
+          rowElement.style.setProperty(
+            "--credit-reveal-start",
+            `${labelBounds.right - rowBounds.left}px`
+          );
+          rowElement.style.setProperty(
+            "--credit-reveal-end",
+            `${rowBounds.width}px`
+          );
+          for (const detailElement of [
+            descriptionRef.current,
+            valueRef.current,
+          ]) {
+            if (detailElement) {
+              detailElement.style.setProperty(
+                "--credit-detail-left",
+                `${detailElement.getBoundingClientRect().left - rowBounds.left}px`
+              );
+            }
+          }
           setIsLabelExpanded(true);
         }
       }}
@@ -104,21 +129,39 @@ function CreditDetailRow({
           ref={labelRef}
           className={
             isLabelExpanded
-              ? "min-w-0 break-all animate-credit-label-reveal motion-reduce:animate-none"
+              ? "min-w-0 flex-1 break-all animate-credit-label-reveal motion-reduce:animate-none"
               : "truncate"
           }
         >
           {label}
         </span>
-        {description && !isLabelExpanded && (
-          <Chip
-            size="mini"
-            label={description}
-            className="shrink-0 font-normal"
-          />
+        {description && (
+          <span
+            ref={descriptionRef}
+            aria-hidden={isLabelExpanded}
+            className={classNames(
+              "flex shrink-0",
+              isLabelExpanded &&
+                "absolute top-2 left-(--credit-detail-left) animate-credit-details-hide motion-reduce:invisible motion-reduce:animate-none"
+            )}
+          >
+            <Chip
+              size="mini"
+              label={description}
+              className="shrink-0 font-normal"
+            />
+          </span>
         )}
       </dt>
-      <dd hidden={isLabelExpanded} className="shrink-0 text-muted-foreground">
+      <dd
+        ref={valueRef}
+        aria-hidden={isLabelExpanded}
+        className={classNames(
+          "shrink-0 text-muted-foreground",
+          isLabelExpanded &&
+            "absolute top-2 left-(--credit-detail-left) animate-credit-details-hide motion-reduce:invisible motion-reduce:animate-none"
+        )}
+      >
         {value}
       </dd>
     </div>

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -48,7 +48,7 @@ interface CreditDetailRowProps {
  * @cc [owner:aubin-tchoi,label:product] reveal-truncated-tool-label
  * When `expandLabelOnHover` is enabled, hovering a truncated label reveals its
  * full text in place of the description and value until the pointer leaves the row.
- * The description and value wipe away along the same edge that reveals the label.
+ * The label reveal and detail wipe start together and share their duration and easing.
  */
 /**
  * @cc [owner:aubin-tchoi,label:product] stationary-visible-label-prefix
@@ -129,7 +129,7 @@ function CreditDetailRow({
           ref={labelRef}
           className={
             isLabelExpanded
-              ? "min-w-0 flex-1 break-all animate-credit-label-reveal motion-reduce:animate-none"
+              ? "min-w-0 break-all animate-credit-label-reveal motion-reduce:animate-none"
               : "truncate"
           }
         >

--- a/front/styles/theme-extras.css
+++ b/front/styles/theme-extras.css
@@ -57,9 +57,7 @@
 
 @keyframes credit-label-reveal {
   from {
-    clip-path: inset(
-      0 calc(100% - var(--credit-label-collapsed-width)) calc(100% - 1lh) 0
-    );
+    clip-path: inset(0 calc(100% - var(--credit-label-collapsed-width)) 0 0);
   }
   to {
     clip-path: inset(0);

--- a/front/styles/theme-extras.css
+++ b/front/styles/theme-extras.css
@@ -57,9 +57,11 @@
 @keyframes credit-label-reveal {
   from {
     clip-path: inset(0 calc(100% - var(--credit-label-collapsed-width)) 0 0);
+    z-index: 0;
   }
   to {
     clip-path: inset(0);
+    z-index: 0;
   }
 }
 

--- a/front/styles/theme-extras.css
+++ b/front/styles/theme-extras.css
@@ -51,6 +51,18 @@
   --animate-input-bar-compact-nav-in: input-bar-compact-nav-in 420ms
     cubic-bezier(0.34, 1.56, 0.64, 1) 160ms both;
   --animate-saved-pulse: saved-pulse 2s ease-out;
+  --animate-credit-label-reveal: credit-label-reveal 150ms var(--ease-enter);
+}
+
+@keyframes credit-label-reveal {
+  from {
+    clip-path: inset(
+      0 calc(100% - var(--credit-label-collapsed-width)) calc(100% - 1lh) 0
+    );
+  }
+  to {
+    clip-path: inset(0);
+  }
 }
 
 @keyframes appear {

--- a/front/styles/theme-extras.css
+++ b/front/styles/theme-extras.css
@@ -52,7 +52,6 @@
     cubic-bezier(0.34, 1.56, 0.64, 1) 160ms both;
   --animate-saved-pulse: saved-pulse 2s ease-out;
   --animate-credit-label-reveal: credit-label-reveal 150ms var(--ease-enter);
-  --animate-credit-details-hide: credit-details-hide 150ms var(--ease-enter) both;
 }
 
 @keyframes credit-label-reveal {
@@ -61,20 +60,6 @@
   }
   to {
     clip-path: inset(0);
-  }
-}
-
-@keyframes credit-details-hide {
-  from {
-    clip-path: inset(
-      0 0 0 calc(var(--credit-reveal-start) - var(--credit-detail-left))
-    );
-  }
-  to {
-    clip-path: inset(
-      0 0 0 calc(var(--credit-reveal-end) - var(--credit-detail-left))
-    );
-    visibility: hidden;
   }
 }
 

--- a/front/styles/theme-extras.css
+++ b/front/styles/theme-extras.css
@@ -52,6 +52,7 @@
     cubic-bezier(0.34, 1.56, 0.64, 1) 160ms both;
   --animate-saved-pulse: saved-pulse 2s ease-out;
   --animate-credit-label-reveal: credit-label-reveal 150ms var(--ease-enter);
+  --animate-credit-details-hide: credit-details-hide 150ms var(--ease-enter) both;
 }
 
 @keyframes credit-label-reveal {
@@ -62,6 +63,20 @@
   }
   to {
     clip-path: inset(0);
+  }
+}
+
+@keyframes credit-details-hide {
+  from {
+    clip-path: inset(
+      0 0 0 calc(var(--credit-reveal-start) - var(--credit-detail-left))
+    );
+  }
+  to {
+    clip-path: inset(
+      0 0 0 calc(var(--credit-reveal-end) - var(--credit-detail-left))
+    );
+    visibility: hidden;
   }
 }
 


### PR DESCRIPTION
## Description

Long tool names in the message consumption breakdown are truncated with no way to read their full name.

This PR makes it so hovering a truncated tool row expands the name into the space occupied by the usage chip and credit count. Both return when the pointer leaves. Names longer than the full row wrap.

https://github.com/user-attachments/assets/a297e561-f745-4e62-a2d4-aa964f92aa60

## Tests

- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
