### PR TITLE
feat(analytics): author the analyst panel's opening message server-side

### DIFF
--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -1489,7 +1489,7 @@
  *           type: string
  *         origin:
  *           type: string
- *           enum: [web, project_kickoff, extension, agent_sidekick, api, cli, cli_programmatic, email, excel, gsheet, make, n8n, powerpoint, raycast, slack, slack_workflow, teams, transcript, triggered_programmatic, triggered, wakeup, zapier, zendesk, onboarding_conversation]
+ *           enum: [web, project_kickoff, extension, agent_sidekick, analytics_panel, api, cli, cli_programmatic, email, excel, gsheet, make, n8n, powerpoint, raycast, slack, slack_workflow, teams, transcript, triggered_programmatic, triggered, wakeup, zapier, zendesk, onboarding_conversation]
  *         selectedSpaceIds:
  *           type: array
  *           items:

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
@@ -94,6 +94,67 @@ describe("POST /api/w/:wId/assistant/conversations/:cId/messages", () => {
     expect(relationships[0].mcpServerViewId).toBe(mcpServerView.id);
   });
 
+  it("promotes a hidden Analytics-panel conversation to the user's history", async () => {
+    const { workspace, auth, user } = await setupTest("admin");
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+      visibility: "test",
+      metadata: { origin: "analytics_panel" },
+    });
+
+    const response = await postMessage(workspace, conversation.sId, {
+      content: "Which agents are used the most?",
+      mentions: [{ configurationId: GLOBAL_AGENTS_SID.DUST }],
+      context: {
+        timezone: "Europe/Paris",
+        profilePictureUrl: user.imageUrl ?? null,
+      },
+      skipToolsValidation: true,
+    });
+
+    expect(response.status).toBe(200);
+
+    await vi.waitFor(async () => {
+      const promoted = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      assert(promoted, "Conversation not found after posting");
+      expect(promoted.visibility).toBe("unlisted");
+    });
+  });
+
+  it("leaves a test conversation without the Analytics-panel marker hidden", async () => {
+    const { workspace, auth, user } = await setupTest("admin");
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+      visibility: "test",
+    });
+
+    const response = await postMessage(workspace, conversation.sId, {
+      content: "Hello",
+      mentions: [{ configurationId: GLOBAL_AGENTS_SID.DUST }],
+      context: {
+        timezone: "Europe/Paris",
+        profilePictureUrl: user.imageUrl ?? null,
+      },
+      skipToolsValidation: true,
+    });
+
+    expect(response.status).toBe(200);
+
+    const unchanged = await ConversationResource.fetchById(
+      auth,
+      conversation.sId
+    );
+    assert(unchanged, "Conversation not found after posting");
+    expect(unchanged.visibility).toBe("test");
+  });
+
   it("returns 404 when conversation doesn't exist", async () => {
     const { workspace } = await setupTest("admin");
 

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -2,6 +2,7 @@ import { validateMCPServerAccess } from "@app/lib/api/actions/mcp/client_side_re
 import { isSidekickConversation } from "@app/lib/api/actions/servers/helpers";
 import { fetchPrecedingContentFragments } from "@app/lib/api/assistant/content_fragments";
 import { postUserMessage } from "@app/lib/api/assistant/conversation";
+import { promoteAnalyticsPanelConversation } from "@app/lib/api/assistant/conversation/analytics_panel";
 import { addSelectedConversationSpaces } from "@app/lib/api/assistant/conversation/selected_spaces";
 import { fetchConversationMessages } from "@app/lib/api/assistant/messages";
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
@@ -12,6 +13,7 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { extractUniqueSkillIds } from "@app/lib/skills/format";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { statsDMetrics } from "@app/lib/utils/statsd";
+import logger from "@app/logger/logger";
 import { InternalPostMessagesRequestBodySchema } from "@app/types/api/assistant";
 import type { PostMessagesResponseBody } from "@app/types/api/assistant/messages";
 import type {
@@ -401,6 +403,17 @@ app.post(
     if (messageRes.isErr()) {
       return apiError(ctx, messageRes.error);
     }
+
+    // Fire and forget: this only decides whether the conversation shows up in the user's history,
+    // so it must not fail a message that was already posted.
+    void promoteAnalyticsPanelConversation(auth, {
+      conversation: conversationResource,
+    }).catch((err) =>
+      logger.error(
+        { err, conversationId: conversation.sId },
+        "Failed to promote Analytics-panel conversation"
+      )
+    );
 
     const contentFragments = await fetchPrecedingContentFragments(auth, {
       conversationResource,

--- a/front-api/routes/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/index.ts
@@ -4,6 +4,10 @@ import {
   postNewContentFragment,
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
+import {
+  ANALYTICS_PANEL_CONVERSATION_INIT,
+  postAnalyticsPanelBootstrapMessage,
+} from "@app/lib/api/assistant/conversation/analytics_panel";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import {
   addSelectedConversationSpaces,
@@ -256,7 +260,12 @@ app.post(
       metadata,
       selectedSpaceIds,
       skipToolsValidation,
+      bootstrap,
     } = ctx.req.valid("json");
+
+    const conversationInit = bootstrap
+      ? ANALYTICS_PANEL_CONVERSATION_INIT
+      : { title, visibility, metadata };
 
     const allSelectedSpaceIds = uniq([
       ...(selectedSpaceIds ?? []),
@@ -332,17 +341,15 @@ app.post(
     }
 
     const newConversationResource = await createConversation(auth, {
-      title,
-      visibility,
+      ...conversationInit,
       spaceId: spaceModelId,
-      metadata,
     });
 
     let newConversation: ConversationType = {
       ...newConversationResource.toJSON(),
       content: [],
       owner: auth.getNonNullableWorkspace(),
-      visibility: visibility,
+      visibility: conversationInit.visibility,
     };
 
     if (allSelectedSpaceIds.length > 0) {
@@ -386,6 +393,18 @@ app.post(
 
     const newContentFragments: ContentFragmentType[] = [];
     let newMessage: UserMessageType | null = null;
+
+    if (bootstrap) {
+      const bootstrapRes = await postAnalyticsPanelBootstrapMessage(auth, {
+        conversation: newConversationResource,
+        user,
+      });
+      if (bootstrapRes.isErr()) {
+        return apiError(ctx, bootstrapRes.error);
+      }
+
+      newMessage = bootstrapRes.value;
+    }
 
     const baseContext = {
       username: user.username,

--- a/front/lib/api/analytics/source_labels.ts
+++ b/front/lib/api/analytics/source_labels.ts
@@ -2,7 +2,7 @@ import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 
 export type AnalyticsVisibleOrigin = Exclude<
   UserMessageOrigin,
-  "reinforced_skill_notification" | "system_activation"
+  "analytics_panel" | "reinforced_skill_notification" | "system_activation"
 >;
 
 export const SOURCE_ORIGIN_LABELS: Record<AnalyticsVisibleOrigin, string> = {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -513,6 +513,7 @@ export function isUserMessageContextValid(
     case "wakeup":
     case "onboarding_conversation":
     case "agent_sidekick":
+    case "analytics_panel":
     case "project_kickoff":
     case "reinforced_skill_notification":
     case "reinforcement":

--- a/front/lib/api/assistant/conversation/analytics_panel.ts
+++ b/front/lib/api/assistant/conversation/analytics_panel.ts
@@ -1,0 +1,90 @@
+import { postUserMessage } from "@app/lib/api/assistant/conversation";
+import type { Authenticator } from "@app/lib/auth";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type {
+  ConversationMetadata,
+  ConversationVisibility,
+  UserMessageType,
+} from "@app/types/assistant/conversation";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+
+// Answered by a static reply rather than a model, see `getStaticReplyForUserMessage`. The tool
+// instruction only applies if that static reply ever stops matching.
+const BOOTSTRAP_MESSAGE = `<dust_system>
+The user just opened the @analyst panel on the workspace Analytics page.
+Do NOT call any tools. Greet briefly and offer 2-3 example questions they could ask.
+</dust_system>`;
+
+/**
+ * How the panel's conversation is created: hidden, so it only reaches the user's history once they
+ * write in it, and titled up front so `ensureConversationTitle` does not name it after the
+ * bootstrap message.
+ */
+export const ANALYTICS_PANEL_CONVERSATION_INIT: {
+  title: string;
+  visibility: ConversationVisibility;
+  metadata: ConversationMetadata;
+} = {
+  title: `Ask ${GLOBAL_AGENTS_SID.ANALYST}`,
+  visibility: "test",
+  metadata: { origin: "analytics_panel" },
+};
+
+/**
+ * @cc [owner:achilleburah,label:security] bootstrap-message-is-server-authored
+ * The `analytics_panel` origin must only ever be written here, on the first message of a
+ * conversation this function was given. The origin hides a message from the conversation UI, so a
+ * caller able to choose it could hide messages the agent still reads.
+ */
+export async function postAnalyticsPanelBootstrapMessage(
+  auth: Authenticator,
+  {
+    conversation,
+    user,
+  }: { conversation: ConversationResource; user: UserResource }
+): Promise<Result<UserMessageType, APIErrorWithContentfulStatusCode>> {
+  const messageRes = await postUserMessage(auth, {
+    conversationResource: conversation,
+    content: BOOTSTRAP_MESSAGE,
+    mentions: [{ configurationId: GLOBAL_AGENTS_SID.ANALYST }],
+    context: {
+      timezone: "UTC",
+      username: user.username,
+      fullName: user.fullName(),
+      email: user.email,
+      profilePictureUrl: user.imageUrl,
+      origin: "analytics_panel",
+    },
+    skipToolsValidation: false,
+  });
+
+  if (messageRes.isErr()) {
+    return messageRes;
+  }
+
+  return new Ok(messageRes.value.userMessage);
+}
+
+/**
+ * @cc [owner:achilleburah,label:product] promotes-only-hidden-analytics-panel-conversations
+ * Makes an Analytics-panel conversation visible in the user's conversation history by moving it
+ * from `test` to `unlisted` visibility. It is a no-op unless the conversation is both
+ * `test`-visibility and marked as Analytics-panel in its metadata, and it is idempotent.
+ */
+export async function promoteAnalyticsPanelConversation(
+  auth: Authenticator,
+  { conversation }: { conversation: ConversationResource }
+): Promise<void> {
+  if (
+    conversation.visibility !== "test" ||
+    conversation.metadata?.origin !== "analytics_panel"
+  ) {
+    return;
+  }
+
+  await conversation.updateVisibilityToUnlisted(auth);
+}

--- a/front/lib/api/assistant/global_agents/configurations/analyst.ts
+++ b/front/lib/api/assistant/global_agents/configurations/analyst.ts
@@ -4,6 +4,7 @@ import type { Authenticator } from "@app/lib/auth";
 import type {
   AgentConfigurationType,
   AgentModelConfigurationType,
+  GlobalAgentContext,
 } from "@app/types/assistant/agent";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
@@ -11,11 +12,14 @@ import {
   AUTO_FAST_MODEL_CONFIG,
   AUTO_MODEL_CONFIG,
 } from "@app/types/assistant/models/auto";
+import { NOOP_MODEL_CONFIG } from "@app/types/assistant/models/noop";
 
 export function _getAnalystGlobalAgent({
   auth,
+  globalAgentContext,
 }: {
   auth: Authenticator;
+  globalAgentContext?: GlobalAgentContext;
 }): AgentConfigurationType {
   const prompt = `<primary_goal>
 You are @analyst, an analytics assistant for workspace admins and managers. You help them understand how their Dust workspace is being used by answering questions with data retrieved through your tools.
@@ -29,18 +33,30 @@ You are @analyst, an analytics assistant for workspace admins and managers. You 
 5. Be concise and lead with the answer; add brief context only when it helps interpretation.
 </guidelines>`;
 
-  // Standard auto stream for upgraded workspaces, Basic one otherwise. Both
-  // sentinels are resolved to a concrete model + effort at message-send time by
-  // resolveModel().
-  const modelConfiguration = auth.isUpgraded()
-    ? AUTO_MODEL_CONFIG
-    : AUTO_FAST_MODEL_CONFIG;
+  // Echoed as a NOOP static reply instead of running the LLM.
+  const staticReply = globalAgentContext?.staticReply;
+
+  const modelConfiguration = (() => {
+    if (staticReply) {
+      return NOOP_MODEL_CONFIG;
+    }
+
+    // Standard auto stream for upgraded workspaces, Basic one otherwise. Both
+    // sentinels are resolved to a concrete model + effort at message-send time by
+    // resolveModel().
+    return auth.isUpgraded() ? AUTO_MODEL_CONFIG : AUTO_FAST_MODEL_CONFIG;
+  })();
 
   const model: AgentModelConfigurationType = {
     providerId: modelConfiguration.providerId,
     modelId: modelConfiguration.modelId,
     temperature: 0.2,
     reasoningEffort: modelConfiguration.defaultReasoningEffort,
+    ...(staticReply && {
+      metaData: {
+        staticResponse: staticReply,
+      },
+    }),
   };
 
   const sId = GLOBAL_AGENTS_SID.ANALYST;

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -901,7 +901,7 @@ function getGlobalAgent({
       agentConfiguration = _getReinforcementGlobalAgent();
       break;
     case GLOBAL_AGENTS_SID.ANALYST:
-      agentConfiguration = _getAnalystGlobalAgent({ auth });
+      agentConfiguration = _getAnalystGlobalAgent({ auth, globalAgentContext });
       break;
     case GLOBAL_AGENTS_SID.NOOP:
       agentConfiguration = _getNoopAgent();

--- a/front/lib/api/assistant/static_reply.ts
+++ b/front/lib/api/assistant/static_reply.ts
@@ -4,6 +4,13 @@ import type {
 } from "@app/types/assistant/conversation";
 import { isReinforcedSkillNotificationMetadata } from "@app/types/assistant/conversation";
 
+export const ANALYTICS_PANEL_GREETING = `I can help you understand your workspace usage and costs across your analytics data.
+
+A few things you could ask:
+- Which agents are used the most?
+- How has my workspace's spend evolved over the last 30 days?
+- Who are my most active users?`;
+
 /**
  * Returns pre-formatted text that the Dust global agent should echo as its
  * NOOP static reply for this turn, or `undefined` to fall back to the normal
@@ -30,5 +37,14 @@ export function getStaticReplyForUserMessage({
   ) {
     return userMessage.content;
   }
+
+  // A constant rather than the message content, which here is the hidden bootstrap message.
+  if (
+    userMessage.context.origin === "analytics_panel" &&
+    userMessage.rank === 0
+  ) {
+    return ANALYTICS_PANEL_GREETING;
+  }
+
   return undefined;
 }

--- a/front/lib/api/programmatic_usage/common.ts
+++ b/front/lib/api/programmatic_usage/common.ts
@@ -35,6 +35,7 @@ export const USAGE_ORIGINS_CLASSIFICATION: Record<
   zendesk: "user",
   onboarding_conversation: "user",
   agent_sidekick: "user",
+  analytics_panel: "user",
   project_kickoff: "user",
   reinforced_skill_notification: "user",
   reinforcement: "programmatic",

--- a/front/lib/credits/agent_message_billing.ts
+++ b/front/lib/credits/agent_message_billing.ts
@@ -20,6 +20,13 @@ export { TOOL_COST_CATEGORIES, type ToolCostCategory } from "@app/lib/api/mcp";
 export const LEGACY_RUN_KEY = "__legacy__";
 
 // Platform-assistive messages are metered for observability but not billed.
+/**
+ * @cc [owner:achilleburah,label:security] free-client-origins-need-targeting-guards
+ * An origin in `CLIENT_MESSAGE_ORIGINS` must not be added to `FREE_ORIGINS` unless
+ * `checkMessagesLimit` also restricts which agents it may mention and caps it per actor, as it
+ * does for `agent_sidekick`. Clients choose their own origin on the internal message endpoints, so
+ * a free client-claimable origin otherwise lets any user run any agent for free.
+ */
 export const FREE_ORIGINS: ReadonlySet<UserMessageOrigin> =
   new Set<UserMessageOrigin>([
     "agent_sidekick",

--- a/front/lib/notifications/workflows/conversation-unread.test.ts
+++ b/front/lib/notifications/workflows/conversation-unread.test.ts
@@ -79,6 +79,7 @@ describe("conversation-unread workflow business logic", () => {
     api: false,
     onboarding_conversation: false,
     agent_sidekick: false,
+    analytics_panel: false,
     project_kickoff: false,
     excel: false,
     gsheet: false,

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -79,6 +79,7 @@ export const shouldSendNotificationForAgentAnswer = (
       return true;
     case "onboarding_conversation":
     case "agent_sidekick":
+    case "analytics_panel":
     case "reinforced_skill_notification":
     case "reinforcement":
     case "system_activation":

--- a/front/temporal/agent_loop/config.ts
+++ b/front/temporal/agent_loop/config.ts
@@ -63,6 +63,7 @@ export function getQueueForUserMessageOrigin(
     case "zendesk":
       return "programmatic";
     case "agent_sidekick":
+    case "analytics_panel":
     case "onboarding_conversation":
     case "project_kickoff":
     case "reinforced_skill_notification":

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -25,6 +25,7 @@ import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   AgentMessageStatus,
   AgentMessageType,
+  ConversationMetadata,
   ConversationType,
   ConversationVisibility,
   ConversationWithoutContentType,
@@ -97,6 +98,7 @@ export class ConversationFactory {
       requestedSpaceIds,
       spaceId,
       visibility = "unlisted",
+      metadata,
       depth,
       triggerId,
       t,
@@ -107,6 +109,7 @@ export class ConversationFactory {
       requestedSpaceIds?: ModelId[];
       spaceId?: ModelId;
       visibility?: ConversationVisibility;
+      metadata?: ConversationMetadata;
       depth?: number;
       triggerId?: ModelId | null;
       t?: Transaction;
@@ -118,6 +121,7 @@ export class ConversationFactory {
     const conversation = await createConversation(auth, {
       title: "Test Conversation",
       visibility,
+      metadata,
       depth,
       triggerId,
       spaceId: spaceId ?? null,

--- a/front/types/api/assistant.ts
+++ b/front/types/api/assistant.ts
@@ -184,16 +184,24 @@ export const InternalPostContentFragmentRequestBodySchema = z.intersection(
 
 const ConversationMetadataSchema = z.record(z.unknown());
 
-export const InternalPostConversationsRequestBodySchema = z.object({
-  title: z.string().nullable(),
-  visibility: z.enum(["unlisted", "deleted", "test"]),
-  spaceId: z.string().nullable(),
-  message: MessageBaseSchema.nullable(),
-  contentFragments: z.array(InternalPostContentFragmentRequestBodySchema),
-  metadata: ConversationMetadataSchema.optional(),
-  selectedSpaceIds: z.array(z.string()).optional(),
-  skipToolsValidation: z.boolean().optional(),
-});
+export const InternalPostConversationsRequestBodySchema = z
+  .object({
+    title: z.string().nullable(),
+    visibility: z.enum(["unlisted", "deleted", "test"]),
+    spaceId: z.string().nullable(),
+    message: MessageBaseSchema.nullable(),
+    contentFragments: z.array(InternalPostContentFragmentRequestBodySchema),
+    metadata: ConversationMetadataSchema.optional(),
+    selectedSpaceIds: z.array(z.string()).optional(),
+    skipToolsValidation: z.boolean().optional(),
+    // Asks the server to author the opening message itself, for surfaces whose conversation is
+    // not started by something the user typed. The server owns its content, mentions and origin.
+    bootstrap: z.literal("analytics_panel").optional(),
+  })
+  .refine((body) => !(body.bootstrap && body.message), {
+    message: "`bootstrap` cannot be combined with `message`.",
+    path: ["bootstrap"],
+  });
 
 /** Response shape for POST /api/w/[wId]/assistant/conversations (deferred or combined). */
 export const PostConversationsResponseBodySchema = z.object({

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -124,10 +124,14 @@ export type UserMessageOrigin =
   | "wakeup"
   | "zapier"
   | "zendesk"
-  // TODO onboarding_conversation, agent_sidekick, and project_kickoff aren't message origins. They
-  // have been used as a hack but should be removed and most likely handled as message metadata
-  // (to be created).
+  // TODO onboarding_conversation, agent_sidekick, analytics_panel, and project_kickoff aren't
+  // message origins. They have been used as a hack but should be removed and most likely handled
+  // as message metadata (to be created).
   | "onboarding_conversation"
+  // Bootstrap message the Analytics conversation panel opens on. Server-only: it is not in
+  // `CLIENT_MESSAGE_ORIGINS`, and since it is in `HIDDEN_MESSAGE_ORIGINS` a client able to claim
+  // it could hide arbitrary messages from a shared conversation while the agent still reads them.
+  | "analytics_panel"
   // for internal use, for reinforced agent batch LLM operations
   | "reinforcement"
   // Opening message of an Activation Pod nudge, authored by the system on the
@@ -142,6 +146,7 @@ export type UserMessageOrigin =
 export const ACTIVATION_NUDGE_ORIGIN = "system_activation" as const;
 
 export const HIDDEN_MESSAGE_ORIGINS: UserMessageOrigin[] = [
+  "analytics_panel",
   "onboarding_conversation",
   "project_kickoff",
   "reinforced_skill_notification",
@@ -524,12 +529,18 @@ export type ConversationUrlAccessMode =
 
 const CONVERSATION_METADATA_URL_ACCESS_MODE_KEY = "urlAccessMode";
 
+export const CONVERSATION_ORIGINS = ["analytics_panel"] as const;
+
+export type ConversationOrigin = (typeof CONVERSATION_ORIGINS)[number];
+
 export type ConversationMetadata = Record<string, unknown> & {
   urlAccessMode?: ConversationUrlAccessMode;
   projectTaskId?: string;
   useFileSystem?: boolean;
   /** Selects the database-backed filesystem for a fresh standalone conversation. */
   useDatabaseFileSystem?: boolean;
+  /** The surface that created the conversation, when it was not a plain user conversation. */
+  origin?: ConversationOrigin;
 };
 
 function isConversationUrlAccessMode(

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -495,6 +495,7 @@ const USER_MESSAGE_ORIGINS = [
   "zendesk",
   "onboarding_conversation",
   "agent_sidekick",
+  "analytics_panel",
   "project_kickoff",
   "reinforced_skill_notification",
   "reinforcement",


### PR DESCRIPTION
## Description

Currently the Analytics page's "Ask @analyst" panel opens on a hardcoded greeting bubble with its own input bar, and only creates a conversation once the user submits

PR stack: Directly start a conversation with the from the Ask Analyst side conversation panel instead of first presenting a empty state "fake message". 

- PR#1 implements the backend necessary to do that.
- PR#2 connects the front

## Tests

Tested Locally.

## Risk

Low. Still behind Dust Only FF. 

## Deploy Plan

Standard deploy.
