### PR TITLE
Clear membership_upgrade_requests on workspace hard delete

### DIFF
--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -47,6 +47,7 @@ import { KeyResource } from "@app/lib/resources/key_resource";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { MembershipUpgradeRequestResource } from "@app/lib/resources/membership_upgrade_request_resource";
 import { OnboardingTaskResource } from "@app/lib/resources/onboarding_task_resource";
 import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
 import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
@@ -825,6 +826,7 @@ export async function deleteWorkspaceActivity({
   await FileResource.deleteAllForWorkspace(auth);
   await RunResource.deleteAllForWorkspace(auth);
   await MembershipResource.deleteAllForWorkspace(auth);
+  await MembershipUpgradeRequestResource.deleteAllForWorkspace(auth);
   await GroupPermissionResource.deleteAllForWorkspace(auth);
   await GroupMembershipModel.destroy({
     where: { workspaceId: workspace.id },


### PR DESCRIPTION
## Description

The poke workspace hard-delete path fails when a workspace still has rows in `membership_upgrade_requests`.

`MembershipUpgradeRequestModel` extends `WorkspaceAwareModel`, which gives its `workspaceId` foreign key `onDelete: "RESTRICT"` (`front/lib/resources/storage/wrappers/workspace_models.ts`). The activity that actually destroys the workspace row — `deleteWorkspaceActivity` in `front/poke/temporal/activities.ts` — cleans up memberships, groups, credits, etc. but never cleared `membership_upgrade_requests`. As a result, any remaining request rows RESTRICT-block the final `WorkspaceResource.delete()` with a foreign key violation and the deletion workflow fails.

This adds `MembershipUpgradeRequestResource.deleteAllForWorkspace(auth)` right after the membership deletion, before the workspace row is destroyed — mirroring what the `scrub_workspace` workflow already does (`front/temporal/scrub_workspace/activities.ts`).

## Tests

Manual reasoning; no behavioral tests added. `npx tsgo --noEmit` passes for the touched file (one pre-existing unrelated `archiver` module error remains). Ordering is safe: `membership_upgrade_requests` also has a RESTRICT FK to `users`, but user rows are not deleted in this workflow, so clearing the requests before/after memberships has no impact.

## Risk

Low. Adds a single scoped delete to an existing hard-delete Temporal activity, run under an internal admin authenticator. Rollback is trivial (revert the commit). Note: workspaces already stuck mid-delete will still have orphaned rows; they will be cleared on the next workflow run once this is deployed (or manually).

## Deploy Plan

Standard deploy. No migration or ordering constraints.