### PR TITLE
[FRAMES] Pin or add Pod Frames as banner/tab from the conversation file explorer

### DIFF
--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -10,10 +10,12 @@ import type {
 } from "@app/components/file_explorer/types";
 import { useFileDownload } from "@app/components/file_explorer/useFileDownload";
 import { withVirtualExplorerPath } from "@app/components/file_explorer/utils";
+import { EditPodFileTabDialog } from "@app/components/pod/files/EditPodFileTabDialog";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
 import { useFolderPathUrlState } from "@app/hooks/useFolderPathUrlState";
 import { usePinPodBanner } from "@app/hooks/usePinPodBanner";
+import { usePodFileTabs } from "@app/hooks/usePodFileTabs";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import {
   downloadFile,
@@ -25,9 +27,15 @@ import { useSpaceInfo } from "@app/lib/swr/spaces";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { isPodConversation } from "@app/types/assistant/conversation";
 import { opensInSidePanel } from "@app/types/files";
+import type { PodFileTab } from "@app/types/pod_file_tab";
+import {
+  DEFAULT_POD_FILE_TAB_ICON,
+  MAX_POD_FILE_TAB_TITLE_LENGTH,
+  podFileTabBasename,
+} from "@app/types/pod_file_tab";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Button, Pin02, XClose } from "@dust-tt/sparkle";
-import { useCallback, useContext, useMemo } from "react";
+import { Button, LayoutAlt02, Pin02, XClose } from "@dust-tt/sparkle";
+import { useCallback, useContext, useMemo, useState } from "react";
 
 function isFramePackageEntry(entry: FileExplorerEntry): boolean {
   return entry.kind === "frame_package";
@@ -99,19 +107,33 @@ export function ConversationFileExplorer({
     spaceId: isPod ? conversation.spaceId : null,
   });
 
-  const canPin = isPod && (podInfo?.isEditor ?? false) && !podInfo?.archivedAt;
+  const canEditPod =
+    isPod && (podInfo?.isEditor ?? false) && !podInfo?.archivedAt;
 
   const { togglePin, isPinned } = usePinPodBanner({
     owner,
     podId: isPod ? conversation.spaceId : "",
     pinnedFramePath: podInfo?.pinnedFramePath ?? null,
-    isEditor: canPin,
+    isEditor: canEditPod,
   });
+
+  const hasFileTabs = hasFeature("pod_frame_tabs");
+
+  const { removeFileTab, isFileTab } = usePodFileTabs({
+    owner,
+    podId: isPod ? conversation.spaceId : "",
+    fileTabs: podInfo?.frameTabs ?? [],
+    tabsOrder: podInfo?.tabsOrder ?? [],
+    isEditor: canEditPod,
+  });
+
+  const [createFileTabDraft, setCreateFileTabDraft] =
+    useState<PodFileTab | null>(null);
 
   const getExtraFileMenuItems = useCallback(
     (entry: FileExplorerEntry): FileExplorerMenuAction[] => {
       if (
-        !canPin ||
+        !canEditPod ||
         entry.kind !== "frame_package" ||
         !entry.path.startsWith(`pod-${conversation.spaceId}/`)
       ) {
@@ -119,7 +141,7 @@ export function ConversationFileExplorer({
       }
 
       const pinned = isPinned(entry.path);
-      return [
+      const items: FileExplorerMenuAction[] = [
         {
           label: pinned ? "Unpin from banner" : "Pin as Pod banner",
           icon: Pin02,
@@ -129,8 +151,41 @@ export function ConversationFileExplorer({
           },
         },
       ];
+
+      if (hasFileTabs) {
+        const asTab = isFileTab(entry.path);
+        items.push({
+          label: asTab ? "Remove from Pod tabs" : "Add as Pod tab",
+          icon: LayoutAlt02,
+          onClick: (e) => {
+            e.stopPropagation();
+            if (asTab) {
+              void removeFileTab(entry.path, { fileName: entry.fileName });
+              return;
+            }
+            setCreateFileTabDraft({
+              path: entry.path,
+              title: podFileTabBasename(entry.fileName).slice(
+                0,
+                MAX_POD_FILE_TAB_TITLE_LENGTH
+              ),
+              icon: DEFAULT_POD_FILE_TAB_ICON,
+            });
+          },
+        });
+      }
+
+      return items;
     },
-    [canPin, conversation.spaceId, isPinned, togglePin]
+    [
+      canEditPod,
+      conversation.spaceId,
+      hasFileTabs,
+      isFileTab,
+      isPinned,
+      removeFileTab,
+      togglePin,
+    ]
   );
 
   const getFileUrl = useCallback(
@@ -230,6 +285,21 @@ export function ConversationFileExplorer({
           virtualScopeRoots={virtualScopeRoots}
         />
       </div>
+
+      {createFileTabDraft && (
+        <EditPodFileTabDialog
+          key={createFileTabDraft.path}
+          owner={owner}
+          podId={isPod ? conversation.spaceId : ""}
+          fileTabs={podInfo?.frameTabs ?? []}
+          tabsOrder={podInfo?.tabsOrder ?? []}
+          isEditor={canEditPod}
+          tab={createFileTabDraft}
+          mode="create"
+          isOpen
+          onClose={() => setCreateFileTabDraft(null)}
+        />
+      )}
     </div>
   );
 }

--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -4,6 +4,7 @@ import { FileExplorer } from "@app/components/file_explorer/FileExplorer";
 import type {
   FileEntry,
   FileExplorerEntry,
+  FileExplorerMenuAction,
   FileExplorerPathEntry,
   FileExplorerVirtualScopeRoot,
 } from "@app/components/file_explorer/types";
@@ -12,6 +13,7 @@ import { withVirtualExplorerPath } from "@app/components/file_explorer/utils";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
 import { useFolderPathUrlState } from "@app/hooks/useFolderPathUrlState";
+import { usePinPodBanner } from "@app/hooks/usePinPodBanner";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import {
   downloadFile,
@@ -19,11 +21,12 @@ import {
   useDeleteFileByPath,
 } from "@app/lib/swr/files";
 import { usePodFiles } from "@app/lib/swr/pods";
+import { useSpaceInfo } from "@app/lib/swr/spaces";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { isPodConversation } from "@app/types/assistant/conversation";
 import { opensInSidePanel } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Button, XClose } from "@dust-tt/sparkle";
+import { Button, Pin02, XClose } from "@dust-tt/sparkle";
 import { useCallback, useContext, useMemo } from "react";
 
 function isFramePackageEntry(entry: FileExplorerEntry): boolean {
@@ -90,6 +93,45 @@ export function ConversationFileExplorer({
       ...podFiles.map((f) => withVirtualExplorerPath(f, "pod")),
     ];
   }, [isPod, podFiles, sandboxFiles]);
+
+  const { spaceInfo: podInfo } = useSpaceInfo({
+    workspaceId: owner.sId,
+    spaceId: isPod ? conversation.spaceId : null,
+  });
+
+  const canPin = isPod && (podInfo?.isEditor ?? false) && !podInfo?.archivedAt;
+
+  const { togglePin, isPinned } = usePinPodBanner({
+    owner,
+    podId: isPod ? conversation.spaceId : "",
+    pinnedFramePath: podInfo?.pinnedFramePath ?? null,
+    isEditor: canPin,
+  });
+
+  const getExtraFileMenuItems = useCallback(
+    (entry: FileExplorerEntry): FileExplorerMenuAction[] => {
+      if (
+        !canPin ||
+        entry.kind !== "frame_package" ||
+        !entry.path.startsWith(`pod-${conversation.spaceId}/`)
+      ) {
+        return [];
+      }
+
+      const pinned = isPinned(entry.path);
+      return [
+        {
+          label: pinned ? "Unpin from banner" : "Pin as Pod banner",
+          icon: Pin02,
+          onClick: (e) => {
+            e.stopPropagation();
+            void togglePin(entry.path, { fileName: entry.fileName });
+          },
+        },
+      ];
+    },
+    [canPin, conversation.spaceId, isPinned, togglePin]
+  );
 
   const getFileUrl = useCallback(
     (path: string) => getFilePathViewUrl(owner, path),
@@ -170,6 +212,7 @@ export function ConversationFileExplorer({
           defaultViewMode={isPod ? "list" : "grid"}
           displayFramePackages={hasFeature("frames_v2")}
           files={files}
+          getExtraFileMenuItems={getExtraFileMenuItems}
           hideBreadcrumbAtRoot={!isPod}
           isLoading={
             isPod


### PR DESCRIPTION
## Description

Adds "Pin as Pod banner" and (behind the `pod_frame_tabs` flag) "Add as Pod tab" context-menu actions on Pod-scoped Frame packages in the conversation file explorer, so Pod editors can promote a Frame without leaving the conversation.


https://github.com/user-attachments/assets/6faba6f3-2c6a-4500-a7be-83060b2d806b



## Tests

Tested locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`
