### PR TITLE
Use req: for Slack review requesters

### DIFF
--- a/.github/actions/review-bot/README.md
+++ b/.github/actions/review-bot/README.md
@@ -24,7 +24,7 @@ for review requests GitHub rejects with a validation error, while still sending 
 Each eligible request also posts to `#engineering_pr_reviews` (`C09GELMTTRT`):
 
 ```text
-r? @reviewer please take a look https://github.com/dust-tt/dust/pull/123 (from: @requester)
+r? @reviewer please take a look https://github.com/dust-tt/dust/pull/123 (req:@requester)
 ```
 
 The requester and reviewer handles become real Slack mentions through `.authors` email mappings

--- a/.github/actions/review-bot/review-bot.ts
+++ b/.github/actions/review-bot/review-bot.ts
@@ -275,7 +275,7 @@ function escapeSlackText(text: string): string {
 /**
  * @cc [label:product] review-request-slack-format
  * Format each eligible `r?` line with trailing prose preserved, followed by the PR URL and
- * `(from: @requester)` on the same line. Resolve requester and reviewer mentions through `.authors`
+ * `(req:@requester)` on the same line. Resolve requester and reviewer mentions through `.authors`
  * emails and Slack user lookup; unresolved handles remain plain text.
  */
 /**
@@ -371,7 +371,7 @@ export async function formatSlackNotification({
   return lines
     .map(
       (line) =>
-        `${line} ${escapeSlackText(notification.prUrl)} (from: ${requester})`
+        `${line} ${escapeSlackText(notification.prUrl)} (req:${requester})`
     )
     .join("\n");
 }


### PR DESCRIPTION
## Description

Use `(req:@requester)` instead of `(from: @requester)` at the end of review-bot Slack notifications. Update the formatting contract and README example to match.

r? @davidebbo PMRR

## Tests

Manually checked formatter output with resolved Slack mentions and unmapped GitHub handles.

## Risk

Low. Notification wording only.

## Deploy Plan

Merge to main to activate the updated action.
