### PR TITLE
Track activity steps toggle clicks

### DIFF
--- a/front/components/actions/mcp/details/ChildAgentActivityTimeline.tsx
+++ b/front/components/actions/mcp/details/ChildAgentActivityTimeline.tsx
@@ -45,6 +45,7 @@ export function ChildAgentActivityTimeline({
       }
       activeCotContent={activeCotContent}
       isDone={isDone}
+      source="run_agent_details"
       headerLabel={
         isDone ? (
           isError ? (

--- a/front/components/assistant/conversation/actions/inline/ActivityTimeline.tsx
+++ b/front/components/assistant/conversation/actions/inline/ActivityTimeline.tsx
@@ -4,6 +4,11 @@ import {
   getActionStepIcon,
   getCollapseAnimationStyle,
 } from "@app/components/assistant/conversation/actions/inline/utils";
+import {
+  TRACKING_ACTIONS,
+  TRACKING_AREAS,
+  trackEvent,
+} from "@app/lib/tracking";
 import type { InlineActivityStep } from "@app/types/assistant/conversation";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { ChevronRight, cn, Icon } from "@dust-tt/sparkle";
@@ -21,6 +26,7 @@ interface ActivityTimelineProps {
   activeCotContent: string;
   isDone: boolean;
   headerLabel: React.ReactNode;
+  source: "message" | "run_agent_details";
   onActionClick?: (actionId: string | undefined) => void;
   showTrailingSpinner: boolean;
   terminalRow?: {
@@ -37,6 +43,7 @@ export function ActivityTimeline({
   activeCotContent,
   isDone,
   headerLabel,
+  source,
   onActionClick,
   showTrailingSpinner,
   terminalRow,
@@ -48,7 +55,18 @@ export function ActivityTimeline({
   const showActiveCoT = !isDone && activeCotContent.length > 0;
   const hasRunningRows = runningToolRows.length > 0;
 
-  const toggleCollapse = () => setIsCollapsed((c) => !c);
+  const toggleCollapse = () => {
+    trackEvent({
+      area: TRACKING_AREAS.CONVERSATION,
+      object: "activity_steps",
+      action: isCollapsed ? TRACKING_ACTIONS.OPEN : TRACKING_ACTIONS.CLOSE,
+      extra: {
+        source,
+        message_state: isDone ? "done" : "generating",
+      },
+    });
+    setIsCollapsed((c) => !c);
+  };
 
   return (
     <div className="flex flex-col text-sm">

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -221,6 +221,7 @@ export function InlineActivitySteps({
       activeCotContent={showActiveThinking ? chainOfThought : ""}
       isDone={isDone}
       headerLabel={headerLabel ?? <AnimatedText>Thinking…</AnimatedText>}
+      source="message"
       onActionClick={openBreakdownPanel}
       showTrailingSpinner={showTrailingSpinner}
       terminalRow={terminalRow}


### PR DESCRIPTION
## Description

Track clicks on the inline activity steps toggle ("Thinking…" while generating, "Completed in …" once done) so we can see whether people open or close the steps, and whether they do it while the message is still generating.

Event: `conversation:activity_steps:open` / `conversation:activity_steps:close`

| property | values |
|---|---|
| `source` | `message`, `run_agent_details` |
| `message_state` | `generating`, `done` |

`source` is a required prop on `ActivityTimeline` so any new consumer has to declare where it lives.

## Risk

Low, tracking only.

## Deploy Plan

- Deploy front