### PR TITLE
[front] refactor: route agent maintenance through resources

### DIFF
--- a/front/lib/skill_search/README.md
+++ b/front/lib/skill_search/README.md
@@ -1,33 +1,290 @@
-# Ranked skill search
+# Shared skill and agent search
 
-Custom skills stay in the workspace-scoped ES index. Global and system skills
-stay in their code registries; adding one requires no search migration or sync.
+PostgreSQL is authoritative. Custom skills have one document per logical skill in
+`front.skills`, initially backed by `front.skills_1`, with document ID
+`<workspaceId>_<skillId>`. Global/system skills and global agents stay code-defined and
+need no ES migration. Workspace agents use `front.agents`, initially backed by
+`front.agents_1`. Both resource types own their mutation and indexing paths.
 
-ES and TypeScript use the same fixed relevance tiers: exact name/alias (100),
-prefix (80), substring (60), subsequence (40), description substring (20), and
-description subsequence (10). The best match wins. Empty queries score 1.
-Ties use name and skill ID in ES keyword byte order. Wildcard matching folds
-ASCII case only, matching ES 8's behavior. BM25 is not the final ranking.
+Agent configuration reads, listing views and serialization now live on `AgentResource`,
+with compatibility functions for existing callers. Favorites and action serialization
+belong to their relationship resources. Creation commits the configuration, grants, tags, tools
+and skills together, and upgrades lock the stable agent identity. Tool relationships
+and tag writes are batched; tag and editor-group reads use the creation transaction.
+Auth refresh, cache invalidation, audit and trigger effects wait until
+commit, including when a caller owns an outer transaction. Agent indexing is wired
+for create/version changes, archive/restore, editor/scope changes, requested-space
+propagation, favorites, tag metadata/attachments and feedback counts.
 
-`GET /api/w/:wId/skills/search` accepts optional `limit` (1–150) and `cursor`.
-It returns `skills` with scores and `nextCursor` (null when exhausted).
+## Mapping
 
-The backend merges two sorted streams. The ES cursor advances past returned or
-permission-rejected candidates, never authorized hits displaced by globals.
-Unconsumed hits are refetched. Globals have an independent position.
+| Fields | Mapping |
+| --- | --- |
+| `workspace_id`, `skill_id`, `status`, `availability` | `keyword` |
+| `name` | compound-name `text`, `keyword`, `wildcard` |
+| `description` | English `text`, `wildcard` |
+| `requested_space_ids`, `editor_user_ids`, `tools` | `keyword` arrays |
+| `editor_group_ids` (skills) | `keyword` array |
+| `icon`, `edited_by`, `updated_at` | `keyword`, `long`, `date` |
+| `active_users`, `favorite_count`, `is_default` | `integer`, `integer`, `boolean` |
+| `resource_id` | alias to `skill_id` (or `agent_id` in the agent index) |
+| `metadata` | source-only object, `enabled: false` |
 
-Cursors are immutable opaque Redis keys with a five-minute TTL, bound to the
-workspace, caller, ES query and matching global catalog. Changed eligibility,
-catalog or query, missing cursor state, or an expired PIT requires restarting
-the search (400). Permission checks still run live on each candidate batch;
-a PIT freezes index state, not authorization.
+Tools are MCP server view sIds; editor user/group IDs are internal IDs supplied from the
+authenticator, not caller-provided model IDs. The builder's individual-editor list remains in
+`editor_user_ids`. `editor_group_ids` includes every instance editor grant, including manual,
+provisioned and global groups, without expanding their membership into user lists.
+Instructions are never indexed.
+All requested spaces, including projects/pods, are stored in a single field.
+Missing, duplicate or foreign-workspace space references invalidate a projection.
+Only active skills are indexed, using a repeatable-read snapshot of row and relations.
+Source-only metadata carries the remaining stripped listing fields: creation time,
+agent-facing description, source attribution, reinforcement settings and manually
+requested spaces. The authorized document hydrates `SkillResource`; its canonical
+serializer produces `SkillWithoutInstructionsAndToolsType`, never a parallel skill type.
 
-Each request prepares readable non-pod IDs once and runs at most five batches
-of 50–200 ES candidates. Pod and canonical DB validation remain batched. A short
-or empty page can have a continuation cursor: consumers must use `nextCursor`,
-not the number of results, to decide whether search is exhausted.
+`front.agents` (initially `front.agents_1`) uses the same shared fields with `agent_id`
+instead of `skill_id`, plus `tags`, `skills` (keyword arrays) and `feedbacks` (integer).
+It omits `is_default` and `editor_group_ids`. A source-only stable `agent_model_id` and metadata object allow
+reuse of `LightAgentConfigurationType` without reading or indexing prompts or tool
+configuration. `resource_id` aliases `agent_id` for shared sorting. The projector
+selects the latest version of each stable identity; inactive latest versions never
+fall back to older active rows. Workspace/space/editor validity is checked in a
+repeatable-read snapshot, with batched relation reads.
 
