### PR TITLE
Fix folder archive streaming lifecycle

### DIFF
--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
@@ -18,6 +18,7 @@ import {
   streamFolderArchive,
 } from "@app/lib/api/files/folder_archive";
 import { requestDustProjectIncrementalSyncForScopedPath } from "@app/lib/api/projects/request_incremental_sync";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import type { DustFileSystemError } from "@app/types/file_system";
 import {
   DUST_FILE_CONTENT_TYPE_HEADER,
@@ -136,7 +137,9 @@ async function resolveFs(
   return { fs: fsResult.value, err: null };
 }
 
-function mapFolderArchiveError(error: FolderArchivePlanError) {
+function mapFolderArchiveError(
+  error: FolderArchivePlanError
+): APIErrorWithContentfulStatusCode {
   if (!isFolderArchiveError(error)) {
     return mapDustFsError(error);
   }
@@ -147,26 +150,26 @@ function mapFolderArchiveError(error: FolderArchivePlanError) {
       return {
         status_code: 404,
         api_error: { type: "file_not_found", message: error.message },
-      } as const;
+      };
 
     case "not_directory":
       return {
         status_code: 400,
         api_error: { type: "invalid_request_error", message: error.message },
-      } as const;
+      };
 
     case "too_many_entries":
     case "too_large":
       return {
         status_code: 413,
         api_error: { type: "invalid_request_error", message: error.message },
-      } as const;
+      };
 
     case "internal":
       return {
         status_code: 500,
         api_error: { type: "internal_server_error", message: error.message },
-      } as const;
+      };
 
     default:
       return assertNever(code);
@@ -203,10 +206,10 @@ async function handleFolderArchiveRequest(
     return new Response(null, { status: 200, headers });
   }
 
-  return new Response(
-    readableToReadableStream(streamFolderArchive(dustFs, planResult.value)),
-    { status: 200, headers }
-  );
+  return new Response(streamFolderArchive(dustFs, planResult.value), {
+    status: 200,
+    headers,
+  });
 }
 
 async function handleHeadRequest(
@@ -613,42 +616,44 @@ app.delete(
   }
 );
 
-function mapDustFsError(err: DustFileSystemError) {
+function mapDustFsError(
+  err: DustFileSystemError
+): APIErrorWithContentfulStatusCode {
   switch (err.code) {
     case "not_found":
       return {
         status_code: 404,
         api_error: { type: "file_not_found", message: err.message },
-      } as const;
+      };
 
     case "unauthorized":
       return {
         status_code: 403,
         api_error: { type: "workspace_auth_error", message: err.message },
-      } as const;
+      };
 
     case "invalid_path":
     case "legacy_path":
       return {
         status_code: 400,
         api_error: { type: "invalid_request_error", message: err.message },
-      } as const;
+      };
 
     case "already_exists":
       return {
         status_code: 409,
         api_error: { type: "invalid_request_error", message: err.message },
-      } as const;
+      };
 
     case "too_many_mounts":
     case "internal":
       return {
         status_code: 500,
         api_error: { type: "internal_server_error", message: err.message },
-      } as const;
+      };
 
     default:
-      assertNever(err.code);
+      return assertNever(err.code);
   }
 }
 

--- a/front/lib/api/files/folder_archive.test.ts
+++ b/front/lib/api/files/folder_archive.test.ts
@@ -1,12 +1,11 @@
 // @vitest-environment node: ZIP inspection requires Node builtins.
 
-import { Readable } from "node:stream";
+import { PassThrough, Readable } from "node:stream";
 import type { FolderArchiveFileSystem } from "@app/lib/api/files/folder_archive";
 import {
   planFolderArchive,
   streamFolderArchive,
 } from "@app/lib/api/files/folder_archive";
-import { streamToBuffer } from "@app/lib/utils/streams";
 import type { FileSystemEntry } from "@app/types/api/file_system/types";
 import type { FileSystemMount } from "@app/types/file_system";
 import { Ok } from "@app/types/shared/result";
