### PR TITLE
[front] fix: defer nested transaction effects until outer commit

### DIFF
--- a/front/lib/utils/cache.ts
+++ b/front/lib/utils/cache.ts
@@ -1,5 +1,6 @@
 import { getRedisCacheClient } from "@app/lib/api/redis";
 import { distributedLock, distributedUnlock } from "@app/lib/lock";
+import { runAfterTransactionCommit } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -449,21 +450,12 @@ export function invalidateCacheAfterCommit(
   transaction: Transaction | undefined,
   invalidateFn: () => Promise<void>
 ): void {
-  if (transaction) {
-    transaction.afterCommit(() =>
-      invalidateFn().catch((err) => {
-        logger.error(
-          { panic: true, err },
-          "Failed to invalidate cache after transaction commit"
-        );
-      })
-    );
-  } else {
-    invalidateFn().catch((err) => {
+  void runAfterTransactionCommit(transaction, async () => {
+    await invalidateFn().catch((err) => {
       logger.error(
         { panic: true, err },
         "Failed to invalidate cache after transaction commit"
       );
     });
-  }
+  });
 }

--- a/front/lib/utils/sql_utils.test.ts
+++ b/front/lib/utils/sql_utils.test.ts
@@ -1,0 +1,98 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import { invalidateCacheAfterCommit } from "@app/lib/utils/cache";
+import {
+  runAfterTransactionCommit,
+  withTransaction,
+  withTransactionResult,
+} from "@app/lib/utils/sql_utils";
+import { Ok } from "@app/types/shared/result";
+import { describe, expect, it, vi } from "vitest";
+
+vi.unmock("@app/lib/utils/cache");
+
+describe("withTransactionResult", () => {
+  it("defers successful nested result effects until the root commits", async () => {
+    const effect = vi.fn(async () => {});
+    await frontSequelize.transaction(async (root) => {
+      const result = await withTransactionResult(async (outer) => {
+        const result = await withTransactionResult(async (inner) => {
+          await runAfterTransactionCommit(inner, effect);
+          return new Ok("committed");
+        }, outer);
+        expect(effect).not.toHaveBeenCalled();
+        return result;
+      }, root);
+      expect(result).toEqual(new Ok("committed"));
+      expect(effect).not.toHaveBeenCalled();
+    });
+    expect(effect).toHaveBeenCalledOnce();
+  });
+});
+
+describe("withTransaction savepoints", () => {
+  it("runs descendant effects only after the root transaction commits", async () => {
+    const effect = vi.fn(async () => {});
+    await frontSequelize.transaction(async (root) => {
+      await withTransaction(
+        async (outer) => {
+          await withTransaction(
+            async (inner) => {
+              await runAfterTransactionCommit(inner, effect);
+            },
+            outer,
+            { useSavepoint: true }
+          );
+          expect(effect).not.toHaveBeenCalled();
+        },
+        root,
+        { useSavepoint: true }
+      );
+      expect(effect).not.toHaveBeenCalled();
+    });
+    expect(effect).toHaveBeenCalledOnce();
+  });
+});
+
+describe("runAfterTransactionCommit", () => {
+  it("runs directly when no caller-owned transaction remains", async () => {
+    const effect = vi.fn(async () => {});
+    await runAfterTransactionCommit(undefined, effect);
+    expect(effect).toHaveBeenCalledOnce();
+  });
+
+  it("waits for the outer commit even after a savepoint succeeds", async () => {
+    const effect = vi.fn(async () => {});
+    const invalidate = vi.fn(async () => {});
+    await frontSequelize.transaction(async (outer) => {
+      await frontSequelize.transaction(
+        { transaction: outer },
+        async (inner) => {
+          await runAfterTransactionCommit(inner, effect);
+          invalidateCacheAfterCommit(inner, invalidate);
+          expect(effect).not.toHaveBeenCalled();
+        }
+      );
+      expect(effect).not.toHaveBeenCalled();
+      expect(invalidate).not.toHaveBeenCalled();
+    });
+    expect(effect).toHaveBeenCalledOnce();
+    expect(invalidate).toHaveBeenCalledOnce();
+  });
+
+  it("does not run after a rolled-back savepoint or outer transaction", async () => {
+    const effect = vi.fn(async () => {});
+    await frontSequelize.transaction(async (outer) => {
+      const inner = await frontSequelize.transaction({ transaction: outer });
+      await runAfterTransactionCommit(inner, effect);
+      await inner.rollback();
+    });
+    expect(effect).not.toHaveBeenCalled();
+
+    const outer = await frontSequelize.transaction();
+    await frontSequelize.transaction({ transaction: outer }, async (inner) => {
+      await runAfterTransactionCommit(inner, effect);
+    });
+    await outer.rollback();
+    expect(effect).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/utils/sql_utils.ts
+++ b/front/lib/utils/sql_utils.ts
@@ -1,5 +1,7 @@
+import config from "@app/lib/api/config";
 import { frontSequelize } from "@app/lib/resources/storage";
-import type { Transaction } from "sequelize";
+import type { Result } from "@app/types/shared/result";
+import type { Transaction, TransactionOptions } from "sequelize";
 import { Sequelize } from "sequelize";
 import { injectReplacements } from "sequelize/lib/utils/sql";
 
@@ -44,26 +46,112 @@ function getCurrentTransaction(): Transaction | null {
   return (Sequelize as any)._cls?.get("transaction") || null;
 }
 
+// PostgreSQL savepoints are ordered on one connection, not a tree. Keep the logical
+// tree separately so effects still wait for every enclosing scope to commit.
+const savepointParents = new WeakMap<Transaction, Transaction>();
+
+/**
+ * @cc [owner:aubin-tchoi,label:backend;concurrency] nested-savepoint-atomicity
+ * Savepoints created by withTransaction must have distinct rollback boundaries;
+ * inner rollback preserves earlier outer writes, and outer rollback undoes committed inner writes.
+ */
 export async function withTransaction<T>(
   fn: (transaction: Transaction) => Promise<T>,
-  transaction?: Transaction
+  transaction?: Transaction,
+  {
+    useSavepoint = false,
+    ...options
+  }: Pick<TransactionOptions, "isolationLevel"> & {
+    useSavepoint?: boolean;
+  } = {}
 ): Promise<T> {
-  if (transaction) {
-    return fn(transaction);
-  }
-
   // Check if there's already a transaction in CLS (see above).
-  const clsTransaction = getCurrentTransaction();
-  if (clsTransaction) {
-    return fn(clsTransaction);
+  const parent = transaction ?? getCurrentTransaction();
+  if (parent) {
+    if (!useSavepoint) {
+      return fn(parent);
+    }
+    // Sequelize v6 gives descendants the same ID and per-parent savepoint counters,
+    // and overwrites parent.name on creation/rollback (sequelize/sequelize#18207).
+    // Root-owned savepoints share one counter and never mutate an enclosing savepoint.
+    let root = parent;
+    while (root.parent) {
+      root = root.parent;
+    }
+    return frontSequelize.transaction(
+      { ...options, transaction: root },
+      async (savepoint) => {
+        savepointParents.set(savepoint, parent);
+        return fn(savepoint);
+      }
+    );
   }
 
   // Create new transaction if no transaction in CLS.
-  if (process.env.NODE_ENV === "test") {
+  if (config.getDustAPIConfig().nodeEnv === "test") {
     throw new Error(
       "No transaction provided and no transaction in CLS while running tests, this should not happen."
     );
   }
 
-  return frontSequelize.transaction(fn);
+  return frontSequelize.transaction(options, fn);
+}
+
+/**
+ * @cc [owner:aubin-tchoi,label:backend;concurrency] error-results-rollback
+ * A callback's Err result or thrown error rolls back this scope's writes and suppresses its commit
+ * effects; an Ok result commits only this scope, leaving any caller transaction in control.
+ */
+export async function withTransactionResult<T extends Result<unknown, unknown>>(
+  fn: (transaction: Transaction) => Promise<T>,
+  transaction?: Transaction
+): Promise<T> {
+  const parent = transaction ?? getCurrentTransaction();
+  if (!parent && config.getDustAPIConfig().nodeEnv === "test") {
+    throw new Error(
+      "No transaction provided and no transaction in CLS while running tests."
+    );
+  }
+  // Share the physical root's savepoint counter, as in withTransaction above.
+  let root = parent;
+  while (root?.parent) {
+    root = root.parent;
+  }
+  const current = await frontSequelize.transaction({ transaction: root });
+  if (parent) {
+    savepointParents.set(current, parent);
+  }
+  let shouldRollback = true;
+  try {
+    const result = await fn(current);
+    if (result.isOk()) {
+      // Sequelize owns cleanup once commit starts, including commit or afterCommit errors.
+      shouldRollback = false;
+      await current.commit();
+    }
+    return result;
+  } finally {
+    if (shouldRollback) {
+      await current.rollback();
+    }
+  }
+}
+
+/**
+ * @cc [owner:aubin-tchoi,label:backend;concurrency] external-effects-after-outer-commit
+ * An explicit transaction defers the effect until it and all parent transactions commit;
+ * rolling back any of them must suppress the effect. Without a transaction, run it immediately.
+ */
+export async function runAfterTransactionCommit(
+  transaction: Transaction | undefined,
+  effect: () => Promise<void>
+): Promise<void> {
+  if (!transaction) {
+    await effect();
+    return;
+  }
+  transaction.afterCommit(async () => {
+    const parent = savepointParents.get(transaction) ?? transaction.parent;
+    await runAfterTransactionCommit(parent, effect);
+  });
 }


### PR DESCRIPTION
## Description

Search indexation must not run when only an inner savepoint has committed. Add shared transaction helpers that defer effects until the outer commit, suppress them on rollback, and support atomic operations returning `Result`.

Cache invalidation uses the same outer-commit boundary. Nested savepoints share a unique physical counter while retaining their logical parent for effect ordering.

Foundation for the revised shared skill/agent search, stacked after #32046.

## Tests

- Added real-transaction coverage for nested commits, rollback, and deferred cache invalidation.

## Risk

- Medium. Changes nested transaction and cache-invalidation timing.

## Deploy Plan

- Deploy front.
