### PR TITLE
Move sandbox live databases dir to /sandbox-state/databases

### DIFF
--- a/cli/dust-sandbox/functions-runner/runner.ts
+++ b/cli/dust-sandbox/functions-runner/runner.ts
@@ -24,7 +24,7 @@ import { serve } from "./serve.ts";
 
 // Everything this process creates — including files the function body creates
 // itself — must stay group-writable. The shared sandbox directories are setgid
-// with a `g::rwx` default ACL (`/pod-state/databases`, `/files`), but a default
+// with a `g::rwx` default ACL (`/sandbox-state/databases`, `/files`), but a default
 // ACL only masks the mode a process asks for; it cannot add bits the umask
 // stripped. With the inherited 022/027 umask, a SQLite database a function
 // opens directly lands at 0644/0640 owned by `agent-proxied:agent`, and

--- a/cli/dust-sandbox/src/commands/db/mod.rs
+++ b/cli/dust-sandbox/src/commands/db/mod.rs
@@ -1,7 +1,7 @@
 //! `dsbx db` — pod database subcommands (reconcile/schema/list/query).
 //!
 //! Databases are per-pod SQLite files `{name}.db` under `$DUST_POD_DATABASES_DIR`
-//! (falling back to the image's `/pod-state/databases`). This Rust layer owns name
+//! (falling back to the image's `/sandbox-state/databases`). This Rust layer owns name
 //! validation and path resolution; the DDL/SQL
 //! work runs in the embedded Bun runner (same privilege-drop machinery as
 //! `dsbx function`: dropped to `agent-proxied` via `runuser` whenever dsbx runs as
@@ -33,7 +33,7 @@ pub(crate) use super::function::emit_error;
 /// an Option-typed `pod_databases_dir()` for `function run` — dedup onto a single shared
 /// definition (these here are the superset: PathBuf-typed helper + empty-value fallback).
 pub(crate) const POD_DATABASES_DIR_ENV: &str = "DUST_POD_DATABASES_DIR";
