### PR TITLE
Put review requests first in Slack notifications

### DIFF
--- a/.github/actions/review-bot/README.md
+++ b/.github/actions/review-bot/README.md
@@ -23,13 +23,13 @@ for review requests GitHub rejects with a validation error, while still sending 
 Each eligible request also posts to `#engineering_pr_reviews` (`C09GELMTTRT`):
 
 ```text
-@requester: https://github.com/dust-tt/dust/pull/123
-r? @reviewer please take a look
+r? @reviewer please take a look https://github.com/dust-tt/dust/pull/123 (from: @requester)
 ```
 
 The requester and reviewer handles become real Slack mentions through `.authors` email mappings
 and Slack's `users.lookupByEmail`. Unmapped handles remain plain text. Only request lines are
-forwarded, with trailing prose preserved; other PR description or comment text is omitted.
+forwarded, each followed by the PR URL and requester on the same line. Trailing prose is preserved;
+other PR description or comment text is omitted.
 Slack delivery errors fail the workflow so rejected notifications are visible in the run logs.
 
 The workflow uses `GITHUB_TOKEN` and the existing `SLACK_BOT_TOKEN`, and loads this action from the

--- a/.github/actions/review-bot/review-bot.ts
+++ b/.github/actions/review-bot/review-bot.ts
@@ -231,9 +231,9 @@ function escapeSlackText(text: string): string {
 
 /**
  * @cc [label:product] review-request-slack-format
- * Format an eligible request as the requester mention and PR URL, followed by its `r?` lines with
- * trailing prose preserved. Resolve requester and reviewer mentions through `.authors` emails and
- * Slack user lookup; unresolved handles remain plain text.
+ * Format each eligible `r?` line with trailing prose preserved, followed by the PR URL and
+ * `(from: @requester)` on the same line. Resolve requester and reviewer mentions through `.authors`
+ * emails and Slack user lookup; unresolved handles remain plain text.
  */
 /**
  * @cc [label:error-handling] review-request-slack-delivery
@@ -325,5 +325,10 @@ export async function formatSlackNotification({
       (mention) => mentions.get(mention.slice(1).toLowerCase()) ?? mention
     )
   );
-  return `${requester}: ${escapeSlackText(notification.prUrl)}\n${lines.join("\n")}`;
+  return lines
+    .map(
+      (line) =>
+        `${line} ${escapeSlackText(notification.prUrl)} (from: ${requester})`
+    )
+    .join("\n");
 }


### PR DESCRIPTION
## Description

Put each Slack review request on one line: `r? @reviewer <request text> {PR_URL} (from: @requester)`. Preserve the original request text and resolve both users to actual Slack mentions. Update the formatting contract and README example.

r? @Fraggle PMRR

## Tests

Locally verified the updated Slack payload with mocked GitHub and Slack responses, including mention resolution, escaping, lookup fallbacks, and closed/merged PR requests.

## Risk

Low. Changes Slack message formatting.

## Deploy Plan

Merge to `main` to activate the updated action.
