### PR TITLE
Add: + button to add files as tabs. Remove: click to edit a tab.

### DIFF
--- a/front/components/pages/pod/PodPage.tsx
+++ b/front/components/pages/pod/PodPage.tsx
@@ -1,5 +1,5 @@
-import { EditPodFileTabDialog } from "@app/components/pod/files/EditPodFileTabDialog";
 import { PodHeaderActions } from "@app/components/pod/PodHeaderActions";
+import { PodNavAddFileTabButton } from "@app/components/pod/PodNavAddFileTabButton";
 import { PodPageContent } from "@app/components/pod/PodPageContent";
 import { getIcon } from "@app/components/resources/resources_icons";
 import { useActivePodId } from "@app/hooks/useActivePodId";
@@ -15,10 +15,10 @@ import {
   useWorkspace,
 } from "@app/lib/auth/AuthContext";
 import { useActivationPod } from "@app/lib/swr/activation";
+import { usePodFiles } from "@app/lib/swr/pods";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { classNames } from "@app/lib/utils";
-import type { PodFileTab } from "@app/types/pod_file_tab";
 import {
   buildPodNavItemsBeforeSettings,
   makePodFileTabValue,
@@ -29,6 +29,7 @@ import {
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import {
   CheckCircle,
+  cn,
   Folder,
   MessageChatSquare,
   NavTabPill,
@@ -37,7 +38,7 @@ import {
   Settings01,
   Spinner,
 } from "@dust-tt/sparkle";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 
 const SYSTEM_TAB_TRIGGERS = {
   conversations: {
@@ -54,6 +55,11 @@ const SYSTEM_TAB_TRIGGERS = {
   },
 } as const;
 
+const MISSING_FILE_TAB_TRIGGER_CLASSNAME = cn(
+  "text-warning-700 hover:bg-warning-50",
+  "data-[state=active]:bg-warning-50 data-[state=active]:text-warning-700"
+);
+
 export function PodPage() {
   const owner = useWorkspace();
   const { user } = useAuth();
@@ -62,7 +68,6 @@ export function PodPage() {
   const { podKind } = useActivationPod({ workspaceId: owner.sId, podId });
   const isGoalPod = podKind === "goal";
   const hasFileTabs = hasFeature("pod_frame_tabs");
-  const [editingFileTab, setEditingFileTab] = useState<PodFileTab | null>(null);
 
   const {
     spaceInfo: podInfo,
@@ -89,9 +94,23 @@ export function PodPage() {
     setPodUiPreferences,
   });
 
+  const { files: podFiles, isPodFilesLoading } = usePodFiles({
+    owner,
+    podId,
+    disabled: !hasFileTabs,
+  });
+
   const fileTabs = useMemo(
     () => (hasFileTabs ? sortPodFileTabs(podInfo?.frameTabs ?? []) : []),
     [hasFileTabs, podInfo?.frameTabs]
+  );
+
+  const podFilePaths = useMemo(
+    () =>
+      new Set(
+        podFiles.filter((file) => !file.isDirectory).map((file) => file.path)
+      ),
+    [podFiles]
   );
 
   const tabsOrder = useMemo(
@@ -162,7 +181,7 @@ export function PodPage() {
             isMobile && "pl-12"
           )}
         >
-          <NavTabPillList>
+          <NavTabPillList className="group/pod-tabs">
             {navItemsBeforeSettings.map((item) => {
               const kind = item.kind;
               switch (kind) {
@@ -179,18 +198,18 @@ export function PodPage() {
                   );
                 }
                 case "file": {
-                  const tabValue = makePodFileTabValue(item.tab.path);
+                  const isFileMissing =
+                    !isPodFilesLoading && !podFilePaths.has(item.tab.path);
                   return (
                     <NavTabPillTrigger
                       key={item.tab.path}
-                      value={tabValue}
+                      value={makePodFileTabValue(item.tab.path)}
                       icon={getIcon(item.tab.icon)}
-                      onPointerDown={() => {
-                        // Re-click of the already-active tab opens the editor.
-                        if (podInfo.isEditor && currentTab === tabValue) {
-                          setEditingFileTab(item.tab);
-                        }
-                      }}
+                      className={
+                        isFileMissing
+                          ? MISSING_FILE_TAB_TRIGGER_CLASSNAME
+                          : undefined
+                      }
                     >
                       {item.tab.title}
                     </NavTabPillTrigger>
@@ -201,6 +220,14 @@ export function PodPage() {
                 }
               }
             })}
+            {hasFileTabs && podInfo.isEditor && (
+              <PodNavAddFileTabButton
+                owner={owner}
+                podId={podInfo.sId}
+                fileTabs={fileTabs}
+                tabsOrder={tabsOrder}
+              />
+            )}
             <NavTabPillTrigger value="settings" icon={Settings01}>
               Settings
             </NavTabPillTrigger>
@@ -230,20 +257,6 @@ export function PodPage() {
           fileTabs={fileTabs}
         />
       </NavTabPill>
-
-      {editingFileTab && (
-        <EditPodFileTabDialog
-          key={editingFileTab.path}
-          owner={owner}
-          podId={podInfo.sId}
-          fileTabs={fileTabs}
-          tabsOrder={tabsOrder}
-          isEditor={podInfo.isEditor}
-          tab={editingFileTab}
-          isOpen
-          onClose={() => setEditingFileTab(null)}
-        />
-      )}
     </div>
   );
 }

--- a/front/components/pod/MissingPodFileTabCallout.tsx
+++ b/front/components/pod/MissingPodFileTabCallout.tsx
@@ -1,0 +1,30 @@
+import { getScopedRelativePath } from "@app/components/file_explorer/utils";
+import { AlertCircle, ContentMessage } from "@dust-tt/sparkle";
+
+interface MissingPodFileTabCalloutProps {
+  path: string;
+  /** Prefer "frame" when the missing tab was expected to be a Frame. */
+  kind?: "file" | "frame";
+}
+
+export function MissingPodFileTabCallout({
+  path,
+  kind = "file",
+}: MissingPodFileTabCalloutProps) {
+  const relativePath = getScopedRelativePath(path);
+
+  return (
+    <div className="flex h-full w-full items-center justify-center p-8">
+      <ContentMessage
+        variant="warning"
+        icon={AlertCircle}
+        size="lg"
+        title={`${kind === "frame" ? "Frame" : "File"} no longer available`}
+        className="max-w-md"
+      >
+        This {kind} is missing or was renamed in Pod files ({relativePath}).
+        Remove it from Tabs in Settings, or restore the file.
+      </ContentMessage>
+    </div>
+  );
+}

--- a/front/components/pod/PodFileTabContent.tsx
+++ b/front/components/pod/PodFileTabContent.tsx
@@ -1,4 +1,4 @@
-import { getScopedRelativePath } from "@app/components/file_explorer/utils";
+import { MissingPodFileTabCallout } from "@app/components/pod/MissingPodFileTabCallout";
 import { PodFileTabPreview } from "@app/components/pod/PodFileTabPreview";
 import { PodFrameVisualization } from "@app/components/pod/PodFrameVisualization";
 import { usePodFrameRenderableContent } from "@app/hooks/usePodFrameRenderableContent";
@@ -44,12 +44,7 @@ export function PodFileTabContent({
   }
 
   if (isFileMetadataNotFound) {
-    return (
-      <div className="flex h-full w-full items-center justify-center p-8 text-center text-sm text-muted-foreground">
-        This file is no longer available in the Pod files (
-        {getScopedRelativePath(tab.path)}).
-      </div>
-    );
+    return <MissingPodFileTabCallout path={tab.path} />;
   }
 
   if (!isFrame) {
@@ -98,12 +93,7 @@ function PodFileTabVisualization({
   }
 
   if (isNotFound || !fileId || !fileContent || !vizUrl) {
-    return (
-      <div className="flex h-full w-full items-center justify-center p-8 text-center text-sm text-muted-foreground">
-        This frame is no longer available in the Pod files (
-        {getScopedRelativePath(framePath)}).
-      </div>
-    );
+    return <MissingPodFileTabCallout path={framePath} kind="frame" />;
   }
 
   return (

--- a/front/components/pod/PodFileTabPreview.tsx
+++ b/front/components/pod/PodFileTabPreview.tsx
@@ -5,7 +5,7 @@ import {
 import type { MarkdownFilePreviewViewMode } from "@app/components/file_explorer/MarkdownFilePreview";
 import { MarkdownFilePreviewViewModeSwitch } from "@app/components/file_explorer/MarkdownFilePreview";
 import type { FileEntry } from "@app/components/file_explorer/types";
-import { getScopedRelativePath } from "@app/components/file_explorer/utils";
+import { MissingPodFileTabCallout } from "@app/components/pod/MissingPodFileTabCallout";
 import { useSendNotification } from "@app/hooks/useNotification";
 import {
   getFilePathContentApiPath,
@@ -200,12 +200,7 @@ export function PodFileTabPreview({
   }
 
   if (isFileMetadataNotFound || !entry) {
-    return (
-      <div className="flex h-full w-full items-center justify-center p-8 text-center text-sm text-muted-foreground">
-        This file is no longer available in the Pod files (
-        {getScopedRelativePath(filePath)}).
-      </div>
-    );
+    return <MissingPodFileTabCallout path={filePath} />;
   }
 
   return (

--- a/front/components/pod/PodNavAddFileTabButton.tsx
+++ b/front/components/pod/PodNavAddFileTabButton.tsx
@@ -1,0 +1,98 @@
+import { listAddablePodTabFiles } from "@app/components/pod/files/addablePodTabFiles";
+import type { AddablePodTabFile } from "@app/components/pod/settings/AddPodFileMenu";
+import { AddPodFileMenu } from "@app/components/pod/settings/AddPodFileMenu";
+import { usePodFileTabs } from "@app/hooks/usePodFileTabs";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { usePodFiles } from "@app/lib/swr/pods";
+import type { PodFileTab } from "@app/types/pod_file_tab";
+import { MAX_POD_FILE_TABS } from "@app/types/pod_file_tab";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Button, cn, Plus } from "@dust-tt/sparkle";
+import { useMemo } from "react";
+
+interface PodNavAddFileTabButtonProps {
+  owner: LightWorkspaceType;
+  podId: string;
+  fileTabs: PodFileTab[];
+  tabsOrder?: string[];
+}
+
+/**
+ * Hover-reveal "+" next to Pod nav tabs that opens the same searchable file
+ * picker used in Settings → Tabs customization.
+ */
+export function PodNavAddFileTabButton({
+  owner,
+  podId,
+  fileTabs,
+  tabsOrder,
+}: PodNavAddFileTabButtonProps) {
+  const { hasFeature } = useFeatureFlags();
+  const displayFramePackages = hasFeature("frames_v2");
+
+  const { addFileTab } = usePodFileTabs({
+    owner,
+    podId,
+    fileTabs,
+    tabsOrder,
+    isEditor: true,
+  });
+
+  const { files: podFiles } = usePodFiles({
+    owner,
+    podId,
+  });
+
+  const existingTabPaths = useMemo(
+    () => new Set(fileTabs.map((tab) => tab.path)),
+    [fileTabs]
+  );
+
+  const addableFiles = useMemo(
+    () =>
+      listAddablePodTabFiles({
+        podFiles,
+        existingTabPaths,
+        displayFramePackages,
+      }),
+    [displayFramePackages, existingTabPaths, podFiles]
+  );
+
+  const atTabLimit = fileTabs.length >= MAX_POD_FILE_TABS;
+
+  const handleAddFile = (file: AddablePodTabFile) => {
+    void addFileTab(file.path, {
+      fileName: file.fileName,
+      skipConfirm: true,
+    });
+  };
+
+  return (
+    <div
+      className={cn(
+        "transition-opacity",
+        "[@media(hover:hover)_and_(pointer:fine)]:opacity-0",
+        "group-hover/pod-tabs:opacity-100 group-focus-within/pod-tabs:opacity-100",
+        "has-[[data-state=open]]:opacity-100"
+      )}
+    >
+      <AddPodFileMenu
+        files={addableFiles}
+        onSelect={handleAddFile}
+        trigger={
+          <Button
+            size="xs"
+            variant="ghost"
+            icon={Plus}
+            tooltip={
+              atTabLimit
+                ? `A pod can have at most ${MAX_POD_FILE_TABS} custom tabs.`
+                : "Add file to Tabs"
+            }
+            disabled={atTabLimit}
+          />
+        }
+      />
+    </div>
+  );
+}

--- a/front/components/pod/files/addablePodTabFiles.ts
+++ b/front/components/pod/files/addablePodTabFiles.ts
@@ -1,0 +1,69 @@
+import { getFileExplorerPipeline } from "@app/components/file_explorer/fileExplorerPipeline";
+import type {
+  FileEntry,
+  FileExplorerEntry,
+  FramePackageEntry,
+} from "@app/components/file_explorer/types";
+import { isFilePreviewableContentType } from "@app/components/file_explorer/utils";
+import type { AddablePodTabFile } from "@app/components/pod/settings/AddPodFileMenu";
+import type { FileSystemEntry } from "@app/types/api/file_system/types";
+import { frameV2ContentType } from "@app/types/files";
+
+function isAddablePodTabEntry(
+  entry: FileExplorerEntry,
+  existingTabPaths: ReadonlySet<string>
+): entry is FileEntry | FramePackageEntry {
+  if (existingTabPaths.has(entry.path)) {
+    return false;
+  }
+
+  if (entry.kind === "frame_package") {
+    return true;
+  }
+
+  if (entry.kind !== "file") {
+    return false;
+  }
+
+  return (
+    entry.contentType !== frameV2ContentType &&
+    isFilePreviewableContentType(entry.contentType)
+  );
+}
+
+/**
+ * Previewable Pod files (and Frame packages) that are not already pinned as tabs.
+ * Mirrors the "Add as Pod tab" eligibility in the Files explorer.
+ */
+export function listAddablePodTabFiles({
+  podFiles,
+  existingTabPaths,
+  displayFramePackages,
+}: {
+  podFiles: FileSystemEntry[];
+  existingTabPaths: ReadonlySet<string>;
+  displayFramePackages: boolean;
+}): AddablePodTabFile[] {
+  const { entryByRelativePath } = getFileExplorerPipeline({
+    activeFilter: "all",
+    contentNodes: [],
+    currentFolderPath: "",
+    displayFramePackages,
+    files: podFiles,
+    searchQuery: "",
+    sortMode: "name-asc",
+  });
+
+  return [...entryByRelativePath.values()]
+    .filter((entry): entry is FileEntry | FramePackageEntry =>
+      isAddablePodTabEntry(entry, existingTabPaths)
+    )
+    .map((entry) => ({
+      path: entry.path,
+      fileName: entry.fileName,
+      contentType: entry.contentType,
+    }))
+    .sort((a, b) =>
+      a.fileName.localeCompare(b.fileName, undefined, { sensitivity: "base" })
+    );
+}

--- a/front/components/pod/settings/PodTabsCustomizationSection.tsx
+++ b/front/components/pod/settings/PodTabsCustomizationSection.tsx
@@ -1,13 +1,5 @@
-import { getFileExplorerPipeline } from "@app/components/file_explorer/fileExplorerPipeline";
-import type {
-  FileEntry,
-  FileExplorerEntry,
-  FramePackageEntry,
-} from "@app/components/file_explorer/types";
-import {
-  getScopedRelativePath,
-  isFilePreviewableContentType,
-} from "@app/components/file_explorer/utils";
+import { getScopedRelativePath } from "@app/components/file_explorer/utils";
+import { listAddablePodTabFiles } from "@app/components/pod/files/addablePodTabFiles";
 import type { AddablePodTabFile } from "@app/components/pod/settings/AddPodFileMenu";
 import { AddPodFileMenu } from "@app/components/pod/settings/AddPodFileMenu";
 import { isCustomResourceIconType } from "@app/components/resources/resources_icon_names";
@@ -15,7 +7,6 @@ import { getIcon } from "@app/components/resources/resources_icons";
 import { usePodFileTabs } from "@app/hooks/usePodFileTabs";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { usePodFiles } from "@app/lib/swr/pods";
-import { frameV2ContentType } from "@app/types/files";
 import type { PodFileTab } from "@app/types/pod_file_tab";
 import {
   DEFAULT_POD_FILE_TAB_ICON,
@@ -56,28 +47,6 @@ interface PodTabsCustomizationSectionProps {
 
 function isTabReorderDrag(event: DragEvent) {
   return event.dataTransfer.types.includes(POD_TAB_DRAG_MIME);
-}
-
-function isAddablePodTabEntry(
-  entry: FileExplorerEntry,
-  existingTabPaths: ReadonlySet<string>
-): entry is FileEntry | FramePackageEntry {
-  if (existingTabPaths.has(entry.path)) {
-    return false;
-  }
-
-  if (entry.kind === "frame_package") {
-    return true;
-  }
-
-  if (entry.kind !== "file") {
-    return false;
-  }
-
-  return (
-    entry.contentType !== frameV2ContentType &&
-    isFilePreviewableContentType(entry.contentType)
-  );
 }
 
 export function PodTabsCustomizationSection({
@@ -122,30 +91,15 @@ export function PodTabsCustomizationSection({
     [podFiles]
   );
 
-  const addableFiles = useMemo((): AddablePodTabFile[] => {
-    const { entryByRelativePath } = getFileExplorerPipeline({
-      activeFilter: "all",
-      contentNodes: [],
-      currentFolderPath: "",
-      displayFramePackages,
-      files: podFiles,
-      searchQuery: "",
-      sortMode: "name-asc",
-    });
-
-    return [...entryByRelativePath.values()]
-      .filter((entry): entry is FileEntry | FramePackageEntry =>
-        isAddablePodTabEntry(entry, existingTabPaths)
-      )
-      .map((entry) => ({
-        path: entry.path,
-        fileName: entry.fileName,
-        contentType: entry.contentType,
-      }))
-      .sort((a, b) =>
-        a.fileName.localeCompare(b.fileName, undefined, { sensitivity: "base" })
-      );
-  }, [displayFramePackages, existingTabPaths, podFiles]);
+  const addableFiles = useMemo(
+    () =>
+      listAddablePodTabFiles({
+        podFiles,
+        existingTabPaths,
+        displayFramePackages,
+      }),
+    [displayFramePackages, existingTabPaths, podFiles]
+  );
 
   const [draggingPath, setDraggingPath] = useState<string | null>(null);
   const [dropTargetPath, setDropTargetPath] = useState<string | null>(null);

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -119,7 +119,7 @@ export function usePodFiles({
   disabled,
 }: {
   owner: LightWorkspaceType;
-  podId: string;
+  podId: string | null;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
@@ -129,7 +129,7 @@ export function usePodFiles({
     useSWRWithDefaults(
       !podId ? null : `/api/w/${owner.sId}/spaces/${podId}/files`,
       podFilesFetcher,
-      { disabled, keepPreviousData: true }
+      { disabled: disabled || !podId, keepPreviousData: true }
     );
 
   const refreshPodFiles = useCallback(async () => {


### PR DESCRIPTION
## Description

Add a hover-revealed `+` button beside Pod navigation tabs that reuses `AddPodFileMenu` to pin previewable Pod files and Frame packages without opening Settings. Remove click-to-edit behavior from existing tabs and surface missing or renamed tabs with warning styling and a recovery callout.

<img width="549" height="435" alt="file-ea958e49301692f05b3f93b1306038d7" src="https://github.com/user-attachments/assets/7b5d082a-6c08-4ff2-8962-1e97a5937c89" />

<img width="582" height="553" alt="file-ec74f7fab947375278413bac55922104" src="https://github.com/user-attachments/assets/1c45102d-8d83-4121-9549-99befea2969a" />

r? @fabiencelier 

## Tests

I manually tested adding eligible files and Frame packages from the Pod navigation, the maximum tab limit, exclusion of existing and non-previewable entries, missing-tab states, and the existing Settings picker flow. No automated tests were added.

## Risk

Low. The change is front-end only and preserves the existing persisted tab model. Revert the front deployment to roll back.

## Deploy Plan

Deploy `front`. No SQL migrations or infrastructure changes.