### PR TITLE
[Admin Governance] Support admin API keys in agent ACLs

### DIFF
--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations.test.ts
@@ -80,7 +80,7 @@ describe("GET /api/v1/w/[wId]/assistant/agent_configurations", () => {
     expect(response.status).toBe(200);
     expect(
       agentConfigurations.find((a) => a.name === "Published Agent")?.canEdit
-    ).toBe(role !== "user");
+    ).toBe(role === "admin");
     expect(
       agentConfigurations
         .filter((a) => a.scope === "global")

--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.test.ts
@@ -1,11 +1,31 @@
 import { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { honoApp } from "@front-api/app";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+beforeEach(() => {
+  vi.spyOn(logger, "warn");
+});
+
+afterEach(() => {
+  try {
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        check: "agent_permissions",
+        authMethod: "api_key",
+      }),
+      "group_permissions_shadow_mismatch"
+    );
+  } finally {
+    vi.mocked(logger.warn).mockRestore();
+  }
+});
 
 async function setupTest(role: "admin" | "builder" | "user" = "builder") {
   const { workspace, key } = await createPublicApiMockRequest({ role });
@@ -22,6 +42,7 @@ async function setupTest(role: "admin" | "builder" | "user" = "builder") {
   );
 
   const agentConfig = await AgentConfigurationFactory.createTestAgent(auth);
+  await FeatureFlagFactory.basic(auth, "group_permissions_shadow");
 
   return { workspace, key, agentConfig, auth, user };
 }