-The first page also opens a PIT. Single-page searches close it immediately;
-paginated snapshots expire naturally so earlier cursors remain retryable.
-Continuation pages read one Redis cursor, and pages with more results write
-one. No skill documents, permission grants or result bodies are cached there.
+Visible agents map to `workspace_users`, hidden agents to `editors`. Agent editor IDs
+include the existing author fallback. Unlike the skills-specific API-key exception,
+agent search keeps the existing agent visibility rules. Admin redaction preserves
+the light listing with `canRead: false` and no prompt, skills or tool configurations.
+The stable `AgentResource` ACL and configuration visibility are distinct existing
+contracts: administrative access to the stable resource does not make private
+configuration details readable. Search follows the configuration author/editor and
+requested-space checks, matching the existing details reader.
+
+## Permissions and queries
+
+`auth.getResourceIdsWithVerb("space", "read")` supplies readable space IDs with no
+fetch. Open spaces and pods are included through global-group reader grants. A
+type-wide grant means all spaces; an admin role alone does not confer read access.
+
+Every resource search query filters `workspace_id` and active status. Strict search also requires:
+
+- Every requested space is readable: no requirements matches directly; otherwise
+  `terms_set` on `requested_space_ids` requires `doc['requested_space_ids'].size()`
+  matches. The invariant is `skill spaces ⊆ caller readable spaces`, not the reverse.
+- Published availability or a matching editor user/group for editors-only skills.
+  Type-wide skill write grants use Authenticator's resolved permissions, without per-skill
+  indexing fanout. Those skill-specific paths never grant access to hidden agents.
+  API keys retain their existing skill editor-visibility exception.
+
+Group matching reuses `auth.groupModelIds()`; it adds no membership read to search. This is
+needed for parity with generic grants, which `canWrite` accepts even when the individual-editor
+list is empty. `editedByMe` uses the same editor predicate. New workspace members immediately
+match an indexed global-group grant, without reindexing skills. The additive group field must
+be mapped before deploying its writer and backfilled for existing group-based grants. Old
+documents without the field remain usable through the individual-editor path during backfill.
+
+Candidate batches undergo committed-state validation of row-read permissions,
+spaces, availability, editor user/group grants and lifecycle. Stale permission fields fail closed.
+There is no per-skill SQL query or separate candidate-pod fetch. Selection filters
+never replace ACL predicates; a PIT freezes index state, not authorization.
+
+Admins can opt into `permissionFiltering=redact_unreadable`. ES still filters
+workspace, status and selections but omits visibility gates. Canonical resource
+redaction retains unreadable listing metadata with `canRead: false`; readable
+entries retain `canRead: true`. Editor and administration flags also keep their
+canonical meaning: a workspace-wide skill reader grant can permit reading an
+editors-only skill even when strict search hides it from a non-editor. Instructions,
+tools and files never appear in search responses. Non-admin redaction requests receive 403.
+
+For an admin management listing, pass `permissionFiltering=redact_unreadable` to
+either search endpoint (or the skill search hook). Omit it for slash commands and
+other selection flows: strict filtering remains the default. Redaction changes
+listing visibility only; it grants no read, edit or execution permission. A cursor
+cannot be reused between strict and redacted searches.
+
+## Ranking and filters
+
+`GET /api/w/:wId/search/resources` exposes the shared search. Optional
+`resourceTypes=skill,agent` chooses either type or both (default). Results contain
+`type`, `resource` (the existing stripped skill or light agent shape), and `score`,
+plus one response-level `nextCursor`. The existing `/skills/search` endpoint delegates
+to the same engine and preserves its slash-menu summary response.
+
+Both accept `query`, optional `limit` (1–150), `cursor`, `permissionFiltering`, and `mode`:
+
+- `autocomplete` (default): name/alias only; exact (100), prefix (80), substring
+  (60), subsequence (40). Usage does not affect slash ordering.
+- `management`: text recall includes descriptions; sort by active users, then name.
+- `discovery`: text relevance plus `log1p(active_users)` and, for agents,
+  `log1p(feedbacks)`. Description substring and
+  subsequence scores are 20 and 10. This initial formula is an experiment, not a
+  claim of measured discovery quality.
+
+Empty text matches all eligible resources. ES and TypeScript share scoring rules,
+float32 comparisons and name/ID keyword-byte tie-breakers. Wildcards fold ASCII only.
+
+Comma-separated `spaceIds`, `toolIds`, `availability` match any value within each
+dimension, ANDed across dimensions. `isDefault` and `editedByMe` accept true/false.
+Globals obey these filters too: no editors or explicit space requirements; tools
+come from their definitions. The existing summary response adds score and `nextCursor`.
+The shared endpoint also accepts `tagIds` and `skillIds`, which select agents.
+`isDefault` selects skills. The indexed agent stream contains workspace-owned agents only;
+active global agents join the same synthetic stream as code-defined skills. Their canonical
+catalog applies current workspace settings, provider allowlists, feature flags, retirement
+and audience rules before search. Redaction does not bypass those global-agent gates.
+
+Ordinary global-agent search uses the existing light catalog reader. Tool/skill selection
+uses the full canonical capability reader because some attachments depend on live company
+knowledge; it is read-only and never creates automatic tool views. This path currently loads
+the catalog's company data-source views and is more expensive than ordinary name/usage search.
+Its production latency still needs measurement. Responses always use the light schema with
+instructions, tool configurations and skill attachments stripped. Discovery adds one batched,
+workspace-scoped feedback-count query for the eligible global agents.
+
+Global-agent availability settings are read and written through
+`GlobalAgentSettingsResource`, including workspace scrub. Updates are admin-only and use
+one workspace/agent upsert. Search reads current settings, so changes invalidate the catalog
+fingerprint without indexing global documents. The existing Deep Dive restriction cache
+retains its three-second TTL.
+
+The implementation lives in `lib/search/{resource_query,resource_candidates,ranking,cursor}.ts`
+and `lib/api/resource_search.ts`. Skill-only helpers are compatibility forwarders, not a
+second query or pagination implementation. Each candidate batch uses one ES request over
+the selected aliases and batched current-state reads for each returned resource type.
+
+## Pagination
+
+One PIT spans the selected indexes, sorted by score, name and the shared `resource_id`
+alias (with PIT's shard-document tiebreaker). The backend merges indexed and code-defined
+streams. The ES cursor advances only
+past returned or denied hits, never authorized hits displaced by globals.
+Unconsumed hits are refetched; globals have an independent offset.
+
+Immutable Redis cursors expire after five minutes and bind workspace, caller,
+resource types, permission mode, ranking mode, query and global catalog. Changed readable spaces
+(including pods), filters or global ranking require restarting after a 400.
+Redaction still rechecks `canRead` when its broad query remains unchanged.
+
+Each request processes at most five batches of 50–200 candidates. Short/empty pages
+can have a continuation: use `nextCursor`, not result count, for exhaustion.
+Single-page searches close their PIT; other PITs expire naturally for retryability.
+
+## Freshness and operations
+
+Temporal indexes the latest committed projection or deletes an inactive/invalid
+document. `SkillResource` owns indexation for creation, updates, archive/restore,
+deletion, availability, editors, favorites and self-improvement metadata. Routes,
+imports and skill-authoring tools no longer launch a second indexing workflow.
+Explicit outer transactions defer enqueueing until commit; rollback suppresses it.
+Skill row, attachment, knowledge, tool and editor writes share the update transaction.
+Space cleanup includes skill updates in its transaction, so a later cleanup failure
+does not leave committed skill changes behind. Favorites update their list/count
+atomically. `GroupResource` owns editor-membership fanout for additions, removals,
+suspension, restoration, identity merges and group deletion. It resolves affected
+skills and logical agents in batches; deletion captures targets before cascading
+their grants and invalidates cached grants after commit. WorkOS retries retain a
+historical-membership repair path. Workspace membership changes alone do not change
+the indexed editor grant holders; request authentication checks membership live.
+Workspace scrub, backfill and relocation also enqueue current projections.
+
+Tag changes refresh all affected logical agents, deduplicating configuration versions;
+deletion captures those targets before removing links. Feedback creation/deletion and
+batched message cleanup refresh the total feedback count. Editing feedback text,
+direction or dismissal does not change that total. These writers share the dependency-light
+`AgentSearchIndexationResource` entrypoint with `AgentResource` and group/space propagation.
+
+Direct editor-grant writes refresh their exact resource targets. Standalone tool/skill
+attachments and skill deletion refresh affected agents; parent-reference rewrites refresh
+changed parents' indexed timestamps. Agent favorite writes and identity merges belong to
+their resources. The favorite backfill uses bounded inserts, preserves existing opt-outs,
+and supports a no-write dry run; workspace scrub deletes relations in one scoped operation.
+
+Tool-view hard deletion and promotion from regular spaces to the global space remove stored
+agent/skill attachments and enqueue their projections after commit. Promotion does not
+automatically reattach the new global view. Soft deletion retains stored attachment rows, so
+the indexed `tools` IDs remain unchanged: this filter describes stored attachments, not a
+tool's current executability.
+
+Agent version deletion, author cleanup and workspace scrub go through `AgentResource`.
+Tool dependencies (including pod attachments) are deleted in the same transaction.
+Deleting an old version preserves the stable identity, grants, favorites and memory while
+another version remains; legacy editor groups are removed only when no version references them.
+The author-deletion script supports a read-only dry run. Workspace scrub also clears global
+agent preferences and retries the workspace-wide index deletion even when DB rows are already gone.
+The draft-cleanup script uses the same deletion path, excludes mentioned drafts with a
+batched lookup, and never writes during a dry run.
+Orphaned-space repair is also resource-owned: it removes missing or foreign-workspace
+requirements from active versions, preserves other fields and refreshes affected agents.
+It supports dry runs and an optional single-workspace scope.
+
+`update_agent_requested_group_and_space_ids.ts` delegates to
+`AgentResource.rebuildSpaceRequirements`. It batches tool and attached-skill reads, includes
+unreadable skills' required spaces and pods, preserves non-permission fields, and indexes only
+after commit. Workspace/agent selection, active-only filtering and dry runs remain supported.
+Unlike orphan repair, this operator command replaces requirements with those derived from
+capabilities: manually supplied additional agent restrictions are not retained. Use orphan repair
+when the goal is only to remove missing space IDs.
+
+MCP view/server deletion and skills-only restriction updates also refresh affected tools.
+Their dependency cleanup includes agent pod attachments and runs in the enclosing transaction;
+skill/agent indexing and sandbox output-file removal wait for the outer commit. A rolled-back
+view deletion restores both the links and the files it references.
+
+Nested mutation savepoints use `withTransaction(..., { useSavepoint: true })`. It keeps
+database savepoint names unique on the root connection and tracks logical parents for
+after-commit effects, avoiding Sequelize v6's native nested-savepoint naming bugs.
+Do not introduce native nested `sequelize.transaction`/`findOrCreate` savepoints inside
+these aggregate writes; they bypass this helper.
+For callbacks returning `Result`, use `withTransactionResult`: `Err` rolls back rather
+than committing a successful prefix. Agent editor updates use this for both legacy
+memberships and stable grants; indexation and success audit follow only a successful commit.
+
+Daily usage snapshots cover the previous 30 complete UTC days, matching the existing
+agent ranking window. Consumption aggregations count distinct users, not steps/tool
+documents, and follow every composite `after_key`. Skill attribution uses
+`tool.attributed_skill_ids`, agent attribution `agent.attributed_id`, restricted to
+existing human usage origins with a user ID.
+
+Ordinary upserts preserve `active_users`. Daily updates reset absent counts to zero
+and never recreate deleted documents. Code-defined skill and agent counts live in separate
+workspace Redis snapshots with 48-hour TTL: ranking data only, never ACL decisions. Autocomplete
+does not read it. The existing ES worker runs the daily workflow and refreshes both
+skill and agent documents, using the same evaluation timestamp and 30-day window.
+
+Install the schedule in each region after deployment:
+
+```sh
+tsx front/scripts/refresh_search_usage.ts --execute
+# Refresh one workspace immediately:
+tsx front/scripts/refresh_search_usage.ts --wId WORKSPACE_ID --execute
+```
+
+Create the registered `skills` index and run `backfill_skill_search.ts` before reader
+cutover. Completion means workflows finished and ES refreshed, not merely enqueued.
+Validate canonical counts/ACL parity before alias cutover; retain the old physical
+index. Local POC data was migrated from `front.skill_search` to `front.skills` this way.
+An existing local `front.skills_1` also needs the additive `resource_id` alias and
+`metadata` mapping before the shared reader/indexer runs; reindex its canonical documents
+to populate metadata. The reader can hydrate missing legacy metadata from its existing
+validation projection during that backfill, without adding a second DB fetch.
+
+The existing backfill command now also accepts `--resourceType agent`; its default
+and `--fromSkillModelId` resume option remain compatible. Agent pagination uses the
+stable identity key, with `--fromAgentModelId` for resuming. For example:
+
+```sh
+tsx front/scripts/create_elasticsearch_index.ts --indexName agents --execute
+tsx front/scripts/backfill_skill_search.ts --resourceType agent --wId WORKSPACE_ID --execute
+```
+
+Workspace hard deletion/scrub removes agent documents too. Relocation clears and
+rebuilds the agent index in the destination region, protected by a workflow patch
+marker for existing executions. Agent backfill includes inactive identities so the
+same projector workflow can delete stale documents. Orphaned identities still need
+workspace reconciliation.
+
+There is no transactional outbox. A lost launch can leave hidden/stale data until
+another mutation or repair. Eventual visibility, a few hundred readable pods, and
+acceptable wildcard cost remain hypotheses to validate against production SLOs,
+not authorization exceptions.

--- a/front/scripts/add_agent_favorites.ts
+++ b/front/scripts/add_agent_favorites.ts
@@ -1,9 +1,7 @@
-import { AgentUserRelationModel } from "@app/lib/models/agent/agent";
-import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { Authenticator } from "@app/lib/auth";
+import { AgentUserRelationResource } from "@app/lib/resources/agent_user_relation_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { makeScript } from "@app/scripts/helpers";
-import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 
 makeScript(
   {
@@ -28,82 +26,23 @@ makeScript(
       return;
     }
 
-    // Get all active members of the workspace
-    const { memberships } = await MembershipResource.getActiveMemberships({
-      workspace: renderLightWorkspaceType({ workspace }),
-    });
-
-    // Parse agent names
-    const agents = agentConfigurationIds.split(",").map((sid) => sid.trim());
-
-    // Check if all agents exist by looking up in AgentConfiguration and GlobalAgentSettings
-    for (const agentConfigurationId of agents) {
-      // Skip check for global agents
-      if (agentConfigurationId in GLOBAL_AGENTS_SID) {
-        continue;
-      }
-
-      const agentRelation = await AgentUserRelationModel.findOne({
-        where: {
-          workspaceId: workspace.id,
-          agentConfiguration: agentConfigurationId,
-        },
-      });
-
-      if (!agentRelation) {
-        logger.error(
-          { agentConfigurationId },
-          "Agent configuration not found in workspace"
-        );
-        return;
-      }
-    }
-
-    logger.info(
-      { wId, agents, memberCount: memberships.length },
-      "Adding agent favorites"
-    );
-
-    if (!execute) {
-      return;
-    }
-
-    // For each member and agent combination
-    for (const membership of memberships) {
-      for (const agentConfigurationId of agents) {
-        // Check if relation already exists
-        const [, created] = await AgentUserRelationModel.findOrCreate({
-          where: {
-            workspaceId: workspace.id,
-            userId: membership.userId,
-            agentConfiguration: agentConfigurationId,
-          },
-          defaults: {
-            workspaceId: workspace.id,
-            userId: membership.userId,
-            agentConfiguration: agentConfigurationId,
-            favorite: true,
-          },
-        });
-
-        if (created) {
-          logger.info(
-            {
-              userId: membership.userId,
-              agentConfigurationId,
-            },
-            "Created agent favorite"
-          );
-        } else {
-          logger.info(
-            {
-              userId: membership.userId,
-              agentConfigurationId,
-            },
-            "Agent relation already exists - skipping"
-          );
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const agentIds = [
+      ...new Set(agentConfigurationIds.split(",").map((id) => id.trim())),
+    ];
+    const result =
+      await AgentUserRelationResource.addMissingFavoritesForWorkspaceMembers(
+        auth,
+        {
+          agentIds,
+          dryRun: !execute,
         }
-      }
-    }
+      );
+    logger.info(
+      { wId, agentIds, execute, ...result },
+      execute
+        ? "Added missing agent favorites"
+        : "Agent favorite backfill dry run"
+    );
   }
 );

--- a/front/scripts/delete_agents_by_author.ts
+++ b/front/scripts/delete_agents_by_author.ts
@@ -1,130 +1,7 @@
 import { Authenticator } from "@app/lib/auth";
-import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
-import {
-  AgentChildAgentConfigurationModel,
-  AgentMCPServerConfigurationModel,
-} from "@app/lib/models/agent/actions/mcp";
-import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
-import {
-  AgentConfigurationModel,
-  AgentUserRelationModel,
-} from "@app/lib/models/agent/agent";
-import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
-import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
-import { GroupResource } from "@app/lib/resources/group_resource";
-import { AgentMemoryModel } from "@app/lib/resources/storage/models/agent_memories";
+import { AgentResource } from "@app/lib/resources/agent_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
-import { Op } from "sequelize";
-
-async function deleteAgentAndRelatedResources(
-  auth: Authenticator,
-  agent: AgentConfigurationModel,
-  logger: Logger,
-  execute: boolean
-): Promise<boolean> {
-  const workspaceId = auth.getNonNullableWorkspace().id;
-
-  logger.info(
-    { agentId: agent.sId, agentModelId: agent.id, agentName: agent.name },
-    "Processing agent for deletion"
-  );
-
-  if (!execute) {
-    return true;
-  }
-
-  // 1. Delete MCP server configurations and their children
-  const mcpServerConfigurations =
-    await AgentMCPServerConfigurationModel.findAll({
-      where: {
-        agentConfigurationId: agent.id,
-        workspaceId,
-      },
-    });
-
-  if (mcpServerConfigurations.length > 0) {
-    const mcpIds = mcpServerConfigurations.map((r) => r.id);
-
-    await AgentDataSourceConfigurationModel.destroy({
-      where: {
-        mcpServerConfigurationId: { [Op.in]: mcpIds },
-      },
-    });
-
-    await AgentTablesQueryConfigurationTableModel.destroy({
-      where: {
-        mcpServerConfigurationId: { [Op.in]: mcpIds },
-      },
-    });
-
-    await AgentChildAgentConfigurationModel.destroy({
-      where: {
-        mcpServerConfigurationId: { [Op.in]: mcpIds.map((id) => `${id}`) },
-        workspaceId,
-      },
-    });
-
-    await AgentMCPServerConfigurationModel.destroy({
-      where: {
-        agentConfigurationId: agent.id,
-        workspaceId,
-      },
-    });
-  }
-
-  // 2. Delete user relations (favorites, etc.)
-  await AgentUserRelationModel.destroy({
-    where: {
-      agentConfiguration: agent.sId,
-    },
-  });
-
-  // 3. Delete tag associations
-  await TagAgentModel.destroy({
-    where: {
-      agentConfigurationId: agent.id,
-      workspaceId,
-    },
-  });
-
-  // 4. Delete agent memories
-  await AgentMemoryModel.destroy({
-    where: {
-      agentConfigurationId: agent.sId,
-      workspaceId,
-    },
-  });
-
-  // 5. Delete agent skills
-  await AgentSkillModel.destroy({
-    where: {
-      agentConfigurationId: agent.id,
-      workspaceId,
-    },
-  });
-
-  // 6. Delete editor group (if exists)
-  const group = await GroupResource.fetchByAgentConfiguration({
-    auth,
-    agentConfiguration: agent,
-    isDeletionFlow: true,
-  });
-  if (group) {
-    await group.delete(auth);
-  }
-
-  // 7. Finally delete the agent configuration itself
-  await agent.destroy();
-
-  logger.info(
-    { agentId: agent.sId, agentModelId: agent.id },
-    "Successfully deleted agent"
-  );
-
-  return true;
-}
 
 makeScript(
   {
@@ -135,7 +12,8 @@ makeScript(
     },
     userId: {
       type: "number",
-      description: "The numeric user ID (authorId) whose agents to delete",
+      description:
+        "The numeric user ID (authorId) whose agent versions to delete",
       demandOption: true,
     },
   },
@@ -147,42 +25,23 @@ makeScript(
     }
 
     const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
-
-    // Find all agents authored by this user in this workspace
-    const agents = await AgentConfigurationModel.findAll({
-      where: {
-        workspaceId: workspace.id,
-        authorId: userId,
-      },
-    });
-
-    if (agents.length === 0) {
-      logger.info(
-        { workspaceId, userId },
-        "No agents found for this user in this workspace"
-      );
-      return;
-    }
-
-    logger.info(
-      { workspaceId, userId, agentCount: agents.length },
-      `Found ${agents.length} agent(s) to delete`
-    );
-
-    for (const agent of agents) {
-      await deleteAgentAndRelatedResources(auth, agent, logger, execute);
-    }
+    const { configurationCount, agentIds } =
+      await AgentResource.deleteConfigurationsByAuthor(auth, {
+        authorModelId: userId,
+        dryRun: !execute,
+      });
 
     logger.info(
       {
         workspaceId,
         userId,
-        totalAgents: agents.length,
+        configurationCount,
+        agentIds,
         dryRun: !execute,
       },
       execute
-        ? `Completed: deleted ${agents.length} agents`
-        : `Dry run: would delete ${agents.length} agents`
+        ? "Deleted agent configuration versions authored by the user"
+        : "Dry run: agent configuration versions selected for deletion"
     );
   }
 );

--- a/front/scripts/fix_orphaned_space_ids_in_agent_configurations.ts
+++ b/front/scripts/fix_orphaned_space_ids_in_agent_configurations.ts
@@ -1,130 +1,43 @@
-import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
-import { frontSequelize } from "@app/lib/resources/storage";
+import { Authenticator } from "@app/lib/auth";
+import { AgentResource } from "@app/lib/resources/agent_resource";
 import { makeScript } from "@app/scripts/helpers";
-import { QueryTypes } from "sequelize";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 
-interface AgentWithOrphanedSpaces {
-  id: number;
-  sId: string;
-  version: number;
-  createdAt: Date;
-  workspaceId: number;
-  allRequestedSpaceIds: number[];
-  orphanedSpaceIds: number[];
-}
-
-makeScript({}, async ({ execute }, logger) => {
-  // Find all agent configurations with orphaned space IDs
-  const agentsWithOrphanedSpaces =
-    // biome-ignore lint/plugin/noRawSql: script uses raw SQL for complex query
-    await frontSequelize.query<AgentWithOrphanedSpaces>(
-      `
-      WITH agent_with_orphaned_spaces AS (
-        SELECT 
-          ac.id,
-          ac."sId",
-          ac.version,
-          ac."createdAt",
-          ac."workspaceId",
-          ac."requestedSpaceIds" AS "allRequestedSpaceIds",
-          array_agg(DISTINCT orphaned_id) AS "orphanedSpaceIds"
-        FROM agent_configurations ac
-        CROSS JOIN LATERAL unnest(ac."requestedSpaceIds") AS orphaned_id
-        WHERE NOT EXISTS (
-          SELECT 1 
-          FROM vaults v 
-          WHERE v.id = orphaned_id AND v."deletedAt" IS NULL
-        )
-        AND ac.status = 'active'
-        GROUP BY ac.id, ac."sId", ac.version, ac."workspaceId", ac."requestedSpaceIds"
-      )
-      SELECT * FROM agent_with_orphaned_spaces
-      ORDER BY "workspaceId", "sId", version
-      `,
-      { type: QueryTypes.SELECT }
-    );
-
-  const totalCount = agentsWithOrphanedSpaces.length;
-
-  logger.info(
-    { totalCount, execute },
-    execute
-      ? `Found ${totalCount} agent configurations with orphaned space IDs`
-      : `Would fix ${totalCount} agent configurations with orphaned space IDs (dry run)`
-  );
-
-  if (totalCount === 0) {
-    logger.info("No agent configurations to fix");
-    return;
-  }
-
-  let updatedCount = 0;
-  let errorCount = 0;
-
-  for (const agent of agentsWithOrphanedSpaces) {
-    // Filter out orphaned space IDs
-    // orphanedSpaceIds should never be null due to the query, but handle it safely
-    const orphanedIds = agent.orphanedSpaceIds || [];
-    const validSpaceIds = agent.allRequestedSpaceIds.filter(
-      (spaceId) => !orphanedIds.includes(spaceId)
-    );
-
-    logger.info(
-      {
-        agentId: agent.sId,
-        agentVersion: agent.version,
-        workspaceId: agent.workspaceId,
-        originalSpaceIds: agent.allRequestedSpaceIds,
-        orphanedSpaceIds: orphanedIds,
-        newSpaceIds: validSpaceIds,
-        execute,
-      },
-      execute
-        ? "Updating agent configuration to remove orphaned space IDs"
-        : "[DRY RUN] Would update agent configuration to remove orphaned space IDs"
-    );
-
-    if (execute) {
-      try {
-        await AgentConfigurationModel.update(
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      description: "Optionally repair a single workspace.",
+    },
+  },
+  async ({ execute, workspaceId }, logger) => {
+    let configurationCount = 0;
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        const auth = await Authenticator.internalAdminForWorkspace(
+          workspace.sId
+        );
+        const result = await AgentResource.repairOrphanedSpaceRequirements(
+          auth,
           {
-            requestedSpaceIds: validSpaceIds,
-          },
-          {
-            where: {
-              id: agent.id,
-              workspaceId: agent.workspaceId,
-            },
-            hooks: false,
-            silent: true,
+            dryRun: !execute,
           }
         );
-        updatedCount++;
-      } catch (error) {
-        logger.error(
-          {
-            agentId: agent.sId,
-            agentVersion: agent.version,
-            error: error instanceof Error ? error.message : String(error),
-          },
-          "Failed to update agent configuration"
-        );
-        errorCount++;
-      }
-    } else {
-      updatedCount++;
-    }
+        configurationCount += result.configurationCount;
+        if (result.configurationCount > 0) {
+          logger.info(
+            { workspaceId: workspace.sId, ...result, dryRun: !execute },
+            execute
+              ? "Repaired orphaned agent space requirements"
+              : "Dry run: found orphaned agent space requirements"
+          );
+        }
+      },
+      { wId: workspaceId }
+    );
+    logger.info(
+      { configurationCount, dryRun: !execute },
+      "Agent space repair completed"
+    );
   }
-
-  logger.info(
-    {
-      totalCount,
-      updated: updatedCount,
-      errors: errorCount,
-      execute,
-    },
-    execute
-      ? `Migration completed: updated ${updatedCount} agent configurations`
-      : `Dry run completed: would have updated ${totalCount} agent configurations`
-  );
-});
+);

