### PR TITLE
[connectors] fix: classify Graph authentication failures in Microsoft activities

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/cast_known_errors.test.ts
+++ b/connectors/src/connectors/microsoft/temporal/cast_known_errors.test.ts
@@ -1,4 +1,7 @@
-import { ThirdPartyConfigurationError } from "@connectors/lib/error";
+import {
+  ExternalOAuthTokenError,
+  ThirdPartyConfigurationError,
+} from "@connectors/lib/error";
 import { GraphError } from "@microsoft/microsoft-graph-client";
 import type {
   ActivityExecuteInput,
@@ -10,6 +13,41 @@ import { describe, expect, it, vi } from "vitest";
 import { MicrosoftCastKnownErrorsInterceptor } from "./cast_known_errors";
 
 describe("MicrosoftCastKnownErrorsInterceptor", () => {
+  it("classifies Graph authentication failures as OAuth errors and preserves the cause", async () => {
+    const error = new GraphError(
+      401,
+      "There has been an error authenticating the request."
+    );
+    error.code = "accessDenied";
+    const next = vi.fn(async () => {
+      throw error;
+    }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+
+    const result = new MicrosoftCastKnownErrorsInterceptor().execute(
+      { args: [], headers: {} } satisfies ActivityExecuteInput,
+      next
+    );
+
+    await expect(result).rejects.toBeInstanceOf(ExternalOAuthTokenError);
+    await expect(result).rejects.toHaveProperty("cause", error);
+  });
+
+  it.each([
+    404, 429, 503,
+  ])("preserves Graph %i failures for existing retry handling", async (statusCode) => {
+    const error = new GraphError(statusCode, "Microsoft Graph request failed");
+    const next = vi.fn(async () => {
+      throw error;
+    }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+
+    await expect(
+      new MicrosoftCastKnownErrorsInterceptor().execute(
+        { args: [], headers: {} } satisfies ActivityExecuteInput,
+        next
+      )
+    ).rejects.toBe(error);
+  });
+
   it("classifies a missing SharePoint license as a terminal configuration error", async () => {
     const error = new GraphError(400, "Tenant does not have a SPO license.");
     const next = vi.fn(async () => {

--- a/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
@@ -113,6 +113,11 @@ export function isJSONParsingError(err: unknown): err is Error {
 export class MicrosoftCastKnownErrorsInterceptor
   implements ActivityInboundCallsInterceptor
 {
+  /**
+   * @cc [owner:aubin-tchoi,label:error-handling] graph-authentication-failures
+   * Graph HTTP 401 errors escaping Microsoft activities are rethrown as
+   * `ExternalOAuthTokenError`, preserving the original Graph error as the cause.
+   */
   async execute(
     input: ActivityExecuteInput,
     next: Next<ActivityInboundCallsInterceptor, "execute">
@@ -126,6 +131,9 @@ export class MicrosoftCastKnownErrorsInterceptor
           nextRetryDelay: err.retryAfterMs,
           cause: err,
         });
+      }
+      if (err instanceof GraphError && err.statusCode === 401) {
+        throw new ExternalOAuthTokenError(err);
       }
       // See https://learn.microsoft.com/en-us/answers/questions/1339560/sign-in-error-code-50173
       // TODO(2025-02-12): add an error type for Microsoft client errors and catch them at strategic locations (e.g. API call to instantiate a client)

--- a/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
@@ -113,11 +113,6 @@ export function isJSONParsingError(err: unknown): err is Error {
 export class MicrosoftCastKnownErrorsInterceptor
   implements ActivityInboundCallsInterceptor
 {
-  /**
-   * @cc [owner:aubin-tchoi,label:error-handling] graph-authentication-failures
-   * Graph HTTP 401 errors escaping Microsoft activities are rethrown as
-   * `ExternalOAuthTokenError`, preserving the original Graph error as the cause.
-   */
   async execute(
     input: ActivityExecuteInput,
     next: Next<ActivityInboundCallsInterceptor, "execute">


### PR DESCRIPTION
## Description

Microsoft full syncs can repeatedly fail in `syncFiles` with `GraphError: There has been an error authenticating the request.`

Map unhandled Graph HTTP 401 responses to `ExternalOAuthTokenError` in the Microsoft activity interceptor. The existing monitoring then marks the connector as `oauth_token_revoked` and pauses it for reauthorization. Errors already handled inside activities, including `syncFiles`' site-level `generalException` case, keep their existing behavior.

## Tests

- Added regression coverage for Graph 401 classification, preservation of the original cause, and propagation of non-authentication Graph errors.

## Risk

- Low. Applies to unhandled Graph 401 errors across Microsoft activities.

## Deploy Plan

- Deploy connectors.