--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.test.ts
@@ -135,7 +135,7 @@ describe("GET /api/v1/w/[wId]/assistant/agent_configurations/[sId]", () => {
     "admin",
     "builder",
     "user",
-  ] as const)("reports whether a %s key can patch a published agent", async (role) => {
+  ] as const)("reports edit permissions for a %s key on a published agent", async (role) => {
     const { workspace, key, agentConfig } = await setupTest(role);
     const response = await getAgentConfiguration(
       workspace,
@@ -145,7 +145,7 @@ describe("GET /api/v1/w/[wId]/assistant/agent_configurations/[sId]", () => {
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(data.agentConfiguration.canEdit).toBe(role !== "user");
+    expect(data.agentConfiguration.canEdit).toBe(role === "admin");
 
     const patchResponse = await patchAgentConfiguration(
       workspace,
@@ -153,6 +153,7 @@ describe("GET /api/v1/w/[wId]/assistant/agent_configurations/[sId]", () => {
       agentConfig.sId,
       { instructions: "Updated through the API" }
     );
+    // The PATCH endpoint still accepts legacy builder keys independently of `canEdit`.
     expect(patchResponse.status).toBe(role === "user" ? 403 : 200);
   });
 

--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -132,7 +132,12 @@ describe("getAgentConfigurations", () => {
         requestedRole: "admin",
       });
     assert(impersonatedAuth);
+    const resource = await AgentResource.fetchByAgentConfiguration(
+      authenticator,
+      agent
+    );
     for (const auth of [adminAuth, impersonatedAuth]) {
+      expect(auth.can("write", resource)).toBe(false);
       const configuration = await getAgentConfiguration(auth, {
         agentId: agent.sId,
         variant: "light",

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -96,24 +96,6 @@ export async function getAgentIdFromName(
   return agent.sId;
 }
 
-/**
- * @cc [owner:philipperolet,label:security] regular-key-agent-editability
- * For regular keys on custom agents, `canEdit` requires workspace admin access, active status,
- * and read access to every requested space.
- */
-function canEditWithApiKey(
-  auth: Authenticator,
-  {
-    status,
-    canReadSpaces,
-  }: {
-    status: AgentConfigurationType["status"];
-    canReadSpaces: boolean;
-  }
-): boolean {
-  return auth.isAdmin() && status === "active" && canReadSpaces;
-}
-
 async function shadowAgentPermissions(
   auth: Authenticator,
   agentModels: AgentConfigurationModel[],
@@ -135,14 +117,9 @@ async function shadowAgentPermissions(
         const resource = AgentResource.fromAgentConfigurationModel(agent);
         const read = auth.can("read", resource);
         const write = isRegularApiKey
-          ? canEditWithApiKey(auth, {
-              status: agent.status,
-              canReadSpaces: canReadRequestedSpaces(
-                auth,
-                spaceById,
-                agent.requestedSpaceIds
-              ),
-            })
+          ? auth.isAdmin() &&
+            agent.status === "active" &&
+            canReadRequestedSpaces(auth, spaceById, agent.requestedSpaceIds)
           : auth.can("write", resource);
         return {
           agentId: agent.sId,
@@ -179,6 +156,11 @@ async function shadowAgentPermissions(
 
 /**
  * Enrich agent configurations with additional data (actions, tags, favorites).
+ */
+/**
+ * @cc [owner:philipperolet,label:security] regular-key-agent-editability
+ * For regular keys on custom agents, `canEdit` requires workspace admin access, active status,
+ * and read access to every requested space.
  */
 /**
  * @cc [owner:philipperolet,label:security] agent-editability
@@ -254,14 +236,9 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
     const canRead =
       isAuthor || isMember || canEditAsSystem || agent.scope === "visible";
     const canEdit = isRegularApiKey
-      ? canEditWithApiKey(auth, {
-          status: agent.status,
-          canReadSpaces: canReadRequestedSpaces(
-            auth,
-            spaceById,
-            agent.requestedSpaceIds
-          ),
-        })
+      ? auth.isAdmin() &&
+        agent.status === "active" &&
+        canReadRequestedSpaces(auth, spaceById, agent.requestedSpaceIds)
       : isAuthor || isMember || canEditAsSystem;
     const agentConfigurationType: AgentConfigurationType = {
       id: agent.id,

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -116,19 +116,21 @@ async function shadowAgentPermissions(
       agentModels.map((agent) => {
         const resource = AgentResource.fromAgentConfigurationModel(agent);
         const read = auth.can("read", resource);
-        const write = isRegularApiKey
-          ? auth.isAdmin() &&
-            agent.status === "active" &&
-            canReadRequestedSpaces(auth, spaceById, agent.requestedSpaceIds)
-          : auth.can("write", resource);
+        const write =
+          auth.can("write", resource) &&
+          (!isRegularApiKey ||
+            (agent.status === "active" &&
+              canReadRequestedSpaces(
+                auth,
+                spaceById,
+                agent.requestedSpaceIds
+              )));
         return {
           agentId: agent.sId,
           agentConfigurationModelId: agent.id,
           read,
           write,
-          admin: isRegularApiKey
-            ? write || auth.isAdmin()
-            : auth.can("admin", resource),
+          admin: auth.can("admin", resource),
         };
       }),
     context: {

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -96,11 +96,38 @@ export async function getAgentIdFromName(
   return agent.sId;
 }
 
+/**
+ * @cc [owner:philipperolet,label:security] regular-key-agent-editability
+ * For regular keys on custom agents, editing requires builder access, active status, agent read
+ * access or workspace admin, and read access to every requested space.
+ */
+function canEditWithApiKey(
+  auth: Authenticator,
+  {
+    status,
+    canRead,
+    canReadSpaces,
+  }: {
+    status: AgentConfigurationType["status"];
+    canRead: boolean;
+    canReadSpaces: boolean;
+  }
+): boolean {
+  return (
+    auth.isBuilder() &&
+    status === "active" &&
+    (canRead || auth.isAdmin()) &&
+    canReadSpaces
+  );
+}
+
 async function shadowAgentPermissions(
   auth: Authenticator,
   agentModels: AgentConfigurationModel[],
-  legacyAgents: AgentConfigurationType[]
+  legacyAgents: AgentConfigurationType[],
+  spaceById: Map<ModelId, SpaceResource>
 ): Promise<void> {
+  const isRegularApiKey = auth.isKey() && !auth.isSystemKey();
   await shadowCompare({
     auth,
     legacy: legacyAgents.map((agent) => ({
@@ -113,12 +140,26 @@ async function shadowAgentPermissions(
     candidate: async () =>
       agentModels.map((agent) => {
         const resource = AgentResource.fromAgentConfigurationModel(agent);
+        const read = auth.can("read", resource);
+        const write = isRegularApiKey
+          ? canEditWithApiKey(auth, {
+              status: agent.status,
+              canRead: read,
+              canReadSpaces: canReadRequestedSpaces(
+                auth,
+                spaceById,
+                agent.requestedSpaceIds
+              ),
+            })
+          : auth.can("write", resource);
         return {
           agentId: agent.sId,
           agentConfigurationModelId: agent.id,
-          read: auth.can("read", resource),
-          write: auth.can("write", resource),
-          admin: auth.can("admin", resource),
+          read,
+          write,
+          admin: isRegularApiKey
+            ? write || auth.isAdmin()
+            : auth.can("admin", resource),
         };
       }),
     context: {
@@ -221,10 +262,15 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
     const canRead =
       isAuthor || isMember || canEditAsSystem || agent.scope === "visible";
     const canEdit = isRegularApiKey
-      ? auth.isBuilder() &&
-        agent.status === "active" &&
-        (canRead || auth.isAdmin()) &&
-        canReadRequestedSpaces(auth, spaceById, agent.requestedSpaceIds)
+      ? canEditWithApiKey(auth, {
+          status: agent.status,
+          canRead,
+          canReadSpaces: canReadRequestedSpaces(
+            auth,
+            spaceById,
+            agent.requestedSpaceIds
+          ),
+        })
       : isAuthor || isMember || canEditAsSystem;
     const agentConfigurationType: AgentConfigurationType = {
       id: agent.id,
@@ -269,7 +315,8 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
   await shadowAgentPermissions(
     auth,
     agentConfigurations,
-    agentConfigurationTypes
+    agentConfigurationTypes,
+    spaceById
   );
 
   return agentConfigurationTypes;

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -98,27 +98,20 @@ export async function getAgentIdFromName(
 
 /**
  * @cc [owner:philipperolet,label:security] regular-key-agent-editability
- * For regular keys on custom agents, editing requires builder access, active status, agent read
- * access or workspace admin, and read access to every requested space.
+ * For regular keys on custom agents, `canEdit` requires workspace admin access, active status,
+ * and read access to every requested space.
  */
 function canEditWithApiKey(
   auth: Authenticator,
   {
     status,
-    canRead,
     canReadSpaces,
   }: {
     status: AgentConfigurationType["status"];
-    canRead: boolean;
     canReadSpaces: boolean;
   }
 ): boolean {
-  return (
-    auth.isBuilder() &&
-    status === "active" &&
-    (canRead || auth.isAdmin()) &&
-    canReadSpaces
-  );
+  return auth.isAdmin() && status === "active" && canReadSpaces;
 }
 
 async function shadowAgentPermissions(
@@ -144,7 +137,6 @@ async function shadowAgentPermissions(
         const write = isRegularApiKey
           ? canEditWithApiKey(auth, {
               status: agent.status,
-              canRead: read,
               canReadSpaces: canReadRequestedSpaces(
                 auth,
                 spaceById,
@@ -233,7 +225,7 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
       ? await TagResource.listForAgents(auth, configurationIds)
       : [];
   const spacesForApiKey =
-    isRegularApiKey && auth.isBuilder()
+    isRegularApiKey && auth.isAdmin()
       ? await SpaceResource.fetchByModelIds(auth, [
           ...new Set(
             agentConfigurations.flatMap((agent) => agent.requestedSpaceIds)
@@ -264,7 +256,6 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
     const canEdit = isRegularApiKey
       ? canEditWithApiKey(auth, {
           status: agent.status,
-          canRead,
           canReadSpaces: canReadRequestedSpaces(
             auth,
             spaceById,

--- a/front/lib/resources/agent_resource.test.ts
+++ b/front/lib/resources/agent_resource.test.ts
@@ -2,6 +2,7 @@ import { Authenticator } from "@app/lib/auth";
 import { AgentResource } from "@app/lib/resources/agent_resource";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
@@ -126,6 +127,45 @@ describe("AgentResource", () => {
       otherAuth.hasPermission("write", resource),
       otherAuth.hasPermission("admin", resource),
     ]).toEqual([true, true, true]);
+  });
+
+  it.each([
+    "admin",
+    "builder",
+  ] as const)("applies the %s API-key write policy only to workspace custom agents", async (role) => {
+    const { auth, workspace } = await createPublicApiMockRequest({ role });
+    const configuration = {
+      agentId: AGENT_MODEL_ID,
+      authorId: testContext.user.id,
+      sId: "custom-agent",
+      scope: "hidden" as const,
+      workspaceId: workspace.id,
+    };
+
+    expect(
+      auth.can(
+        "write",
+        AgentResource.fromAgentConfigurationModel(configuration)
+      )
+    ).toBe(role === "admin");
+    expect(
+      auth.can(
+        "write",
+        AgentResource.fromAgentConfigurationModel({
+          ...configuration,
+          workspaceId: testContext.workspace.id,
+        })
+      )
+    ).toBe(false);
+    expect(
+      auth.can(
+        "write",
+        AgentResource.fromGlobalAgent({
+          agentId: GLOBAL_AGENTS_SID.HELPER,
+          workspaceModelId: workspace.id,
+        })
+      )
+    ).toBe(false);
   });
 
   it("lets workspace members read visible agents without editing them", async () => {

--- a/front/lib/resources/agent_resource.ts
+++ b/front/lib/resources/agent_resource.ts
@@ -32,7 +32,7 @@ import type { Transaction } from "sequelize";
 // editor role rather than granting write alone.
 const AGENT_EDITOR_VERBS: GrantVerb[] = ["read", "write", "admin"];
 
-// Workspace admins manage editors but must grant themselves editor access to change the agent.
+// Human workspace admins manage editors but must grant themselves editor access to change the agent.
 const HIDDEN_AGENT_ROLE_GRANTS: RoleGrant[] = [
   { role: "admin", permissions: ["read", "admin"] },
 ];
@@ -338,6 +338,11 @@ export class AgentResource implements WithAccessControl {
     }
   }
 
+  /**
+   * @cc [owner:philipperolet,label:security] admin-key-agent-write
+   * The admin role grants `write` on custom agents to regular API keys only; human and system-key
+   * callers receive no agent write access from their role. Global agents remain read-only.
+   */
   getAccessControlLists(auth: Authenticator): AccessControlList[] {
     switch (this.kind) {
       case "global":
@@ -360,13 +365,17 @@ export class AgentResource implements WithAccessControl {
         const isAuthor =
           auth.workspace()?.id === this.workspaceId &&
           auth.user()?.id === this.authorId;
+        const roles =
+          this.scope === "visible"
+            ? VISIBLE_AGENT_ROLE_GRANTS
+            : HIDDEN_AGENT_ROLE_GRANTS;
 
         return [
           {
             roles:
-              this.scope === "visible"
-                ? VISIBLE_AGENT_ROLE_GRANTS
-                : HIDDEN_AGENT_ROLE_GRANTS,
+              auth.isKey() && !auth.isSystemKey()
+                ? [...roles, { role: "admin", permissions: ["write"] }]
+                : roles,
             grantedVerbs: isAuthor
               ? [...new Set([...grants, ...AGENT_EDITOR_VERBS])]
               : grants,

--- a/x/pr/agent_governance_migration.md
+++ b/x/pr/agent_governance_migration.md
@@ -116,9 +116,9 @@ editor-list, permission, listing, backfill, and cache-related mismatches to reac
 Serve editor lists, permission decisions, and list/manage/archive filtering from grants at the same
 time, behind one operational switch with a single kill-switch fallback to legacy reads.
 
-Preserve regular API-key editability on top of grant-backed agent read access: builder role, active
-status, agent visibility or admin access, and access to every requested space. This shared policy
-must survive rollout cleanup; it is not an agent editor grant.
+Preserve regular API-key editability alongside grant-backed agent read access: admin role, active
+status, and access to every requested space. This shared policy must survive rollout cleanup; it
+is not an agent editor grant.
 
 **Operational gate:** observe the complete read flip before removing the fallback.
 

--- a/x/pr/agent_governance_migration.md
+++ b/x/pr/agent_governance_migration.md
@@ -116,6 +116,10 @@ editor-list, permission, listing, backfill, and cache-related mismatches to reac
 Serve editor lists, permission decisions, and list/manage/archive filtering from grants at the same
 time, behind one operational switch with a single kill-switch fallback to legacy reads.
 
+Preserve regular API-key editability on top of grant-backed agent read access: builder role, active
+status, agent visibility or admin access, and access to every requested space. This shared policy
+must survive rollout cleanup; it is not an agent editor grant.
+
 **Operational gate:** observe the complete read flip before removing the fallback.
 
 ### PR 13: Remove legacy reads and rollout infrastructure

--- a/x/pr/agent_governance_migration.md
+++ b/x/pr/agent_governance_migration.md
@@ -116,9 +116,11 @@ editor-list, permission, listing, backfill, and cache-related mismatches to reac
 Serve editor lists, permission decisions, and list/manage/archive filtering from grants at the same
 time, behind one operational switch with a single kill-switch fallback to legacy reads.
 
-Preserve regular API-key editability alongside grant-backed agent read access: admin role, active
-status, and access to every requested space. This shared policy must survive rollout cleanup; it
-is not an agent editor grant.
+Use `auth.can("write", agentResource)` for agent authorization, including regular admin API keys via
+the resource ACL. Keep the existing active-status and requested-space checks outside that ACL.
+Remove the legacy admin-key condition in configuration enrichment when flipping and cleaning up.
+`getResourceIdsWithVerb()` only enumerates governance grants, not role-based ACL permissions; account
+for that distinction when using it to filter editable agents.
 
 **Operational gate:** observe the complete read flip before removing the fallback.
 


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/32024.

Admin API keys can edit agents without belonging to a user editor group. The served `canEdit` reflects that behavior, but the permission shadow still checks only the agent ACL, producing false write/admin mismatches.

Grant regular admin API keys `write` in `AgentResource`'s ACL and make the shadow candidate use `auth.can()` for all three verbs. Keep active-status and requested-space checks outside the ACL, using the already-loaded spaces. The legacy admin-key condition remains only until the read flip; the migration plan records this boundary and the distinction between grant enumeration and effective ACL permissions.

Require admin rather than builder role, since builder is being retired: builder keys now report `canEdit: false`. Human and system-key rules, global-agent restrictions, and stored grants remain unchanged.

The PATCH endpoint's existing acceptance of legacy builder keys is unchanged; tightening that authorization is separate from permission reporting.

## Risks

Blast radius: Agent ACL checks, permission reporting, and shadow comparisons for regular API keys.
Risk: low

## Deploy Plan

- Deploy front; no migration or backfill.

## Tests

- [x] Existing API-key endpoint suites with shadow-parity assertions: 16 passed, including admin-only edit reporting on single-agent and list responses.
- [x] Agent configuration, AgentResource, and shadow suites: 47 passed, including admin/builder keys, workspace scoping, read-only global agents, and human/system-key restrictions.
