### PR TITLE
[front] fix: remove `dd.internal.entity_tag` from StatsD metrics

### DIFF
--- a/front/lib/utils/statsd.ts
+++ b/front/lib/utils/statsd.ts
@@ -3,13 +3,15 @@ import { StatsD } from "hot-shots";
 
 let statsDClient: StatsD | undefined = undefined;
 
+/**
+ * @cc [owner:aubin-tchoi,label:performance] statsd-pod-origin-tag
+ * When `DD_ENTITY_ID` is set, the client must identify the pod through
+ * `dd.internal.entity_id` without adding `dd.internal.entity_tag` as a global tag.
+ */
 function getStatsDClient(): StatsD {
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   if (!statsDClient) {
     statsDClient = new StatsD({
-      globalTags: process.env.DD_ENTITY_ID
-        ? { "dd.internal.entity_tag": process.env.DD_ENTITY_ID }
-        : {},
       // Without an errorHandler, hot-shots emits "error" on its dgram socket with no listener
       // attached, which crashes the process on the rare send failure. Metrics are best-effort,
       // so log and move on.

--- a/front/lib/utils/statsd.ts
+++ b/front/lib/utils/statsd.ts
@@ -3,10 +3,13 @@ import { StatsD } from "hot-shots";
 
 let statsDClient: StatsD | undefined = undefined;
 
-function getStatsDClient(): StatsD {
+export function getStatsDClient(): StatsD {
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   if (!statsDClient) {
     statsDClient = new StatsD({
+      globalTags: process.env.DD_ENTITY_ID
+        ? { "dd.internal.entity_id": process.env.DD_ENTITY_ID }
+        : {},
       // Without an errorHandler, hot-shots emits "error" on its dgram socket with no listener
       // attached, which crashes the process on the rare send failure. Metrics are best-effort,
       // so log and move on.

--- a/front/lib/utils/statsd.ts
+++ b/front/lib/utils/statsd.ts
@@ -3,11 +3,6 @@ import { StatsD } from "hot-shots";
 
 let statsDClient: StatsD | undefined = undefined;
 
-/**
- * @cc [owner:aubin-tchoi,label:performance] statsd-pod-origin-tag
- * When `DD_ENTITY_ID` is set, the client must identify the pod through
- * `dd.internal.entity_id` without adding `dd.internal.entity_tag` as a global tag.
- */
 function getStatsDClient(): StatsD {
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   if (!statsDClient) {

--- a/front/scripts/debug/send_dummy_statsd_metric.ts
+++ b/front/scripts/debug/send_dummy_statsd_metric.ts
@@ -1,0 +1,23 @@
+import { getStatsDClient } from "@app/lib/utils/statsd";
+import { makeScript } from "@app/scripts/helpers";
+import { promisify } from "util";
+
+makeScript({}, async ({ execute }, logger) => {
+  const metricName = "statsd.dummy.count";
+  if (!execute) {
+    logger.info({ metricName }, "Would send one dummy StatsD metric");
+    return;
+  }
+
+  const client = getStatsDClient();
+  const increment = promisify(client.increment.bind(client));
+  const close = promisify(client.close.bind(client));
+
+  try {
+    await increment(metricName, 1);
+  } finally {
+    await close();
+  }
+
+  logger.info({ metricName }, "Sent one dummy StatsD metric");
+});


### PR DESCRIPTION
## Description

We have seen examples where some dd metrics have a high cardinality due to the `dd.internal.entity_tag` tag (example [here](https://app.datadoghq.eu/metric/volume?metric=llm_cache.token_hit_ratio&sort=-volume_total)). This tag contains the pod UID as value.

This PR renames it into `dd.internal.entity_id`, it's the name used by the Datadog agent to add the tags for `podLabelsAsTags`. This tag is stripped from the tags that end up in the metric so does not contribute to the billed cardinality.

Example of metric emitted with the renamed tag [here](https://app.datadoghq.eu/metric/summary?filter=statsd.dummy.count&metric=statsd.dummy.count&sort=name).

## Tests

- Added a script that increments a dummy metric so that we can check in datadog what tags on it.

## Risk

- Low.

## Deploy Plan

- Deploy front.
