### PR TITLE
chore: untrack mcp errors due to invalid IDs in data sources

### DIFF
--- a/front/lib/actions/mcp_internal_actions/tools/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/utils.ts
@@ -251,7 +251,11 @@ export async function getAgentDataSourceConfigurations(
   });
 
   if (configInfosRes.some((res) => res.isErr())) {
-    return new Err(new MCPError("Failed to parse data source configurations."));
+    return new Err(
+      new MCPError("Failed to parse data source configurations.", {
+        tracked: false,
+      })
+    );
   }
 
   const configInfos = removeNulls(
@@ -265,14 +269,20 @@ export async function getAgentDataSourceConfigurations(
       if (!sIdParts) {
         return new Err(
           new MCPError(
-            `Invalid data source configuration ID: ${configInfo.sId}`
+            `Invalid data source configuration ID: ${configInfo.sId}`,
+            {
+              tracked: false,
+            }
           )
         );
       }
       if (sIdParts.resourceName !== "data_source_configuration") {
         return new Err(
           new MCPError(
-            `ID is not a data source configuration ID: ${configInfo.sId}`
+            `ID is not a data source configuration ID: ${configInfo.sId}`,
+            {
+              tracked: false,
+            }
           )
         );
       }
@@ -296,7 +306,10 @@ export async function getAgentDataSourceConfigurations(
   ) {
     return new Err(
       new MCPError(
-        "Failed to fetch data source configurations, mismatched number of configurations found."
+        "Failed to fetch data source configurations, mismatched number of configurations found.",
+        {
+          tracked: false,
+        }
       )
     );
   }
@@ -327,7 +340,10 @@ export async function getAgentDataSourceConfigurations(
       if (!sIdParts) {
         return new Err(
           new MCPError(
-            `Invalid data source view ID: ${configInfo.configuration.dataSourceViewId}`
+            `Invalid data source view ID: ${configInfo.configuration.dataSourceViewId}`,
+            {
+              tracked: false,
+            }
           )
         );
       }
@@ -343,7 +359,10 @@ export async function getAgentDataSourceConfigurations(
   if (dataSourceViews.some((dataSourceView) => !dataSourceView.canRead(auth))) {
     return new Err(
       new MCPError(
-        "Failed to fetch data source views, some views are not readable."
+        "Failed to fetch data source views, some views are not readable.",
+        {
+          tracked: false,
+        }
       )
     );
   }
@@ -351,7 +370,10 @@ export async function getAgentDataSourceConfigurations(
   if (dataSourceViews.length !== dataSourceViewIDs.size) {
     return new Err(
       new MCPError(
-        "Failed to fetch data source views, mismatched number of views found."
+        "Failed to fetch data source views, mismatched number of views found.",
+        {
+          tracked: false,
+        }
       )
     );
   }
@@ -376,9 +398,7 @@ export async function getAgentDataSourceConfigurations(
         );
         if (!agentConfig) {
           return new Err(
-            new MCPError(
-              `Data source configuration not found: ${configInfo.sId}`
-            )
+            new Error(`Data source configuration not found: ${configInfo.sId}`)
           );
         }
         const dataSourceViewSId = DataSourceViewResource.modelIdToSId({


### PR DESCRIPTION
## Description

This PR fixes [these logs](https://app.datadoghq.eu/logs?query=cell%3Acell-00001%20%40toolName%3Alist%20%22Tool%20execution%20error%22%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cworkspace.sId%2CtoolName%2Cerror&event=AwAAAaCFHhkpaf9NvgAAABhBYUNGSGg1REFBRHFjUHZtVmpVcGd3QXYAAAAkZjFhMDg1MWUtNGNhNy00M2YyLWIwNmMtMTZhZGEzZmIxN2UzAASb9g&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1788939060000&to_ts=1788940260000&live=false).
It untracks errors due to invalid IDs generated by models in the `list` tool (+ the other data source file system tools).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
