### PR TITLE
fix(slack): block auto-respond without mention on private channels

### DIFF
--- a/connectors/src/api/slack_channels_linked_with_agent.ts
+++ b/connectors/src/api/slack_channels_linked_with_agent.ts
@@ -90,6 +90,10 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
     new Set(slackChannelIds.filter((id) => !foundSlackChannelIds.has(id)))
   );
 
+  const privateByChannelId = new Map(
+    slackChannels.map((c) => [c.slackChannelId, c.private])
+  );
+
   const slackClient = await getSlackClient(parseInt(connectorId));
 
   await withTransaction(async (t) => {
@@ -108,6 +112,8 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
                 `Unexpected error: Unable to find Slack channel ${slackChannelId}.`
               );
             }
+            const isPrivate = !!remoteChannel.is_private;
+            privateByChannelId.set(slackChannelId, isPrivate);
             return await SlackChannelModel.create(
               {
                 connectorId: parseInt(connectorId),
@@ -115,10 +121,13 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
                 slackChannelName: remoteChannel.name,
                 agentConfigurationId,
                 permission: "write",
-                private: !!remoteChannel.is_private,
-                autoRespondWithoutMention: autoRespondWithoutMention ?? false,
+                private: isPrivate,
+                // Private channels never receive unmentioned messages (no message.groups).
+                autoRespondWithoutMention:
+                  !isPrivate && (autoRespondWithoutMention ?? false),
                 autoRespondWithoutMentionSkipThreadReplies:
-                  autoRespondWithoutMentionSkipThreadReplies ?? false,
+                  !isPrivate &&
+                  (autoRespondWithoutMentionSkipThreadReplies ?? false),
               },
               {
                 transaction: t,
@@ -144,17 +153,21 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
       }
     );
     await Promise.all(
-      slackChannelIds.map((slackChannelId) =>
-        SlackChannelModel.update(
+      slackChannelIds.map((slackChannelId) => {
+        const isPrivate = privateByChannelId.get(slackChannelId) ?? false;
+        return SlackChannelModel.update(
           {
             agentConfigurationId,
-            autoRespondWithoutMention: autoRespondWithoutMention ?? false,
+            // Private channels never receive unmentioned messages (no message.groups).
+            autoRespondWithoutMention:
+              !isPrivate && (autoRespondWithoutMention ?? false),
             autoRespondWithoutMentionSkipThreadReplies:
-              autoRespondWithoutMentionSkipThreadReplies ?? false,
+              !isPrivate &&
+              (autoRespondWithoutMentionSkipThreadReplies ?? false),
           },
           { where: { connectorId, slackChannelId }, transaction: t }
-        )
-      )
+        );
+      })
     );
   });
   const joinPromises = await Promise.all(
@@ -218,6 +231,7 @@ type GetSlackChannelsLinkedWithAgentResBody = WithConnectorsAPIErrorReponse<{
     agentConfigurationId: string;
     autoRespondWithoutMention: boolean;
     autoRespondWithoutMentionSkipThreadReplies: boolean;
+    isPrivate: boolean;
   }[];
 }>;
 
@@ -256,6 +270,7 @@ const _getSlackChannelsLinkedWithAgentHandler = async (
       autoRespondWithoutMention: c.autoRespondWithoutMention,
       autoRespondWithoutMentionSkipThreadReplies:
         c.autoRespondWithoutMentionSkipThreadReplies,
+      isPrivate: c.private,
     })),
   });
 };

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -296,6 +296,7 @@ function AgentBuilderForm({
         autoRespondWithoutMention: channel.autoRespondWithoutMention,
         autoRespondWithoutMentionSkipThreadReplies:
           channel.autoRespondWithoutMentionSkipThreadReplies,
+        isPrivate: channel.isPrivate,
       }));
   }, [agentConfiguration, slackChannelsLinkedWithAgent]);
 

