### PR TITLE
[front-api] docs: clarify public trigger serialization contracts

### DIFF
--- a/front-api/routes/v1/w/[wId]/triggers/serialize.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/serialize.ts
@@ -6,10 +6,15 @@ import type { TriggerType as PublicTriggerType } from "@dust-tt/client";
 
 /**
  * @cc [owner:adrien,label:api] public-api-trigger-serialization
- * Serializes a workspace-wide `TriggerResource` list for the read-only public API: internal
- * fields with no meaning outside the workspace (`editor`, `origin`, `spaceId`,
- * `webhookSourceViewId`) are dropped, and webhook triggers get a `webhookSource` label
- * (`name`/`provider`) resolved from their view instead of the raw internal view id.
+ * Returned triggers MUST NOT contain `editor`, `origin`, `spaceId`,
+ * or `webhookSourceViewId`.
+ */
+/**
+ * @cc [owner:adrien,label:api] public-api-webhook-source
+ * For each webhook trigger, the returned `webhookSource` MUST be:
+ * - `null` if no matching source view was returned;
+ * - otherwise, exactly `{ name, provider }`, using the view's name and
+ *   its source's provider, with `"custom"` when that provider is null or undefined.
  */
 export async function serializeTriggersForPublicApi(
   auth: Authenticator,


### PR DESCRIPTION
## Description

Split the public trigger serialization contract into explicit requirements for excluded internal fields and webhook source metadata, including missing views and the `"custom"` fallback for nullish providers.

## Tests

- Verified both contracts against the serializer and its callers, and checked contract syntax and discoverability.
- Attempted both existing trigger endpoint suites; neither could run because Vite could not resolve `@novu/framework`.

## Risk

None. Comment-only change.

## Deploy Plan

No deployment required.
