### PR TITLE
feat(analytics): make the analyst panel greeting instant and free

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/analyst.ts
+++ b/front/lib/api/assistant/global_agents/configurations/analyst.ts
@@ -4,6 +4,7 @@ import type { Authenticator } from "@app/lib/auth";
 import type {
   AgentConfigurationType,
   AgentModelConfigurationType,
+  GlobalAgentContext,
 } from "@app/types/assistant/agent";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
@@ -11,11 +12,14 @@ import {
   AUTO_FAST_MODEL_CONFIG,
   AUTO_MODEL_CONFIG,
 } from "@app/types/assistant/models/auto";
+import { NOOP_MODEL_CONFIG } from "@app/types/assistant/models/noop";
 
 export function _getAnalystGlobalAgent({
   auth,
+  globalAgentContext,
 }: {
   auth: Authenticator;
+  globalAgentContext?: GlobalAgentContext;
 }): AgentConfigurationType {
   const prompt = `<primary_goal>
 You are @analyst, an analytics assistant for workspace admins and managers. You help them understand how their Dust workspace is being used by answering questions with data retrieved through your tools.
@@ -29,18 +33,30 @@ You are @analyst, an analytics assistant for workspace admins and managers. You 
 5. Be concise and lead with the answer; add brief context only when it helps interpretation.
 </guidelines>`;
 
-  // Standard auto stream for upgraded workspaces, Basic one otherwise. Both
-  // sentinels are resolved to a concrete model + effort at message-send time by
-  // resolveModel().
-  const modelConfiguration = auth.isUpgraded()
-    ? AUTO_MODEL_CONFIG
-    : AUTO_FAST_MODEL_CONFIG;
+  // Echoed as a NOOP static reply instead of running the LLM.
+  const staticReply = globalAgentContext?.staticReply;
+
+  const modelConfiguration = (() => {
+    if (staticReply) {
+      return NOOP_MODEL_CONFIG;
+    }
+
+    // Standard auto stream for upgraded workspaces, Basic one otherwise. Both
+    // sentinels are resolved to a concrete model + effort at message-send time by
+    // resolveModel().
+    return auth.isUpgraded() ? AUTO_MODEL_CONFIG : AUTO_FAST_MODEL_CONFIG;
+  })();
 
   const model: AgentModelConfigurationType = {
     providerId: modelConfiguration.providerId,
     modelId: modelConfiguration.modelId,
     temperature: 0.2,
     reasoningEffort: modelConfiguration.defaultReasoningEffort,
+    ...(staticReply && {
+      metaData: {
+        staticResponse: staticReply,
+      },
+    }),
   };
 
   const sId = GLOBAL_AGENTS_SID.ANALYST;

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -901,7 +901,7 @@ function getGlobalAgent({
       agentConfiguration = _getReinforcementGlobalAgent();
       break;
     case GLOBAL_AGENTS_SID.ANALYST:
-      agentConfiguration = _getAnalystGlobalAgent({ auth });
+      agentConfiguration = _getAnalystGlobalAgent({ auth, globalAgentContext });
       break;
     case GLOBAL_AGENTS_SID.NOOP:
       agentConfiguration = _getNoopAgent();

--- a/front/lib/api/assistant/static_reply.ts
+++ b/front/lib/api/assistant/static_reply.ts
@@ -4,6 +4,13 @@ import type {
 } from "@app/types/assistant/conversation";
 import { isReinforcedSkillNotificationMetadata } from "@app/types/assistant/conversation";
 
+export const ANALYTICS_PANEL_GREETING = `I can help you understand your workspace usage and costs across your analytics data.
+
+A few things you could ask:
+- Which agents are used the most?
+- How has my workspace's spend evolved over the last 30 days?
+- Who are my most active users?`;
+
 /**
  * Returns pre-formatted text that the Dust global agent should echo as its
  * NOOP static reply for this turn, or `undefined` to fall back to the normal
@@ -30,5 +37,14 @@ export function getStaticReplyForUserMessage({
   ) {
     return userMessage.content;
   }
+
+  // A constant rather than the message content, which here is the hidden bootstrap message.
+  if (
+    conversation.metadata?.origin === "analytics_panel" &&
+    userMessage.rank === 0
+  ) {
+    return ANALYTICS_PANEL_GREETING;
+  }
+
   return undefined;
 }

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -525,12 +525,18 @@ export type ConversationUrlAccessMode =
 
 const CONVERSATION_METADATA_URL_ACCESS_MODE_KEY = "urlAccessMode";
 
+export const CONVERSATION_ORIGINS = ["analytics_panel"] as const;
+
+export type ConversationOrigin = (typeof CONVERSATION_ORIGINS)[number];
+
 export type ConversationMetadata = Record<string, unknown> & {
   urlAccessMode?: ConversationUrlAccessMode;
   projectTaskId?: string;
   useFileSystem?: boolean;
   /** Selects the database-backed filesystem for a fresh standalone conversation. */
   useDatabaseFileSystem?: boolean;
+  /** The surface that created the conversation, when it was not a plain user conversation. */
+  origin?: ConversationOrigin;
   /** Set when the conversation's first message was written by that surface, not by the user. */
   bootstrapped?: boolean;
 };


### PR DESCRIPTION
## Description

The Ask @analyst panel opens on a hardcoded greeting bubble and only creates a conversation once the user submits. This stack makes it open on a real conversation instead.

Stack, merges in order:

1. `1-hide-bootstrapped-opening-message` hides an opening message the user did not write
2. `2-instant-greeting` makes the analyst greeting instant and free
3. `3-promote-on-first-write` adds the conversation to history on first write
4. `4-open-panel-on-conversation` opens the Ask @analyst panel on it

**This PR (2).** @analyst answers the opening message of an analytics panel conversation with a fixed greeting on the noop model, through the existing `getStaticReplyForUserMessage` hook, so it costs no credits and no latency.

## Tests

Existing global agent suites pass. No new automated coverage.

## Risk

Low, scoped to rank 0 of a conversation marked `analytics_panel`.

## Deploy Plan

Standard, no migration.