--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -39,6 +39,7 @@ const agentSettingsSchema = z.object({
       slackChannelName: z.string(),
       autoRespondWithoutMention: z.boolean().optional(),
       autoRespondWithoutMentionSkipThreadReplies: z.boolean().optional(),
+      isPrivate: z.boolean(),
     })
   ),
   tags: z.array(tagSchema),

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -5,7 +5,6 @@ import { useSlackUserPrivateChannels } from "@app/lib/swr/assistants";
 import { useConnectorPermissions } from "@app/lib/swr/connectors";
 import type { DataSourceType } from "@app/types/data_source";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type { WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
 import {
   Button,
@@ -37,7 +36,7 @@ type SlackChannel = {
   sourceUrl?: string | null;
   autoRespondWithoutMention?: boolean;
   autoRespondWithoutMentionSkipThreadReplies?: boolean;
-  isPrivate?: boolean;
+  isPrivate: boolean;
 };
 
 type SheetState = {
@@ -57,11 +56,12 @@ function sheetReducer(state: SheetState, action: SheetAction): SheetState {
     case "sync":
       return {
         localSlackChannels: [...action.channels],
-        autoRespondWithoutMentionEnabled:
-          action.channels[0]?.autoRespondWithoutMention ?? false,
-        skipThreadRepliesEnabled:
-          action.channels[0]?.autoRespondWithoutMentionSkipThreadReplies ??
-          false,
+        autoRespondWithoutMentionEnabled: action.channels.some(
+          (channel) => channel.autoRespondWithoutMention
+        ),
+        skipThreadRepliesEnabled: action.channels.some(
+          (channel) => channel.autoRespondWithoutMentionSkipThreadReplies
+        ),
       };
     case "set_channels":
       return { ...state, localSlackChannels: action.channels };
@@ -84,46 +84,21 @@ function sheetReducer(state: SheetState, action: SheetAction): SheetState {
 }
 
 interface SlackChannelsListProps {
-  disabled?: boolean;
   existingSelection: SlackChannel[];
+  isLoading: boolean;
+  isResourcesError: boolean;
+  mergedChannels: SlackChannel[];
   onSelectionChange: (channels: SlackChannel[]) => void;
-  owner: WorkspaceType;
-  slackDataSource: DataSourceType;
 }
 
 function SlackChannelsList({
-  disabled,
   existingSelection,
+  isLoading,
+  isResourcesError,
+  mergedChannels,
   onSelectionChange,
-  owner,
-  slackDataSource,
 }: SlackChannelsListProps) {
   const [searchQuery, setSearchQuery] = useState("");
-
-  const { resources, isResourcesLoading, isResourcesError } =
-    useConnectorPermissions({
-      dataSource: slackDataSource,
-      disabled,
-      filterPermission: "write",
-      owner,
-      parentId: null,
-      viewType: "all",
-    });
-
-  const { privateChannels, isPrivateChannelsLoading } =
-    useSlackUserPrivateChannels({
-      workspaceId: owner.sId,
-      disabled,
-    });
-
-  const mergedChannels = useMemo(
-    () =>
-      buildDefaultAgentSlackPickerChannels({
-        connectorResources: resources ?? [],
-        privateChannels,
-      }),
-    [resources, privateChannels]
-  );
 
   const filteredChannels = useMemo(() => {
     if (searchQuery.trim() === "") {
@@ -176,8 +151,6 @@ function SlackChannelsList({
       </div>
     );
   }
-
-  const isLoading = isResourcesLoading || isPrivateChannelsLoading;
 
   return (
     <div className="space-y-4">
@@ -274,11 +247,47 @@ export function SlackSettingsSheet({
     dispatch,
   ] = useReducer(sheetReducer, slackChannels ?? [], (channels) => ({
     localSlackChannels: [...channels],
-    autoRespondWithoutMentionEnabled:
-      channels[0]?.autoRespondWithoutMention ?? false,
-    skipThreadRepliesEnabled:
-      channels[0]?.autoRespondWithoutMentionSkipThreadReplies ?? false,
+    autoRespondWithoutMentionEnabled: channels.some(
+      (channel) => channel.autoRespondWithoutMention
+    ),
+    skipThreadRepliesEnabled: channels.some(
+      (channel) => channel.autoRespondWithoutMentionSkipThreadReplies
+    ),
   }));
+
+  const fetchDisabled = !isOpen || !isAdmin(owner);
+
+  const { resources, isResourcesLoading, isResourcesError } =
+    useConnectorPermissions({
+      dataSource: slackDataSource,
+      disabled: fetchDisabled,
+      filterPermission: "write",
+      owner,
+      parentId: null,
+      viewType: "all",
+    });
+
+  const { privateChannels, isPrivateChannelsLoading } =
+    useSlackUserPrivateChannels({
+      workspaceId: owner.sId,
+      disabled: fetchDisabled,
+    });
+
+  const mergedChannels = useMemo(
+    () =>
+      buildDefaultAgentSlackPickerChannels({
+        connectorResources: resources ?? [],
+        privateChannels,
+      }),
+    [resources, privateChannels]
+  );
+
+  const hasPrivateSelected = localSlackChannels.some(
+    (channel) => channel.isPrivate
+  );
+  const canAutoRespond = localSlackChannels.some(
+    (channel) => !channel.isPrivate
+  );
 
   useEffect(() => {
     dispatch({ type: "sync", channels: slackChannels ?? [] });
@@ -289,13 +298,18 @@ export function SlackSettingsSheet({
   };
 
   const onSave = () => {
-    const channelsWithSettings = localSlackChannels.map((channel) => ({
-      ...channel,
-      autoRespondWithoutMention: autoRespondWithoutMentionEnabled,
-      autoRespondWithoutMentionSkipThreadReplies:
-        autoRespondWithoutMentionEnabled ? skipThreadRepliesEnabled : false,
-    }));
-    onChange(channelsWithSettings);
+    onChange(
+      localSlackChannels.map((channel) => ({
+        ...channel,
+        // Private channels never receive unmentioned messages (no message.groups).
+        autoRespondWithoutMention:
+          !channel.isPrivate && autoRespondWithoutMentionEnabled,
+        autoRespondWithoutMentionSkipThreadReplies:
+          !channel.isPrivate &&
+          autoRespondWithoutMentionEnabled &&
+          skipThreadRepliesEnabled,
+      }))
+    );
     onOpenChange();
   };
 
@@ -320,10 +334,12 @@ export function SlackSettingsSheet({
       (id) => !localChannelIds.has(id as string)
     );
 
-    const savedAutoRespond =
-      slackChannels?.[0]?.autoRespondWithoutMention ?? false;
-    const savedSkipThreadReplies =
-      slackChannels?.[0]?.autoRespondWithoutMentionSkipThreadReplies ?? false;
+    const savedAutoRespond = (slackChannels ?? []).some(
+      (channel) => channel.autoRespondWithoutMention
+    );
+    const savedSkipThreadReplies = (slackChannels ?? []).some(
+      (channel) => channel.autoRespondWithoutMentionSkipThreadReplies
+    );
 
     return (
       channelSelectionChanged ||
@@ -377,11 +393,11 @@ export function SlackSettingsSheet({
 
             {isAdmin(owner) && (
               <SlackChannelsList
-                disabled={!isOpen}
                 existingSelection={localSlackChannels}
+                isLoading={isResourcesLoading || isPrivateChannelsLoading}
+                isResourcesError={isResourcesError}
+                mergedChannels={mergedChannels}
                 onSelectionChange={handleSelectionChange}
-                owner={owner}
-                slackDataSource={slackDataSource}
               />
             )}
           </div>
@@ -407,19 +423,25 @@ export function SlackSettingsSheet({
                     Respond to all messages in channel
                   </span>
                   <span className="text-xs text-muted-foreground">
-                    Agent will automatically respond to messages in selected
-                    channels (not just @mentions)
+                    {hasPrivateSelected
+                      ? canAutoRespond
+                        ? "Private channels only reply to @mentions. Auto-respond applies to public channels."
+                        : "Auto-respond isn't available in private Slack channels. The agent will only reply when @Dust is mentioned."
+                      : "Agent will automatically respond to messages in selected channels (not just @mentions)"}
                   </span>
                 </div>
                 <SliderToggle
-                  selected={autoRespondWithoutMentionEnabled}
+                  disabled={!canAutoRespond}
+                  selected={canAutoRespond && autoRespondWithoutMentionEnabled}
                   onClick={() => dispatch({ type: "toggle_auto_respond" })}
                 />
               </div>
               <div className="flex items-center justify-between gap-4">
                 <div
                   className={`flex min-w-0 flex-1 flex-col gap-1 ${
-                    autoRespondWithoutMentionEnabled ? "" : "opacity-50"
+                    canAutoRespond && autoRespondWithoutMentionEnabled
+                      ? ""
+                      : "opacity-50"
                   }`}
                 >
                   <span className="text-sm text-foreground">
@@ -431,8 +453,14 @@ export function SlackSettingsSheet({
                   </span>
                 </div>
                 <Checkbox
-                  checked={skipThreadRepliesEnabled}
-                  disabled={!autoRespondWithoutMentionEnabled}
+                  checked={
+                    canAutoRespond &&
+                    autoRespondWithoutMentionEnabled &&
+                    skipThreadRepliesEnabled
+                  }
+                  disabled={
+                    !canAutoRespond || !autoRespondWithoutMentionEnabled
+                  }
                   onCheckedChange={(checked) =>
                     dispatch({
                       type: "set_skip_thread_replies",

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -573,14 +573,12 @@ export async function submitAgentBuilderForm({
     // Make the call even if slackChannels is empty, since if the user deselects all channels,
     // the call need to be made to unlink them.
     if (slackProvider && areSlackChannelsChanged) {
-      const autoRespondWithoutMention =
-        slackChannels.length > 0
-          ? slackChannels[0].autoRespondWithoutMention
-          : false;
-      const autoRespondWithoutMentionSkipThreadReplies =
-        slackChannels.length > 0
-          ? slackChannels[0].autoRespondWithoutMentionSkipThreadReplies
-          : false;
+      const autoRespondWithoutMention = slackChannels.some(
+        (channel) => channel.autoRespondWithoutMention
+      );
+      const autoRespondWithoutMentionSkipThreadReplies = slackChannels.some(
+        (channel) => channel.autoRespondWithoutMentionSkipThreadReplies
+      );
       const slackRequestBody = JSON.stringify({
         provider: slackProvider,
         slack_channel_internal_ids: slackChannels.map(

--- a/front/lib/api/assistant/configuration/yaml_export.ts
+++ b/front/lib/api/assistant/configuration/yaml_export.ts
@@ -72,8 +72,11 @@ export async function getAgentConfigurationAsYAMLConfig(
   const editors: UserType[] = editorUsers.map((m) => m.toJSON());
 
   let slackProvider: "slack" | "slack_bot" | null = null;
-  let slackChannels: { slackChannelId: string; slackChannelName: string }[] =
-    [];
+  let slackChannels: {
+    slackChannelId: string;
+    slackChannelName: string;
+    isPrivate: boolean;
+  }[] = [];
 
   const [slackDs] = await DataSourceResource.listByConnectorProvider(
     auth,
@@ -115,6 +118,7 @@ export async function getAgentConfigurationAsYAMLConfig(
         .map((ch) => ({
           slackChannelId: ch.slackChannelId,
           slackChannelName: ch.slackChannelName,
+          isPrivate: ch.isPrivate,
         }));
     }
   }

--- a/front/types/api/assistant/builder/slack/channels_linked_with_agent.ts
+++ b/front/types/api/assistant/builder/slack/channels_linked_with_agent.ts
@@ -8,6 +8,7 @@ export type GetSlackChannelsLinkedWithAgentResponseBody = {
     agentConfigurationId: string;
     autoRespondWithoutMention: boolean;
     autoRespondWithoutMentionSkipThreadReplies: boolean;
+    isPrivate: boolean;
   }[];
   slackDataSource?: DataSourceType;
 };

--- a/front/types/connectors/connectors_api.ts
+++ b/front/types/connectors/connectors_api.ts
@@ -547,6 +547,7 @@ export class ConnectorsAPI {
         agentConfigurationId: string;
         autoRespondWithoutMention: boolean;
         autoRespondWithoutMentionSkipThreadReplies: boolean;
+        isPrivate: boolean;
       }[];
     }>
   > {


### PR DESCRIPTION
## Summary
- https://github.com/dust-tt/tasks/issues/10157
- Auto-respond without mention does not work in private Slack channels because the bot app is not subscribed to `message.groups`. The agent builder was still letting admins enable it, so the setting appeared to work and then silently did nothing.
- The Slack prefs sheet now disables the toggle when the selection is only private channels, and never writes the flag onto private channels when the selection is mixed.

## Testing
<img width="322" height="892" alt="Screenshot 2026-09-08 at 1 12 37 PM" src="https://github.com/user-attachments/assets/3f99d491-e515-446e-bfc9-50c1d9e1e52b" />

## Risk
Low

## Deploy Plan
1. Deploy front