@@ -22,6 +21,24 @@ const mount: FileSystemMount = {
   legacySandboxMountPoint: "/files/conversation",
   permissions: { canRead: true, canWrite: true },
 };
+
+const podMount: FileSystemMount = {
+  kind: "pod",
+  id: "p1",
+  scopedPrefix: "pod-p1",
+  sandboxMountPoint: "/files/pod-p1",
+  legacyPrefix: "project",
+  legacySandboxMountPoint: "/files/pod",
+  permissions: { canRead: true, canWrite: true },
+};
+
+async function webStreamToBuffer(stream: ReadableStream): Promise<Buffer> {
+  return Buffer.from(await new Response(stream).arrayBuffer());
+}
+
+async function nextEventLoopTurn(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+}
 
 function file(path: string, sizeBytes: number): FileSystemEntry {
   return {
@@ -105,14 +122,20 @@ describe("planFolderArchive", () => {
     });
   });
 
-  it("allows an empty mount root", async () => {
-    const result = await planFolderArchive(makeFileSystem(), "conversation-c1");
+  it.each([
+    mount,
+    podMount,
+  ])("allows an empty $kind mount root", async (currentMount) => {
+    const result = await planFolderArchive(
+      makeFileSystem({ mounts: [currentMount] }),
+      currentMount.scopedPrefix
+    );
 
     expect(result.isOk()).toBe(true);
     if (result.isErr()) {
       throw result.error;
     }
-    expect(result.value.directories).toEqual(["conversation-c1/"]);
+    expect(result.value.directories).toEqual([`${currentMount.scopedPrefix}/`]);
     expect(result.value.files).toEqual([]);
   });
 
@@ -203,7 +226,7 @@ describe("streamFolderArchive", () => {
       return new Ok(stream);
     };
 
-    const result = await streamToBuffer(
+    const result = await webStreamToBuffer(
       streamFolderArchive(fileSystem, {
         archiveFileName: "reports.zip",
         directories: ["reports/", "reports/empty/"],
@@ -220,11 +243,7 @@ describe("streamFolderArchive", () => {
       })
     );
 
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) {
-      throw new Error(result.error);
-    }
-    const zip = new AdmZip(result.value);
+    const zip = new AdmZip(result);
     expect(zip.getEntries().map((entry) => entry.entryName)).toEqual([
       "reports/",
       "reports/empty/",
@@ -234,5 +253,73 @@ describe("streamFolderArchive", () => {
     expect(zip.readAsText("reports/a.txt")).toBe("alpha");
     expect(zip.readAsText("reports/nested/b.txt")).toBe("bravo");
     expect(maxActiveReads).toBe(1);
+  });
+
+  it("cancels an active source after its delayed pipe setup", async () => {
+    const source = new PassThrough();
+    const fileSystem = makeFileSystem();
+    fileSystem.read = async () => new Ok(source);
+
+    const reader = streamFolderArchive(fileSystem, {
+      archiveFileName: "reports.zip",
+      directories: ["reports/"],
+      files: [
+        {
+          archivePath: "reports/a.txt",
+          canonicalPath: "conversation-c1/reports/a.txt",
+        },
+      ],
+    }).getReader();
+    await nextEventLoopTurn();
+
+    await reader.cancel();
+    await nextEventLoopTurn();
+
+    expect(source.destroyed).toBe(false);
+    const upstream = new PassThrough();
+    upstream.pipe(source);
+    expect(source.destroyed).toBe(true);
+    upstream.destroy();
+  });
+
+  it("cancels a source returned after the archive download is cancelled", async () => {
+    type ReadResult = Awaited<ReturnType<FolderArchiveFileSystem["read"]>>;
+
+    let resolveRead!: (result: ReadResult) => void;
+    const pendingRead = new Promise<ReadResult>((resolve) => {
+      resolveRead = resolve;
+    });
+    let markReadStarted!: () => void;
+    const readStarted = new Promise<void>((resolve) => {
+      markReadStarted = resolve;
+    });
+    const fileSystem = makeFileSystem();
+    fileSystem.read = () => {
+      markReadStarted();
+      return pendingRead;
+    };
+
+    const reader = streamFolderArchive(fileSystem, {
+      archiveFileName: "reports.zip",
+      directories: ["reports/"],
+      files: [
+        {
+          archivePath: "reports/a.txt",
+          canonicalPath: "conversation-c1/reports/a.txt",
+        },
+      ],
+    }).getReader();
+    await readStarted;
+    await reader.cancel();
+
+    const source = new PassThrough();
+    resolveRead(new Ok(source));
+    await nextEventLoopTurn();
+
+    expect(source.destroyed).toBe(false);
+    const upstream = new PassThrough();
+    upstream.pipe(source);
+    expect(source.destroyed).toBe(true);
+    upstream.destroy();
   });
 });

--- a/front/lib/api/files/folder_archive.ts
+++ b/front/lib/api/files/folder_archive.ts
@@ -1,15 +1,17 @@
 import path from "node:path";
-import type { Readable } from "node:stream";
-import { PassThrough } from "node:stream";
+import { PassThrough, Readable } from "node:stream";
 import { finished } from "node:stream/promises";
 import type { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import type { DustFileSystemError } from "@app/types/file_system";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { createReadableCancellationHandler } from "@app/types/shared/utils/streams";
 import { ZipArchive } from "archiver";
 
 const DIRECTORY_CONTENT_TYPE = "application/x-directory";
+// One slot permits a backend root-directory placeholder; the other detects one entry over limit.
+const FOLDER_ARCHIVE_LIST_EXTRA_ENTRIES = 2;
 
 export const DEFAULT_FOLDER_ARCHIVE_LIMITS: FolderArchiveLimits = {
   maxEntries: 5_000,
@@ -62,6 +64,11 @@ export type FolderArchiveFileSystem = Pick<
 
 export type FolderArchivePlanError = DustFileSystemError | FolderArchiveError;
 
+/**
+ * @cc [owner:davidebbo,label:product] mounted-root-is-downloadable
+ * A readable conversation or pod mount root is a valid archive target even when it has no stat
+ * result or listed children.
+ */
 export async function planFolderArchive(
   fileSystem: FolderArchiveFileSystem,
   canonicalFolderPath: string,
@@ -90,7 +97,7 @@ export async function planFolderArchive(
   }
 
   const listResult = await fileSystem.list(normalizedFolderPath, {
-    maxFiles: limits.maxEntries + 2,
+    maxFiles: limits.maxEntries + FOLDER_ARCHIVE_LIST_EXTRA_ENTRIES,
   });
   if (listResult.isErr()) {
     return new Err(listResult.error);
@@ -171,13 +178,25 @@ export async function planFolderArchive(
   });
 }
 
+/**
+ * @cc [owner:davidebbo,label:performance] archive-stream-backpressure
+ * The returned Web stream must propagate consumer backpressure to the ZIP output.
+ */
+/**
+ * @cc [owner:davidebbo,label:error-handling] archive-stream-cancellation
+ * Cancelling the returned Web stream must abort the archive and stop both active and subsequently
+ * resolved file-source streams without destroying a source before its first `pipe` event.
+ */
 export function streamFolderArchive(
   fileSystem: FolderArchiveFileSystem,
   plan: FolderArchivePlan
-): Readable {
+): ReadableStream {
   const output = new PassThrough();
+  // Node's stream/web declarations and TypeScript's DOM declarations describe the same runtime
+  // Web stream but currently disagree on BYOB generic constraints.
+  const webOutput = Readable.toWeb(output) as ReadableStream;
   const archive = new ZipArchive({ zlib: { level: 6 } });
-  let activeReadStream: Readable | null = null;
+  let cancelActiveReadStream: (() => void) | null = null;
   let failed = false;
 
   const fail = (error: unknown) => {
@@ -185,7 +204,7 @@ export function streamFolderArchive(
       return;
     }
     failed = true;
-    activeReadStream?.destroy();
+    cancelActiveReadStream?.();
     void archive.abort();
     output.destroy(normalizeError(error));
   };
@@ -221,16 +240,30 @@ export function streamFolderArchive(
         return;
       }
 
-      activeReadStream = readResult.value;
-      const streamFinished = finished(activeReadStream, { cleanup: true });
-      archive.append(activeReadStream, { name: file.archivePath });
-      await streamFinished;
-      activeReadStream = null;
+      const readStream = readResult.value;
+      const cancelReadStream = createReadableCancellationHandler(readStream);
+      if (failed) {
+        cancelReadStream();
+        return;
+      }
+
+      cancelActiveReadStream = cancelReadStream;
+      try {
+        const streamFinished = finished(readStream, { cleanup: true });
+        archive.append(readStream, { name: file.archivePath });
+        await streamFinished;
+      } finally {
+        cancelActiveReadStream = null;
+      }
+
+      if (failed) {
+        return;
+      }
     }
 
     await archive.finalize();
   };
 
   void writeArchive().catch(fail);
-  return output;
+  return webOutput;
 }

--- a/front/types/shared/utils/streams.ts
+++ b/front/types/shared/utils/streams.ts
@@ -13,19 +13,44 @@ export function readableStreamToReadable<T = unknown>(
   return Readable.fromWeb(webStream as NodeReadableStream<T>);
 }
 
+/**
+ * @cc [owner:davidebbo,label:error-handling] delayed-pipe-readable-cancellation
+ * Cancelling before the first `pipe` event must drain the readable and delay destruction until
+ * that event; cancelling after it must destroy the readable immediately.
+ */
+export function createReadableCancellationHandler(
+  readable: Readable
+): () => void {
+  let pipeReceived = false;
+  let cancelled = false;
+  const onPipe = () => {
+    pipeReceived = true;
+  };
+  readable.on("pipe", onPipe);
+
+  return () => {
+    if (cancelled) {
+      return;
+    }
+    cancelled = true;
+    readable.off("pipe", onPipe);
+    readable.on("error", () => {});
+
+    if (pipeReceived) {
+      readable.destroy();
+    } else {
+      // GCS connects its upstream pipeline asynchronously. Draining lets that setup finish; the
+      // listener then stops the transfer without triggering ERR_STREAM_UNABLE_TO_PIPE.
+      readable.once("pipe", () => readable.destroy());
+      readable.resume();
+    }
+  };
+}
+
 export function readableToReadableStream<T = unknown>(
   readable: Readable
 ): ReadableStream<T> {
-  // Track whether node:pipeline() has already piped into this readable (GCS calls pipeline()
-  // inside its HTTP onResponse callback). The 'pipe' event fires on the destination synchronously
-  // during pipeline() setup, after the isWritable() check passes. So destroying here is safe and
-  // causes pipeline() to call onComplete(ERR_STREAM_PREMATURE_CLOSE) instead
-  // of throwing ERR_STREAM_UNABLE_TO_PIPE as an uncaught exception.
-  let pipeReceived = false;
-  // Additive: does not replace any existing listeners on the stream.
-  readable.on("pipe", () => {
-    pipeReceived = true;
-  });
+  const cancelReadable = createReadableCancellationHandler(readable);
 
   return new ReadableStream<T>({
     start(controller) {
@@ -38,16 +63,7 @@ export function readableToReadableStream<T = unknown>(
       readable.removeAllListeners("end");
       readable.removeAllListeners("error");
       readable.removeAllListeners("pipe");
-      readable.on("error", () => {});
-
-      if (pipeReceived) {
-        readable.destroy();
-      } else {
-        // pipeline() hasn't piped into this stream yet. Wait for 'pipe', then destroy immediately.
-        // Stops the GCS transfer with zero bytes read past what was already in-flight.
-        readable.once("pipe", () => readable.destroy());
-        readable.resume();
-      }
+      cancelReadable();
     },
   });
 }


### PR DESCRIPTION
## Description

Follow-up to #31926.

- Use `Readable.toWeb` so folder ZIP downloads propagate client backpressure.
- Abort active and pending file streams when the client cancels, while preserving delayed GCS pipe setup.
- Document the folder-list overscan and mount-root archive behavior.
- Type the route error mappers without per-return `as const` assertions.

## Deploy Plan

Front