### PR TITLE
Add Pod customization settings

### DIFF
--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -8,6 +8,7 @@ import { PodGroupMembersTable } from "@app/components/pod/settings/PodGroupMembe
 import { PodMembersTable } from "@app/components/pod/settings/PodMembersTable";
 import { PodNetworkSection } from "@app/components/pod/settings/PodNetworkSection";
 import { PodSettingsOptionLabel } from "@app/components/pod/settings/PodSettingsOptionLabel";
+import { PodTabsCustomizationSection } from "@app/components/pod/settings/PodTabsCustomizationSection";
 import { SandboxEnvVarsSection } from "@app/components/sandbox/SandboxEnvVarsSection";
 import { usePodConversationsSummary } from "@app/hooks/conversations";
 import { useArchivePod } from "@app/hooks/useArchivePod";
@@ -107,6 +108,7 @@ export function PodSettingsTab({
   const { hasFeature } = useFeatureFlags();
   const { isAdmin } = useAuth();
   const hasWorkspaceDefaultAgentFeature = hasFeature("workspace_default_agent");
+  const hasFileTabs = hasFeature("pod_frame_tabs");
   // The pod env vars section stays workspace-admin only (matching the API,
   // which keeps env-vars admin-only). Mirrors that gate — change both together.
   const isPodSandboxAdminEnabled = isAdmin && hasFeature("frames_v2");
@@ -778,6 +780,16 @@ export function PodSettingsTab({
             </div>
           </div>
         </div>
+
+        {hasFileTabs && (
+          <PodTabsCustomizationSection
+            owner={owner}
+            podId={pod.sId}
+            fileTabs={pod.frameTabs ?? []}
+            tabsOrder={pod.tabsOrder}
+            isEditor={isPodEditor}
+          />
+        )}
 
         <div className="flex flex-col gap-3">
           <div className="flex items-center gap-2">

--- a/front/components/pod/settings/PodTabsCustomizationSection.tsx
+++ b/front/components/pod/settings/PodTabsCustomizationSection.tsx
@@ -1,0 +1,300 @@
+import { isCustomResourceIconType } from "@app/components/resources/resources_icon_names";
+import { getIcon } from "@app/components/resources/resources_icons";
+import { usePodFileTabs } from "@app/hooks/usePodFileTabs";
+import type { PodFileTab } from "@app/types/pod_file_tab";
+import {
+  DEFAULT_POD_FILE_TAB_ICON,
+  MAX_POD_FILE_TAB_TITLE_LENGTH,
+} from "@app/types/pod_file_tab";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  ActionIcons,
+  Button,
+  ChevronSelectorVertical,
+  cn,
+  Icon,
+  IconPicker,
+  Input,
+  ListGroup,
+  ListItem,
+  Plus,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
+  XClose,
+} from "@dust-tt/sparkle";
+import type { DragEvent } from "react";
+import { useState } from "react";
+
+const POD_TAB_DRAG_MIME = "application/x-dust-pod-tab-path";
+
+interface PodTabsCustomizationSectionProps {
+  owner: LightWorkspaceType;
+  podId: string;
+  fileTabs: PodFileTab[];
+  tabsOrder?: string[];
+  isEditor: boolean;
+}
+
+function isTabReorderDrag(event: DragEvent) {
+  return event.dataTransfer.types.includes(POD_TAB_DRAG_MIME);
+}
+
+export function PodTabsCustomizationSection({
+  owner,
+  podId,
+  fileTabs,
+  tabsOrder,
+  isEditor,
+}: PodTabsCustomizationSectionProps) {
+  const { orderedFileTabs, updateFileTab, removeFileTab, reorderFileTab } =
+    usePodFileTabs({
+      owner,
+      podId,
+      fileTabs,
+      tabsOrder,
+      isEditor,
+    });
+
+  const [draggingPath, setDraggingPath] = useState<string | null>(null);
+  const [dropTargetPath, setDropTargetPath] = useState<string | null>(null);
+  const [iconPickerPath, setIconPickerPath] = useState<string | null>(null);
+  const [editingTitlePath, setEditingTitlePath] = useState<string | null>(null);
+  const [editingTitleValue, setEditingTitleValue] = useState("");
+
+  const handleDragStart = (path: string, event: DragEvent<HTMLDivElement>) => {
+    event.dataTransfer.setData(POD_TAB_DRAG_MIME, path);
+    event.dataTransfer.effectAllowed = "move";
+    setDraggingPath(path);
+  };
+
+  const handleDragEnd = () => {
+    setDraggingPath(null);
+    setDropTargetPath(null);
+  };
+
+  const handleDragOver = (path: string, event: DragEvent<HTMLDivElement>) => {
+    if (!isTabReorderDrag(event) || draggingPath === path) {
+      return;
+    }
+
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+    setDropTargetPath(path);
+  };
+
+  const handleDrop = (path: string, event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const draggedPath = event.dataTransfer.getData(POD_TAB_DRAG_MIME);
+    if (draggedPath) {
+      void reorderFileTab(draggedPath, path);
+    }
+    handleDragEnd();
+  };
+
+  const startTitleEdit = (tab: PodFileTab) => {
+    if (!isEditor) {
+      return;
+    }
+    setEditingTitlePath(tab.path);
+    setEditingTitleValue(tab.title);
+  };
+
+  const cancelTitleEdit = () => {
+    setEditingTitlePath(null);
+    setEditingTitleValue("");
+  };
+
+  const saveTitleEdit = async (tab: PodFileTab) => {
+    const nextTitle = editingTitleValue.trim();
+    if (!nextTitle || nextTitle === tab.title) {
+      cancelTitleEdit();
+      return;
+    }
+    // Start the mutation first so SWR's optimistic cache write lands before we
+    // leave edit mode (otherwise one frame can still show the old title).
+    const updatePromise = updateFileTab(tab.path, { title: nextTitle });
+    cancelTitleEdit();
+    await updatePromise;
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-2">
+      <h3 className="heading-lg">Pod Customization</h3>
+      <div className="flex w-full flex-col gap-3">
+        <div className="flex items-center gap-2">
+          <h4 className="heading-base flex-1">Pod Tabs</h4>
+          {isEditor && (
+            <Button
+              size="xs"
+              variant="outline"
+              icon={Plus}
+              tooltip="Add file to top bar"
+              disabled
+            />
+          )}
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Files pinned to this Pod&apos;s top bar. Drag to reorder, or pick a
+          custom icon.
+        </p>
+        {orderedFileTabs.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No files in the top bar yet. Add one from Files.
+          </p>
+        ) : (
+          <ListGroup>
+            {orderedFileTabs.map((tab) => {
+              const selectedIcon = isCustomResourceIconType(tab.icon)
+                ? tab.icon
+                : DEFAULT_POD_FILE_TAB_ICON;
+              const IconComponent = getIcon(selectedIcon);
+              const isPickerOpen = iconPickerPath === tab.path;
+              const isEditingTitle = editingTitlePath === tab.path;
+              const canDrag = isEditor && !isEditingTitle;
+
+              return (
+                <div
+                  key={tab.path}
+                  draggable={canDrag}
+                  onDragStart={(event) => {
+                    if (!canDrag) {
+                      event.preventDefault();
+                      return;
+                    }
+                    if (
+                      event.target instanceof HTMLElement &&
+                      event.target.closest("button, input")
+                    ) {
+                      event.preventDefault();
+                      return;
+                    }
+                    handleDragStart(tab.path, event);
+                  }}
+                  onDragEnd={handleDragEnd}
+                  onDragOver={(event) => {
+                    if (!isEditor) {
+                      return;
+                    }
+                    handleDragOver(tab.path, event);
+                  }}
+                  onDrop={(event) => {
+                    if (!isEditor) {
+                      return;
+                    }
+                    handleDrop(tab.path, event);
+                  }}
+                  className={cn(
+                    canDrag && "cursor-grab active:cursor-grabbing",
+                    draggingPath === tab.path && "opacity-50",
+                    dropTargetPath === tab.path && "bg-highlight-50"
+                  )}
+                >
+                  <ListItem
+                    itemsAlignment="center"
+                    hasSeparatorIfLast
+                    ignorePressSelector="button, input"
+                  >
+                    {isEditor && (
+                      <Icon
+                        visual={ChevronSelectorVertical}
+                        size="sm"
+                        className="shrink-0 cursor-grab text-faint active:cursor-grabbing"
+                      />
+                    )}
+                    {isEditor ? (
+                      <PopoverRoot
+                        modal={false}
+                        open={isPickerOpen}
+                        onOpenChange={(open) => {
+                          setIconPickerPath(open ? tab.path : null);
+                        }}
+                      >
+                        <PopoverTrigger asChild>
+                          <Button
+                            size="xs"
+                            variant="outline"
+                            icon={IconComponent}
+                            tooltip="Change icon"
+                          />
+                        </PopoverTrigger>
+                        <PopoverContent
+                          className="w-fit p-0"
+                          onOpenAutoFocus={(event) => event.preventDefault()}
+                        >
+                          <IconPicker
+                            icons={ActionIcons}
+                            selectedIcon={selectedIcon}
+                            onIconSelect={(iconName: string) => {
+                              if (isCustomResourceIconType(iconName)) {
+                                void updateFileTab(tab.path, {
+                                  icon: iconName,
+                                });
+                              }
+                              setIconPickerPath(null);
+                            }}
+                          />
+                        </PopoverContent>
+                      </PopoverRoot>
+                    ) : (
+                      <Button
+                        size="xs"
+                        variant="outline"
+                        icon={IconComponent}
+                        disabled
+                      />
+                    )}
+                    {isEditingTitle ? (
+                      <Input
+                        autoFocus
+                        value={editingTitleValue}
+                        maxLength={MAX_POD_FILE_TAB_TITLE_LENGTH}
+                        onChange={(e) => setEditingTitleValue(e.target.value)}
+                        onBlur={() => void saveTitleEdit(tab)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            e.preventDefault();
+                            void saveTitleEdit(tab);
+                          } else if (e.key === "Escape") {
+                            e.preventDefault();
+                            cancelTitleEdit();
+                          }
+                        }}
+                        containerClassName="min-w-0 flex-1"
+                      />
+                    ) : (
+                      <button
+                        type="button"
+                        className={cn(
+                          "min-w-0 flex-1 truncate text-left text-sm text-foreground",
+                          isEditor && "hover:underline"
+                        )}
+                        disabled={!isEditor}
+                        onClick={() => startTitleEdit(tab)}
+                      >
+                        {tab.title}
+                      </button>
+                    )}
+                    {isEditor && (
+                      <Button
+                        size="xs"
+                        variant="ghost-secondary"
+                        icon={XClose}
+                        tooltip="Remove from top bar"
+                        onClick={() =>
+                          void removeFileTab(tab.path, {
+                            fileName: tab.title,
+                          })
+                        }
+                      />
+                    )}
+                  </ListItem>
+                </div>
+              );
+            })}
+          </ListGroup>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/front/hooks/usePodFileTabs.ts
+++ b/front/hooks/usePodFileTabs.ts
@@ -9,7 +9,9 @@ import {
   MAX_POD_FILE_TABS,
   moveFileTabInTabsOrder,
   normalizeTabsOrder,
+  orderedPodFileTabs,
   podFileTabBasename,
+  reorderFileTabsInTabsOrder,
   sortPodFileTabs,
 } from "@app/types/pod_file_tab";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -220,8 +222,34 @@ export function usePodFileTabs({
     [isEditor, navOrder, persist, sortedTabs]
   );
 
+  const reorderFileTab = useCallback(
+    async (draggedPath: string, targetPath: string) => {
+      if (!isEditor) {
+        return false;
+      }
+
+      const nextNavOrder = reorderFileTabsInTabsOrder(
+        navOrder,
+        draggedPath,
+        targetPath
+      );
+      if (!nextNavOrder) {
+        return false;
+      }
+
+      return persist(sortedTabs, nextNavOrder);
+    },
+    [isEditor, navOrder, persist, sortedTabs]
+  );
+
+  const orderedFileTabs = useMemo(
+    () => orderedPodFileTabs(sortedTabs, navOrder),
+    [navOrder, sortedTabs]
+  );
+
   return {
     fileTabs: sortedTabs,
+    orderedFileTabs,
     tabsOrder: navOrder,
     isFileTab,
     addFileTab,
@@ -229,5 +257,6 @@ export function usePodFileTabs({
     toggleFileTab,
     updateFileTab,
     moveFileTab,
+    reorderFileTab,
   };
 }

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -50,6 +50,7 @@ import type {
 } from "@app/types/api/sandbox/egress_policy";
 import type {
   CheckNameResponseBody,
+  GetSpaceResponseBody,
   PatchPodMetadataBodyType,
 } from "@app/types/api/spaces";
 import type {
@@ -1078,59 +1079,163 @@ export function useUpdatePodMetadata({
     options: { disabled: true },
   });
 
-  const { mutateSpaceInfoRegardlessOfQueryParams } = useSpaceInfo({
-    workspaceId: owner.sId,
-    spaceId: podId,
-    disabled: true,
-  });
+  // `includeAllMembers: true` matches PodPage's live space-info key so
+  // optimistic updates land in the cache the settings UI reads from.
+  const { mutateSpaceInfo, mutateSpaceInfoRegardlessOfQueryParams } =
+    useSpaceInfo({
+      workspaceId: owner.sId,
+      spaceId: podId,
+      includeAllMembers: true,
+      disabled: true,
+    });
 
   return async (
     updates: PatchPodMetadataBodyType
   ): Promise<PodMetadataType | null> => {
     const url = `/api/w/${owner.sId}/spaces/${podId}/project_metadata`;
 
-    const res = await clientFetch(url, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(updates),
-    });
+    const applyMutationOnSpace =
+      updates.description !== undefined ||
+      updates.pinnedFramePath !== undefined ||
+      updates.frameTabs !== undefined ||
+      updates.tabsOrder !== undefined ||
+      updates.archive !== undefined;
 
-    if (!res.ok) {
-      const errorData = await getErrorFromResponse(res);
-      sendNotification({
-        type: "error",
-        title: "Error updating Pod metadata",
-        description: `Error: ${errorData.message}`,
+    const applySpaceOptimistic = (
+      data: GetSpaceResponseBody | undefined
+    ): GetSpaceResponseBody | undefined => {
+      if (!data) {
+        return data;
+      }
+      return {
+        ...data,
+        space: {
+          ...data.space,
+          ...(updates.description !== undefined
+            ? { description: updates.description }
+            : {}),
+          ...(updates.pinnedFramePath !== undefined
+            ? { pinnedFramePath: updates.pinnedFramePath }
+            : {}),
+          ...(updates.frameTabs !== undefined
+            ? { frameTabs: updates.frameTabs }
+            : {}),
+          ...(updates.tabsOrder !== undefined
+            ? { tabsOrder: updates.tabsOrder }
+            : {}),
+          ...(updates.archive === true
+            ? { archivedAt: data.space.archivedAt ?? Date.now() }
+            : updates.archive === false
+              ? { archivedAt: null }
+              : {}),
+        },
+      };
+    };
+
+    const applySpaceFromMetadata = (
+      data: GetSpaceResponseBody | undefined,
+      metadata: PodMetadataType
+    ): GetSpaceResponseBody | undefined => {
+      if (!data) {
+        return data;
+      }
+      return {
+        ...data,
+        space: {
+          ...data.space,
+          description: metadata.description,
+          pinnedFramePath: metadata.pinnedFramePath,
+          frameTabs: metadata.frameTabs,
+          tabsOrder: metadata.tabsOrder,
+          archivedAt: metadata.archivedAt,
+        },
+      };
+    };
+
+    const patchRequest = async (): Promise<PodMetadataType> => {
+      const res = await clientFetch(url, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(updates),
       });
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Error updating Pod metadata",
+          description: `Error: ${errorData.message}`,
+        });
+        throw new Error(errorData.message);
+      }
+
+      const response: PatchPodMetadataResponseBody = await res.json();
+      return response.projectMetadata;
+    };
+
+    try {
+      let projectMetadata: PodMetadataType;
+
+      if (applyMutationOnSpace) {
+        // Official SWR optimistic update: write the pending space fields into
+        // cache immediately, roll back on error, then populate from the PATCH.
+        let patched: PodMetadataType | null = null;
+        await mutateSpaceInfo(
+          async (current) => {
+            patched = await patchRequest();
+            void mutatePodMetadata(
+              { projectMetadata: patched },
+              { revalidate: false }
+            );
+            return applySpaceFromMetadata(current, patched);
+          },
+          {
+            optimisticData: (current) =>
+              applySpaceOptimistic(current) as GetSpaceResponseBody,
+            rollbackOnError: true,
+            populateCache: true,
+            revalidate: false,
+          }
+        );
+        if (!patched) {
+          return null;
+        }
+        projectMetadata = patched;
+        // Refresh any other space-info query-param variants (not the live key —
+        // we already populated it above).
+        void mutateSpaceInfoRegardlessOfQueryParams();
+      } else {
+        projectMetadata = await patchRequest();
+        void mutatePodMetadata({ projectMetadata }, { revalidate: false });
+        void mutateSpaceInfoRegardlessOfQueryParams();
+      }
+
+      void mutatePodConversationsSummary();
+
+      const title =
+        updates.frameTabs !== undefined || updates.tabsOrder !== undefined
+          ? updates.frameTabs?.length === 0
+            ? "Pod tabs cleared"
+            : "Pod tabs updated"
+          : updates.pinnedFramePath !== undefined
+            ? updates.pinnedFramePath
+              ? "Frame pinned as Pod banner"
+              : "Banner unpinned"
+            : updates.archive !== undefined
+              ? updates.archive
+                ? "Pod archived"
+                : "Pod unarchived"
+              : "Pod updated";
+
+      sendNotification({
+        type: "success",
+        title,
+      });
+
+      return projectMetadata;
+    } catch {
       return null;
     }
-
-    void mutatePodMetadata();
-    void mutatePodConversationsSummary();
-    void mutateSpaceInfoRegardlessOfQueryParams();
-
-    const title =
-      updates.frameTabs !== undefined || updates.tabsOrder !== undefined
-        ? updates.frameTabs?.length === 0
-          ? "Pod tabs cleared"
-          : "Pod tabs updated"
-        : updates.pinnedFramePath !== undefined
-          ? updates.pinnedFramePath
-            ? "Frame pinned as Pod banner"
-            : "Banner unpinned"
-          : updates.archive !== undefined
-            ? updates.archive
-              ? "Pod archived"
-              : "Pod unarchived"
-            : "Pod updated";
-
-    sendNotification({
-      type: "success",
-      title,
-    });
-
-    const response: PatchPodMetadataResponseBody = await res.json();
-    return response.projectMetadata;
   };
 }
 

--- a/front/types/pod_file_tab.test.ts
+++ b/front/types/pod_file_tab.test.ts
@@ -1,4 +1,9 @@
-import { podFileTabBasename } from "@app/types/pod_file_tab";
+import type { PodFileTab } from "@app/types/pod_file_tab";
+import {
+  orderedPodFileTabs,
+  podFileTabBasename,
+  reorderFileTabsInTabsOrder,
+} from "@app/types/pod_file_tab";
 import { describe, expect, it } from "vitest";
 
 describe("podFileTabBasename", () => {
@@ -15,5 +20,50 @@ describe("podFileTabBasename", () => {
 
   it("keeps names without extensions", () => {
     expect(podFileTabBasename("pod-p1/notes/README")).toBe("README");
+  });
+});
+
+describe("reorderFileTabsInTabsOrder", () => {
+  it("reorders file tabs while keeping system-tab slots fixed", () => {
+    const tabsOrder = [
+      "conversations",
+      "a.tsx",
+      "files",
+      "b.md",
+      "tasks",
+      "c.tsx",
+    ];
+
+    expect(reorderFileTabsInTabsOrder(tabsOrder, "c.tsx", "a.tsx")).toEqual([
+      "conversations",
+      "c.tsx",
+      "files",
+      "a.tsx",
+      "tasks",
+      "b.md",
+    ]);
+  });
+
+  it("returns null when the drag is a no-op or paths are missing", () => {
+    const tabsOrder = ["conversations", "a.tsx", "files", "b.md"];
+    expect(reorderFileTabsInTabsOrder(tabsOrder, "a.tsx", "a.tsx")).toBeNull();
+    expect(
+      reorderFileTabsInTabsOrder(tabsOrder, "missing", "a.tsx")
+    ).toBeNull();
+  });
+});
+
+describe("orderedPodFileTabs", () => {
+  it("returns file tabs in nav order", () => {
+    const tabs: PodFileTab[] = [
+      { path: "b.md", title: "B", icon: "ActionDashboardIcon" },
+      { path: "a.tsx", title: "A", icon: "ActionDashboardIcon" },
+    ];
+
+    expect(
+      orderedPodFileTabs(tabs, ["conversations", "b.md", "files", "a.tsx"]).map(
+        (tab) => tab.path
+      )
+    ).toEqual(["b.md", "a.tsx"]);
   });
 });

--- a/front/types/pod_file_tab.ts
+++ b/front/types/pod_file_tab.ts
@@ -146,6 +146,60 @@ export function moveFileTabInTabsOrder(
   return next;
 }
 
+/**
+ * Reorder file tabs among themselves while keeping system-tab slots fixed.
+ * Returns null when either path is missing or the order is unchanged.
+ *
+ * @cc [label:product] system-slots-fixed
+ * System tab entries keep their indices; only non-system (file-tab) entries are
+ * permuted among those slots.
+ */
+export function reorderFileTabsInTabsOrder(
+  tabsOrder: string[],
+  draggedPath: string,
+  targetPath: string
+): string[] | null {
+  if (draggedPath === targetPath) {
+    return null;
+  }
+
+  const fileIndices: number[] = [];
+  const filePaths: string[] = [];
+  for (let i = 0; i < tabsOrder.length; i++) {
+    const entry = tabsOrder[i];
+    if (!isPodNavSystemTabBeforeSettings(entry)) {
+      fileIndices.push(i);
+      filePaths.push(entry);
+    }
+  }
+
+  const fromIndex = filePaths.indexOf(draggedPath);
+  const toIndex = filePaths.indexOf(targetPath);
+  if (fromIndex < 0 || toIndex < 0) {
+    return null;
+  }
+
+  const nextFilePaths = [...filePaths];
+  const [moved] = nextFilePaths.splice(fromIndex, 1);
+  nextFilePaths.splice(toIndex, 0, moved);
+
+  const next = [...tabsOrder];
+  for (let i = 0; i < fileIndices.length; i++) {
+    next[fileIndices[i]] = nextFilePaths[i];
+  }
+  return next;
+}
+
+/** File tabs in nav order (system tabs omitted). */
+export function orderedPodFileTabs(
+  fileTabs: PodFileTab[],
+  tabsOrder: string[]
+): PodFileTab[] {
+  return buildPodNavItemsBeforeSettings(fileTabs, tabsOrder).flatMap((item) =>
+    item.kind === "file" ? [item.tab] : []
+  );
+}
+
 export function podFileTabBasename(path: string): string {
   const base = path.split("/").pop() ?? path;
   // Strip the last extension for any previewable file (frames, .md, etc.).


### PR DESCRIPTION
## Description

Adds the `Pod Customization` settings section for `pod_frame_tabs`. Editors can rename pinned file tabs, choose custom icons, remove tabs, and reorder file tabs while preserving system-tab slots. The UI uses `usePodFileTabs` and optimistic `useUpdatePodMetadata` updates so settings and Pod navigation stay in sync. 

<img width="963" height="257" alt="image" src="https://github.com/user-attachments/assets/0dd57220-2de2-4218-8f83-c7ba83b23f6e" />


## Tests

Added Vitest coverage for `reorderFileTabsInTabsOrder` and `orderedPodFileTabs`, including system-slot preservation, no-op/missing paths, and navigation ordering.

## Risk

Low. The UI is feature-gated and reuses the existing Pod metadata PATCH endpoint. The main risk is an optimistic cache mismatch after a failed metadata update; SWR rolls back the live space-info cache and the mutation returns an error state. Rollback is safe because the change is front-end only.

## Deploy Plan

Deploy `front`. No SQL migrations or infrastructure changes.