### PR TITLE
[Email Agents] Relay workspace misses in cell order

### DIFF
--- a/front-api/routes/email/webhook.test.ts
+++ b/front-api/routes/email/webhook.test.ts
@@ -1,13 +1,10 @@
 import { randomUUID } from "node:crypto";
-import { makeEmailAgentsDisabledEmailTriggerError } from "@app/lib/api/assistant/email/email_trigger";
 import {
   EMAIL_WEBHOOK_RELAY_HEADER,
   EMAIL_WEBHOOK_RELAY_HEADER_VALUE,
-  EMAIL_WEBHOOK_RELAY_LOOKUP,
+  EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER,
   EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER,
 } from "@app/lib/api/assistant/email/webhook_helpers";
-import { config as cellsConfig } from "@app/lib/api/cells/config";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -19,6 +16,7 @@ vi.mock("@app/lib/api/cells/config", async (importOriginal) => {
     ...actual,
     config: {
       ...actual.config,
+      getCurrentRegion: () => "europe-west1",
       getLookupApiSecret: () => "test-lookup-secret",
       getOtherCells: () => [
         {
@@ -128,9 +126,7 @@ describe("POST /api/email/webhook", () => {
 
   it("relays with the source error type when no local workspace has email agents enabled", async () => {
     const { user } = await createResourceTest({ role: "admin" });
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(Response.json({ success: true }));
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}"));
     vi.stubGlobal("fetch", fetchMock);
 
     try {
@@ -145,9 +141,9 @@ describe("POST /api/email/webhook", () => {
       expect(relayInit.headers[EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]).toBe(
         "email_agents_disabled"
       );
-      expect(relayInit.headers[EMAIL_WEBHOOK_RELAY_HEADER]).toBe(
-        EMAIL_WEBHOOK_RELAY_LOOKUP
-      );
+      expect(
+        relayInit.headers[EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]
+      ).toBe("cell-00002");
       // No bounce from the source region once the relay succeeded.
       expect(sendEmailToRecipients).not.toHaveBeenCalled();
     } finally {
@@ -155,153 +151,52 @@ describe("POST /api/email/webhook", () => {
     }
   });
 
-  it("US tries the next cell on a lookup miss", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(
-        Response.json({
-          success: true,
-          lookupError: makeEmailAgentsDisabledEmailTriggerError(),
-        })
-      )
-      .mockResolvedValueOnce(Response.json({ success: true }));
+  it("forwards lookup misses without sending an error reply", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}"));
     vi.stubGlobal("fetch", fetchMock);
+
     try {
-      await postWebhook("unknown-sender@example.com", {
-        Authorization: SENDGRID_AUTH_HEADER,
+      const response = await postWebhook("unknown-sender@example.com", {
+        ...RELAY_AUTH_HEADERS,
+        [EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]: "cell-00002",
+        [EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]: "email_agents_disabled",
       });
-      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
-      expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
-        "http://other-region.test/api/email/webhook",
-        "http://last-cell.test/api/email/webhook",
-      ]);
+      expect(response.status).toBe(200);
+
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+      const [relayUrl, relayInit] = fetchMock.mock.calls[0];
+      expect(relayUrl).toBe("http://last-cell.test/api/email/webhook");
       expect(
-        fetchMock.mock.calls[1][1].headers[
-          EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER
-        ]
-      ).toBe("email_agents_disabled");
+        relayInit.headers[EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]
+      ).toBe("");
+      expect(relayInit.headers[EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]).toBe(
+        "email_agents_disabled"
+      );
       expect(sendEmailToRecipients).not.toHaveBeenCalled();
     } finally {
       vi.unstubAllGlobals();
     }
   });
 
-  it("US sends one error reply after all cells miss", async () => {
-    const fetchMock = vi.fn().mockImplementation(async () =>
-      Response.json({
-        success: true,
-        lookupError: makeEmailAgentsDisabledEmailTriggerError(),
-      })
-    );
-    vi.stubGlobal("fetch", fetchMock);
-    try {
-      await postWebhook("unknown-sender@example.com", {
-        Authorization: SENDGRID_AUTH_HEADER,
-      });
-      await vi.waitFor(() =>
-        expect(sendEmailToRecipients).toHaveBeenCalledOnce()
-      );
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-      const [{ message }] = vi.mocked(sendEmailToRecipients).mock.calls[0];
-      expect(message.html).toContain("Email agents are disabled");
-    } finally {
-      vi.unstubAllGlobals();
-    }
-  });
-
-  it("stops on an HTTP rejection", async () => {
+  it("tries the next cell after an HTTP error", async () => {
+    const { user } = await createResourceTest({ role: "admin" });
     const fetchMock = vi
       .fn()
-      .mockResolvedValue(new Response(null, { status: 403 }));
+      .mockResolvedValueOnce(new Response(null, { status: 403 }))
+      .mockResolvedValueOnce(new Response("{}"));
     vi.stubGlobal("fetch", fetchMock);
-    try {
-      await postWebhook("unknown-sender@example.com", {
-        Authorization: SENDGRID_AUTH_HEADER,
-      });
-      await vi.waitFor(() =>
-        expect(sendEmailToRecipients).toHaveBeenCalledOnce()
-      );
-      expect(fetchMock).toHaveBeenCalledOnce();
-    } finally {
-      vi.unstubAllGlobals();
-    }
-  });
 
-  it("returns a lookup miss again on retry, without replying or forwarding", async () => {
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
-    const messageId = `<${randomUUID()}@example.com>`;
     try {
-      for (let attempt = 0; attempt < 2; attempt++) {
-        const response = await postWebhook(
-          "unknown-sender@example.com",
-          {
-            ...RELAY_AUTH_HEADERS,
-            [EMAIL_WEBHOOK_RELAY_HEADER]: EMAIL_WEBHOOK_RELAY_LOOKUP,
-            [EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]: "email_agents_disabled",
-          },
-          messageId
-        );
-        expect(response.status).toBe(200);
-        expect(await response.json()).toEqual({
-          success: true,
-          lookupError: makeEmailAgentsDisabledEmailTriggerError(),
-        });
-      }
-      expect(fetchMock).not.toHaveBeenCalled();
+      await postWebhook(user.email, { Authorization: SENDGRID_AUTH_HEADER });
+
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+      const [relayUrl, relayInit] = fetchMock.mock.calls[1];
+      expect(relayUrl).toBe("http://last-cell.test/api/email/webhook");
+      expect(
+        relayInit.headers[EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]
+      ).toBe("");
       expect(sendEmailToRecipients).not.toHaveBeenCalled();
     } finally {
-      vi.unstubAllGlobals();
-    }
-  });
-
-  it("keeps an accepted email deduplicated after workspace eligibility changes", async () => {
-    const { user, workspace } = await createResourceTest({ role: "admin" });
-    await WorkspaceResource.updateMetadata(workspace.id, {
-      allowEmailAgents: true,
-      emailBlacklistedAgentIds: "invalid",
-    });
-    const messageId = `<${randomUUID()}@example.com>`;
-    for (let attempt = 0; attempt < 2; attempt++) {
-      const response = await postWebhook(
-        user.email,
-        {
-          ...RELAY_AUTH_HEADERS,
-          [EMAIL_WEBHOOK_RELAY_HEADER]: EMAIL_WEBHOOK_RELAY_LOOKUP,
-        },
-        messageId
-      );
-      expect(await response.json()).toEqual({ success: true });
-      await vi.waitFor(() =>
-        expect(sendEmailToRecipients).toHaveBeenCalledOnce()
-      );
-      await WorkspaceResource.updateMetadata(workspace.id, {
-        allowEmailAgents: false,
-      });
-    }
-    const [{ message }] = vi.mocked(sendEmailToRecipients).mock.calls[0];
-    expect(message.html).toContain("temporarily unavailable");
-  });
-
-  it.each([
-    "cell-00001",
-    "cell-00002",
-  ] as const)("never relays from %s", async (cell) => {
-    const cellMock = vi
-      .spyOn(cellsConfig, "getCurrentCell")
-      .mockReturnValue(cellsConfig.getCellInfo(cell));
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
-    try {
-      await postWebhook("unknown-sender@example.com", {
-        Authorization: SENDGRID_AUTH_HEADER,
-      });
-      await vi.waitFor(() =>
-        expect(sendEmailToRecipients).toHaveBeenCalledOnce()
-      );
-      expect(fetchMock).not.toHaveBeenCalled();
-    } finally {
-      cellMock.mockRestore();
       vi.unstubAllGlobals();
     }
   });
@@ -354,7 +249,7 @@ describe("POST /api/email/webhook", () => {
       .fn()
       .mockResolvedValueOnce(new Response(null, { status: 502 }))
       .mockResolvedValueOnce(new Response(null, { status: 502 }))
-      .mockResolvedValueOnce(Response.json({ success: true }));
+      .mockResolvedValueOnce(new Response("{}"));
     vi.stubGlobal("fetch", fetchMock);
 
     try {
@@ -429,15 +324,31 @@ describe("POST /api/email/webhook", () => {
     expect(message.html).toContain("Email agents are disabled");
   });
 
-  it("never forwards a legacy relay", async () => {
+  it.each([
+    undefined,
+    "",
+  ])("replies once after relay exhaustion (%s)", async (remainingCells) => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
+
     try {
-      await postWebhook("unknown-sender@example.com", RELAY_AUTH_HEADERS);
+      const response = await postWebhook("unknown-sender@example.com", {
+        ...RELAY_AUTH_HEADERS,
+        ...(remainingCells === undefined
+          ? {}
+          : {
+              [EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]: remainingCells,
+            }),
+        [EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]: "email_agents_disabled",
+      });
+      expect(response.status).toBe(200);
+
       await vi.waitFor(() =>
         expect(sendEmailToRecipients).toHaveBeenCalledOnce()
       );
       expect(fetchMock).not.toHaveBeenCalled();
+      const [{ message }] = vi.mocked(sendEmailToRecipients).mock.calls[0];
+      expect(message.html).toContain("Email agents are disabled");
     } finally {
       vi.unstubAllGlobals();
     }

--- a/front-api/routes/email/webhook.test.ts
+++ b/front-api/routes/email/webhook.test.ts
@@ -201,6 +201,26 @@ describe("POST /api/email/webhook", () => {
     }
   });
 
+  it("does not try another cell when receipt is uncertain", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("Response lost"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      await postWebhook("unknown-sender@example.com", {
+        Authorization: SENDGRID_AUTH_HEADER,
+      });
+
+      await vi.waitFor(() =>
+        expect(sendEmailToRecipients).toHaveBeenCalledOnce()
+      );
+      expect(new Set(fetchMock.mock.calls.map(([url]) => url))).toEqual(
+        new Set(["http://other-region.test/api/email/webhook"])
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("ignores a relayed email with the same Message-ID", async () => {
     const messageId = `<${randomUUID()}@example.com>`;
 

--- a/front-api/routes/email/webhook.test.ts
+++ b/front-api/routes/email/webhook.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import {
   EMAIL_WEBHOOK_RELAY_HEADER,
   EMAIL_WEBHOOK_RELAY_HEADER_VALUE,
+  EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER,
   EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER,
 } from "@app/lib/api/assistant/email/webhook_helpers";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -22,6 +23,11 @@ vi.mock("@app/lib/api/cells/config", async (importOriginal) => {
           name: "cell-00001",
           region: "europe-west1",
           url: "http://other-region.test",
+        } satisfies CellInfo,
+        {
+          name: "cell-00002",
+          region: "europe-west1",
+          url: "http://last-cell.test",
         } satisfies CellInfo,
       ],
     },
@@ -135,7 +141,60 @@ describe("POST /api/email/webhook", () => {
       expect(relayInit.headers[EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]).toBe(
         "email_agents_disabled"
       );
+      expect(
+        relayInit.headers[EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]
+      ).toBe("cell-00002");
       // No bounce from the source region once the relay succeeded.
+      expect(sendEmailToRecipients).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("forwards lookup misses without sending an error reply", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const response = await postWebhook("unknown-sender@example.com", {
+        ...RELAY_AUTH_HEADERS,
+        [EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]: "cell-00002",
+        [EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]: "email_agents_disabled",
+      });
+      expect(response.status).toBe(200);
+
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+      const [relayUrl, relayInit] = fetchMock.mock.calls[0];
+      expect(relayUrl).toBe("http://last-cell.test/api/email/webhook");
+      expect(
+        relayInit.headers[EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]
+      ).toBe("");
+      expect(relayInit.headers[EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]).toBe(
+        "email_agents_disabled"
+      );
+      expect(sendEmailToRecipients).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("tries the next cell after an HTTP error", async () => {
+    const { user } = await createResourceTest({ role: "admin" });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 403 }))
+      .mockResolvedValueOnce(new Response("{}"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      await postWebhook(user.email, { Authorization: SENDGRID_AUTH_HEADER });
+
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+      const [relayUrl, relayInit] = fetchMock.mock.calls[1];
+      expect(relayUrl).toBe("http://last-cell.test/api/email/webhook");
+      expect(
+        relayInit.headers[EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]
+      ).toBe("");
       expect(sendEmailToRecipients).not.toHaveBeenCalled();
     } finally {
       vi.unstubAllGlobals();
@@ -245,14 +304,22 @@ describe("POST /api/email/webhook", () => {
     expect(message.html).toContain("Email agents are disabled");
   });
 
-  it("does not relay again from a relayed request", async () => {
+  it.each([
+    undefined,
+    "",
+  ])("replies once after relay exhaustion (%s)", async (remainingCells) => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
     try {
       const response = await postWebhook("unknown-sender@example.com", {
         ...RELAY_AUTH_HEADERS,
-        [EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]: "user_not_found",
+        ...(remainingCells === undefined
+          ? {}
+          : {
+              [EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]: remainingCells,
+            }),
+        [EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]: "email_agents_disabled",
       });
       expect(response.status).toBe(200);
 
@@ -260,6 +327,8 @@ describe("POST /api/email/webhook", () => {
         expect(sendEmailToRecipients).toHaveBeenCalledOnce()
       );
       expect(fetchMock).not.toHaveBeenCalled();
+      const [{ message }] = vi.mocked(sendEmailToRecipients).mock.calls[0];
+      expect(message.html).toContain("Email agents are disabled");
     } finally {
       vi.unstubAllGlobals();
     }

--- a/front-api/routes/email/webhook.test.ts
+++ b/front-api/routes/email/webhook.test.ts
@@ -2,9 +2,9 @@ import { randomUUID } from "node:crypto";
 import {
   EMAIL_WEBHOOK_RELAY_HEADER,
   EMAIL_WEBHOOK_RELAY_HEADER_VALUE,
-  EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER,
   EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER,
 } from "@app/lib/api/assistant/email/webhook_helpers";
+import { config as cellsConfig } from "@app/lib/api/cells/config";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -16,18 +16,19 @@ vi.mock("@app/lib/api/cells/config", async (importOriginal) => {
     ...actual,
     config: {
       ...actual.config,
-      getCurrentRegion: () => "europe-west1",
+      getCurrentCell: vi.fn(),
       getLookupApiSecret: () => "test-lookup-secret",
-      getOtherCells: () => [
-        {
-          name: "cell-00001",
-          region: "europe-west1",
-          url: "http://other-region.test",
-        } satisfies CellInfo,
+      getAllCells: () => [
         {
           name: "cell-00002",
           region: "europe-west1",
           url: "http://last-cell.test",
+        } satisfies CellInfo,
+        actual.config.getCellInfo("cell-00000"),
+        {
+          name: "cell-00001",
+          region: "europe-west1",
+          url: "http://other-region.test",
         } satisfies CellInfo,
       ],
     },
@@ -112,9 +113,12 @@ const postWebhook = async (
   });
 };
 
+const getCurrentCellMock = vi.mocked(cellsConfig.getCurrentCell);
+
 describe("POST /api/email/webhook", () => {
   beforeEach(() => {
     vi.mocked(sendEmailToRecipients).mockClear();
+    getCurrentCellMock.mockReturnValue(cellsConfig.getCellInfo("cell-00002"));
   });
 
   it("rejects requests without valid authorization", async () => {
@@ -125,6 +129,7 @@ describe("POST /api/email/webhook", () => {
   });
 
   it("relays with the source error type when no local workspace has email agents enabled", async () => {
+    getCurrentCellMock.mockReturnValue(cellsConfig.getCellInfo("cell-00000"));
     const { user } = await createResourceTest({ role: "admin" });
     const fetchMock = vi.fn().mockResolvedValue(new Response("{}"));
     vi.stubGlobal("fetch", fetchMock);
@@ -141,9 +146,6 @@ describe("POST /api/email/webhook", () => {
       expect(relayInit.headers[EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]).toBe(
         "email_agents_disabled"
       );
-      expect(
-        relayInit.headers[EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]
-      ).toBe("cell-00002");
       // No bounce from the source region once the relay succeeded.
       expect(sendEmailToRecipients).not.toHaveBeenCalled();
     } finally {
@@ -152,13 +154,13 @@ describe("POST /api/email/webhook", () => {
   });
 
   it("forwards lookup misses without sending an error reply", async () => {
+    getCurrentCellMock.mockReturnValue(cellsConfig.getCellInfo("cell-00001"));
     const fetchMock = vi.fn().mockResolvedValue(new Response("{}"));
     vi.stubGlobal("fetch", fetchMock);
 
     try {
       const response = await postWebhook("unknown-sender@example.com", {
         ...RELAY_AUTH_HEADERS,
-        [EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]: "cell-00002",
         [EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]: "email_agents_disabled",
       });
       expect(response.status).toBe(200);
@@ -166,9 +168,6 @@ describe("POST /api/email/webhook", () => {
       await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
       const [relayUrl, relayInit] = fetchMock.mock.calls[0];
       expect(relayUrl).toBe("http://last-cell.test/api/email/webhook");
-      expect(
-        relayInit.headers[EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]
-      ).toBe("");
       expect(relayInit.headers[EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]).toBe(
         "email_agents_disabled"
       );
@@ -179,6 +178,7 @@ describe("POST /api/email/webhook", () => {
   });
 
   it("tries the next cell after an HTTP error", async () => {
+    getCurrentCellMock.mockReturnValue(cellsConfig.getCellInfo("cell-00000"));
     const { user } = await createResourceTest({ role: "admin" });
     const fetchMock = vi
       .fn()
@@ -190,11 +190,10 @@ describe("POST /api/email/webhook", () => {
       await postWebhook(user.email, { Authorization: SENDGRID_AUTH_HEADER });
 
       await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
-      const [relayUrl, relayInit] = fetchMock.mock.calls[1];
-      expect(relayUrl).toBe("http://last-cell.test/api/email/webhook");
-      expect(
-        relayInit.headers[EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]
-      ).toBe("");
+      expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+        "http://other-region.test/api/email/webhook",
+        "http://last-cell.test/api/email/webhook",
+      ]);
       expect(sendEmailToRecipients).not.toHaveBeenCalled();
     } finally {
       vi.unstubAllGlobals();
@@ -202,6 +201,7 @@ describe("POST /api/email/webhook", () => {
   });
 
   it("does not try another cell when receipt is uncertain", async () => {
+    getCurrentCellMock.mockReturnValue(cellsConfig.getCellInfo("cell-00000"));
     const fetchMock = vi.fn().mockRejectedValue(new Error("Response lost"));
     vi.stubGlobal("fetch", fetchMock);
 
@@ -244,6 +244,7 @@ describe("POST /api/email/webhook", () => {
   });
 
   it("retries transient relay failures", async () => {
+    getCurrentCellMock.mockReturnValue(cellsConfig.getCellInfo("cell-00000"));
     const { user } = await createResourceTest({ role: "admin" });
     const fetchMock = vi
       .fn()
@@ -324,21 +325,13 @@ describe("POST /api/email/webhook", () => {
     expect(message.html).toContain("Email agents are disabled");
   });
 
-  it.each([
-    undefined,
-    "",
-  ])("replies once after relay exhaustion (%s)", async (remainingCells) => {
+  it("replies once in the last cell without relaying back", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
     try {
       const response = await postWebhook("unknown-sender@example.com", {
         ...RELAY_AUTH_HEADERS,
-        ...(remainingCells === undefined
-          ? {}
-          : {
-              [EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]: remainingCells,
-            }),
         [EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]: "email_agents_disabled",
       });
       expect(response.status).toBe(200);

--- a/front-api/routes/email/webhook.test.ts
+++ b/front-api/routes/email/webhook.test.ts
@@ -1,10 +1,13 @@
 import { randomUUID } from "node:crypto";
+import { makeEmailAgentsDisabledEmailTriggerError } from "@app/lib/api/assistant/email/email_trigger";
 import {
   EMAIL_WEBHOOK_RELAY_HEADER,
   EMAIL_WEBHOOK_RELAY_HEADER_VALUE,
-  EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER,
+  EMAIL_WEBHOOK_RELAY_LOOKUP,
   EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER,
 } from "@app/lib/api/assistant/email/webhook_helpers";
+import { config as cellsConfig } from "@app/lib/api/cells/config";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -16,7 +19,6 @@ vi.mock("@app/lib/api/cells/config", async (importOriginal) => {
     ...actual,
     config: {
       ...actual.config,
-      getCurrentRegion: () => "europe-west1",
       getLookupApiSecret: () => "test-lookup-secret",
       getOtherCells: () => [
         {
@@ -126,7 +128,9 @@ describe("POST /api/email/webhook", () => {
 
   it("relays with the source error type when no local workspace has email agents enabled", async () => {
     const { user } = await createResourceTest({ role: "admin" });
-    const fetchMock = vi.fn().mockResolvedValue(new Response("{}"));
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(Response.json({ success: true }));
     vi.stubGlobal("fetch", fetchMock);
 
     try {
@@ -141,9 +145,9 @@ describe("POST /api/email/webhook", () => {
       expect(relayInit.headers[EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]).toBe(
         "email_agents_disabled"
       );
-      expect(
-        relayInit.headers[EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]
-      ).toBe("cell-00002");
+      expect(relayInit.headers[EMAIL_WEBHOOK_RELAY_HEADER]).toBe(
+        EMAIL_WEBHOOK_RELAY_LOOKUP
+      );
       // No bounce from the source region once the relay succeeded.
       expect(sendEmailToRecipients).not.toHaveBeenCalled();
     } finally {
@@ -151,52 +155,150 @@ describe("POST /api/email/webhook", () => {
     }
   });
 
-  it("forwards lookup misses without sending an error reply", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(new Response("{}"));
+  it("US tries the next cell on a lookup miss", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json({
+          success: true,
+          lookupError: makeEmailAgentsDisabledEmailTriggerError(),
+        })
+      )
+      .mockResolvedValueOnce(Response.json({ success: true }));
     vi.stubGlobal("fetch", fetchMock);
-
     try {
-      const response = await postWebhook("unknown-sender@example.com", {
-        ...RELAY_AUTH_HEADERS,
-        [EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]: "cell-00002",
-        [EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]: "email_agents_disabled",
+      await postWebhook("unknown-sender@example.com", {
+        Authorization: SENDGRID_AUTH_HEADER,
       });
-      expect(response.status).toBe(200);
-
-      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
-      const [relayUrl, relayInit] = fetchMock.mock.calls[0];
-      expect(relayUrl).toBe("http://last-cell.test/api/email/webhook");
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+      expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+        "http://other-region.test/api/email/webhook",
+        "http://last-cell.test/api/email/webhook",
+      ]);
       expect(
-        relayInit.headers[EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]
-      ).toBe("");
-      expect(relayInit.headers[EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]).toBe(
-        "email_agents_disabled"
-      );
+        fetchMock.mock.calls[1][1].headers[
+          EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER
+        ]
+      ).toBe("email_agents_disabled");
       expect(sendEmailToRecipients).not.toHaveBeenCalled();
     } finally {
       vi.unstubAllGlobals();
     }
   });
 
-  it("tries the next cell after an HTTP error", async () => {
-    const { user } = await createResourceTest({ role: "admin" });
+  it("US sends one error reply after all cells miss", async () => {
+    const fetchMock = vi.fn().mockImplementation(async () =>
+      Response.json({
+        success: true,
+        lookupError: makeEmailAgentsDisabledEmailTriggerError(),
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      await postWebhook("unknown-sender@example.com", {
+        Authorization: SENDGRID_AUTH_HEADER,
+      });
+      await vi.waitFor(() =>
+        expect(sendEmailToRecipients).toHaveBeenCalledOnce()
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const [{ message }] = vi.mocked(sendEmailToRecipients).mock.calls[0];
+      expect(message.html).toContain("Email agents are disabled");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("stops on an HTTP rejection", async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(new Response(null, { status: 403 }))
-      .mockResolvedValueOnce(new Response("{}"));
+      .mockResolvedValue(new Response(null, { status: 403 }));
     vi.stubGlobal("fetch", fetchMock);
-
     try {
-      await postWebhook(user.email, { Authorization: SENDGRID_AUTH_HEADER });
+      await postWebhook("unknown-sender@example.com", {
+        Authorization: SENDGRID_AUTH_HEADER,
+      });
+      await vi.waitFor(() =>
+        expect(sendEmailToRecipients).toHaveBeenCalledOnce()
+      );
+      expect(fetchMock).toHaveBeenCalledOnce();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 
-      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
-      const [relayUrl, relayInit] = fetchMock.mock.calls[1];
-      expect(relayUrl).toBe("http://last-cell.test/api/email/webhook");
-      expect(
-        relayInit.headers[EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]
-      ).toBe("");
+  it("returns a lookup miss again on retry, without replying or forwarding", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const messageId = `<${randomUUID()}@example.com>`;
+    try {
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const response = await postWebhook(
+          "unknown-sender@example.com",
+          {
+            ...RELAY_AUTH_HEADERS,
+            [EMAIL_WEBHOOK_RELAY_HEADER]: EMAIL_WEBHOOK_RELAY_LOOKUP,
+            [EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]: "email_agents_disabled",
+          },
+          messageId
+        );
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({
+          success: true,
+          lookupError: makeEmailAgentsDisabledEmailTriggerError(),
+        });
+      }
+      expect(fetchMock).not.toHaveBeenCalled();
       expect(sendEmailToRecipients).not.toHaveBeenCalled();
     } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("accepts a workspace match and deduplicates processing errors", async () => {
+    const { user, workspace } = await createResourceTest({ role: "admin" });
+    await WorkspaceResource.updateMetadata(workspace.id, {
+      allowEmailAgents: true,
+      emailBlacklistedAgentIds: "invalid",
+    });
+    const messageId = `<${randomUUID()}@example.com>`;
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const response = await postWebhook(
+        user.email,
+        {
+          ...RELAY_AUTH_HEADERS,
+          [EMAIL_WEBHOOK_RELAY_HEADER]: EMAIL_WEBHOOK_RELAY_LOOKUP,
+        },
+        messageId
+      );
+      expect(await response.json()).toEqual({ success: true });
+      await vi.waitFor(() =>
+        expect(sendEmailToRecipients).toHaveBeenCalledOnce()
+      );
+    }
+    const [{ message }] = vi.mocked(sendEmailToRecipients).mock.calls[0];
+    expect(message.html).toContain("temporarily unavailable");
+  });
+
+  it.each([
+    "cell-00001",
+    "cell-00002",
+  ] as const)("never relays from %s", async (cell) => {
+    const cellMock = vi
+      .spyOn(cellsConfig, "getCurrentCell")
+      .mockReturnValue(cellsConfig.getCellInfo(cell));
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      await postWebhook("unknown-sender@example.com", {
+        Authorization: SENDGRID_AUTH_HEADER,
+      });
+      await vi.waitFor(() =>
+        expect(sendEmailToRecipients).toHaveBeenCalledOnce()
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      cellMock.mockRestore();
       vi.unstubAllGlobals();
     }
   });
@@ -249,7 +351,7 @@ describe("POST /api/email/webhook", () => {
       .fn()
       .mockResolvedValueOnce(new Response(null, { status: 502 }))
       .mockResolvedValueOnce(new Response(null, { status: 502 }))
-      .mockResolvedValueOnce(new Response("{}"));
+      .mockResolvedValueOnce(Response.json({ success: true }));
     vi.stubGlobal("fetch", fetchMock);
 
     try {
@@ -324,31 +426,15 @@ describe("POST /api/email/webhook", () => {
     expect(message.html).toContain("Email agents are disabled");
   });
 
-  it.each([
-    undefined,
-    "",
-  ])("replies once after relay exhaustion (%s)", async (remainingCells) => {
+  it("never forwards a legacy relay", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
-
     try {
-      const response = await postWebhook("unknown-sender@example.com", {
-        ...RELAY_AUTH_HEADERS,
-        ...(remainingCells === undefined
-          ? {}
-          : {
-              [EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]: remainingCells,
-            }),
-        [EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]: "email_agents_disabled",
-      });
-      expect(response.status).toBe(200);
-
+      await postWebhook("unknown-sender@example.com", RELAY_AUTH_HEADERS);
       await vi.waitFor(() =>
         expect(sendEmailToRecipients).toHaveBeenCalledOnce()
       );
       expect(fetchMock).not.toHaveBeenCalled();
-      const [{ message }] = vi.mocked(sendEmailToRecipients).mock.calls[0];
-      expect(message.html).toContain("Email agents are disabled");
     } finally {
       vi.unstubAllGlobals();
     }

--- a/front-api/routes/email/webhook.test.ts
+++ b/front-api/routes/email/webhook.test.ts
@@ -255,7 +255,7 @@ describe("POST /api/email/webhook", () => {
     }
   });
 
-  it("accepts a workspace match and deduplicates processing errors", async () => {
+  it("keeps an accepted email deduplicated after workspace eligibility changes", async () => {
     const { user, workspace } = await createResourceTest({ role: "admin" });
     await WorkspaceResource.updateMetadata(workspace.id, {
       allowEmailAgents: true,
@@ -275,6 +275,9 @@ describe("POST /api/email/webhook", () => {
       await vi.waitFor(() =>
         expect(sendEmailToRecipients).toHaveBeenCalledOnce()
       );
+      await WorkspaceResource.updateMetadata(workspace.id, {
+        allowEmailAgents: false,
+      });
     }
     const [{ message }] = vi.mocked(sendEmailToRecipients).mock.calls[0];
     expect(message.html).toContain("temporarily unavailable");

--- a/front-api/routes/email/webhook.ts
+++ b/front-api/routes/email/webhook.ts
@@ -199,9 +199,8 @@ app.post("/", async (ctx): HandlerResult<PostResponseBody> => {
           localError: userRes.error,
           senderEmail: email.sender.email,
         });
-        if (shouldRelayToOtherCells({ headers, error: userRes.error })) {
+        if (shouldRelayToOtherCells(userRes.error)) {
           const relayRes = await relayEmailToOtherCells(email, {
-            headers,
             sourceError: error,
           });
           if (relayRes.isOk()) {

--- a/front-api/routes/email/webhook.ts
+++ b/front-api/routes/email/webhook.ts
@@ -15,8 +15,8 @@ import {
   EMAIL_WEBHOOK_RELAY_LOOKUP,
   hasValidRelayAuthorization,
   hasValidSendgridAuthorization,
+  isDuplicateEmailRelay,
   parseSendgridWebhookContent,
-  recordEmailRelay,
   relayEmailToOtherCells,
   replyToError,
   resolveRelayedErrorReply,
@@ -149,12 +149,25 @@ app.post("/", async (ctx): HandlerResult<PostResponseBody> => {
 
   const email = emailRes.value;
 
-  // Lookup relays return misses to US before deduplication; a retry must return the miss again.
+  // Resolve lookup relays before responding, but only claim emails accepted for processing.
   const relayUserRes =
     isRelayRequest &&
     headers[EMAIL_WEBHOOK_RELAY_HEADER] === EMAIL_WEBHOOK_RELAY_LOOKUP
       ? await userAndWorkspaceFromEmail({ email: email.sender.email })
       : undefined;
+  if (
+    isRelayRequest &&
+    (await isDuplicateEmailRelay(email.threadingHeaders.messageId, {
+      record: !relayUserRes?.isErr(),
+    }))
+  ) {
+    logger.info(
+      { senderEmail: email.sender.email },
+      "[email] Ignoring duplicate inbound email relay"
+    );
+    return ctx.json({ success: true });
+  }
+
   if (relayUserRes?.isErr()) {
     return ctx.json({
       success: true,
@@ -164,17 +177,6 @@ app.post("/", async (ctx): HandlerResult<PostResponseBody> => {
         senderEmail: email.sender.email,
       }),
     });
-  }
-
-  if (
-    isRelayRequest &&
-    !(await recordEmailRelay(email.threadingHeaders.messageId))
-  ) {
-    logger.info(
-      { senderEmail: email.sender.email },
-      "[email] Ignoring duplicate inbound email relay"
-    );
-    return ctx.json({ success: true });
   }
 
   // Acknowledge the webhook now — from here on, all errors should be sent as

--- a/front-api/routes/email/webhook.ts
+++ b/front-api/routes/email/webhook.ts
@@ -1,5 +1,4 @@
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
-import type { EmailTriggerError } from "@app/lib/api/assistant/email/email_trigger";
 import {
   ASSISTANT_EMAIL_SUBDOMAIN,
   emailAssistantMatcher,
@@ -11,12 +10,10 @@ import { evaluateInboundAuth } from "@app/lib/api/assistant/email/inbound_auth";
 import { validateSendgridParseWebhookSignature } from "@app/lib/api/assistant/email/sendgrid_parse_webhook_signature";
 import type { EmailWebhookHeaders } from "@app/lib/api/assistant/email/webhook_helpers";
 import {
-  EMAIL_WEBHOOK_RELAY_HEADER,
-  EMAIL_WEBHOOK_RELAY_LOOKUP,
   hasValidRelayAuthorization,
   hasValidSendgridAuthorization,
-  isDuplicateEmailRelay,
   parseSendgridWebhookContent,
+  recordEmailRelay,
   relayEmailToOtherCells,
   replyToError,
   resolveRelayedErrorReply,
@@ -27,6 +24,7 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import { config as cellsConfig } from "@app/lib/api/cells/config";
 import apiConfig from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
@@ -37,13 +35,8 @@ import { isString } from "@app/types/shared/utils/general";
 import { createHono } from "@front-api/lib/hono";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 
-/**
- * @cc [owner:philipperolet,label:api] relay-lookup-miss
- * A lookupError response must not start an agent, send an error reply, or claim the Message-ID.
- */
 export type PostResponseBody = {
   success: boolean;
-  lookupError?: EmailTriggerError;
 };
 
 // SendGrid Parse limits inbound mail to ~30MB; matches the original
@@ -149,34 +142,15 @@ app.post("/", async (ctx): HandlerResult<PostResponseBody> => {
 
   const email = emailRes.value;
 
-  // Resolve lookup relays before responding, but only claim emails accepted for processing.
-  const relayUserRes =
-    isRelayRequest &&
-    headers[EMAIL_WEBHOOK_RELAY_HEADER] === EMAIL_WEBHOOK_RELAY_LOOKUP
-      ? await userAndWorkspaceFromEmail({ email: email.sender.email })
-      : undefined;
   if (
     isRelayRequest &&
-    (await isDuplicateEmailRelay(email.threadingHeaders.messageId, {
-      record: !relayUserRes?.isErr(),
-    }))
+    !(await recordEmailRelay(email.threadingHeaders.messageId))
   ) {
     logger.info(
       { senderEmail: email.sender.email },
       "[email] Ignoring duplicate inbound email relay"
     );
     return ctx.json({ success: true });
-  }
-
-  if (relayUserRes?.isErr()) {
-    return ctx.json({
-      success: true,
-      lookupError: resolveRelayedErrorReply({
-        headers,
-        localError: relayUserRes.error,
-        senderEmail: email.sender.email,
-      }),
-    });
   }
 
   // Acknowledge the webhook now — from here on, all errors should be sent as
@@ -216,29 +190,33 @@ app.post("/", async (ctx): HandlerResult<PostResponseBody> => {
         "[email] Inbound sender authenticated"
       );
 
-      const userRes =
-        relayUserRes ??
-        (await userAndWorkspaceFromEmail({
-          email: email.sender.email,
-        }));
+      const userRes = await userAndWorkspaceFromEmail({
+        email: email.sender.email,
+      });
       if (userRes.isErr()) {
+        const error = resolveRelayedErrorReply({
+          headers,
+          localError: userRes.error,
+          senderEmail: email.sender.email,
+        });
         if (shouldRelayToOtherCells({ headers, error: userRes.error })) {
           const relayRes = await relayEmailToOtherCells(email, {
-            sourceError: userRes.error,
-          });
-          if (relayRes.isErr()) {
-            await replyToError(email, relayRes.error);
-          }
-          return;
-        }
-        await replyToError(
-          email,
-          resolveRelayedErrorReply({
             headers,
-            localError: userRes.error,
-            senderEmail: email.sender.email,
-          })
-        );
+            sourceError: error,
+          });
+          if (relayRes.isOk()) {
+            return;
+          }
+          logger.error(
+            {
+              senderEmail: email.sender.email,
+              error: relayRes.error,
+              sourceCell: cellsConfig.getCurrentCell().name,
+            },
+            "[email] Failed to relay inbound email to other cells"
+          );
+        }
+        await replyToError(email, error);
         return;
       }
 

--- a/front-api/routes/email/webhook.ts
+++ b/front-api/routes/email/webhook.ts
@@ -194,9 +194,15 @@ app.post("/", async (ctx): HandlerResult<PostResponseBody> => {
         email: email.sender.email,
       });
       if (userRes.isErr()) {
+        const error = resolveRelayedErrorReply({
+          headers,
+          localError: userRes.error,
+          senderEmail: email.sender.email,
+        });
         if (shouldRelayToOtherCells({ headers, error: userRes.error })) {
           const relayRes = await relayEmailToOtherCells(email, {
-            sourceError: userRes.error,
+            headers,
+            sourceError: error,
           });
           if (relayRes.isOk()) {
             return;
@@ -210,14 +216,7 @@ app.post("/", async (ctx): HandlerResult<PostResponseBody> => {
             "[email] Failed to relay inbound email to other cells"
           );
         }
-        await replyToError(
-          email,
-          resolveRelayedErrorReply({
-            headers,
-            localError: userRes.error,
-            senderEmail: email.sender.email,
-          })
-        );
+        await replyToError(email, error);
         return;
       }
 

--- a/front-api/routes/email/webhook.ts
+++ b/front-api/routes/email/webhook.ts
@@ -1,4 +1,5 @@
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
+import type { EmailTriggerError } from "@app/lib/api/assistant/email/email_trigger";
 import {
   ASSISTANT_EMAIL_SUBDOMAIN,
   emailAssistantMatcher,
@@ -10,6 +11,8 @@ import { evaluateInboundAuth } from "@app/lib/api/assistant/email/inbound_auth";
 import { validateSendgridParseWebhookSignature } from "@app/lib/api/assistant/email/sendgrid_parse_webhook_signature";
 import type { EmailWebhookHeaders } from "@app/lib/api/assistant/email/webhook_helpers";
 import {
+  EMAIL_WEBHOOK_RELAY_HEADER,
+  EMAIL_WEBHOOK_RELAY_LOOKUP,
   hasValidRelayAuthorization,
   hasValidSendgridAuthorization,
   parseSendgridWebhookContent,
@@ -24,7 +27,6 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
-import { config as cellsConfig } from "@app/lib/api/cells/config";
 import apiConfig from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
@@ -35,8 +37,13 @@ import { isString } from "@app/types/shared/utils/general";
 import { createHono } from "@front-api/lib/hono";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 
+/**
+ * @cc [owner:philipperolet,label:api] relay-lookup-miss
+ * A lookupError response must not start an agent, send an error reply, or claim the Message-ID.
+ */
 export type PostResponseBody = {
   success: boolean;
+  lookupError?: EmailTriggerError;
 };
 
 // SendGrid Parse limits inbound mail to ~30MB; matches the original
@@ -142,6 +149,23 @@ app.post("/", async (ctx): HandlerResult<PostResponseBody> => {
 
   const email = emailRes.value;
 
+  // Lookup relays return misses to US before deduplication; a retry must return the miss again.
+  const relayUserRes =
+    isRelayRequest &&
+    headers[EMAIL_WEBHOOK_RELAY_HEADER] === EMAIL_WEBHOOK_RELAY_LOOKUP
+      ? await userAndWorkspaceFromEmail({ email: email.sender.email })
+      : undefined;
+  if (relayUserRes?.isErr()) {
+    return ctx.json({
+      success: true,
+      lookupError: resolveRelayedErrorReply({
+        headers,
+        localError: relayUserRes.error,
+        senderEmail: email.sender.email,
+      }),
+    });
+  }
+
   if (
     isRelayRequest &&
     !(await recordEmailRelay(email.threadingHeaders.messageId))
@@ -190,33 +214,29 @@ app.post("/", async (ctx): HandlerResult<PostResponseBody> => {
         "[email] Inbound sender authenticated"
       );
 
-      const userRes = await userAndWorkspaceFromEmail({
-        email: email.sender.email,
-      });
+      const userRes =
+        relayUserRes ??
+        (await userAndWorkspaceFromEmail({
+          email: email.sender.email,
+        }));
       if (userRes.isErr()) {
-        const error = resolveRelayedErrorReply({
-          headers,
-          localError: userRes.error,
-          senderEmail: email.sender.email,
-        });
         if (shouldRelayToOtherCells({ headers, error: userRes.error })) {
           const relayRes = await relayEmailToOtherCells(email, {
-            headers,
-            sourceError: error,
+            sourceError: userRes.error,
           });
-          if (relayRes.isOk()) {
-            return;
+          if (relayRes.isErr()) {
+            await replyToError(email, relayRes.error);
           }
-          logger.error(
-            {
-              senderEmail: email.sender.email,
-              error: relayRes.error,
-              sourceCell: cellsConfig.getCurrentCell().name,
-            },
-            "[email] Failed to relay inbound email to other cells"
-          );
+          return;
         }
-        await replyToError(email, error);
+        await replyToError(
+          email,
+          resolveRelayedErrorReply({
+            headers,
+            localError: userRes.error,
+            senderEmail: email.sender.email,
+          })
+        );
         return;
       }
 

--- a/front/lib/api/assistant/email/webhook_helpers.ts
+++ b/front/lib/api/assistant/email/webhook_helpers.ts
@@ -201,20 +201,28 @@ function makeEmailRelayKey(messageId: string): string {
   return `${EMAIL_RELAY_KEY_PREFIX}:${messageId}`;
 }
 
-export async function recordEmailRelay(
-  messageId: string | null
+/**
+ * @cc [owner:philipperolet,label:product] accepted-relay-dedupe
+ * Accepted Message-IDs remain duplicates within the TTL; lookup misses must not record new IDs.
+ */
+export async function isDuplicateEmailRelay(
+  messageId: string | null,
+  { record }: { record: boolean }
 ): Promise<boolean> {
   if (!messageId) {
-    return true;
+    return false;
   }
 
   const redis = await getRedisStreamClient({ origin: "email_context" });
+  if (!record) {
+    return (await redis.exists(makeEmailRelayKey(messageId))) > 0;
+  }
   const result = await redis.set(makeEmailRelayKey(messageId), "1", {
     NX: true,
     EX: EMAIL_RELAY_DEDUPE_TTL_SECONDS,
   });
 
-  return result === "OK";
+  return result !== "OK";
 }
 
 /**

--- a/front/lib/api/assistant/email/webhook_helpers.ts
+++ b/front/lib/api/assistant/email/webhook_helpers.ts
@@ -24,6 +24,7 @@ import apiConfig from "@app/lib/api/config";
 import { getRedisStreamClient } from "@app/lib/api/redis";
 import { withRetry } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
+import type { CellInfo } from "@app/types/cell";
 import { isSupportedFileContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -45,6 +46,8 @@ const EMAIL_WEBHOOK_RELAY_SOURCE_CELL_HEADER =
   "x-dust-email-webhook-source-cell";
 export const EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER =
   "x-dust-email-webhook-source-error";
+export const EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER =
+  "x-dust-email-webhook-remaining-cells";
 export const EMAIL_WEBHOOK_RELAY_HEADER_VALUE = "1";
 
 const EMAIL_RELAY_KEY_PREFIX = "email-webhook-relay";
@@ -75,6 +78,25 @@ function isRelayEligibleError(error: EmailTriggerError): boolean {
   return isRelayEligibleErrorType(error.type);
 }
 
+/**
+ * @cc [owner:philipperolet,label:product] remaining-relay-cells
+ * Relayed requests may only visit configured cells listed in the remaining-cells header;
+ * legacy relays without that header must not relay again.
+ */
+function getEmailRelayCells(headers: EmailWebhookHeaders): CellInfo[] {
+  const cells = cellsConfig.getOtherCells();
+  if (!isRelayedWebhookRequest(headers)) {
+    return cells;
+  }
+
+  const remainingCells = headers[EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER];
+  if (!isString(remainingCells)) {
+    return [];
+  }
+  const remaining = new Set(remainingCells.split(","));
+  return cells.filter((cell) => remaining.has(cell.name));
+}
+
 export function shouldRelayToOtherCells({
   headers,
   error,
@@ -82,7 +104,7 @@ export function shouldRelayToOtherCells({
   headers: EmailWebhookHeaders;
   error: EmailTriggerError;
 }): boolean {
-  return isRelayEligibleError(error) && !isRelayedWebhookRequest(headers);
+  return isRelayEligibleError(error) && getEmailRelayCells(headers).length > 0;
 }
 
 // Ordered from least to most informative: a user unknown in one cell may still
@@ -95,8 +117,8 @@ const RELAY_ERROR_INFORMATIVENESS: Record<RelayEligibleErrorType, number> = {
 };
 
 /**
- * On a relayed request, cells' lookups have failed and the relayed cell's
- * sends the error reply. The source cell's error type (forwarded via header) may
+ * Carry the most informative lookup error across relay hops, for the final cell's
+ * error reply. The source cell's error type (forwarded via header) may
  * be more informative than the local one — e.g. the sender has a real account with
  * Email Agents disabled in the source cell but no account locally; replying with
  * the local `user_not_found` ("please sign up") would be wrong.
@@ -191,12 +213,23 @@ export async function recordEmailRelay(
   return result === "OK";
 }
 
+/**
+ * @cc [owner:philipperolet,label:product] relay-handoff
+ * Each relay passes only the cells after its target as remaining destinations, and stops
+ * after a successful HTTP handoff. The receiving cell owns further lookup and error replies.
+ */
 export async function relayEmailToOtherCells(
   email: InboundEmail,
-  { sourceError }: { sourceError: EmailTriggerError }
+  {
+    sourceError,
+    headers: requestHeaders,
+  }: {
+    sourceError: EmailTriggerError;
+    headers: EmailWebhookHeaders;
+  }
 ): Promise<Result<void, Error>> {
   try {
-    const cells = cellsConfig.getOtherCells();
+    const cells = getEmailRelayCells(requestHeaders);
 
     const headers = {
       Authorization: `Bearer ${cellsConfig.getLookupApiSecret()}`,
@@ -227,12 +260,18 @@ export async function relayEmailToOtherCells(
       );
     }
 
-    for (const cell of cells) {
+    for (const [index, cell] of cells.entries()) {
       const responseRes = await withRetry(
         async () => {
           const response = await fetch(`${cell.url}/api/email/webhook`, {
             method: "POST",
-            headers,
+            headers: {
+              ...headers,
+              [EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]: cells
+                .slice(index + 1)
+                .map((remainingCell) => remainingCell.name)
+                .join(","),
+            },
             body,
           });
 
@@ -259,15 +298,20 @@ export async function relayEmailToOtherCells(
         }
       );
 
-      if (responseRes.isErr()) {
-        return responseRes;
-      }
-      if (!responseRes.value.ok) {
-        return new Err(
-          new Error(
-            `Relay to ${cell.name} failed with status ${responseRes.value.status}: ${responseRes.value.statusText}`
-          )
+      if (responseRes.isErr() || !responseRes.value.ok) {
+        logger.error(
+          {
+            error: responseRes.isErr()
+              ? responseRes.error
+              : new Error(
+                  `Relay to ${cell.name} failed with status ${responseRes.value.status}: ${responseRes.value.statusText}`
+                ),
+            sourceCell: cellsConfig.getCurrentCell().name,
+            targetCell: cell.name,
+          },
+          "[email] Failed to relay inbound email to cell"
         );
+        continue;
       }
 
       logger.info(

--- a/front/lib/api/assistant/email/webhook_helpers.ts
+++ b/front/lib/api/assistant/email/webhook_helpers.ts
@@ -218,6 +218,10 @@ export async function recordEmailRelay(
  * Each relay passes only the cells after its target as remaining destinations, and stops
  * after a successful HTTP handoff. The receiving cell owns further lookup and error replies.
  */
+/**
+ * @cc [owner:philipperolet,label:product] uncertain-relay-stops
+ * Exhausted transport retries must stop routing, since the target may already be processing.
+ */
 export async function relayEmailToOtherCells(
   email: InboundEmail,
   {
@@ -311,6 +315,9 @@ export async function relayEmailToOtherCells(
           },
           "[email] Failed to relay inbound email to cell"
         );
+        if (responseRes.isErr()) {
+          break;
+        }
         continue;
       }
 

--- a/front/lib/api/assistant/email/webhook_helpers.ts
+++ b/front/lib/api/assistant/email/webhook_helpers.ts
@@ -24,6 +24,7 @@ import apiConfig from "@app/lib/api/config";
 import { getRedisStreamClient } from "@app/lib/api/redis";
 import { withRetry } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
+import type { CellInfo } from "@app/types/cell";
 import { isSupportedFileContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -32,7 +33,6 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 import { IncomingForm } from "formidable";
 import { readFile } from "fs/promises";
-import { z } from "zod";
 
 /**
  * Node-style headers shape: matches the record built from
@@ -46,8 +46,9 @@ const EMAIL_WEBHOOK_RELAY_SOURCE_CELL_HEADER =
   "x-dust-email-webhook-source-cell";
 export const EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER =
   "x-dust-email-webhook-source-error";
+export const EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER =
+  "x-dust-email-webhook-remaining-cells";
 export const EMAIL_WEBHOOK_RELAY_HEADER_VALUE = "1";
-export const EMAIL_WEBHOOK_RELAY_LOOKUP = "lookup";
 
 const EMAIL_RELAY_KEY_PREFIX = "email-webhook-relay";
 const EMAIL_RELAY_DEDUPE_TTL_SECONDS = 5 * 60;
@@ -55,8 +56,7 @@ const HTTP_SERVER_ERROR_STATUS_MIN = 500;
 
 function isRelayedWebhookRequest(headers: EmailWebhookHeaders): boolean {
   return (
-    headers[EMAIL_WEBHOOK_RELAY_HEADER] === EMAIL_WEBHOOK_RELAY_HEADER_VALUE ||
-    headers[EMAIL_WEBHOOK_RELAY_HEADER] === EMAIL_WEBHOOK_RELAY_LOOKUP
+    headers[EMAIL_WEBHOOK_RELAY_HEADER] === EMAIL_WEBHOOK_RELAY_HEADER_VALUE
   );
 }
 
@@ -65,21 +65,6 @@ const RELAY_ELIGIBLE_ERROR_TYPES = [
   "workspace_not_found",
   "email_agents_disabled",
 ] as const;
-
-const EmailRelayResponseSchema = z.object({
-  success: z.literal(true),
-  lookupError: z
-    .object({
-      type: z.enum(RELAY_ELIGIBLE_ERROR_TYPES),
-      message: z.string(),
-    })
-    .optional(),
-});
-
-const EMAIL_RELAY_ERROR: EmailTriggerError = {
-  type: "unexpected_error",
-  message: "Failed to relay your email. Please try again later.",
-};
 
 type RelayEligibleErrorType = (typeof RELAY_ELIGIBLE_ERROR_TYPES)[number];
 
@@ -94,9 +79,24 @@ function isRelayEligibleError(error: EmailTriggerError): boolean {
 }
 
 /**
- * @cc [owner:philipperolet,label:product] main-cell-only-relay
- * Only the main cell may relay a SendGrid request; relayed requests must never relay again.
+ * @cc [owner:philipperolet,label:product] remaining-relay-cells
+ * Relayed requests may only visit configured cells listed in the remaining-cells header;
+ * legacy relays without that header must not relay again.
  */
+function getEmailRelayCells(headers: EmailWebhookHeaders): CellInfo[] {
+  const cells = cellsConfig.getOtherCells();
+  if (!isRelayedWebhookRequest(headers)) {
+    return cells;
+  }
+
+  const remainingCells = headers[EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER];
+  if (!isString(remainingCells)) {
+    return [];
+  }
+  const remaining = new Set(remainingCells.split(","));
+  return cells.filter((cell) => remaining.has(cell.name));
+}
+
 export function shouldRelayToOtherCells({
   headers,
   error,
@@ -104,11 +104,7 @@ export function shouldRelayToOtherCells({
   headers: EmailWebhookHeaders;
   error: EmailTriggerError;
 }): boolean {
-  return (
-    cellsConfig.isMainCell() &&
-    isRelayEligibleError(error) &&
-    !isRelayedWebhookRequest(headers)
-  );
+  return isRelayEligibleError(error) && getEmailRelayCells(headers).length > 0;
 }
 
 // Ordered from least to most informative: a user unknown in one cell may still
@@ -121,8 +117,8 @@ const RELAY_ERROR_INFORMATIVENESS: Record<RelayEligibleErrorType, number> = {
 };
 
 /**
- * Compare the local lookup error with the source cell's error for the final reply.
- * The source cell's error type (forwarded via header) may
+ * Carry the most informative lookup error across relay hops, for the final cell's
+ * error reply. The source cell's error type (forwarded via header) may
  * be more informative than the local one — e.g. the sender has a real account with
  * Email Agents disabled in the source cell but no account locally; replying with
  * the local `user_not_found` ("please sign up") would be wrong.
@@ -201,34 +197,26 @@ function makeEmailRelayKey(messageId: string): string {
   return `${EMAIL_RELAY_KEY_PREFIX}:${messageId}`;
 }
 
-/**
- * @cc [owner:philipperolet,label:product] accepted-relay-dedupe
- * Accepted Message-IDs remain duplicates within the TTL; lookup misses must not record new IDs.
- */
-export async function isDuplicateEmailRelay(
-  messageId: string | null,
-  { record }: { record: boolean }
+export async function recordEmailRelay(
+  messageId: string | null
 ): Promise<boolean> {
   if (!messageId) {
-    return false;
+    return true;
   }
 
   const redis = await getRedisStreamClient({ origin: "email_context" });
-  if (!record) {
-    return (await redis.exists(makeEmailRelayKey(messageId))) > 0;
-  }
   const result = await redis.set(makeEmailRelayKey(messageId), "1", {
     NX: true,
     EX: EMAIL_RELAY_DEDUPE_TTL_SECONDS,
   });
 
-  return result !== "OK";
+  return result === "OK";
 }
 
 /**
  * @cc [owner:philipperolet,label:product] relay-handoff
- * Try cells sequentially on lookup misses, stop on acceptance, and return the most
- * informative lookup error to the main cell when no cell matches.
+ * Each relay passes only the cells after its target as remaining destinations, and stops
+ * after a successful HTTP handoff. The receiving cell owns further lookup and error replies.
  */
 /**
  * @cc [owner:philipperolet,label:product] uncertain-relay-stops
@@ -236,17 +224,23 @@ export async function isDuplicateEmailRelay(
  */
 export async function relayEmailToOtherCells(
   email: InboundEmail,
-  { sourceError }: { sourceError: EmailTriggerError }
-): Promise<Result<void, EmailTriggerError>> {
-  let relayError = sourceError;
+  {
+    sourceError,
+    headers: requestHeaders,
+  }: {
+    sourceError: EmailTriggerError;
+    headers: EmailWebhookHeaders;
+  }
+): Promise<Result<void, Error>> {
   try {
-    const cells = cellsConfig.getOtherCells();
+    const cells = getEmailRelayCells(requestHeaders);
 
     const headers = {
       Authorization: `Bearer ${cellsConfig.getLookupApiSecret()}`,
-      [EMAIL_WEBHOOK_RELAY_HEADER]: EMAIL_WEBHOOK_RELAY_LOOKUP,
+      [EMAIL_WEBHOOK_RELAY_HEADER]: EMAIL_WEBHOOK_RELAY_HEADER_VALUE,
       [EMAIL_WEBHOOK_RELAY_SOURCE_CELL_HEADER]:
         cellsConfig.getCurrentCell().name,
+      [EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]: sourceError.type,
     };
 
     const body = new FormData();
@@ -270,14 +264,17 @@ export async function relayEmailToOtherCells(
       );
     }
 
-    for (const cell of cells) {
+    for (const [index, cell] of cells.entries()) {
       const responseRes = await withRetry(
         async () => {
           const response = await fetch(`${cell.url}/api/email/webhook`, {
             method: "POST",
             headers: {
               ...headers,
-              [EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]: relayError.type,
+              [EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]: cells
+                .slice(index + 1)
+                .map((remainingCell) => remainingCell.name)
+                .join(","),
             },
             body,
           });
@@ -318,14 +315,9 @@ export async function relayEmailToOtherCells(
           },
           "[email] Failed to relay inbound email to cell"
         );
-        return new Err(EMAIL_RELAY_ERROR);
-      }
-
-      const data = EmailRelayResponseSchema.parse(
-        await responseRes.value.json()
-      );
-      if (data.lookupError) {
-        relayError = data.lookupError;
+        if (responseRes.isErr()) {
+          break;
+        }
         continue;
       }
 
@@ -340,15 +332,11 @@ export async function relayEmailToOtherCells(
 
       return new Ok(undefined);
     }
-    return new Err(relayError);
   } catch (error) {
-    logger.error(
-      { error: normalizeError(error) },
-      "[email] Failed to relay inbound email"
-    );
+    return new Err(normalizeError(error));
   }
 
-  return new Err(EMAIL_RELAY_ERROR);
+  return new Err(new Error("Failed to relay inbound email to other cells"));
 }
 
 function parseThreadingHeaders(rawHeaders: string | null) {

--- a/front/lib/api/assistant/email/webhook_helpers.ts
+++ b/front/lib/api/assistant/email/webhook_helpers.ts
@@ -31,6 +31,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
+import assert from "assert";
 import { IncomingForm } from "formidable";
 import { readFile } from "fs/promises";
 
@@ -46,8 +47,6 @@ const EMAIL_WEBHOOK_RELAY_SOURCE_CELL_HEADER =
   "x-dust-email-webhook-source-cell";
 export const EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER =
   "x-dust-email-webhook-source-error";
-export const EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER =
-  "x-dust-email-webhook-remaining-cells";
 export const EMAIL_WEBHOOK_RELAY_HEADER_VALUE = "1";
 
 const EMAIL_RELAY_KEY_PREFIX = "email-webhook-relay";
@@ -79,32 +78,20 @@ function isRelayEligibleError(error: EmailTriggerError): boolean {
 }
 
 /**
- * @cc [owner:philipperolet,label:product] remaining-relay-cells
- * Relayed requests may only visit configured cells listed in the remaining-cells header;
- * legacy relays without that header must not relay again.
+ * @cc [owner:philipperolet,label:product] forward-only-relay
+ * Email relays only visit cells after the current cell in name order, with US first.
  */
-function getEmailRelayCells(headers: EmailWebhookHeaders): CellInfo[] {
-  const cells = cellsConfig.getOtherCells();
-  if (!isRelayedWebhookRequest(headers)) {
-    return cells;
-  }
-
-  const remainingCells = headers[EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER];
-  if (!isString(remainingCells)) {
-    return [];
-  }
-  const remaining = new Set(remainingCells.split(","));
-  return cells.filter((cell) => remaining.has(cell.name));
+function getNextEmailRelayCells(): CellInfo[] {
+  const cells = cellsConfig
+    .getAllCells()
+    .sort((a, b) => a.name.localeCompare(b.name));
+  assert(cells[0].name === "cell-00000", "US must come first");
+  const currentCell = cellsConfig.getCurrentCell();
+  return cells.filter((cell) => cell.name > currentCell.name);
 }
 
-export function shouldRelayToOtherCells({
-  headers,
-  error,
-}: {
-  headers: EmailWebhookHeaders;
-  error: EmailTriggerError;
-}): boolean {
-  return isRelayEligibleError(error) && getEmailRelayCells(headers).length > 0;
+export function shouldRelayToOtherCells(error: EmailTriggerError): boolean {
+  return isRelayEligibleError(error) && getNextEmailRelayCells().length > 0;
 }
 
 // Ordered from least to most informative: a user unknown in one cell may still
@@ -215,8 +202,8 @@ export async function recordEmailRelay(
 
 /**
  * @cc [owner:philipperolet,label:product] relay-handoff
- * Each relay passes only the cells after its target as remaining destinations, and stops
- * after a successful HTTP handoff. The receiving cell owns further lookup and error replies.
+ * Advance to another cell only after an explicit HTTP rejection. On acceptance, the
+ * receiving cell owns further lookup, forwarding, and error replies.
  */
 /**
  * @cc [owner:philipperolet,label:product] uncertain-relay-stops
@@ -224,16 +211,10 @@ export async function recordEmailRelay(
  */
 export async function relayEmailToOtherCells(
   email: InboundEmail,
-  {
-    sourceError,
-    headers: requestHeaders,
-  }: {
-    sourceError: EmailTriggerError;
-    headers: EmailWebhookHeaders;
-  }
+  { sourceError }: { sourceError: EmailTriggerError }
 ): Promise<Result<void, Error>> {
   try {
-    const cells = getEmailRelayCells(requestHeaders);
+    const cells = getNextEmailRelayCells();
 
     const headers = {
       Authorization: `Bearer ${cellsConfig.getLookupApiSecret()}`,
@@ -264,18 +245,12 @@ export async function relayEmailToOtherCells(
       );
     }
 
-    for (const [index, cell] of cells.entries()) {
+    for (const cell of cells) {
       const responseRes = await withRetry(
         async () => {
           const response = await fetch(`${cell.url}/api/email/webhook`, {
             method: "POST",
-            headers: {
-              ...headers,
-              [EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]: cells
-                .slice(index + 1)
-                .map((remainingCell) => remainingCell.name)
-                .join(","),
-            },
+            headers,
             body,
           });
 
@@ -316,8 +291,9 @@ export async function relayEmailToOtherCells(
           "[email] Failed to relay inbound email to cell"
         );
         if (responseRes.isErr()) {
-          break;
+          return responseRes;
         }
+        // Only an explicit rejection lets us try the next cell.
         continue;
       }
 

--- a/front/lib/api/assistant/email/webhook_helpers.ts
+++ b/front/lib/api/assistant/email/webhook_helpers.ts
@@ -24,7 +24,6 @@ import apiConfig from "@app/lib/api/config";
 import { getRedisStreamClient } from "@app/lib/api/redis";
 import { withRetry } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import type { CellInfo } from "@app/types/cell";
 import { isSupportedFileContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -33,6 +32,7 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 import { IncomingForm } from "formidable";
 import { readFile } from "fs/promises";
+import { z } from "zod";
 
 /**
  * Node-style headers shape: matches the record built from
@@ -46,9 +46,8 @@ const EMAIL_WEBHOOK_RELAY_SOURCE_CELL_HEADER =
   "x-dust-email-webhook-source-cell";
 export const EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER =
   "x-dust-email-webhook-source-error";
-export const EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER =
-  "x-dust-email-webhook-remaining-cells";
 export const EMAIL_WEBHOOK_RELAY_HEADER_VALUE = "1";
+export const EMAIL_WEBHOOK_RELAY_LOOKUP = "lookup";
 
 const EMAIL_RELAY_KEY_PREFIX = "email-webhook-relay";
 const EMAIL_RELAY_DEDUPE_TTL_SECONDS = 5 * 60;
@@ -56,7 +55,8 @@ const HTTP_SERVER_ERROR_STATUS_MIN = 500;
 
 function isRelayedWebhookRequest(headers: EmailWebhookHeaders): boolean {
   return (
-    headers[EMAIL_WEBHOOK_RELAY_HEADER] === EMAIL_WEBHOOK_RELAY_HEADER_VALUE
+    headers[EMAIL_WEBHOOK_RELAY_HEADER] === EMAIL_WEBHOOK_RELAY_HEADER_VALUE ||
+    headers[EMAIL_WEBHOOK_RELAY_HEADER] === EMAIL_WEBHOOK_RELAY_LOOKUP
   );
 }
 
@@ -65,6 +65,21 @@ const RELAY_ELIGIBLE_ERROR_TYPES = [
   "workspace_not_found",
   "email_agents_disabled",
 ] as const;
+
+const EmailRelayResponseSchema = z.object({
+  success: z.literal(true),
+  lookupError: z
+    .object({
+      type: z.enum(RELAY_ELIGIBLE_ERROR_TYPES),
+      message: z.string(),
+    })
+    .optional(),
+});
+
+const EMAIL_RELAY_ERROR: EmailTriggerError = {
+  type: "unexpected_error",
+  message: "Failed to relay your email. Please try again later.",
+};
 
 type RelayEligibleErrorType = (typeof RELAY_ELIGIBLE_ERROR_TYPES)[number];
 
@@ -79,24 +94,9 @@ function isRelayEligibleError(error: EmailTriggerError): boolean {
 }
 
 /**
- * @cc [owner:philipperolet,label:product] remaining-relay-cells
- * Relayed requests may only visit configured cells listed in the remaining-cells header;
- * legacy relays without that header must not relay again.
+ * @cc [owner:philipperolet,label:product] main-cell-only-relay
+ * Only the main cell may relay a SendGrid request; relayed requests must never relay again.
  */
-function getEmailRelayCells(headers: EmailWebhookHeaders): CellInfo[] {
-  const cells = cellsConfig.getOtherCells();
-  if (!isRelayedWebhookRequest(headers)) {
-    return cells;
-  }
-
-  const remainingCells = headers[EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER];
-  if (!isString(remainingCells)) {
-    return [];
-  }
-  const remaining = new Set(remainingCells.split(","));
-  return cells.filter((cell) => remaining.has(cell.name));
-}
-
 export function shouldRelayToOtherCells({
   headers,
   error,
@@ -104,7 +104,11 @@ export function shouldRelayToOtherCells({
   headers: EmailWebhookHeaders;
   error: EmailTriggerError;
 }): boolean {
-  return isRelayEligibleError(error) && getEmailRelayCells(headers).length > 0;
+  return (
+    cellsConfig.isMainCell() &&
+    isRelayEligibleError(error) &&
+    !isRelayedWebhookRequest(headers)
+  );
 }
 
 // Ordered from least to most informative: a user unknown in one cell may still
@@ -117,8 +121,8 @@ const RELAY_ERROR_INFORMATIVENESS: Record<RelayEligibleErrorType, number> = {
 };
 
 /**
- * Carry the most informative lookup error across relay hops, for the final cell's
- * error reply. The source cell's error type (forwarded via header) may
+ * Compare the local lookup error with the source cell's error for the final reply.
+ * The source cell's error type (forwarded via header) may
  * be more informative than the local one — e.g. the sender has a real account with
  * Email Agents disabled in the source cell but no account locally; replying with
  * the local `user_not_found` ("please sign up") would be wrong.
@@ -215,8 +219,8 @@ export async function recordEmailRelay(
 
 /**
  * @cc [owner:philipperolet,label:product] relay-handoff
- * Each relay passes only the cells after its target as remaining destinations, and stops
- * after a successful HTTP handoff. The receiving cell owns further lookup and error replies.
+ * Try cells sequentially on lookup misses, stop on acceptance, and return the most
+ * informative lookup error to the main cell when no cell matches.
  */
 /**
  * @cc [owner:philipperolet,label:product] uncertain-relay-stops
@@ -224,23 +228,17 @@ export async function recordEmailRelay(
  */
 export async function relayEmailToOtherCells(
   email: InboundEmail,
-  {
-    sourceError,
-    headers: requestHeaders,
-  }: {
-    sourceError: EmailTriggerError;
-    headers: EmailWebhookHeaders;
-  }
-): Promise<Result<void, Error>> {
+  { sourceError }: { sourceError: EmailTriggerError }
+): Promise<Result<void, EmailTriggerError>> {
+  let relayError = sourceError;
   try {
-    const cells = getEmailRelayCells(requestHeaders);
+    const cells = cellsConfig.getOtherCells();
 
     const headers = {
       Authorization: `Bearer ${cellsConfig.getLookupApiSecret()}`,
-      [EMAIL_WEBHOOK_RELAY_HEADER]: EMAIL_WEBHOOK_RELAY_HEADER_VALUE,
+      [EMAIL_WEBHOOK_RELAY_HEADER]: EMAIL_WEBHOOK_RELAY_LOOKUP,
       [EMAIL_WEBHOOK_RELAY_SOURCE_CELL_HEADER]:
         cellsConfig.getCurrentCell().name,
-      [EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]: sourceError.type,
     };
 
     const body = new FormData();
@@ -264,17 +262,14 @@ export async function relayEmailToOtherCells(
       );
     }
 
-    for (const [index, cell] of cells.entries()) {
+    for (const cell of cells) {
       const responseRes = await withRetry(
         async () => {
           const response = await fetch(`${cell.url}/api/email/webhook`, {
             method: "POST",
             headers: {
               ...headers,
-              [EMAIL_WEBHOOK_RELAY_REMAINING_CELLS_HEADER]: cells
-                .slice(index + 1)
-                .map((remainingCell) => remainingCell.name)
-                .join(","),
+              [EMAIL_WEBHOOK_RELAY_SOURCE_ERROR_HEADER]: relayError.type,
             },
             body,
           });
@@ -315,9 +310,14 @@ export async function relayEmailToOtherCells(
           },
           "[email] Failed to relay inbound email to cell"
         );
-        if (responseRes.isErr()) {
-          break;
-        }
+        return new Err(EMAIL_RELAY_ERROR);
+      }
+
+      const data = EmailRelayResponseSchema.parse(
+        await responseRes.value.json()
+      );
+      if (data.lookupError) {
+        relayError = data.lookupError;
         continue;
       }
 
@@ -332,11 +332,15 @@ export async function relayEmailToOtherCells(
 
       return new Ok(undefined);
     }
+    return new Err(relayError);
   } catch (error) {
-    return new Err(normalizeError(error));
+    logger.error(
+      { error: normalizeError(error) },
+      "[email] Failed to relay inbound email"
+    );
   }
 
-  return new Err(new Error("Failed to relay inbound email to other cells"));
+  return new Err(EMAIL_RELAY_ERROR);
 }
 
 function parseThreadingHeaders(rawHeaders: string | null) {


### PR DESCRIPTION
## Description

Fixes email routing introduced in https://github.com/dust-tt/dust/pull/31973: a successful webhook response acknowledges receipt before workspace lookup, so email never reached the second remote cell.

On a workspace lookup miss, forward to the next cell in alphabetical name order: US → EU1 → EU2. Each cell derives later destinations from the shared configuration; no remaining-cells header is needed. Assert that US comes first. The receiving cell owns further lookup and forwarding, and the last cell sends one error reply using the most informative lookup error.

Keep fallback to later cells after an explicit HTTP rejection. Stop on acceptance or exhausted transport retries, because the target may already be processing.

## Risks

Blast radius: inbound Email Agents routing between cells.
Risk: standard

## Deploy Plan

- Deploy front-api from the last cell to the first: EU2, EU1, then US. No migrations.

## Tests

- [x] Email webhook suite: 12 tests, including US → EU1 and EU1 → EU2 routing with an unsorted cell configuration, HTTP rejection fallback, stopping after uncertain receipt, duplicate detection, and one final error reply without relaying back.
