### PR TITLE
Automate PR review requests and Slack notifications

### DIFF
--- a/.github/actions/review-bot/README.md
+++ b/.github/actions/review-bot/README.md
@@ -1,0 +1,23 @@
+# Review bot
+
+Start a line in a PR description or message with `r?`, followed by GitHub user mentions:
+
+```text
+r? @spolu @flvndvd
+r? @spolu please take a look
+```
+
+Each description edit containing a request and each new conversation comment, inline comment, or
+review summary containing a request requests reviews again, including from users who already
+reviewed. Opening a PR with a request also works. Title edits, pushes, and comment edits do not
+request reviews.
+
+The `r?` must start the line without indentation. Surrounding lines and trailing prose are allowed;
+only the consecutive mentions immediately after `r?` are reviewers. Fenced code, HTML comments,
+quoted lines, team mentions, and mentions after trailing prose are ignored.
+
+Only human requesters with repository write access can trigger the bot. The bot skips closed PRs
+and the PR author, and logs a warning for reviewers GitHub rejects.
+
+The workflow uses `GITHUB_TOKEN` and loads this action from the default branch. Merge the workflow
+and action into that branch to activate it.

--- a/.github/actions/review-bot/README.md
+++ b/.github/actions/review-bot/README.md
@@ -16,8 +16,20 @@ The `r?` must start the line without indentation. Surrounding lines and trailing
 only the consecutive mentions immediately after `r?` are reviewers. Fenced code, HTML comments,
 quoted lines, team mentions, and mentions after trailing prose are ignored.
 
-Only human requesters with repository write access can trigger the bot. The bot skips closed PRs
-and the PR author, and logs a warning for reviewers GitHub rejects.
+Only human requesters with repository `write`, `maintain`, or `admin` permission can trigger the bot.
+The bot skips closed PRs and the PR author, and logs a warning for reviewers GitHub rejects.
 
-The workflow uses `GITHUB_TOKEN` and loads this action from the default branch. Merge the workflow
-and action into that branch to activate it.
+Each eligible request also posts to `#engineering_pr_reviews` (`C09GELMTTRT`):
+
+```text
+@requester: https://github.com/dust-tt/dust/pull/123
+r? @reviewer please take a look
+```
+
+The requester and reviewer handles become real Slack mentions through `.authors` email mappings
+and Slack's `users.lookupByEmail`. Unmapped handles remain plain text. Only request lines are
+forwarded, with trailing prose preserved; other PR description or comment text is omitted.
+
+The workflow uses `GITHUB_TOKEN` and the existing `SLACK_BOT_TOKEN`, and loads this action from the
+default branch. The Slack bot needs `users:read.email` and permission to post in the reviews channel.
+Merge the workflow and action into that branch to activate it.

--- a/.github/actions/review-bot/action.yml
+++ b/.github/actions/review-bot/action.yml
@@ -1,15 +1,49 @@
 name: Review bot
-description: Request PR reviews from r? commands in descriptions and messages.
+description: Request PR reviews and notify Slack from r? commands in descriptions and messages.
+
+inputs:
+  slack_token:
+    description: Slack bot token for user lookup and review notifications.
+    required: true
+  slack_channel:
+    description: Slack channel ID for review notifications.
+    required: true
 
 runs:
   using: composite
   steps:
     - name: Request reviews
+      id: request
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         REVIEW_BOT_ACTION_PATH: ${{ github.action_path }}
+        SLACK_BOT_TOKEN: ${{ inputs.slack_token }}
+        SLACK_CHANNEL_ID: ${{ inputs.slack_channel }}
       with:
         script: |
           const path = require('node:path');
-          const { requestReviews } = require(path.join(process.env.REVIEW_BOT_ACTION_PATH, 'review-bot.ts'));
-          await requestReviews({ github, context, core });
+          const { readFileSync } = require('node:fs');
+          const { requestReviews, formatSlackNotification } = require(path.join(process.env.REVIEW_BOT_ACTION_PATH, 'review-bot.ts'));
+          const notification = await requestReviews({ github, context, core });
+          if (notification) {
+            const text = await formatSlackNotification({
+              notification,
+              authors: readFileSync('.authors', 'utf8'),
+              slackToken: process.env.SLACK_BOT_TOKEN,
+              core,
+            });
+            core.setOutput('slack_payload', JSON.stringify({
+              channel: process.env.SLACK_CHANNEL_ID,
+              text,
+              unfurl_links: false,
+              unfurl_media: false,
+            }));
+          }
+
+    - name: Post review request to Slack
+      if: steps.request.outputs.slack_payload != ''
+      uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+      with:
+        method: chat.postMessage
+        token: ${{ inputs.slack_token }}
+        payload: ${{ steps.request.outputs.slack_payload }}