--- a/front/scripts/remove_draft_agent_configurations.ts
+++ b/front/scripts/remove_draft_agent_configurations.ts
@@ -1,147 +1,7 @@
-import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
-import {
-  AgentChildAgentConfigurationModel,
-  AgentMCPServerConfigurationModel,
-} from "@app/lib/models/agent/actions/mcp";
-import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
-import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
-import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
-import { MentionModel } from "@app/lib/models/agent/conversation";
-import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { renderLightWorkspaceType } from "@app/lib/workspace";
-import type { Logger } from "@app/logger/logger";
+import { Authenticator } from "@app/lib/auth";
+import { AgentResource } from "@app/lib/resources/agent_resource";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
-import type { LightWorkspaceType } from "@app/types/user";
-
-/**
- * Destroys a draft agent configuration and all associated configurations.
- * Avoids using transactions to prevent locks.
- * Deletes the agent configuration last, allowing retries if deletion fails.
- *
- * /!\ Only deletes draft agent configuration if it hasn't been used in any messages.
- */
-async function deleteDraftAgentConfigurationAndRelatedResources(
-  workspace: LightWorkspaceType,
-  agent: AgentConfigurationModel,
-  logger: Logger,
-  execute: boolean
-): Promise<boolean> {
-  if (agent.status !== "draft") {
-    logger.info(`Agent ${agent.sId} is not in draft status. Skipping.`);
-    return false;
-  }
-
-  // Only deletes draft agent configuration without mentions.
-  const hasAtLeastOneMention = await MentionModel.findOne({
-    where: {
-      workspaceId: workspace.id,
-      agentConfigurationId: agent.sId,
-    },
-  });
-  if (hasAtLeastOneMention) {
-    logger.info(`Agent ${agent.sId} has related messages. Skipping.`);
-
-    return false;
-  }
-
-  // If in dry run, return early.
-  if (!execute) {
-    return true;
-  }
-
-  const mcpServerConfigurations =
-    await AgentMCPServerConfigurationModel.findAll({
-      where: {
-        agentConfigurationId: agent.id,
-      },
-    });
-
-  await AgentDataSourceConfigurationModel.destroy({
-    where: {
-      mcpServerConfigurationId: mcpServerConfigurations.map((r) => r.id),
-    },
-  });
-
-  await AgentTablesQueryConfigurationTableModel.destroy({
-    where: {
-      mcpServerConfigurationId: mcpServerConfigurations.map((r) => r.id),
-    },
-  });
-
-  await AgentChildAgentConfigurationModel.destroy({
-    where: {
-      mcpServerConfigurationId: mcpServerConfigurations.map((r) => r.id),
-    },
-  });
-
-  await TagAgentModel.destroy({
-    where: {
-      agentConfigurationId: agent.id,
-    },
-  });
-
-  await AgentSkillModel.destroy({
-    where: {
-      agentConfigurationId: agent.id,
-    },
-  });
-
-  // Finally delete the agent configuration.
-  await AgentConfigurationModel.destroy({
-    where: {
-      id: agent.id,
-    },
-  });
-
-  return true;
-}
-
-async function removeDraftAgentConfigurationsForWorkspace(
-  workspace: LightWorkspaceType,
-  logger: Logger,
-  execute: boolean
-) {
-  let nbAgentsDeleted = 0;
-
-  const draftAgents = await AgentConfigurationModel.findAll({
-    where: {
-      workspaceId: workspace.id,
-      status: "draft",
-    },
-    attributes: ["id", "sId", "status"],
-  });
-
-  if (draftAgents.length === 0) {
-    logger.info(
-      `No draft agents found for workspace(${workspace.sId}). Skipping.`
-    );
-    return;
-  }
-
-  logger.info(
-    `Found ${draftAgents.length} draft agents for workspace(${workspace.sId}).`
-  );
-
-  for (const agent of draftAgents) {
-    const isDeleted = await deleteDraftAgentConfigurationAndRelatedResources(
-      workspace,
-      agent,
-      logger,
-      execute
-    );
-
-    if (isDeleted) {
-      nbAgentsDeleted++;
-      logger.info(`Agent ${agent.sId} has been deleted.`);
-    }
-  }
-
-  logger.info(
-    `Deleted ${nbAgentsDeleted}/${draftAgents.length} draft agents for workspace(${workspace.sId}).`
-  );
-}
 
 makeScript(
   {
@@ -155,27 +15,26 @@ makeScript(
       description: "A single workspace id.",
     },
   },
-  async ({ workspaceId, execute }, logger) => {
-    if (workspaceId) {
-      const workspace = await WorkspaceResource.fetchById(workspaceId);
-      if (!workspace) {
-        logger.info({ workspaceId }, "Workspace not found!");
-        return;
-      }
-
-      return removeDraftAgentConfigurationsForWorkspace(
-        renderLightWorkspaceType({ workspace }),
-        logger,
-        execute
-      );
-    }
-
-    return runOnAllWorkspaces(async (workspace) => {
-      await removeDraftAgentConfigurationsForWorkspace(
-        workspace,
-        logger,
-        execute
-      );
-    });
+  async ({ workspaceId, execute, concurrency }, logger) => {
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        const auth = await Authenticator.internalAdminForWorkspace(
+          workspace.sId
+        );
+        const result = await AgentResource.deleteUnusedDraftConfigurations(
+          auth,
+          {
+            dryRun: !execute,
+          }
+        );
+        logger.info(
+          { workspaceId: workspace.sId, ...result, dryRun: !execute },
+          execute
+            ? "Deleted unused draft agent configurations"
+            : "Dry run: selected unused draft agent configurations"
+        );
+      },
+      { wId: workspaceId, concurrency }
+    );
   }
 );

