### PR TITLE
[front] Archive per-API-key cap alerts in spend-cap cleanup script

### DIFF
--- a/front/lib/metronome/alerts/spend_limits.test.ts
+++ b/front/lib/metronome/alerts/spend_limits.test.ts
@@ -1,6 +1,7 @@
 import * as alerts from "@app/lib/metronome/alerts";
 import {
   getMetronomeDefaultUserCapAlertForSeatType,
+  isUnusedSpendCapAlertUniquenessKey,
   upsertMetronomeDefaultUserCapAlertForSeatType,
 } from "@app/lib/metronome/alerts/spend_limits";
 import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
@@ -25,6 +26,96 @@ const WORKSPACE_ID = "wks_test_xxx";
 beforeEach(() => {
   vi.mocked(alerts.findMetronomeAlert).mockReset();
   vi.mocked(alerts.upsertMetronomeAlert).mockReset();
+});
+
+describe("isUnusedSpendCapAlertUniquenessKey", () => {
+  it("matches per-user cap and warning keys", () => {
+    expect(
+      isUnusedSpendCapAlertUniquenessKey(
+        `per-user-cap-${WORKSPACE_ID}-usr_123`,
+        WORKSPACE_ID
+      )
+    ).toBe(true);
+    expect(
+      isUnusedSpendCapAlertUniquenessKey(
+        `per-user-warning-${WORKSPACE_ID}-usr_123`,
+        WORKSPACE_ID
+      )
+    ).toBe(true);
+  });
+
+  it("matches per-API-key cap keys", () => {
+    expect(
+      isUnusedSpendCapAlertUniquenessKey(
+        `per-api-key-cap-${WORKSPACE_ID}-thomas`,
+        WORKSPACE_ID
+      )
+    ).toBe(true);
+  });
+
+  it("matches per-seat-type default and per-group cap / warning keys", () => {
+    expect(
+      isUnusedSpendCapAlertUniquenessKey(
+        `default-user-cap-pro-${WORKSPACE_ID}`,
+        WORKSPACE_ID
+      )
+    ).toBe(true);
+    expect(
+      isUnusedSpendCapAlertUniquenessKey(
+        `default-user-warning-pro-${WORKSPACE_ID}`,
+        WORKSPACE_ID
+      )
+    ).toBe(true);
+    expect(
+      isUnusedSpendCapAlertUniquenessKey(
+        `group-cap-grp_1-${WORKSPACE_ID}`,
+        WORKSPACE_ID
+      )
+    ).toBe(true);
+    expect(
+      isUnusedSpendCapAlertUniquenessKey(
+        `group-warning-grp_1-${WORKSPACE_ID}`,
+        WORKSPACE_ID
+      )
+    ).toBe(true);
+  });
+
+  it("does not match keys for a different workspace", () => {
+    expect(
+      isUnusedSpendCapAlertUniquenessKey(
+        `per-api-key-cap-other_wks-thomas`,
+        WORKSPACE_ID
+      )
+    ).toBe(false);
+    expect(
+      isUnusedSpendCapAlertUniquenessKey(
+        `per-user-cap-other_wks-usr_123`,
+        WORKSPACE_ID
+      )
+    ).toBe(false);
+  });
+
+  it("does not match still-in-use free-seat, workspace balance, or PAYG usage-cap keys", () => {
+    expect(
+      isUnusedSpendCapAlertUniquenessKey(
+        `per-user-credit-${WORKSPACE_ID}-usr_123`,
+        WORKSPACE_ID
+      )
+    ).toBe(false);
+    expect(
+      isUnusedSpendCapAlertUniquenessKey(
+        `workspace-balance-threshold-${WORKSPACE_ID}`,
+        WORKSPACE_ID
+      )
+    ).toBe(false);
+    // PAYG global-consumption spend alert — still in use, must never be archived.
+    expect(
+      isUnusedSpendCapAlertUniquenessKey(
+        `payg-cap-${WORKSPACE_ID}`,
+        WORKSPACE_ID
+      )
+    ).toBe(false);
+  });
 });
 
 describe("getMetronomeDefaultUserCapAlertForSeatType", () => {

--- a/front/lib/metronome/alerts/spend_limits.ts
+++ b/front/lib/metronome/alerts/spend_limits.ts
@@ -50,6 +50,10 @@ function perUserWarningAlertUniquenessKeyPrefix(workspaceId: string): string {
   return `per-user-warning-${workspaceId}-`;
 }
 
+function perApiKeyCapAlertUniquenessKeyPrefix(workspaceId: string): string {
+  return `per-api-key-cap-${workspaceId}-`;
+}
+
 // Prefixes for the per-seat-type default and per-group cap/warning alert
 // uniqueness keys. Unlike the per-user keys, these carry the workspace id as
 // their final `-<workspaceId>` segment. Kept as the single source of truth for
@@ -76,13 +80,14 @@ export function isUnusedSpendCapAlertUniquenessKey(
   uniquenessKey: string,
   workspaceId: string
 ): boolean {
-  // Per-user cap / warning: workspace id is embedded in the prefix, followed by
-  // the user id.
+  // Per-user cap / warning and per-API-key cap: workspace id is embedded in the
+  // prefix, followed by the user id (resp. the api key name).
   if (
     uniquenessKey.startsWith(perUserAlertUniquenessKeyPrefix(workspaceId)) ||
     uniquenessKey.startsWith(
       perUserWarningAlertUniquenessKeyPrefix(workspaceId)
-    )
+    ) ||
+    uniquenessKey.startsWith(perApiKeyCapAlertUniquenessKeyPrefix(workspaceId))
   ) {
     return true;
   }


### PR DESCRIPTION
## Description

The one-off `archive_unused_spend_cap_alerts` script (merged in #31914 cleanup) never archived the per-API-key cap alerts — the ones named `Per-API-key cap <workspaceId>-<keyName>` whose Metronome uniqueness key is `per-api-key-cap-<workspaceId>-<keyName>`.

`isUnusedSpendCapAlertUniquenessKey` only matched the `per-user-cap-<wId>-` / `per-user-warning-<wId>-` prefixes and the `-<workspaceId>`-suffixed default/group keys. The api-key key neither starts with `per-user-cap-<wId>-` nor ends with `-<workspaceId>` (it ends with `-<keyName>`), so it fell through both branches and was never selected. The writer that created those alerts (`lib/metronome/alerts/api_key_caps.ts`) was deleted in the same cleanup commit, so the prefix was left dangling and the alerts stayed enabled in Metronome.

This adds the `per-api-key-cap-<workspaceId>-` prefix to the predicate so the script archives them.

## Tests

- Added unit tests for `isUnusedSpendCapAlertUniquenessKey` covering per-user, per-API-key, default-seat-type, and per-group keys, plus negative cases (other workspace, still-in-use free-seat / workspace-balance keys).
- `npm run test -- lib/metronome/alerts/spend_limits.test.ts` — 12 passing.

## Risk

Low. Pure widening of a one-off cleanup script's selection predicate; the script is dry-run by default and gated behind `--execute`. No runtime enforcement path touches this function.

## Deploy Plan

Merge, then re-run `npx tsx scripts/archive_unused_spend_cap_alerts.ts --execute` to archive the previously-missed per-API-key cap alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)