### PR TITLE
[front] Spend caps: show "capped" for a 0-value per-user cap in poke/usage

### DIFF
--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1340,7 +1340,11 @@ async function isUserRateLimiterSpendCapped(
     billingCycle: BillingCycle | null;
   }
 ): Promise<boolean> {
-  if (thresholdAwuCredits === null || thresholdAwuCredits <= 0) {
+  // A threshold of exactly 0 is a real "block everything" cap, matching
+  // enforcement (`count >= threshold`, so `0 >= 0` blocks). A null threshold
+  // means it couldn't be resolved (not that the member is uncapped — that can't
+  // happen), so fail open; a negative one is nonsensical and also fails open.
+  if (thresholdAwuCredits === null || thresholdAwuCredits < 0) {
     return false;
   }
 
@@ -2500,7 +2504,15 @@ export async function getMembersUsage({
         ? freeStartingBalanceAwu
         : effectiveSpendLimitAwuCredits;
     let rateLimiterState: RateLimiterState | null = null;
-    if (rateCapThresholdAwuCredits !== null && rateCapThresholdAwuCredits > 0) {
+    // Every seat resolves to a numeric cap — there is no "uncapped" member; a
+    // cap of exactly 0 is a real "block everything" cap (enforcement caps on
+    // `count >= threshold`, so `0 >= 0` blocks). A null threshold here means the
+    // value wasn't resolved (not requested, or a free-seat grant read gap), so
+    // render "—"; otherwise evaluate the cap, including 0.
+    if (
+      rateCapThresholdAwuCredits !== null &&
+      rateCapThresholdAwuCredits >= 0
+    ) {
       const spend = rateLimiterSpendAwuCredits ?? 0;
       rateLimiterState =
         spend >= rateCapThresholdAwuCredits


### PR DESCRIPTION
## Description

A per-user spend cap of exactly **0** (a legitimate "block everything" cap) was displayed as `—` in Poke's rate-limiter chip and left `isSpendCapped=false`, so no **Unblock** action showed — even though the member was correctly blocked in the app (banner + blocked usage).

Root cause: two display/verdict guards in `members_usage.ts` treated a `0` threshold as "no cap":
- the members-table `rateLimiterState` computation guarded on `rateCapThresholdAwuCredits > 0`;
- the single-member `isUserRateLimiterSpendCapped` guarded on `thresholdAwuCredits <= 0`.

Enforcement (`isSpendCapCounterReached` / `isUserSpendLimitRateCapReached`) caps on `count >= threshold`, so `0 >= 0` blocks. Every seat resolves to a numeric cap — there is no "uncapped" member — so a `null` threshold only means the value wasn't resolved (not requested, or a free-seat grant read gap), never unlimited.

Fix: only skip on a `null` (unresolved) threshold; evaluate `0` as the block-all cap it is. `isSpendCapped` in both the members-table path and the single-member path now agree with enforcement, so the poke chip shows `capped` and the customer usage page surfaces **Unblock**.

## Tests

- `npx tsgo --noEmit` (front) clean for the touched file.
- Behavior verified by reading against enforcement in `lib/api/users/spend_limit.ts` and `lib/api/credits/access_control.ts`.

## Risk

Low. Two-guard boundary fix (`> 0` → `>= 0`, `<= 0` → `< 0`); no schema, API, or enforcement changes. Only affects how a 0-value cap is displayed/derived in the members-usage response (Poke chip + customer Unblock).

## Deploy Plan

Standard front deploy. No migration, no flag.