### PR TITLE
chore: add scoped empty trigger conversation cleanup script

### DIFF
--- a/front/scripts/cleanup_empty_trigger_conversations.ts
+++ b/front/scripts/cleanup_empty_trigger_conversations.ts
@@ -1,0 +1,264 @@
+import { Authenticator } from "@app/lib/auth";
+import {
+  ConversationParticipantModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { makeScript } from "@app/scripts/helpers";
+import { QueryTypes } from "sequelize";
+
+/**
+ * Finds and soft-deletes empty conversations created by one trigger for one
+ * user during a bounded time window. The script is dry-run by default.
+ */
+interface EmptyTriggeredConversation {
+  id: number;
+  sId: string;
+  createdAt: Date;
+  visibility: string;
+}
+
+function parseTimestamp(value: string, name: string): Date {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`${name} must be a valid ISO-8601 timestamp.`);
+  }
+  return date;
+}
+
+makeScript(
+  {
+    workspaceSId: {
+      alias: "w",
+      describe: "Workspace sId owning the conversations.",
+      type: "string" as const,
+      demandOption: true,
+    },
+    userSId: {
+      alias: "u",
+      describe:
+        "The specific workspace user sId whose private conversations may be removed.",
+      type: "string" as const,
+      demandOption: true,
+    },
+    triggerSId: {
+      alias: "t",
+      describe: "The trigger sId that created the conversations.",
+      type: "string" as const,
+      demandOption: true,
+    },
+    from: {
+      describe: "Inclusive start of the failed-run window, as ISO-8601.",
+      type: "string" as const,
+      demandOption: true,
+    },
+    to: {
+      describe: "Exclusive end of the failed-run window, as ISO-8601.",
+      type: "string" as const,
+      demandOption: true,
+    },
+    maxCandidates: {
+      describe:
+        "Safety limit for the number of conversations that may be selected.",
+      type: "number" as const,
+      default: 1000,
+    },
+  },
+  async (
+    {
+      workspaceSId,
+      userSId,
+      triggerSId,
+      from,
+      to,
+      maxCandidates,
+      execute,
+    },
+    logger
+  ) => {
+    if (maxCandidates <= 0) {
+      throw new Error("maxCandidates must be greater than zero.");
+    }
+
+    const fromDate = parseTimestamp(from, "from");
+    const toDate = parseTimestamp(to, "to");
+    if (fromDate >= toDate) {
+      throw new Error("from must be earlier than to.");
+    }
+
+    const workspace = await WorkspaceResource.fetchById(workspaceSId);
+    if (!workspace) {
+      throw new Error(`Workspace not found: ${workspaceSId}`);
+    }
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const user = await UserModel.findOne({
+      where: { sId: userSId },
+    });
+    if (!user) {
+      throw new Error(`User not found: ${userSId}`);
+    }
+
+    const trigger = await TriggerResource.fetchById(auth, triggerSId);
+    if (!trigger) {
+      throw new Error(
+        `Trigger ${triggerSId} was not found in workspace ${workspaceSId}.`
+      );
+    }
+
+    const candidates = await frontSequelize.query<EmptyTriggeredConversation>(
+      `
+      SELECT
+        c.id,
+        c."sId",
+        c."createdAt",
+        c.visibility
+      FROM conversations c
+      WHERE c."workspaceId" = :workspaceId
+        AND c."triggerId" = :triggerId
+        AND c."createdAt" >= :from
+        AND c."createdAt" < :to
+        AND c.visibility <> 'deleted'
+        AND EXISTS (
+          SELECT 1
+          FROM conversation_participants cp
+          WHERE cp."workspaceId" = c."workspaceId"
+            AND cp."conversationId" = c.id
+            AND cp."userId" = :userId
+        )
+        AND NOT EXISTS (
+          SELECT 1
+          FROM conversation_participants cp_other
+          WHERE cp_other."workspaceId" = c."workspaceId"
+            AND cp_other."conversationId" = c.id
+            AND cp_other."userId" <> :userId
+        )
+        AND NOT EXISTS (
+          SELECT 1
+          FROM messages m
+          WHERE m."workspaceId" = c."workspaceId"
+            AND m."conversationId" = c.id
+        )
+      ORDER BY c."createdAt" ASC, c.id ASC
+      LIMIT :candidateLimit
+      `,
+      {
+        replacements: {
+          workspaceId: workspace.id,
+          userId: user.id,
+          triggerId: trigger.id,
+          from: fromDate,
+          to: toDate,
+          candidateLimit: maxCandidates + 1,
+        },
+        type: QueryTypes.SELECT,
+      }
+    );
+
+    if (candidates.length > maxCandidates) {
+      throw new Error(
+        `Selection exceeded maxCandidates=${maxCandidates}. Refusing to continue.`
+      );
+    }
+
+    logger.info(
+      {
+        workspaceSId,
+        userSId,
+        triggerSId,
+        from: fromDate.toISOString(),
+        to: toDate.toISOString(),
+        candidateCount: candidates.length,
+        execute,
+      },
+      execute
+        ? "Starting targeted empty triggered conversation cleanup"
+        : "[DRY RUN] Found empty triggered conversations"
+    );
+
+    for (const candidate of candidates) {
+      logger.info(
+        {
+          conversationId: candidate.sId,
+          createdAt: candidate.createdAt,
+          visibility: candidate.visibility,
+        },
+        execute
+          ? "Candidate conversation selected for cleanup"
+          : "[DRY RUN] Would soft-delete empty triggered conversation"
+      );
+    }
+
+    if (!execute || candidates.length === 0) {
+      return;
+    }
+
+    let deletedCount = 0;
+    let skippedCount = 0;
+
+    const conversations = await ConversationResource.fetchByIds(
+      auth,
+      candidates.map(({ sId }) => sId),
+      { includeDeleted: true }
+    );
+
+    for (const conversation of conversations) {
+      const messageCount = await MessageModel.count({
+        where: {
+          workspaceId: workspace.id,
+          conversationId: conversation.id,
+        },
+      });
+
+      const participants = await ConversationParticipantModel.findAll({
+        where: {
+          workspaceId: workspace.id,
+          conversationId: conversation.id,
+        },
+      });
+
+      const isStillSafeToDelete =
+        messageCount === 0 &&
+        participants.length === 1 &&
+        participants[0].userId === user.id &&
+        conversation.visibility !== "deleted";
+
+      if (!isStillSafeToDelete) {
+        skippedCount++;
+        logger.warn(
+          {
+            conversationId: conversation.sId,
+            messageCount,
+            participantCount: participants.length,
+            visibility: conversation.visibility,
+          },
+          "Skipping conversation because it no longer matches the cleanup scope"
+        );
+        continue;
+      }
+
+      await conversation.removeAllParticipants(auth);
+      await conversation.updateVisibilityToDeleted(auth);
+      deletedCount++;
+
+      logger.info(
+        { conversationId: conversation.sId },
+        "Soft-deleted empty triggered conversation"
+      );
+    }
+
+    logger.info(
+      {
+        candidateCount: candidates.length,
+        deletedCount,
+        skippedCount,
+      },
+      "Targeted empty triggered conversation cleanup complete"
+    );
+  }
+);