--- a/front/scripts/update_agent_requested_group_and_space_ids.ts
+++ b/front/scripts/update_agent_requested_group_and_space_ids.ts
@@ -1,193 +1,13 @@
-import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import { getAgentConfigurationRequirementsFromCapabilities } from "@app/lib/api/assistant/permissions";
 import { Authenticator } from "@app/lib/auth";
-import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
-import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import type { Logger } from "@app/logger/logger";
+import { AgentResource } from "@app/lib/resources/agent_resource";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
-import isEqual from "lodash/isEqual";
-import type { WhereOptions } from "sequelize";
-
-async function updateAgentRequestedSpaceIds(
-  workspaceId: string,
-  execute: boolean,
-  logger: Logger,
-  options: {
-    onlyActive?: boolean;
-    agentIds?: string[];
-  } = {}
-) {
-  const workspace = await WorkspaceResource.fetchById(workspaceId);
-  if (!workspace) {
-    throw new Error(`Workspace not found: ${workspaceId}`);
-  }
-
-  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId, {
-    dangerouslyRequestAllGroups: true,
-  });
-
-  logger.info(
-    {
-      workspaceId,
-      workspaceName: workspace.name,
-    },
-    "Starting requestedSpaceIds update for workspace"
-  );
-
-  // Build where clause
-  const whereClause: WhereOptions<AgentConfigurationModel> = {
-    workspaceId: workspace.id,
-  };
-
-  if (options.onlyActive) {
-    whereClause.status = "active";
-  }
-
-  if (options.agentIds && options.agentIds.length > 0) {
-    whereClause.sId = options.agentIds;
-  }
-
-  // Fetch all agent configurations that match the criteria
-  // Note: We filter out global agents as they may reference cross-workspace resources
-  const agentConfigurations = await AgentConfigurationModel.findAll({
-    where: {
-      ...whereClause,
-      scope: ["workspace", "published", "hidden", "visible"],
-    },
-    order: [["createdAt", "DESC"]],
-  });
-
-  logger.info(
-    {
-      totalAgents: agentConfigurations.length,
-      onlyActive: options.onlyActive,
-    },
-    "Found agent configurations"
-  );
-
-  let updatedCount = 0;
-  let skippedCount = 0;
-  let errorCount = 0;
-
-  for (const agent of agentConfigurations) {
-    // Get the full agent configuration with actions
-    // Using dangerouslyRequestAllGroups auth ensures we can access all agents
-    const agentConfiguration = await getAgentConfiguration(auth, {
-      agentId: agent.sId,
-      agentVersion: agent.version,
-      variant: "full",
-    });
-
-    if (!agentConfiguration) {
-      logger.warn(
-        { agentId: agent.sId, agentName: agent.name },
-        "Agent configuration not found, skipping"
-      );
-      errorCount++;
-      continue;
-    }
-
-    // Calculate the correct group IDs from actions
-    // Note: You may see workspace_isolation_violation warnings in logs - these are benign
-    // monitoring warnings, not actual errors. The auth parameter ensures proper scoping.
-    const newRequirements =
-      await getAgentConfigurationRequirementsFromCapabilities(auth, {
-        actions: agentConfiguration.actions,
-        skills: [],
-      });
-
-    const currentRequestedSpaceIds = agentConfiguration.requestedSpaceIds.map(
-      (spaceSId) => {
-        const modelId = getResourceIdFromSId(spaceSId);
-        if (modelId === null) {
-          throw new Error(
-            `Invalid space sId: ${spaceSId} for agent ${agent.sId}`
-          );
-        }
-        return modelId;
-      }
-    );
-
-    // Normalize the arrays for comparison
-    const newSpaceIds = newRequirements.requestedSpaceIds;
-
-    // Check if the group IDs have changed
-    if (isEqual(newSpaceIds.sort(), currentRequestedSpaceIds.sort())) {
-      logger.info(
-        {
-          agentId: agent.sId,
-          agentName: agent.name,
-        },
-        "Agent group IDs are already up to date, skipping"
-      );
-      skippedCount++;
-      continue;
-    }
-
-    logger.info(
-      {
-        agentId: agent.sId,
-        agentName: agent.name,
-        newSpaceIds: newSpaceIds,
-        currentSpaceIds: currentRequestedSpaceIds,
-        execute,
-      },
-      execute
-        ? "Updating agent requestedSpaceIds"
-        : "[DRY RUN] Would update agent requestedSpaceIds"
-    );
-
-    if (execute) {
-      await AgentConfigurationModel.update(
-        {
-          requestedSpaceIds: newSpaceIds,
-        },
-        {
-          where: {
-            sId: agent.sId,
-            version: agent.version,
-            workspaceId: workspace.id,
-          },
-          hooks: false,
-          silent: true,
-        }
-      );
-      updatedCount++;
-    } else {
-      updatedCount++;
-    }
-  }
-
-  logger.info(
-    {
-      workspaceId,
-      totalAgents: agentConfigurations.length,
-      updated: updatedCount,
-      skipped: skippedCount,
-      errors: errorCount,
-      execute,
-    },
-    execute
-      ? "Completed requestedSpaceIds update"
-      : "[DRY RUN] Completed requestedSpaceIds dry run"
-  );
-
-  return {
-    total: agentConfigurations.length,
-    updated: updatedCount,
-    skipped: skippedCount,
-    errors: errorCount,
-  };
-}
 
 makeScript(
   {
     workspaceId: {
       type: "string",
       description: "The workspace ID (sId) to update agents for",
-      required: false,
     },
     onlyActive: {
       type: "boolean",
@@ -198,27 +18,31 @@ makeScript(
       type: "array",
       default: [],
       description:
-        "Optional list of specific agent IDs to update. If empty, updates all agents in workspace.",
+        "Optional agent IDs. If empty, rebuild all agents in the workspace.",
     },
   },
   async ({ workspaceId, execute, onlyActive, agentIds }, logger) => {
-    if (workspaceId) {
-      // Process specific workspace
-      await updateAgentRequestedSpaceIds(workspaceId, execute, logger, {
-        onlyActive,
-        agentIds: agentIds.map(String),
-      });
-    } else {
-      // Process all workspaces
-      await runOnAllWorkspaces(
-        async (workspace) => {
-          await updateAgentRequestedSpaceIds(workspace.sId, execute, logger, {
-            onlyActive,
-            agentIds: agentIds.map(String),
-          });
-        },
-        { concurrency: 3 }
-      );
-    }
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        const auth = await Authenticator.internalAdminForWorkspace(
+          workspace.sId,
+          {
+            dangerouslyRequestAllGroups: true,
+          }
+        );
+        const result = await AgentResource.rebuildSpaceRequirements(auth, {
+          onlyActive,
+          agentIds: agentIds.map(String),
+          dryRun: !execute,
+        });
+        logger.info(
+          { workspaceId: workspace.sId, ...result, dryRun: !execute },
+          execute
+            ? "Rebuilt agent space requirements"
+            : "Dry run: agent space requirements"
+        );
+      },
+      { wId: workspaceId, concurrency: 3 }
+    );
   }
 );


### PR DESCRIPTION
## Description

Agent maintenance scripts must use the same mutation paths as the application so repairs and deletions also update search. Route favorite backfill, author/draft deletion, orphan repair, and space-requirement rebuilding through the resource methods introduced in #32109, preserving dry runs and workspace scoping.

Update the search README with the final mappings, permissions, ranking/pagination, mutation coverage, and rollout/repair instructions.

## Tests

- Resource tests cover dry runs, workspace isolation, preservation, and indexation.
- Smoke-tested the script entrypoints locally without `--execute`.

## Risk

- Medium. Operator scripts can mutate or delete configurations when explicitly executed.

## Deploy Plan

- Use these scripts after deploying the resource/search stack.