--- a/.github/actions/review-bot/action.yml
+++ b/.github/actions/review-bot/action.yml
@@ -1,0 +1,15 @@
+name: Review bot
+description: Request PR reviews from r? commands in descriptions and messages.
+
+runs:
+  using: composite
+  steps:
+    - name: Request reviews
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        REVIEW_BOT_ACTION_PATH: ${{ github.action_path }}
+      with:
+        script: |
+          const path = require('node:path');
+          const { requestReviews } = require(path.join(process.env.REVIEW_BOT_ACTION_PATH, 'review-bot.ts'));
+          await requestReviews({ github, context, core });

--- a/.github/actions/review-bot/package.json
+++ b/.github/actions/review-bot/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/.github/actions/review-bot/review-bot.ts
+++ b/.github/actions/review-bot/review-bot.ts
@@ -1,5 +1,11 @@
 type Repository = { owner: string; repo: string };
 type PullRequestParams = Repository & { pull_number: number };
+type ReviewRequest = { line: string; reviewers: string[] };
+type ReviewNotification = {
+  requester: string;
+  prUrl: string;
+  requests: ReviewRequest[];
+};
 
 type ReviewContext = {
   actor: string;
@@ -28,9 +34,9 @@ type ReviewBotOptions = {
         ): Promise<{ data: { permission: string } }>;
       };
       pulls: {
-        get(
-          params: PullRequestParams
-        ): Promise<{ data: { state: string; user: { login: string } } }>;
+        get(params: PullRequestParams): Promise<{
+          data: { state: string; user: { login: string }; html_url: string };
+        }>;
         requestReviewers(
           params: PullRequestParams & { reviewers: string[] }
         ): Promise<unknown>;
@@ -47,11 +53,13 @@ type ReviewBotOptions = {
 /**
  * @cc [label:product] review-request-syntax
  * Parse the leading list of GitHub mentions after a column-zero `r?` followed by whitespace on each
- * line. Trailing prose ends the list. Ignore fenced code and HTML comments, and deduplicate handles
- * case-insensitively.
+ * line, retaining the request line for notifications. Trailing prose ends the list. Ignore fenced
+ * code and HTML comments, and deduplicate handles case-insensitively within each request.
  */
-export function parseReviewers(body: string | null | undefined): string[] {
-  const reviewers = new Set<string>();
+export function parseReviewRequests(
+  body: string | null | undefined
+): ReviewRequest[] {
+  const requests: ReviewRequest[] = [];
   let fence: string | undefined;
   for (const line of (body ?? "")
     .replace(/<!--[\s\S]*?(?:-->|$)/g, (comment) =>
@@ -79,14 +87,18 @@ export function parseReviewers(body: string | null | undefined): string[] {
     if (!request) {
       continue;
     }
+    const reviewers = new Set<string>();
     for (const token of request[1].split(/[ \t]+/)) {
       if (!/^@[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i.test(token)) {
         break;
       }
       reviewers.add(token.slice(1).toLowerCase());
     }
+    if (reviewers.size > 0) {
+      requests.push({ line, reviewers: [...reviewers] });
+    }
   }
-  return [...reviewers];
+  return requests;
 }
 
 function getRequest(context: ReviewContext) {
@@ -135,12 +147,14 @@ function getRequest(context: ReviewContext) {
 
 /**
  * @cc [label:security] review-request-access
- * Only accept human requesters with repository write access and open PRs.
+ * Only accept human requesters with repository `write`, `maintain`, or `admin` permission and open
+ * PRs.
  */
 /**
  * @cc [label:product] review-request-delivery
  * Request every parsed reviewer except the PR author for each eligible description edit or newly
  * posted request, including users who previously reviewed. Invalid reviewers do not block valid
+ * requests. Return the requester, PR URL, and request lines for Slack notification only for eligible
  * requests. Title edits and pushes do not request reviews.
  */
 /**
@@ -152,13 +166,13 @@ export async function requestReviews({
   github,
   context,
   core,
-}: ReviewBotOptions): Promise<void> {
+}: ReviewBotOptions): Promise<ReviewNotification | undefined> {
   const request = getRequest(context);
   if (!request || context.payload.sender?.type !== "User") {
     return;
   }
-  const reviewers = parseReviewers(request.body);
-  if (reviewers.length === 0) {
+  const requests = parseReviewRequests(request.body);
+  if (requests.length === 0) {
     return;
   }
 
@@ -188,6 +202,7 @@ export async function requestReviews({
   if (pr.state !== "open") {
     return;
   }
+  const reviewers = new Set(requests.flatMap((request) => request.reviewers));
   for (const reviewer of reviewers) {
     if (reviewer === pr.user.login.toLowerCase()) {
       continue;
@@ -207,4 +222,107 @@ export async function requestReviews({
       core.warning(`GitHub rejected the review request for @${reviewer}.`);
     }
   }
+  return { requester: context.actor, prUrl: pr.html_url, requests };
+}
+
+function escapeSlackText(text: string): string {
+  return text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+/**
+ * @cc [label:product] review-request-slack-format
+ * Format an eligible request as the requester mention and PR URL, followed by its `r?` lines with
+ * trailing prose preserved. Resolve requester and reviewer mentions through `.authors` emails and
+ * Slack user lookup; unresolved handles remain plain text.
+ */
+/**
+ * @cc [label:security] review-request-slack-mentions
+ * Escape literal Slack control characters before inserting resolved user mentions. Only the
+ * requester and reviewers parsed from the request may become Slack mentions.
+ */
+export async function formatSlackNotification({
+  notification,
+  authors,
+  slackToken,
+  core,
+}: {
+  notification: ReviewNotification;
+  authors: string;
+  slackToken: string;
+  core: ReviewBotOptions["core"];
+}): Promise<string> {
+  const emails = new Map<string, string>();
+  for (const line of authors.split(/\r?\n/)) {
+    const entry = /^([^:]+):\s*(\S+)\s*$/.exec(line);
+    if (entry) {
+      emails.set(entry[1].toLowerCase(), entry[2]);
+    }
+  }
+
+  const handles = new Set([
+    notification.requester.toLowerCase(),
+    ...notification.requests.flatMap((request) => request.reviewers),
+  ]);
+  const mentions = new Map<string, string>();
+  await Promise.all(
+    [...handles].map(async (handle) => {
+      const email = emails.get(handle);
+      if (!email) {
+        core.warning(`No .authors email found for @${handle}.`);
+        return;
+      }
+
+      let data: unknown;
+      try {
+        const response = await fetch(
+          "https://slack.com/api/users.lookupByEmail",
+          {
+            method: "POST",
+            headers: { Authorization: `Bearer ${slackToken}` },
+            body: new URLSearchParams({ email }),
+          }
+        );
+        if (!response.ok) {
+          core.warning(
+            `Slack user lookup failed for @${handle}: HTTP ${response.status}.`
+          );
+          return;
+        }
+        data = await response.json();
+      } catch {
+        core.warning(`Slack user lookup failed for @${handle}.`);
+        return;
+      }
+      if (
+        typeof data === "object" &&
+        data !== null &&
+        "ok" in data &&
+        data.ok === true &&
+        "user" in data &&
+        typeof data.user === "object" &&
+        data.user !== null &&
+        "id" in data.user &&
+        typeof data.user.id === "string" &&
+        /^[UW][A-Z0-9]+$/.test(data.user.id)
+      ) {
+        mentions.set(handle, `<@${data.user.id}>`);
+      } else {
+        core.warning(`No Slack user found for @${handle}.`);
+      }
+    })
+  );
+
+  const requester =
+    mentions.get(notification.requester.toLowerCase()) ??
+    escapeSlackText(`@${notification.requester}`);
+  const lines = notification.requests.map(({ line }) =>
+    escapeSlackText(line).replace(
+      /(?<!\S)@[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?(?=[ \t]|$)/gi,
+      (mention) => mentions.get(mention.slice(1).toLowerCase()) ?? mention
+    )
+  );
+  return `${requester}: ${escapeSlackText(notification.prUrl)}\n${lines.join("\n")}`;
 }

--- a/.github/actions/review-bot/review-bot.ts
+++ b/.github/actions/review-bot/review-bot.ts
@@ -1,0 +1,210 @@
+type Repository = { owner: string; repo: string };
+type PullRequestParams = Repository & { pull_number: number };
+
+type ReviewContext = {
+  actor: string;
+  repo: Repository;
+  eventName: string;
+  payload: {
+    sender?: { type: string };
+    action?: string;
+    pull_request?: { number: number; body?: string | null };
+    issue?: { number: number; pull_request?: unknown };
+    comment?: { body?: string | null };
+    review?: { body?: string | null };
+    changes?: {
+      body?: { from?: string | null };
+      title?: { from?: string };
+    };
+  };
+};
+
+type ReviewBotOptions = {
+  github: {
+    rest: {
+      repos: {
+        getCollaboratorPermissionLevel(
+          params: Repository & { username: string }
+        ): Promise<{ data: { permission: string } }>;
+      };
+      pulls: {
+        get(
+          params: PullRequestParams
+        ): Promise<{ data: { state: string; user: { login: string } } }>;
+        requestReviewers(
+          params: PullRequestParams & { reviewers: string[] }
+        ): Promise<unknown>;
+      };
+    };
+  };
+  context: ReviewContext;
+  core: {
+    info(message: string): void;
+    warning(message: string): void;
+  };
+};
+
+/**
+ * @cc [label:product] review-request-syntax
+ * Parse the leading list of GitHub mentions after a column-zero `r?` followed by whitespace on each
+ * line. Trailing prose ends the list. Ignore fenced code and HTML comments, and deduplicate handles
+ * case-insensitively.
+ */
+export function parseReviewers(body: string | null | undefined): string[] {
+  const reviewers = new Set<string>();
+  let fence: string | undefined;
+  for (const line of (body ?? "")
+    .replace(/<!--[\s\S]*?(?:-->|$)/g, (comment) =>
+      comment.replace(/[^\r\n]/g, " ")
+    )
+    .split(/\r?\n/)) {
+    const delimiter = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
+    if (fence) {
+      if (
+        delimiter &&
+        delimiter[1][0] === fence[0] &&
+        delimiter[1].length >= fence.length &&
+        !delimiter[2].trim()
+      ) {
+        fence = undefined;
+      }
+      continue;
+    }
+    if (delimiter) {
+      fence = delimiter[1];
+      continue;
+    }
+
+    const request = /^r\?[ \t]+(.*)$/.exec(line);
+    if (!request) {
+      continue;
+    }
+    for (const token of request[1].split(/[ \t]+/)) {
+      if (!/^@[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i.test(token)) {
+        break;
+      }
+      reviewers.add(token.slice(1).toLowerCase());
+    }
+  }
+  return [...reviewers];
+}
+
+function getRequest(context: ReviewContext) {
+  const { eventName, payload } = context;
+  if (
+    eventName === "pull_request_target" &&
+    payload.pull_request &&
+    (payload.action === "opened" ||
+      (payload.action === "edited" &&
+        Object.hasOwn(payload.changes?.body ?? {}, "from")))
+  ) {
+    return {
+      number: payload.pull_request.number,
+      body: payload.pull_request.body,
+    };
+  }
+  if (
+    eventName === "issue_comment" &&
+    payload.action === "created" &&
+    payload.issue?.pull_request
+  ) {
+    return { number: payload.issue.number, body: payload.comment?.body };
+  }
+  if (
+    eventName === "pull_request_review_comment" &&
+    payload.pull_request &&
+    payload.action === "created"
+  ) {
+    return {
+      number: payload.pull_request.number,
+      body: payload.comment?.body,
+    };
+  }
+  if (
+    eventName === "pull_request_review" &&
+    payload.pull_request &&
+    payload.action === "submitted"
+  ) {
+    return {
+      number: payload.pull_request.number,
+      body: payload.review?.body,
+    };
+  }
+  return null;
+}
+
+/**
+ * @cc [label:security] review-request-access
+ * Only accept human requesters with repository write access and open PRs.
+ */
+/**
+ * @cc [label:product] review-request-delivery
+ * Request every parsed reviewer except the PR author for each eligible description edit or newly
+ * posted request, including users who previously reviewed. Invalid reviewers do not block valid
+ * requests. Title edits and pushes do not request reviews.
+ */
+/**
+ * @cc [label:security] review-automation-source
+ * Privileged workflow callers load this function from the repository's default branch, never from
+ * a PR revision.
+ */
+export async function requestReviews({
+  github,
+  context,
+  core,
+}: ReviewBotOptions): Promise<void> {
+  const request = getRequest(context);
+  if (!request || context.payload.sender?.type !== "User") {
+    return;
+  }
+  const reviewers = parseReviewers(request.body);
+  if (reviewers.length === 0) {
+    return;
+  }
+
+  let permission;
+  try {
+    const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+      ...context.repo,
+      username: context.actor,
+    });
+    permission = data.permission;
+  } catch (error) {
+    if (
+      !(error instanceof Error && "status" in error && error.status === 404)
+    ) {
+      throw error;
+    }
+  }
+  if (!permission || !["write", "maintain", "admin"].includes(permission)) {
+    core.info(
+      "Skipping review request: the requester lacks repository write access."
+    );
+    return;
+  }
+
+  const params = { ...context.repo, pull_number: request.number };
+  const { data: pr } = await github.rest.pulls.get(params);
+  if (pr.state !== "open") {
+    return;
+  }
+  for (const reviewer of reviewers) {
+    if (reviewer === pr.user.login.toLowerCase()) {
+      continue;
+    }
+    try {
+      await github.rest.pulls.requestReviewers({
+        ...params,
+        reviewers: [reviewer],
+      });
+      core.info(`Requested review from @${reviewer}.`);
+    } catch (error) {
+      if (
+        !(error instanceof Error && "status" in error && error.status === 422)
+      ) {
+        throw error;
+      }
+      core.warning(`GitHub rejected the review request for @${reviewer}.`);
+    }
+  }
+}

--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Request reviews
         uses: ./.github/actions/review-bot
+        with:
+          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack_channel: C09GELMTTRT

--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -1,0 +1,31 @@
+name: Review bot
+
+on:
+  pull_request_target:
+    types: [opened, edited]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+
+jobs:
+  request-reviews:
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      # Execute the default branch action because review events can originate from PR revisions.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Request reviews
+        uses: ./.github/actions/review-bot


### PR DESCRIPTION
## Description

Request GitHub reviews by starting a line in a PR description or message with `r? @spolu @flvndvd`. Trailing text is allowed, such as `r? @spolu PTAL`.

Opening a PR, editing its description while a request is present, or posting a new conversation comment, inline comment, or review summary requests reviews from the listed users, including users who already reviewed. The parser reads consecutive mentions immediately after `r?` and ignores fenced code, HTML comments, and quoted lines.

Each eligible request also posts to `#engineering_pr_reviews` (`C09GELMTTRT`) with the requester and PR URL on the first line, followed by the original request lines. For example, when `spolu` posts `r? @flvndvd this is a test`, Slack receives:

```text
@spolu: https://github.com/dust-tt/dust/pull/123
r? @flvndvd this is a test
```

Handles resolve to actual Slack mentions through `.authors` email mappings and `users.lookupByEmail`. Unresolved handles remain plain text, and literal Slack control characters are escaped. Surrounding PR or comment text is omitted.

Keep the TypeScript implementation, function contracts, action YAML, and usage documentation together in `.github/actions/review-bot`. The workflow loads the action from the default branch.

## Tests

Locally exercised parsing and event handling with mocked GitHub responses, including description edits, repeated requests, invalid reviewers, and `write`, `maintain`, and `admin` permissions. Verified the exact Slack payload, mention resolution, lookup failures, escaping, and ineligible-request suppression with mocked Slack responses. Executed the composite action script locally under Node 24. No live Slack messages were sent.

## Risk

Low. Only human requesters with repository `write`, `maintain`, or `admin` permission can trigger requests on open PRs. The PR author is skipped as a reviewer, and rejected reviewers produce warnings without blocking requests to other users. Slack lookup failures fall back to plain handles; GitHub review requests are made before posting to Slack.

## Deploy Plan

Merge to `main` to activate the workflow. Uses the built-in `GITHUB_TOKEN` and existing `SLACK_BOT_TOKEN`. The Slack bot needs `users:read.email` and permission to post in `#engineering_pr_reviews`.
