### PR TITLE
Free seats: no off-pace warning, unblock only offers seat upgrade

### DIFF
--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -956,11 +956,35 @@ const offPaceColumn: ColumnDef<RowData, string> = {
       overallUsageTarget,
       isSpendCapped,
       canUpgradeSeat,
+      seatType,
       onOpenChangeSeatRecap,
       onOpenSpendLimitRecap,
     } = info.row.original;
 
     if (isSpendCapped) {
+      // Free seats have no pool credits to raise (their cap is just the
+      // seat's built-in allowance), so seat upgrade is the only unblock path.
+      const isFreeSeat = seatType === "free";
+
+      if (isFreeSeat) {
+        return (
+          <DataTable.CellContent className="justify-center">
+            <div
+              onClick={(event) => event.stopPropagation()}
+              onPointerDown={(event) => event.stopPropagation()}
+            >
+              <Button
+                variant="highlight"
+                size="xs"
+                label="Unblock"
+                disabled={!canUpgradeSeat}
+                onClick={onOpenChangeSeatRecap}
+              />
+            </div>
+          </DataTable.CellContent>
+        );
+      }
+
       if (!canUpgradeSeat) {
         return (
           <DataTable.CellContent className="justify-center">

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -2691,8 +2691,13 @@ export async function getMembersUsage({
             nowMs: Date.now(),
           })?.target ?? null)
         : null;
+    // Same lifetime-grant caveat as `seatUsageTarget` above: a free seat's
+    // balance never resets on a billing cycle, so pace-against-the-cycle
+    // doesn't apply to it either.
     const overallUsageTarget =
-      billingCycle && effectiveSpendLimitAwuCredits !== null
+      billingCycle &&
+      membership.seatType !== "free" &&
+      effectiveSpendLimitAwuCredits !== null
         ? (computeCreditUsageStatus({
             consumedAwuCredits: totalConsumedCredits,
             limitAwuCredits: effectiveSpendLimitAwuCredits,


### PR DESCRIPTION
## Description

Free seats have a lifetime, non-renewing credit grant, not a recurring billing-cycle allowance, so pace-against-the-cycle doesn't apply to them. overallUsageTarget already excluded this for seatUsageTarget but not for the overall target, so free-seat members could get flagged elevated/critical incorrectly.

Also, a capped free seat has no pool credits to raise (their cap is just the seat's built-in allowance), so the Unblock control should only ever offer "Upgrade seat", never "Edit spend limit".

## Tests

Tested localy

## Risk

Low

## Deploy Plan

Deploy front