-pub(crate) const DEFAULT_POD_DATABASES_DIR: &str = "/pod-state/databases";
+pub(crate) const DEFAULT_POD_DATABASES_DIR: &str = "/sandbox-state/databases";
 
 #[derive(Subcommand)]
 pub enum DbCommand {

--- a/front/lib/api/sandbox/db.test.ts
+++ b/front/lib/api/sandbox/db.test.ts
@@ -49,11 +49,11 @@ describe("pod state helpers", () => {
 
   test("parses live database enumeration output", () => {
     const findOutput = [
-      "/pod-state/databases/chat.db",
-      "/pod-state/databases/tasks.db",
-      "/pod-state/databases/.restore-chat.db",
-      "/pod-state/databases/UPPER.db",
-      "/pod-state/databases/not-a-db.txt",
+      "/sandbox-state/databases/chat.db",
+      "/sandbox-state/databases/tasks.db",
+      "/sandbox-state/databases/.restore-chat.db",
+      "/sandbox-state/databases/UPPER.db",
+      "/sandbox-state/databases/not-a-db.txt",
     ].join("\n");
 
     expect(parseLiveDatabaseNames(findOutput)).toEqual(["chat", "tasks"]);

--- a/front/lib/api/sandbox/db.ts
+++ b/front/lib/api/sandbox/db.ts
@@ -24,11 +24,11 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 /**
- * Pod state runtime plumbing: SQLite databases under /pod-state/databases,
+ * Pod state runtime plumbing: SQLite databases under /sandbox-state/databases,
  * continuously replicated by a litestream daemon (running as dust-state) to a
  * gcsfuse-mounted GCS prefix at /sandbox-state/replica.
  *
- * The daemon runs litestream's directory watcher over /pod-state/databases
+ * The daemon runs litestream's directory watcher over /sandbox-state/databases
  * (static /etc/litestream.yml baked at image build): databases created at any
  * point — including publish-time `dsbx db reconcile` — are discovered and
  * replicated automatically within seconds. Replica subdirectories are named
@@ -425,7 +425,7 @@ async function startLitestreamDaemon(
 /**
  * Restart the litestream daemon: re-derive the managed set from what is live on disk right now.
  *
- * The directory watcher only enumerates /pod-state/databases at start, so a database whose live
+ * The directory watcher only enumerates /sandbox-state/databases at start, so a database whose live
  * files were just deleted stays open in the running daemon — free to keep writing to, and so
  * recreate, the replica prefix a delete is about to wipe. A restart is what makes the daemon let go
  * of it, and the static config (baked at image build) brings back every database that IS still live.
@@ -706,7 +706,7 @@ async function listLiveDatabases(
 
 /**
  * Live databases whose file content starts with the SQLite header magic.
- * /pod-state/databases is workload-writable by design, so enumeration output
+ * /sandbox-state/databases is workload-writable by design, so enumeration output
  * must be treated as untrusted: non-SQLite files are excluded from the
  * managed set (with a warning log) instead of being handed to litestream,
  * where they would fail every sync and wedge the pod's lifecycle. A valid

--- a/front/lib/api/sandbox/image/litestream/litestream.service
+++ b/front/lib/api/sandbox/image/litestream/litestream.service
@@ -15,18 +15,17 @@ SyslogIdentifier=litestream
 # Control socket directory (/run/litestream), created by systemd as
 # dust-state. The pre-sleep `litestream sync -wait` runs against the socket
 # in there; the socket is enabled by the static /etc/litestream.yml baked at
-# image build (directory-watcher config over /pod-state/databases).
+# image build (directory-watcher config over /sandbox-state/databases).
 RuntimeDirectory=litestream
 RuntimeDirectoryMode=0755
 
 # Defense in depth, modeled on dust-egress-resolver.service. The daemon only
-# needs rw under /pod-state (live databases) and /sandbox-state (replica
-# gcsfuse mount); the
-# control socket is AF_UNIX and the file replica needs no network.
+# needs rw under /sandbox-state (live databases and the replica gcsfuse
+# mount); the control socket is AF_UNIX and the file replica needs no network.
 NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectSystem=strict
-ReadWritePaths=/pod-state /sandbox-state
+ReadWritePaths=/sandbox-state
 ProtectHome=yes
 ProtectKernelTunables=yes
 ProtectKernelModules=yes

--- a/front/lib/api/sandbox/image/litestream/litestream.yml
+++ b/front/lib/api/sandbox/image/litestream/litestream.yml
@@ -21,7 +21,7 @@ socket:
 # ignored by the watcher (header validation). Replica subdirectories are
 # named by database FILENAME: /sandbox-state/replica/{db}.db/ltx/...
 dbs:
-  - dir: /pod-state/databases
+  - dir: /sandbox-state/databases
     pattern: "*.db"
     watch: true
     replica:

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base and sbx bedrock image tags", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.106",
+      tag: "0.8.107",
     });
     expect(getDustBaseImage().baseImage).toEqual({
       type: "docker",
@@ -563,14 +563,17 @@ describe("sandbox image registry", () => {
         expect.stringContaining(
           "useradd --system --no-create-home --gid dust-state --groups agent --shell /usr/sbin/nologin dust-state"
         ),
-        expect.stringContaining("install -d -o root -g root -m 755 /pod-state"),
-        expect.stringContaining(
-          "install -d -o dust-state -g agent -m 2770 /pod-state/databases"
-        ),
-        expect.stringContaining("setfacl -R -d -m g::rwx /pod-state/databases"),
-        expect.stringContaining("setfacl -R -m g::rwx /pod-state/databases"),
         expect.stringContaining(
           "install -d -o root -g root -m 755 /sandbox-state"
+        ),
+        expect.stringContaining(
+          "install -d -o dust-state -g agent -m 2770 /sandbox-state/databases"
+        ),
+        expect.stringContaining(
+          "setfacl -R -d -m g::rwx /sandbox-state/databases"
+        ),
+        expect.stringContaining(
+          "setfacl -R -m g::rwx /sandbox-state/databases"
         ),
         expect.stringContaining(
           "install -d -o dust-state -g dust-state -m 700 /sandbox-state/replica"
@@ -602,9 +605,7 @@ describe("sandbox image registry", () => {
     expect(litestreamUnit).toContain("RuntimeDirectory=litestream");
     expect(litestreamUnit).toContain("NoNewPrivileges=yes");
     expect(litestreamUnit).toContain("ProtectSystem=strict");
-    expect(litestreamUnit).toContain(
-      "ReadWritePaths=/pod-state /sandbox-state"
-    );
+    expect(litestreamUnit).toContain("ReadWritePaths=/sandbox-state");
     expect(litestreamUnit).toContain("RestrictAddressFamilies=AF_UNIX");
     expect(litestreamUnit).toContain("MemoryDenyWriteExecute=yes");
 
@@ -639,7 +640,7 @@ describe("sandbox image registry", () => {
 
     // Directory watcher: post-cold-start databases are discovered
     // automatically; the replica subdir is named by db FILENAME ({db}.db).
-    expect(litestreamConfig).toContain("dir: /pod-state/databases");
+    expect(litestreamConfig).toContain("dir: /sandbox-state/databases");
     expect(litestreamConfig).toContain('pattern: "*.db"');
     expect(litestreamConfig).toContain("watch: true");
     expect(litestreamConfig).toContain("type: file");

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,7 +26,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.11.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.106";
+const DUST_BASE_IMAGE_VERSION = "0.8.107";
 const DSBX_CLI_VERSION = "0.1.57";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
@@ -234,7 +234,7 @@ function getDustStateUserSetupCommand(): string {
 }
 
 function getPodStateSetupCommand(): string {
-  // /pod-state/databases holds the live SQLite files: both agent-proxied
+  // /sandbox-state/databases holds the live SQLite files: both agent-proxied
   // function code (group agent) and the litestream daemon (user dust-state)
   // need rw, so it gets the same setgid + default-ACL treatment as /files.
   // /sandbox-state/replica is the gcsfuse mount point for the litestream replica
@@ -242,11 +242,10 @@ function getPodStateSetupCommand(): string {
   // or tamper with it, so the directory is dust-state-only: 0700 here, no
   // allow_other on the runtime mount.
   return [
-    "install -d -o root -g root -m 755 /pod-state",
-    "install -d -o dust-state -g agent -m 2770 /pod-state/databases",
-    "setfacl -R -d -m g::rwx /pod-state/databases",
-    "setfacl -R -m g::rwx /pod-state/databases",
     "install -d -o root -g root -m 755 /sandbox-state",
+    "install -d -o dust-state -g agent -m 2770 /sandbox-state/databases",
+    "setfacl -R -d -m g::rwx /sandbox-state/databases",
+    "setfacl -R -m g::rwx /sandbox-state/databases",
     "install -d -o dust-state -g dust-state -m 700 /sandbox-state/replica",
   ].join(" && ");
 }

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -889,7 +889,7 @@ describe("SandboxFunctionInvocationResource", () => {
     );
     expect(opts?.envVars).toMatchObject({
       DUST_FUNCTIONS_DIR: `/sandbox-functions/pods/${space.sId}`,
-      DUST_POD_DATABASES_DIR: "/pod-state/databases",
+      DUST_POD_DATABASES_DIR: "/sandbox-state/databases",
       DUST_POD_DATABASE_MAX_SIZE_BYTES: "1073741824",
       // Published outside an app folder, so its databases are unprefixed.
       DUST_POD_DATABASE_PREFIX: "",
@@ -973,7 +973,7 @@ describe("SandboxFunctionInvocationResource", () => {
     const execOptions = execSpy.mock.calls[0]?.[2];
     expect(execOptions?.envVars).toMatchObject({
       DUST_FRAME_PUBLICATION_DESCRIPTOR_PATH: `/frames/${frame.sId}/publications/${publicationId}/publication.json`,
-      DUST_POD_DATABASES_DIR: "/pod-state/databases",
+      DUST_POD_DATABASES_DIR: "/sandbox-state/databases",
       DUST_POD_DATABASE_MAX_SIZE_BYTES: "1073741824",
       DUST_POD_DATABASE_PREFIX: "",
       DUST_FUNCTIONS_DIR: `/frames/${frame.sId}/publications/${publicationId}/functions`,

--- a/front/scripts/sandbox_security_check.test.ts
+++ b/front/scripts/sandbox_security_check.test.ts
@@ -206,9 +206,8 @@ describe("sandbox security check assertions", () => {
 
   test("detects unsafe pod-state directory ownership or modes", () => {
     const safeOutput = [
-      "POD_STATE_DIR=/pod-state root:root 755 drwxr-xr-x",
-      "POD_STATE_DIR=/pod-state/databases dust-state:agent 2770 drwxrws---",
       "POD_STATE_DIR=/sandbox-state root:root 755 drwxr-xr-x",
+      "POD_STATE_DIR=/sandbox-state/databases dust-state:agent 2770 drwxrws---",
       "POD_STATE_DIR=/sandbox-state/replica dust-state:dust-state 700 drwx------",
     ].join("\n");
 
@@ -224,16 +223,16 @@ describe("sandbox security check assertions", () => {
     expect(() =>
       assertPodStateDirsSafe(
         safeOutput.replace(
-          "/pod-state/databases dust-state:agent 2770",
-          "/pod-state/databases agent:agent 2770"
+          "/sandbox-state/databases dust-state:agent 2770",
+          "/sandbox-state/databases agent:agent 2770"
         )
       )
-    ).toThrow("pod-state directory /pod-state/databases");
+    ).toThrow("pod-state directory /sandbox-state/databases");
     expect(() =>
       assertPodStateDirsSafe(
-        "POD_STATE_DIR=/pod-state root:root 755 drwxr-xr-x"
+        "POD_STATE_DIR=/sandbox-state root:root 755 drwxr-xr-x"
       )
-    ).toThrow("missing pod-state directory audit for /pod-state/databases");
+    ).toThrow("missing pod-state directory audit for /sandbox-state/databases");
   });
 
   test("detects root PATH entries that can resolve agent-writable binaries", () => {

--- a/front/scripts/sandbox_security_check.ts
+++ b/front/scripts/sandbox_security_check.ts
@@ -824,9 +824,12 @@ export function assertRootInvokedHelpersSafe(output: string): void {
 }
 
 const POD_STATE_DIR_EXPECTATIONS = [
-  { path: "/pod-state", owner: "root:root", mode: "755" },
-  { path: "/pod-state/databases", owner: "dust-state:agent", mode: "2770" },
   { path: "/sandbox-state", owner: "root:root", mode: "755" },
+  {
+    path: "/sandbox-state/databases",
+    owner: "dust-state:agent",
+    mode: "2770",
+  },
   {
     path: "/sandbox-state/replica",
     owner: "dust-state:dust-state",
@@ -1166,8 +1169,8 @@ async function checkPodStateWorkloadAccess(
     providerId,
     `
 set -euo pipefail
-test -d /pod-state/databases
-proof=$(mktemp /pod-state/databases/dust-security-smoke-XXXXXX)
+test -d /sandbox-state/databases
+proof=$(mktemp /sandbox-state/databases/dust-security-smoke-XXXXXX)
 printf 'db-ok' > "$proof"
 test "$(cat "$proof")" = "db-ok"
 rm -f "$proof"

--- a/front/types/mount_path.ts
+++ b/front/types/mount_path.ts
@@ -139,11 +139,13 @@ export const SANDBOX_STATE_REPLICA_MOUNT_POINT = "/sandbox-state/replica";
 /**
  * Absolute in-sandbox path of the owner's live SQLite databases (`{name}.db` files opened by
  * `@dust/pod`'s `db()`). Local disk, not a gcsfuse mount — Litestream replicates it to GCS.
+ * Lives next to `SANDBOX_STATE_REPLICA_MOUNT_POINT` under the owner-neutral `/sandbox-state`
+ * root (`/pod-state/databases` was a remnant of the pre-Frame, Pod-only implementation).
  * Front is the only layer that hardcodes this location (the paths-env.v1 contract): it is
  * passed per exec to `dsbx function run` as `DUST_POD_DATABASES_DIR`, dsbx forwards it to
  * the bun child, and `@dust/pod` reads the env var — neither carries a fallback copy.
  */
-export const SANDBOX_STATE_DATABASES_DIR = "/pod-state/databases";
+export const SANDBOX_STATE_DATABASES_DIR = "/sandbox-state/databases";
 
 /**
  * Per-database size quota in bytes (1 GiB). The other half of the paths-env.v1 contract: like


### PR DESCRIPTION
## Summary

`SANDBOX_STATE_DATABASES_DIR` still pointed at `/pod-state/databases`, a remnant of the pre-Frame, Pod-only implementation. This moves it to `/sandbox-state/databases`, next to `/sandbox-state/replica`, under the owner-neutral `/sandbox-state` root, and removes the now-unused `/pod-state` root directory from the image.

Updated everywhere this path is hardcoded: the image build setup (`registry.ts`, bumping `DUST_BASE_IMAGE_VERSION` to `0.8.107` since the image layout changed), the baked-in litestream directory-watcher config and systemd unit, the security audit script's expectations and smoke test, the `front/lib/api/sandbox/db.ts` comments, and the `dsbx` CLI's fallback default in Rust. Matching tests were updated for each.

Note: this directory is baked into the sandbox VM image at build time, so need new image.

Fixes https://github.com/dust-tt/tasks/issues/10337