### PR TITLE
fix(front): clear stale side panel hash state without a conversation

### DIFF
--- a/front/components/workspace/analytics/AnalyticsConversationPanel.tsx
+++ b/front/components/workspace/analytics/AnalyticsConversationPanel.tsx
@@ -28,7 +28,7 @@ import {
   Spinner,
   XClose,
 } from "@dust-tt/sparkle";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 
 interface AnalyticsConversationPanelHeaderProps {
   onClose: () => void;
@@ -108,7 +108,15 @@ function AnalyticsConversationPanelBody({
       disabled,
     });
 
-  const { currentPanel } = useConversationSidePanelContext();
+  const { currentPanel, onPanelClosed } = useConversationSidePanelContext();
+
+  // The side panel type lives in the URL hash and outlives the in-memory
+  // conversation across a reload.
+  useEffect(() => {
+    if (!conversation && currentPanel) {
+      onPanelClosed();
+    }
+  }, [conversation, currentPanel, onPanelClosed]);
 
   const stickyMentions = useMemo<RichMention[]>(
     () =>
@@ -145,7 +153,9 @@ function AnalyticsConversationPanelBody({
     <>
       <div
         className={
-          currentPanel ? "hidden" : "flex h-full w-full min-h-0 flex-col"
+          currentPanel && conversation
+            ? "hidden"
+            : "flex h-full w-full min-h-0 flex-col"
         }
       >
         <div className="min-h-0 flex-1 overflow-y-auto">


### PR DESCRIPTION
## Description

Reloading a page with side panel open (with params in the URL `spt` and `sp`) restores the panel, unless conversation is already in a side panel. Like the new Analytics or the Sidekick one.
The panel then opens with nothing in it.

## Tests

Tested locally.

## Risk

Low.

## Deploy Plan

Standard deploy. 
