### PR TITLE
chore: simplify table config fetching error handling

### DIFF
--- a/front/lib/actions/mcp_internal_actions/tools/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/utils.ts
@@ -90,15 +90,18 @@ export function makeCoreSearchNodesFilters({
 export async function fetchTableDataSourceConfigurations(
   auth: Authenticator,
   tablesConfiguration: TablesConfigurationToolType
-): Promise<Result<TableDataSourceConfiguration[], Error>> {
+): Promise<Result<TableDataSourceConfiguration[], MCPError>> {
   const results: TableDataSourceConfiguration[] = [];
 
   for (const tableConfiguration of tablesConfiguration) {
     const match = tableConfiguration.uri.match(TABLE_CONFIGURATION_URI_PATTERN);
     if (!match) {
       return new Err(
-        new Error(
-          `Invalid URI for a table configuration: ${tableConfiguration.uri}`
+        new MCPError(
+          `Invalid URI for a table configuration: ${tableConfiguration.uri}`,
+          {
+            tracked: false,
+          }
         )
       );
     }
@@ -110,18 +113,25 @@ export async function fetchTableDataSourceConfigurations(
       const sIdParts = getResourceNameAndIdFromSId(tableConfigId);
       if (!sIdParts) {
         return new Err(
-          new Error(`Invalid table configuration ID: ${tableConfigId}`)
+          new MCPError(`Invalid table configuration ID: ${tableConfigId}`, {
+            tracked: false,
+          })
         );
       }
       if (sIdParts.resourceName !== "table_configuration") {
         return new Err(
-          new Error(`ID is not a table configuration ID: ${tableConfigId}`)
+          new MCPError(`ID is not a table configuration ID: ${tableConfigId}`, {
+            tracked: false,
+          })
         );
       }
       if (sIdParts.workspaceModelId !== auth.getNonNullableWorkspace().id) {
         return new Err(
-          new Error(
-            `Table configuration ${tableConfigId} does not belong to workspace ${sIdParts.workspaceModelId}`
+          new MCPError(
+            `Table configuration ${tableConfigId} does not belong to workspace ${sIdParts.workspaceModelId}`,
+            {
+              tracked: false,
+            }
           )
         );
       }
@@ -136,7 +146,9 @@ export async function fetchTableDataSourceConfigurations(
 
       if (!agentTableConfiguration) {
         return new Err(
-          new Error(`Table configuration ${tableConfigId} not found`)
+          new MCPError(`Table configuration ${tableConfigId} not found`, {
+            tracked: false,
+          })
         );
       }
 
@@ -148,7 +160,7 @@ export async function fetchTableDataSourceConfigurations(
 
       if (dataSourceView.length !== 1) {
         return new Err(
-          new Error(
+          new MCPError(
             `Data source view not found for table configuration ${tableConfigId}`
           )
         );
@@ -168,7 +180,9 @@ export async function fetchTableDataSourceConfigurations(
       });
     } else {
       return new Err(
-        new Error(`Invalid URI format: ${tableConfiguration.uri}`)
+        new MCPError(`Invalid URI format: ${tableConfiguration.uri}`, {
+          tracked: false,
+        })
       );
     }
   }

--- a/front/lib/api/actions/servers/query_tables_v2/tools/index.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/tools/index.ts
@@ -44,21 +44,14 @@ async function resolveTableConfigurations(
     tables
   );
   if (tableConfigurationsRes.isErr()) {
-    return new Err(
-      new MCPError(
-        `Error fetching table configurations: ${tableConfigurationsRes.error.message}`
-      )
-    );
+    return tableConfigurationsRes;
   }
 
   const tableConfigurations = tableConfigurationsRes.value;
   if (tableConfigurations.length === 0) {
     return new Ok({
       tableConfigurations: [],
-      dataSourceViewsMap: new Map<
-        string,
-        Awaited<ReturnType<typeof DataSourceViewResource.fetchByIds>>[number]
-      >(),
+      dataSourceViewsMap: new Map<string, DataSourceViewResource>(),
     });
   }
 


### PR DESCRIPTION
## Description

This PR simplifies the error handling in table configuration fetching for MCP tools.
Instead of having `fetchTableDataSourceConfigurations` return an Error that needs to be wrapped into an MCP error, it directly supplies an MCPError that is then just passed through.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