--- a/front/scripts/cleanup_empty_trigger_conversations.ts
+++ b/front/scripts/cleanup_empty_trigger_conversations.ts
@@ -111,6 +111,12 @@ makeScript(
       );
     }
 
+    if (trigger.editor !== user.id) {
+      throw new Error(
+        `User ${userSId} is not the current editor of trigger ${triggerSId}.`
+      );
+    }
+
     const candidates = await frontSequelize.query<EmptyTriggeredConversation>(
       `
       SELECT
@@ -124,13 +130,8 @@ makeScript(
         AND c."createdAt" >= :from
         AND c."createdAt" < :to
         AND c.visibility <> 'deleted'
-        AND EXISTS (
-          SELECT 1
-          FROM conversation_participants cp
-          WHERE cp."workspaceId" = c."workspaceId"
-            AND cp."conversationId" = c.id
-            AND cp."userId" = :userId
-        )
+        -- Failed trigger attempts create the conversation before participants
+        -- are added. Only exclude conversations shared with another user.
         AND NOT EXISTS (
           SELECT 1
           FROM conversation_participants cp_other
@@ -222,10 +223,12 @@ makeScript(
         },
       });
 
+      const hasOtherParticipant = participants.some(
+        (participant) => participant.userId !== user.id
+      );
       const isStillSafeToDelete =
         messageCount === 0 &&
-        participants.length === 1 &&
-        participants[0].userId === user.id &&
+        !hasOtherParticipant &&
         conversation.visibility !== "deleted";
 
       if (!isStillSafeToDelete) {


### PR DESCRIPTION
## Description

Adds a reusable front admin script for cleaning up empty conversations created by a scheduled trigger after a terminal failure.

The script requires all cleanup dimensions explicitly:

- Workspace sId
- User sId
- Trigger sId
- Inclusive start timestamp
- Exclusive end timestamp

It is dry-run by default. Candidates must belong to the exact workspace and trigger, be within the requested time window, have zero messages, and have no participant other than the requested user. Empty failed-trigger conversations commonly have no participant because creation happens before participant insertion, so the script validates that the requested user is the trigger editor rather than requiring a participant row. Execution revalidates the message and participant conditions before removing participants and soft-deleting the conversations.

## Tests

- `bun build front/scripts/cleanup_empty_trigger_conversations.ts --target=node --no-bundle --external:'*'`
- `git diff --check`
- No production cleanup was executed.
- Biome was not run because the repository does not have dependencies installed in the Computer and the registry is blocked by the sandbox network policy.

## Risk

Low and bounded. The script is dry-run by default, requires explicit identifiers and timestamps, refuses selections above the configurable safety limit, skips conversations that gain messages or other participants, and uses soft deletion rather than hard deletion. The main operational risk is selecting an overly broad time window, mitigated by the exact trigger and user-editor validation plus the dry run.

## Deploy Plan

1. Run the script without `--execute` and review the candidate conversation IDs and count.
2. Confirm the workspace, user, trigger, and timestamps match the intended incident.
3. Rerun with `--execute` to soft-delete the confirmed empty conversations.
4. Re-run the dry-run query to verify no matching non-deleted conversations remain.

Follow-up application fixes should prevent these empty conversations from being created in the first place.