### PR TITLE
[connectors] fix: improve Microsoft auth errors handling in `retrievePermissions`

### DIFF
--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -31,6 +31,7 @@ import {
   populateDeltas,
   // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
 } from "@connectors/connectors/microsoft/temporal/activities";
+import { isGeneralExceptionError } from "@connectors/connectors/microsoft/temporal/cast_known_errors";
 import {
   launchMicrosoftFullSyncWorkflow,
   launchMicrosoftGarbageCollectionWorkflow,
@@ -329,10 +330,6 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
     return launchMicrosoftFullSyncWorkflow(this.connectorId);
   }
 
-  /**
-   * @cc [owner:aubin-tchoi,label:error-handling] permission-retrieval-auth-errors
-   * Graph HTTP 401 errors return `EXTERNAL_OAUTH_TOKEN_ERROR` regardless of the Graph error code.
-   */
   async retrievePermissions({
     parentInternalId,
     filterPermission,
@@ -485,12 +482,24 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
     } catch (e) {
       if (
         e instanceof ExternalOAuthTokenError ||
-        (e instanceof GraphError && e.statusCode === 401)
+        (e instanceof GraphError &&
+          e.statusCode === 401 &&
+          e.code === "accessDenied")
       ) {
         return new Err(
           new ConnectorManagerError(
             "EXTERNAL_OAUTH_TOKEN_ERROR",
             "Microsoft authorization error, please re-authorize."
+          )
+        );
+      }
+      // 401 generalException indicates site-level permission changes or revoked access.
+      // See https://learn.microsoft.com/en-us/answers/questions/5616949/receiving-general-exception-while-processing-when
+      if (isGeneralExceptionError(e)) {
+        return new Err(
+          new ConnectorManagerError(
+            "EXTERNAL_OAUTH_TOKEN_ERROR",
+            `Microsoft authorization error (general exception), re-authorize or check access (${e.message})`
           )
         );
       }

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -31,7 +31,6 @@ import {
   populateDeltas,
   // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
 } from "@connectors/connectors/microsoft/temporal/activities";
-import { isGeneralExceptionError } from "@connectors/connectors/microsoft/temporal/cast_known_errors";
 import {
   launchMicrosoftFullSyncWorkflow,
   launchMicrosoftGarbageCollectionWorkflow,
@@ -76,7 +75,7 @@ import {
   Ok,
   removeNulls,
 } from "@dust-tt/client";
-import { Client } from "@microsoft/microsoft-graph-client";
+import { Client, GraphError } from "@microsoft/microsoft-graph-client";
 import type { Site } from "@microsoft/microsoft-graph-types";
 import { decodeJwt } from "jose";
 
@@ -330,6 +329,10 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
     return launchMicrosoftFullSyncWorkflow(this.connectorId);
   }
 
+  /**
+   * @cc [owner:aubin-tchoi,label:error-handling] permission-retrieval-auth-errors
+   * Graph HTTP 401 errors return `EXTERNAL_OAUTH_TOKEN_ERROR` regardless of the Graph error code.
+   */
   async retrievePermissions({
     parentInternalId,
     filterPermission,
@@ -480,21 +483,14 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
       }
       return new Ok(nodesWithPermissions);
     } catch (e) {
-      if (e instanceof ExternalOAuthTokenError) {
+      if (
+        e instanceof ExternalOAuthTokenError ||
+        (e instanceof GraphError && e.statusCode === 401)
+      ) {
         return new Err(
           new ConnectorManagerError(
             "EXTERNAL_OAUTH_TOKEN_ERROR",
             "Microsoft authorization error, please re-authorize."
-          )
-        );
-      }
-      // 401 generalException indicates site-level permission changes or revoked access.
-      // See https://learn.microsoft.com/en-us/answers/questions/5616949/receiving-general-exception-while-processing-when
-      if (isGeneralExceptionError(e)) {
-        return new Err(
-          new ConnectorManagerError(
-            "EXTERNAL_OAUTH_TOKEN_ERROR",
-            `Microsoft authorization error (general exception), re-authorize or check access (${e.message})`
           )
         );
       }


### PR DESCRIPTION
## Description

Aims at fixing [this log](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20status%3Aerror%20%40dd.env%3Aprod%20%40dd.service%3Aconnectors&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAaCFesMMSabemQAAABhBYUNGZXRKT0FBQUhqSlJMbC1tRDVBQVcAAAAkMDFhMDg1N2EtZmRlMC00MDRhLThhMDItNDI1OWQ5YTU0NmVkAAAEcA&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1788945540000&to_ts=1788946140000&live=false).

Permission errors in Microsoft connectors are surfaced as unhandled errors in the `retrievePermissions`. This PR handles these as `EXTERNAL_OAUTH_TOKEN_ERROR` errors to avoid raising a monitor.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
