### PR TITLE
Accept reviews on closed PRs and surface Slack failures

### DIFF
--- a/.github/actions/review-bot/README.md
+++ b/.github/actions/review-bot/README.md
@@ -17,7 +17,8 @@ only the consecutive mentions immediately after `r?` are reviewers. Fenced code,
 quoted lines, team mentions, and mentions after trailing prose are ignored.
 
 Only human requesters with repository `write`, `maintain`, or `admin` permission can trigger the bot.
-The bot skips closed PRs and the PR author, and logs a warning for reviewers GitHub rejects.
+Requests are accepted on open, closed, and merged PRs. The bot skips the PR author and logs a warning
+for review requests GitHub rejects with a validation error, while still sending the Slack notification.
 
 Each eligible request also posts to `#engineering_pr_reviews` (`C09GELMTTRT`):
 

--- a/.github/actions/review-bot/README.md
+++ b/.github/actions/review-bot/README.md
@@ -30,6 +30,7 @@ r? @reviewer please take a look
 The requester and reviewer handles become real Slack mentions through `.authors` email mappings
 and Slack's `users.lookupByEmail`. Unmapped handles remain plain text. Only request lines are
 forwarded, with trailing prose preserved; other PR description or comment text is omitted.
+Slack delivery errors fail the workflow so rejected notifications are visible in the run logs.
 
 The workflow uses `GITHUB_TOKEN` and the existing `SLACK_BOT_TOKEN`, and loads this action from the
 default branch. The Slack bot needs `users:read.email` and permission to post in the reviews channel.

--- a/.github/actions/review-bot/action.yml
+++ b/.github/actions/review-bot/action.yml
@@ -44,6 +44,7 @@ runs:
       if: steps.request.outputs.slack_payload != ''
       uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
       with:
+        errors: true
         method: chat.postMessage
         token: ${{ inputs.slack_token }}
         payload: ${{ steps.request.outputs.slack_payload }}

--- a/.github/actions/review-bot/review-bot.ts
+++ b/.github/actions/review-bot/review-bot.ts
@@ -236,6 +236,10 @@ function escapeSlackText(text: string): string {
  * Slack user lookup; unresolved handles remain plain text.
  */
 /**
+ * @cc [label:error-handling] review-request-slack-delivery
+ * Callers must fail the workflow when Slack rejects or cannot deliver the notification.
+ */
+/**
  * @cc [label:security] review-request-slack-mentions
  * Escape literal Slack control characters before inserting resolved user mentions. Only the
  * requester and reviewers parsed from the request may become Slack mentions.

--- a/.github/actions/review-bot/review-bot.ts
+++ b/.github/actions/review-bot/review-bot.ts
@@ -35,7 +35,7 @@ type ReviewBotOptions = {
       };
       pulls: {
         get(params: PullRequestParams): Promise<{
-          data: { state: string; user: { login: string }; html_url: string };
+          data: { user: { login: string }; html_url: string };
         }>;
         requestReviewers(
           params: PullRequestParams & { reviewers: string[] }
@@ -147,15 +147,15 @@ function getRequest(context: ReviewContext) {
 
 /**
  * @cc [label:security] review-request-access
- * Only accept human requesters with repository `write`, `maintain`, or `admin` permission and open
- * PRs.
+ * Only accept human requesters with repository `write`, `maintain`, or `admin` permission.
  */
 /**
  * @cc [label:product] review-request-delivery
  * Request every parsed reviewer except the PR author for each eligible description edit or newly
- * posted request, including users who previously reviewed. Invalid reviewers do not block valid
- * requests. Return the requester, PR URL, and request lines for Slack notification only for eligible
- * requests. Title edits and pushes do not request reviews.
+ * posted request, including users who previously reviewed. Open, closed, and merged PRs are eligible.
+ * GitHub validation failures do not block other reviewers or Slack notifications. Return the
+ * requester, PR URL, and request lines for Slack notification only for eligible requests. Title
+ * edits and pushes do not request reviews.
  */
 /**
  * @cc [label:security] review-automation-source
@@ -199,9 +199,6 @@ export async function requestReviews({
 
   const params = { ...context.repo, pull_number: request.number };
   const { data: pr } = await github.rest.pulls.get(params);
-  if (pr.state !== "open") {
-    return;
-  }
   const reviewers = new Set(requests.flatMap((request) => request.reviewers));
   for (const reviewer of reviewers) {
     if (reviewer === pr.user.login.toLowerCase()) {


### PR DESCRIPTION
## Description

Allow `r? @reviewer` requests on closed and merged PRs by removing the review bot's open-PR restriction. The bot attempts GitHub review requests and sends the Slack notification, including when GitHub returns a validation rejection. Update the function contracts and README to cover all PR states.

Also enable `errors: true` for Slack delivery. The previous [workflow run](https://github.com/dust-tt/dust/actions/runs/34325829023/job/102382739625) submitted the expected payload, but the pinned Slack action silently suppresses API errors by default. Delivery failures will now fail the workflow and expose Slack's reason. Verified with the exact pinned action against a local mock Slack endpoint.

r? @Fraggle PMRR

## Tests

N/A

## Risk

None

## Deploy Plan

Merge to `main` to activate the updated action.
