### PR TITLE
fix(front): apply template seats when the package is unchanged

### DIFF
--- a/front/components/poke/shadcn/ui/form/fields.tsx
+++ b/front/components/poke/shadcn/ui/form/fields.tsx
@@ -57,8 +57,14 @@ export function SelectField<T extends FieldValues>({
       name={name}
       render={({ field }) => {
         const selectedOption = flatOptions.find((o) => o.value === field.value);
+        // Fall back to the title or a neutral placeholder — never the raw field
+        // `name` (a dotted path like `seats.free.paymentSchedule.frequency`),
+        // which leaks when the current value matches no option.
         const displayLabel =
-          selectedOption?.display ?? selectedOption?.value ?? title ?? name;
+          selectedOption?.display ??
+          selectedOption?.value ??
+          title ??
+          "Select…";
 
         return (
           <PokeFormItem>

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -1286,7 +1286,6 @@ export default function SwitchContractDialog({
                             <Button
                               type="button"
                               variant="outline"
-                              size="xs"
                               isSelect
                               disabled={isPackagesLoading}
                               label={

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -154,7 +154,16 @@ type SeatFormValue = {
   minSeats: number;
   maxSeats?: number;
   rate: number;
-  paymentSchedule: { frequency: "one_time" };
+  commitmentPrice?: number;
+  paymentSchedule: {
+    frequency:
+      | "one_time"
+      | "monthly"
+      | "quarterly"
+      | "semi_annually"
+      | "annually";
+    periods?: number;
+  };
 };
 
 // Default seat settings for a package: entitled seats pre-selected, the rest
@@ -178,6 +187,25 @@ function buildDefaultSeats(
       rate,
       paymentSchedule: { frequency: "one_time" },
     };
+  }
+  return next;
+}
+
+// Merge a template's per-seat overrides onto a package's default seats. Seat
+// types the package does not sell have no entry to merge onto and are skipped.
+function mergeTemplateSeats(
+  base: Record<string, SeatFormValue>,
+  templateSeats: SwitchContractTemplate["seats"]
+): Record<string, SeatFormValue> {
+  if (!templateSeats) {
+    return base;
+  }
+  const next = { ...base };
+  for (const [seatType, override] of Object.entries(templateSeats)) {
+    if (!override || !next[seatType]) {
+      continue;
+    }
+    next[seatType] = { ...next[seatType], ...override };
   }
   return next;
 }
@@ -585,18 +613,12 @@ export default function SwitchContractDialog({
       if (template.recurringFreeCredit !== undefined) {
         form.setValue("recurringFreeCredit", template.recurringFreeCredit);
       }
-      // Merge seat overrides onto the current package's seats; a seat type the
-      // package does not sell has no entry to merge onto and is skipped.
+      // Merge seat overrides onto the current package's seats.
       if (template.seats) {
-        const current = form.getValues("seats") ?? {};
-        const next = { ...current };
-        for (const [seatType, override] of Object.entries(template.seats)) {
-          if (!override || !next[seatType]) {
-            continue;
-          }
-          next[seatType] = { ...next[seatType], ...override };
-        }
-        form.setValue("seats", next);
+        form.setValue(
+          "seats",
+          mergeTemplateSeats(form.getValues("seats") ?? {}, template.seats)
+        );
       }
     },
     [form]
@@ -606,23 +628,6 @@ export default function SwitchContractDialog({
     (template: SwitchContractTemplate) => {
       setError(null);
       setAppliedTemplateName(template.name);
-      // Start from a blank form so no field from a previously applied template
-      // lingers. The billing identity (Stripe customer + currency) is preserved
-      // since it identifies the customer, not the contract shape.
-      const current = form.getValues();
-      form.reset({
-        ...formDefaults,
-        stripeCustomerId: current.stripeCustomerId,
-        stripeCollectionMethod: current.stripeCollectionMethod,
-        manualCurrency: current.manualCurrency,
-      });
-      // Duration and offer are local UI state that don't depend on the package,
-      // so set them here in the handler (not from the deferred effect below).
-      setDurationMode(template.duration !== undefined);
-      setDurationValue(template.duration?.value ?? 1);
-      setDurationUnit(template.duration?.unit ?? "years");
-      setOfferValue(template.offerFreePeriod?.value ?? 0);
-      setOfferUnit(template.offerFreePeriod?.unit ?? "weeks");
       pendingTemplateRef.current = null;
 
       const packageId = resolveTemplatePackageId(template);
@@ -638,24 +643,49 @@ export default function SwitchContractDialog({
             "Pick a package manually."
         );
       }
-      if (packageId && packageId !== selectedPackageId) {
+      const isSamePackage =
+        Boolean(packageId) && packageId === selectedPackageId;
+
+      // Start from a blank form so no field from a previously applied template
+      // lingers. The billing identity (Stripe customer + currency) is preserved
+      // since it identifies the customer, not the contract shape. When the
+      // package is unchanged the seat-reset effect won't fire, so seed the
+      // package's default seats (with the template's overrides) into this single
+      // reset — a reset() followed by a setValue() on the nested `seats` object
+      // races and leaves the seat fields blank.
+      const current = form.getValues();
+      form.reset({
+        ...formDefaults,
+        stripeCustomerId: current.stripeCustomerId,
+        stripeCollectionMethod: current.stripeCollectionMethod,
+        manualCurrency: current.manualCurrency,
+        ...(isSamePackage
+          ? {
+              metronomePackageId: packageId,
+              startingAt: defaultStartingAtUTC,
+              seats: mergeTemplateSeats(
+                buildDefaultSeats(selectedSeats, resolvedCurrency),
+                template.seats
+              ),
+            }
+          : {}),
+      });
+      // Duration and offer are local UI state that don't depend on the package,
+      // so set them here in the handler (not from the deferred effect below).
+      setDurationMode(template.duration !== undefined);
+      setDurationValue(template.duration?.value ?? 1);
+      setDurationUnit(template.duration?.unit ?? "years");
+      setOfferValue(template.offerFreePeriod?.value ?? 0);
+      setOfferUnit(template.offerFreePeriod?.unit ?? "weeks");
+
+      if (packageId && !isSamePackage) {
         // The package changes: selecting it repopulates the seats and resets the
         // tier defaults, so defer the rest of the template until that settles.
         pendingTemplateRef.current = template;
         form.setValue("metronomePackageId", packageId);
       } else {
-        // The package is unchanged (or the template names none), so neither the
-        // seat-reset nor the tier-default effect will fire — restore the package,
-        // rebuild its default seats and start (form.reset cleared them), and
-        // apply the template synchronously.
-        if (packageId) {
-          form.setValue("metronomePackageId", packageId);
-          form.setValue(
-            "seats",
-            buildDefaultSeats(selectedSeats, resolvedCurrency)
-          );
-          form.setValue("startingAt", defaultStartingAtUTC);
-        }
+        // Same package (seats already seeded above) or no package: apply the
+        // remaining scalar fields now.
         applyTemplateFields(template);
       }
     },

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -30,6 +30,7 @@ import {
   usePokeStripeCustomerCurrency,
 } from "@app/lib/swr/poke";
 import { usePokePluginAsyncArgs } from "@app/poke/swr/plugins";
+import type { SupportedCurrency } from "@app/types/currency";
 import { SUPPORTED_CURRENCIES } from "@app/types/currency";
 import { BILLABLE_SEAT_TYPES } from "@app/types/memberships";
 import { isCreditPricedPlan } from "@app/types/plan";
@@ -146,6 +147,39 @@ function toDatetimeLocalUTC(d: Date): string {
     `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}` +
     `T${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}`
   );
+}
+
+type SeatFormValue = {
+  selected: boolean;
+  minSeats: number;
+  maxSeats?: number;
+  rate: number;
+  paymentSchedule: { frequency: "one_time" };
+};
+
+// Default seat settings for a package: entitled seats pre-selected, the rest
+// unchecked for the operator to opt into; minSeats 0 and the rate converted from
+// Metronome's fiat unit to the dialog's major units. Shared by the seat-reset
+// effect and template application so they can't drift.
+function buildDefaultSeats(
+  seats: { seatType: string; defaultRate: number | null; entitled: boolean }[],
+  resolvedCurrency: SupportedCurrency | null | undefined
+): Record<string, SeatFormValue> {
+  const next: Record<string, SeatFormValue> = {};
+  for (const seat of seats) {
+    const rate =
+      seat.defaultRate != null && resolvedCurrency
+        ? amountCents(seat.defaultRate, resolvedCurrency) / 100
+        : (seat.defaultRate ?? 0);
+    next[seat.seatType] = {
+      selected: seat.entitled,
+      minSeats: 0,
+      maxSeats: undefined,
+      rate,
+      paymentSchedule: { frequency: "one_time" },
+    };
+  }
+  return next;
 }
 
 const isLegacyPackageName = (name: string) => /\blegacy\b/i.test(name);
@@ -433,30 +467,7 @@ export default function SwitchContractDialog({
   // (dollars/euros), so convert for display. Avoids stale values leaking across
   // package selections.
   useEffect(() => {
-    const next: Record<
-      string,
-      {
-        selected: boolean;
-        minSeats: number;
-        maxSeats?: number;
-        rate: number;
-        paymentSchedule: { frequency: "one_time" };
-      }
-    > = {};
-    for (const seat of selectedSeats) {
-      const rate =
-        seat.defaultRate != null && resolvedCurrency
-          ? amountCents(seat.defaultRate, resolvedCurrency) / 100
-          : (seat.defaultRate ?? 0);
-      next[seat.seatType] = {
-        selected: seat.entitled,
-        minSeats: 0,
-        maxSeats: undefined,
-        rate,
-        paymentSchedule: { frequency: "one_time" },
-      };
-    }
-    form.setValue("seats", next);
+    form.setValue("seats", buildDefaultSeats(selectedSeats, resolvedCurrency));
   }, [selectedSeats, form, resolvedCurrency]);
 
   // Clear a stale package selection when the resolved currency changes so a
@@ -615,16 +626,49 @@ export default function SwitchContractDialog({
       pendingTemplateRef.current = null;
 
       const packageId = resolveTemplatePackageId(template);
-      if (packageId) {
-        // Selecting the package repopulates seats and resets tier defaults;
-        // defer the rest of the template until that settles.
+      // Surface a resolution miss instead of silently applying no package (and
+      // therefore no seats): the package name/currency may not match this env.
+      if (template.package && !packageId) {
+        setError(
+          `Template "${template.name}": no ${template.package.tier} package` +
+            (template.package.namePattern
+              ? ` matching "${template.package.namePattern}"`
+              : "") +
+            ` found for ${resolvedCurrency?.toUpperCase() ?? "the selected currency"}. ` +
+            "Pick a package manually."
+        );
+      }
+      if (packageId && packageId !== selectedPackageId) {
+        // The package changes: selecting it repopulates the seats and resets the
+        // tier defaults, so defer the rest of the template until that settles.
         pendingTemplateRef.current = template;
         form.setValue("metronomePackageId", packageId);
       } else {
+        // The package is unchanged (or the template names none), so neither the
+        // seat-reset nor the tier-default effect will fire — restore the package,
+        // rebuild its default seats and start (form.reset cleared them), and
+        // apply the template synchronously.
+        if (packageId) {
+          form.setValue("metronomePackageId", packageId);
+          form.setValue(
+            "seats",
+            buildDefaultSeats(selectedSeats, resolvedCurrency)
+          );
+          form.setValue("startingAt", defaultStartingAtUTC);
+        }
         applyTemplateFields(template);
       }
     },
-    [resolveTemplatePackageId, form, formDefaults, applyTemplateFields]
+    [
+      resolveTemplatePackageId,
+      selectedPackageId,
+      selectedSeats,
+      resolvedCurrency,
+      defaultStartingAtUTC,
+      form,
+      formDefaults,
+      applyTemplateFields,
+    ]
   );
 
   // Second phase of applying a template: once selecting its package has


### PR DESCRIPTION
## Description

Fixes the "Free pilot" template applying with **no seat enabled at all**.

Selecting a template resets the form (clearing seats + package) and then re-selects the template's package. When the resolved package equals the one already selected — e.g. re-applying a template, or **switching between the two pilots, which both use the Enterprise Pooled package** — `metronomePackageId` never actually changes, so React never sees `selectedSeats` change. The seat-reset effect and the deferred template-apply effect therefore don't fire, and the seats stay `{}` (empty). Applying from a blank form the first time worked; re-applying/switching didn't.

Fix:
- Extract the package's default-seat builder into `buildDefaultSeats` (shared with the seat-reset effect so they can't drift).
- In `applyTemplate`, when the package is unchanged, rebuild the seats and restore the default start **synchronously** (and still apply the template fields), instead of relying on effects that won't fire.
- Also surface an error if a template's package can't be resolved for the current currency, instead of silently applying no package/seats (the other way "no seats" could happen).

## Tests

- `tsgo` and biome pass.
- Manual: apply Free pilot from blank → workspace seat enabled; switch Free pilot ↔ Pilot — 2 months repeatedly → seats stay populated each time; re-apply the same template → seats populated.

## Risk

Low, internal Poke tooling. Behavior only changes the template-apply path (no server/billing changes). Rollback is a straight revert. No migration or feature flag.

## Deploy Plan

Standard `front` deploy. No migration or ordering constraints.