### PR TITLE
[front] refactor: own global agent settings in a resource

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/anthropic.ts
+++ b/front/lib/api/assistant/global_agents/configurations/anthropic.ts
@@ -7,7 +7,7 @@ import type { MCPServerViewsForGlobalAgentsMap } from "@app/lib/api/assistant/gl
 import { _getDefaultWebActionsForGlobalAgent } from "@app/lib/api/assistant/global_agents/tools";
 import { selectEnabledModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
-import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
+import type { GlobalAgentSettings } from "@app/lib/resources/agent/global_agent_settings_resource";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
@@ -35,7 +35,7 @@ export function _getClaude3HaikuGlobalAgent({
   settings,
   mcpServerViews,
 }: {
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   const status = settings ? settings.status : "disabled_by_admin";
@@ -87,7 +87,7 @@ export function _getClaude3OpusGlobalAgent({
   mcpServerViews,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
@@ -142,7 +142,7 @@ export function _getClaude3GlobalAgent({
   mcpServerViews,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
@@ -197,7 +197,7 @@ export function _getClaude4SonnetGlobalAgent({
   mcpServerViews,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
@@ -252,7 +252,7 @@ export function _getClaude3_7GlobalAgent({
   mcpServerViews,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
@@ -308,7 +308,7 @@ export function _getClaude5SonnetGlobalAgent({
   featureFlags,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
   featureFlags: WhitelistableFeature[];
 }): AgentConfigurationType {
@@ -376,7 +376,7 @@ export function _getClaude4_5SonnetGlobalAgent({
   mcpServerViews,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
@@ -432,7 +432,7 @@ export function _getClaude4_5HaikuGlobalAgent({
   mcpServerViews,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -24,7 +24,7 @@ import {
   selectEnabledModel,
 } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
-import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
+import type { GlobalAgentSettings } from "@app/lib/resources/agent/global_agent_settings_resource";
 import type {
   AgentConfigurationType,
   AgentModelConfigurationType,
@@ -456,7 +456,7 @@ export function _getDeepDiveGlobalAgent(
     hasSandbox,
     featureFlags,
   }: {
-    settings: GlobalAgentSettingsModel | null;
+    settings: GlobalAgentSettings | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     hasSandbox?: boolean;
@@ -613,7 +613,7 @@ export function _getDustTaskGlobalAgent(
     mcpServerViews,
     featureFlags,
   }: {
-    settings: GlobalAgentSettingsModel | null;
+    settings: GlobalAgentSettings | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     featureFlags: WhitelistableFeature[];
@@ -729,7 +729,7 @@ export function _getPlanningAgent(
     settings,
     featureFlags,
   }: {
-    settings: GlobalAgentSettingsModel | null;
+    settings: GlobalAgentSettings | null;
     featureFlags: WhitelistableFeature[];
   }
 ): AgentConfigurationType | null {

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -26,11 +26,11 @@ import {
   selectEnabledModel,
 } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
-import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import {
   isDustCompanyPlan,
   isEnterprisePlanPrefix,
 } from "@app/lib/plans/plan_codes";
+import type { GlobalAgentSettings } from "@app/lib/resources/agent/global_agent_settings_resource";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type {
   AgentConfigurationType,
@@ -76,7 +76,7 @@ import type {
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 
 interface DustLikeGlobalAgentArgs {
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   preFetchedDataSources: PrefetchedDataSourcesType | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
   hasDeepDive: boolean;

--- a/front/lib/api/assistant/global_agents/configurations/dust/utils.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/utils.ts
@@ -1,5 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
-import { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
+import { GlobalAgentSettingsResource } from "@app/lib/resources/agent/global_agent_settings_resource";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import memoizer from "lru-memoizer";
 
@@ -10,12 +10,10 @@ const DEEP_DIVE_DISABLED_TTL_MS = 3 * 1000; // 3 seconds
 // causes memory growth.
 const _isDeepDiveDisabledByAdmin = memoizer<Authenticator, boolean>({
   load: (auth, callback) => {
-    GlobalAgentSettingsModel.findOne({
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        agentId: GLOBAL_AGENTS_SID.DEEP_DIVE,
-      },
-    })
+    GlobalAgentSettingsResource.fetchByAgentId(
+      auth,
+      GLOBAL_AGENTS_SID.DEEP_DIVE
+    )
       .then((settings) =>
         callback(null, settings?.status === "disabled_by_admin")
       )

--- a/front/lib/api/assistant/global_agents/configurations/google.ts
+++ b/front/lib/api/assistant/global_agents/configurations/google.ts
@@ -6,7 +6,7 @@ import {
 import type { MCPServerViewsForGlobalAgentsMap } from "@app/lib/api/assistant/global_agents/tools";
 import { _getDefaultWebActionsForGlobalAgent } from "@app/lib/api/assistant/global_agents/tools";
 import type { Authenticator } from "@app/lib/auth";
-import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
+import type { GlobalAgentSettings } from "@app/lib/resources/agent/global_agent_settings_resource";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
@@ -18,7 +18,7 @@ export function _getGeminiProGlobalAgent({
   mcpServerViews,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";

--- a/front/lib/api/assistant/global_agents/configurations/mistral.ts
+++ b/front/lib/api/assistant/global_agents/configurations/mistral.ts
@@ -6,7 +6,7 @@ import {
 import type { MCPServerViewsForGlobalAgentsMap } from "@app/lib/api/assistant/global_agents/tools";
 import { _getDefaultWebActionsForGlobalAgent } from "@app/lib/api/assistant/global_agents/tools";
 import type { Authenticator } from "@app/lib/auth";
-import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
+import type { GlobalAgentSettings } from "@app/lib/resources/agent/global_agent_settings_resource";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
@@ -30,7 +30,7 @@ export function _getMistralLargeGlobalAgent({
   mcpServerViews,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
@@ -84,7 +84,7 @@ export function _getMistralMediumGlobalAgent({
   mcpServerViews,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "disabled_by_admin";
@@ -136,7 +136,7 @@ export function _getMistralSmallGlobalAgent({
   settings,
   mcpServerViews,
 }: {
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   const status = settings ? settings.status : "disabled_by_admin";

--- a/front/lib/api/assistant/global_agents/configurations/openai.ts
+++ b/front/lib/api/assistant/global_agents/configurations/openai.ts
@@ -6,7 +6,7 @@ import {
 import type { MCPServerViewsForGlobalAgentsMap } from "@app/lib/api/assistant/global_agents/tools";
 import { _getDefaultWebActionsForGlobalAgent } from "@app/lib/api/assistant/global_agents/tools";
 import type { Authenticator } from "@app/lib/auth";
-import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
+import type { GlobalAgentSettings } from "@app/lib/resources/agent/global_agent_settings_resource";
 import type {
   AgentConfigurationStatus,
   AgentConfigurationType,
@@ -36,7 +36,7 @@ export function _getGPT35TurboGlobalAgent({
   settings,
   mcpServerViews,
 }: {
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   const status = settings ? settings.status : "active";
@@ -86,7 +86,7 @@ export function _getGPT4GlobalAgent({
   mcpServerViews,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status: AgentConfigurationStatus = "active";
@@ -143,7 +143,7 @@ export function _getGPT5GlobalAgent({
   mcpServerViews,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status: AgentConfigurationStatus = "active";
@@ -207,7 +207,7 @@ export function _getGPT5ThinkingGlobalAgent({
   mcpServerViews,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status: AgentConfigurationStatus = "active";
@@ -268,7 +268,7 @@ export function _getGPT5MiniGlobalAgent({
   mcpServerViews,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status: AgentConfigurationStatus = "active";
@@ -328,7 +328,7 @@ export function _getGPT5NanoGlobalAgent({
   mcpServerViews,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "disabled_by_admin";
@@ -385,7 +385,7 @@ export function _getO3MiniGlobalAgent({
   mcpServerViews,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "disabled_by_admin";
@@ -439,7 +439,7 @@ export function _getO1GlobalAgent({
   mcpServerViews,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
@@ -491,7 +491,7 @@ export function _getO1MiniGlobalAgent({
   settings,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -537,7 +537,7 @@ export function _getO1HighReasoningGlobalAgent({
   mcpServerViews,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
@@ -591,7 +591,7 @@ export function _getO3GlobalAgent({
   mcpServerViews,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettingsModel | null;
+  settings: GlobalAgentSettings | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";

--- a/front/lib/api/assistant/global_agents/configurations/retired_managed.ts
+++ b/front/lib/api/assistant/global_agents/configurations/retired_managed.ts
@@ -11,7 +11,7 @@ import {
   getSmallWhitelistedModel,
 } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
-import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
+import type { GlobalAgentSettings } from "@app/lib/resources/agent/global_agent_settings_resource";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type {
   AgentConfigurationType,
@@ -35,7 +35,7 @@ function _getManagedDataSourceAgent(
     searchMCPServerView,
     featureFlags,
   }: {
-    settings: GlobalAgentSettingsModel | null;
+    settings: GlobalAgentSettings | null;
     connectorProvider: ConnectorProvider;
     agentId: GLOBAL_AGENTS_SID;
     name: string;
@@ -160,7 +160,7 @@ export function _getGoogleDriveGlobalAgent(
     mcpServerViews,
     featureFlags,
   }: {
-    settings: GlobalAgentSettingsModel | null;
+    settings: GlobalAgentSettings | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     featureFlags: WhitelistableFeature[];
@@ -193,7 +193,7 @@ export function _getSlackGlobalAgent(
     mcpServerViews,
     featureFlags,
   }: {
-    settings: GlobalAgentSettingsModel | null;
+    settings: GlobalAgentSettings | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     featureFlags: WhitelistableFeature[];
@@ -226,7 +226,7 @@ export function _getGithubGlobalAgent(
     mcpServerViews,
     featureFlags,
   }: {
-    settings: GlobalAgentSettingsModel | null;
+    settings: GlobalAgentSettings | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     featureFlags: WhitelistableFeature[];
@@ -259,7 +259,7 @@ export function _getNotionGlobalAgent(
     mcpServerViews,
     featureFlags,
   }: {
-    settings: GlobalAgentSettingsModel | null;
+    settings: GlobalAgentSettings | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     featureFlags: WhitelistableFeature[];
@@ -292,7 +292,7 @@ export function _getIntercomGlobalAgent(
     mcpServerViews,
     featureFlags,
   }: {
-    settings: GlobalAgentSettingsModel | null;
+    settings: GlobalAgentSettings | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     featureFlags: WhitelistableFeature[];

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -117,7 +117,8 @@ import { isProviderWhitelistedForAuth } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { getDefaultStreamConfigForAuth } from "@app/lib/model_tiers/enabled_models";
-import { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
+import type { GlobalAgentSettings } from "@app/lib/resources/agent/global_agent_settings_resource";
+import { GlobalAgentSettingsResource } from "@app/lib/resources/agent/global_agent_settings_resource";
 import type {
   AgentConfigurationType,
   AgentFetchVariant,
@@ -151,7 +152,7 @@ function getGlobalAgent({
   auth: Authenticator;
   sId: string | number;
   preFetchedDataSources: PrefetchedDataSourcesType | null;
-  globalAgentSettings: GlobalAgentSettingsModel[];
+  globalAgentSettings: GlobalAgentSettings[];
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
   sidekickContext: SidekickContext | null;
   hasDeepDive: boolean;
@@ -1014,7 +1015,9 @@ export async function getGlobalAgents(
   auth: Authenticator,
   agentIds?: string[],
   variant: AgentFetchVariant = "full",
-  options?: { globalAgentContext?: GlobalAgentContext }
+  options?: {
+    globalAgentContext?: GlobalAgentContext;
+  }
 ): Promise<AgentConfigurationType[]> {
   if (agentIds !== undefined && agentIds.some((sId) => !isGlobalAgentId(sId))) {
     throw new Error("Invalid agentIds.");
@@ -1041,9 +1044,7 @@ export async function getGlobalAgents(
     variant === "full"
       ? getDataSourcesAndWorkspaceIdForGlobalAgents(auth)
       : null,
-    GlobalAgentSettingsModel.findAll({
-      where: { workspaceId: owner.id },
-    }),
+    GlobalAgentSettingsResource.listForWorkspace(auth),
     getMCPServerViewsForGlobalAgents(auth, variant),
   ]);
 
@@ -1235,25 +1236,6 @@ export async function upsertGlobalAgentSettings(
     status: GlobalAgentStatus;
   }
 ): Promise<boolean> {
-  const owner = auth.getNonNullableWorkspace();
-
-  if (!isGlobalAgentId(agentId)) {
-    throw new Error("Global Agent not found: invalid agentId.");
-  }
-
-  const settings = await GlobalAgentSettingsModel.findOne({
-    where: { workspaceId: owner.id, agentId },
-  });
-
-  if (settings) {
-    await settings.update({ status });
-  } else {
-    await GlobalAgentSettingsModel.create({
-      workspaceId: owner.id,
-      agentId,
-      status,
-    });
-  }
-
+  await GlobalAgentSettingsResource.upsert(auth, { agentId, status });
   return true;
 }

--- a/front/lib/resources/agent/global_agent_settings_resource.test.ts
+++ b/front/lib/resources/agent/global_agent_settings_resource.test.ts
@@ -1,0 +1,134 @@
+import { Authenticator } from "@app/lib/auth";
+import { GlobalAgentSettingsResource } from "@app/lib/resources/agent/global_agent_settings_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { describe, expect, it } from "vitest";
+
+describe("GlobalAgentSettingsResource", () => {
+  it("upserts one setting per workspace and exposes only plain settings", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+    const other = await createResourceTest({ role: "admin" });
+    const agentId = GLOBAL_AGENTS_SID.DUST;
+    expect(
+      await GlobalAgentSettingsResource.fetchByAgentId(auth, agentId)
+    ).toBeNull();
+    await GlobalAgentSettingsResource.upsert(other.authenticator, {
+      agentId,
+      status: "disabled_by_admin",
+    });
+    await GlobalAgentSettingsResource.upsert(auth, {
+      agentId,
+      status: "active",
+    });
+    await GlobalAgentSettingsResource.upsert(auth, {
+      agentId,
+      status: "disabled_by_admin",
+    });
+    await GlobalAgentSettingsResource.upsert(auth, {
+      agentId,
+      status: "active",
+    });
+    expect(await GlobalAgentSettingsResource.listForWorkspace(auth)).toEqual([
+      { agentId, status: "active" },
+    ]);
+    expect(
+      await GlobalAgentSettingsResource.fetchByAgentId(auth, agentId)
+    ).toEqual({
+      agentId,
+      status: "active",
+    });
+    expect(
+      await GlobalAgentSettingsResource.listForWorkspace(other.authenticator)
+    ).toEqual([{ agentId, status: "disabled_by_admin" }]);
+  });
+
+  it("rolls back updates, inserts and cleanup with the caller's transaction", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+    const agentId = GLOBAL_AGENTS_SID.DUST;
+    const settings = { agentId, status: "active" } as const;
+    await GlobalAgentSettingsResource.upsert(auth, settings);
+    const rollback = new Error("Rollback global settings");
+    await expect(
+      withTransaction(
+        async (transaction) => {
+          await GlobalAgentSettingsResource.upsert(
+            auth,
+            {
+              agentId,
+              status: "disabled_by_admin",
+            },
+            { transaction }
+          );
+          expect(
+            await GlobalAgentSettingsResource.fetchByAgentId(auth, agentId, {
+              transaction,
+            })
+          ).toEqual({
+            agentId,
+            status: "disabled_by_admin",
+          });
+          await GlobalAgentSettingsResource.deleteAllForWorkspace(auth, {
+            transaction,
+          });
+          expect(
+            await GlobalAgentSettingsResource.listForWorkspace(auth, {
+              transaction,
+            })
+          ).toEqual([]);
+          await GlobalAgentSettingsResource.upsert(
+            auth,
+            {
+              agentId: GLOBAL_AGENTS_SID.DEEP_DIVE,
+              status: "disabled_by_admin",
+            },
+            { transaction }
+          );
+          throw rollback;
+        },
+        undefined,
+        { useSavepoint: true }
+      )
+    ).rejects.toBe(rollback);
+    expect(await GlobalAgentSettingsResource.listForWorkspace(auth)).toEqual([
+      settings,
+    ]);
+  });
+
+  it("rejects non-admin writes and invalid global IDs without changing settings", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const settings = {
+      agentId: GLOBAL_AGENTS_SID.DUST,
+      status: "active",
+    } as const;
+    await GlobalAgentSettingsResource.upsert(auth, settings);
+    await expect(
+      GlobalAgentSettingsResource.upsert(userAuth, {
+        ...settings,
+        status: "disabled_by_admin",
+      })
+    ).rejects.toThrow("Only admins can update global agent settings.");
+    await expect(
+      GlobalAgentSettingsResource.deleteAllForWorkspace(userAuth)
+    ).rejects.toThrow("Only admins can delete global agent settings.");
+    await expect(
+      GlobalAgentSettingsResource.upsert(auth, {
+        agentId: "not-a-global-agent",
+        status: "active",
+      })
+    ).rejects.toThrow("Global Agent not found: invalid agentId.");
+    expect(
+      await GlobalAgentSettingsResource.listForWorkspace(userAuth)
+    ).toEqual([settings]);
+  });
+});

--- a/front/lib/resources/agent/global_agent_settings_resource.ts
+++ b/front/lib/resources/agent/global_agent_settings_resource.ts
@@ -1,0 +1,72 @@
+import type { Authenticator } from "@app/lib/auth";
+import { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
+import type { GlobalAgentStatus } from "@app/types/assistant/agent";
+import { isGlobalAgentId } from "@app/types/assistant/assistant";
+import assert from "assert";
+import type { Transaction } from "sequelize";
+
+export type GlobalAgentSettings = {
+  agentId: string;
+  status: GlobalAgentStatus;
+};
+
+/**
+ * @cc [owner:aubin-tchoi,label:backend;security] workspace-global-agent-settings
+ * Global-agent settings are workspace-scoped, expose no model objects, and can only
+ * be changed by admins. Writes participate in the supplied transaction.
+ */
+export class GlobalAgentSettingsResource {
+  static async listForWorkspace(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<GlobalAgentSettings[]> {
+    const settings = await GlobalAgentSettingsModel.findAll({
+      attributes: ["agentId", "status"],
+      where: { workspaceId: auth.getNonNullableWorkspace().id },
+      transaction,
+    });
+    return settings.map(({ agentId, status }) => ({ agentId, status }));
+  }
+
+  static async fetchByAgentId(
+    auth: Authenticator,
+    agentId: string,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<GlobalAgentSettings | null> {
+    const settings = await GlobalAgentSettingsModel.findOne({
+      attributes: ["agentId", "status"],
+      where: { workspaceId: auth.getNonNullableWorkspace().id, agentId },
+      transaction,
+    });
+    return settings
+      ? { agentId: settings.agentId, status: settings.status }
+      : null;
+  }
+
+  static async upsert(
+    auth: Authenticator,
+    { agentId, status }: GlobalAgentSettings,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    assert(auth.isAdmin(), "Only admins can update global agent settings.");
+    assert(
+      isGlobalAgentId(agentId),
+      "Global Agent not found: invalid agentId."
+    );
+    await GlobalAgentSettingsModel.upsert(
+      { workspaceId: auth.getNonNullableWorkspace().id, agentId, status },
+      { transaction }
+    );
+  }
+
+  static async deleteAllForWorkspace(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    assert(auth.isAdmin(), "Only admins can delete global agent settings.");
+    await GlobalAgentSettingsModel.destroy({
+      where: { workspaceId: auth.getNonNullableWorkspace().id },
+      transaction,
+    });
+  }
+}


### PR DESCRIPTION
## Description

Global-agent availability needs a resource-owned database boundary before it joins shared search. Introduce workspace-scoped settings reads, atomic upserts, and transactional cleanup, with admin-only writes.

Global-agent constructors now consume plain settings instead of Sequelize models. The existing settings endpoint and three-second Deep Dive cache retain their behavior.

## Tests

- Added workspace isolation, idempotent upsert, rollback, and admin-permission coverage.

## Risk

- Low. Preserves the existing global-agent settings API.

## Deploy Plan

- Deploy front.
