### PR TITLE
Add code contract: prefer date-fns over moment

### DIFF
--- a/front/CONTRACTS
+++ b/front/CONTRACTS
@@ -653,3 +653,11 @@ switch (event.type) {
 
 Reviewer: If you see `assertNever` used in frontend component or hook code, require the author to
 switch to `assertNeverAndIgnore`.
+
+@cc [owner:avervaet,label:coding] date-fns-over-moment
+We are deprecating `moment` in favor of `date-fns`. New code must not import `moment`; use
+`date-fns` (see `lib/utils/timestamps.ts` for existing calendar/relative-date helpers), and migrate
+a file's `moment` usage to `date-fns` when otherwise modifying that file's date-handling code.
+
+Reviewer: If you see a new `import moment from "moment"`, require the author to use `date-fns`
+instead.


### PR DESCRIPTION
Adds a `front/CONTRACTS` entry requiring new code to use `date-fns` instead of `moment`, and to migrate a touched file's existing `moment` usage to `date-fns` opportunistically.

Context: found while doing a consistency pass over front/ — moment and date-fns are both used for the same "relative/calendar date" display purpose across ~10 files, with a new moment usage added as recently as 5 weeks ago. This contract stops new moment usage without requiring a migration; see the related decision doc for the phased plan: https://github.com/dust-tt/decisions/issues/1009

No behavior change.