### PR TITLE
[front] Clarify per-user pool limit copy when seats carry no allowance

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -830,6 +830,9 @@ export function UsagePage() {
   const plan = subscription.plan;
   const isEnterprise = isEnterprisePlanPrefix(plan.code);
   const isFreePlanWorkspace = isFreePlan(plan.code);
+  const seatsHaveBuiltInAllowance = Object.values(seatPlans).some(
+    (info) => (info?.awuCredits ?? 0) > 0
+  );
 
   const poolConsumedCredits = Math.max(
     0,
@@ -1388,6 +1391,7 @@ export function UsagePage() {
                     <UsageSettingsCard
                       workspaceId={owner.sId}
                       hasPool={hasPool}
+                      seatsHaveBuiltInAllowance={seatsHaveBuiltInAllowance}
                     />
                   )}
                   <ModelTiersSettingsCard owner={owner} />
@@ -1446,6 +1450,7 @@ export function UsagePage() {
           isOpen={isBulkSpendLimitOpen}
           onClose={() => setIsBulkSpendLimitOpen(false)}
           memberCount={selection.selectedCount}
+          seatsHaveBuiltInAllowance={seatsHaveBuiltInAllowance}
           onValidate={handleBulkSpendLimitValidate}
         />
         <BulkChangeSeatModal

--- a/front/components/workspace/BulkEditSpendLimitModal.tsx
+++ b/front/components/workspace/BulkEditSpendLimitModal.tsx
@@ -28,6 +28,10 @@ interface BulkEditSpendLimitModalProps {
   isOpen: boolean;
   onClose: () => void;
   memberCount: number;
+  // Whether any seat on the workspace's contract carries a built-in credit
+  // allowance. When it doesn't (e.g. pooled plans with no per-seat allowance),
+  // the pool limit is the member's whole monthly budget rather than a top-up.
+  seatsHaveBuiltInAllowance: boolean;
   onValidate: (limit: SpendLimit) => Promise<boolean>;
 }
 
@@ -35,6 +39,7 @@ export function BulkEditSpendLimitModal({
   isOpen,
   onClose,
   memberCount,
+  seatsHaveBuiltInAllowance,
   onValidate,
 }: BulkEditSpendLimitModalProps) {
   return (
@@ -44,6 +49,7 @@ export function BulkEditSpendLimitModal({
           <BulkEditSpendLimitForm
             onClose={onClose}
             memberCount={memberCount}
+            seatsHaveBuiltInAllowance={seatsHaveBuiltInAllowance}
             onValidate={onValidate}
           />
         )}
@@ -55,12 +61,14 @@ export function BulkEditSpendLimitModal({
 interface BulkEditSpendLimitFormProps {
   onClose: () => void;
   memberCount: number;
+  seatsHaveBuiltInAllowance: boolean;
   onValidate: (limit: SpendLimit) => Promise<boolean>;
 }
 
 function BulkEditSpendLimitForm({
   onClose,
   memberCount,
+  seatsHaveBuiltInAllowance,
   onValidate,
 }: BulkEditSpendLimitFormProps) {
   const [kind, setKind] = useState<SpendLimitKind>("override");
@@ -121,9 +129,12 @@ function BulkEditSpendLimitForm({
           Edit spend limit for {memberCount.toLocaleString("en-US")} members
         </DialogTitle>
         <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          They will be able to consume this amount from the pool after reaching
-          their plan usage limit. This limit is added on top of each seat&apos;s
-          built-in allowance.
+          {seatsHaveBuiltInAllowance
+            ? "They will be able to consume this amount from the pool after " +
+              "reaching their plan usage limit. This limit is added on top of " +
+              "each seat's built-in allowance."
+            : "This is the total amount of credits each member will be able to " +
+              "consume from the workspace credit pool per month."}
         </p>
       </DialogHeader>
       <DialogContainer>

--- a/front/components/workspace/EditMemberSpendLimitModal.tsx
+++ b/front/components/workspace/EditMemberSpendLimitModal.tsx
@@ -191,9 +191,19 @@ function MemberSpendLimitForm({
           <div>
             <DialogTitle>Edit spend limit for {member?.name}</DialogTitle>
             <DialogDescription>
-              This user can currently consume{" "}
-              {formatCredits(seatAllowanceAwuCredits)} credits from their seat,
-              plus {formatCredits(extraAwuCredits)} on the&nbsp;pool.
+              {seatAllowanceAwuCredits > 0 ? (
+                <>
+                  This user can currently consume{" "}
+                  {formatCredits(seatAllowanceAwuCredits)} credits from their
+                  seat, plus {formatCredits(extraAwuCredits)} on the&nbsp;pool.
+                </>
+              ) : (
+                <>
+                  This user can currently consume{" "}
+                  {formatCredits(extraAwuCredits)} credits from the workspace
+                  credit&nbsp;pool.
+                </>
+              )}
             </DialogDescription>
           </div>
         </div>

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -58,6 +58,13 @@ export function EditSpendLimitModal({
   }
   const displayedMember = member ?? lastMemberRef.current;
 
+  // `memberUsageLimit` is this member's built-in seat allowance (0 when the seat
+  // carries none, e.g. pooled enterprise). When there is no allowance, the pool
+  // limit is the member's whole budget, so drop the "on top of the seat
+  // allowance" wording.
+  const seatsHaveBuiltInAllowance =
+    (displayedMember?.memberUsageLimit ?? 0) > 0;
+
   const {
     spendLimit,
     isSpendLimitLoading,
@@ -207,9 +214,18 @@ export function EditSpendLimitModal({
                 Edit spend limit for {displayedMember?.name}
               </DialogTitle>
               <p className="text-sm text-muted-foreground">
-                Maximum pool credits this member can consume during a billing
-                cycle. This limit is added on top of the seat&apos;s built-in
-                allowance.
+                {seatsHaveBuiltInAllowance ? (
+                  <>
+                    Maximum pool credits this member can consume during a
+                    billing cycle. This limit is added on top of the seat&apos;s
+                    built-in allowance.
+                  </>
+                ) : (
+                  <>
+                    Total credits this member can consume from the workspace
+                    credit pool during a billing cycle.
+                  </>
+                )}
               </p>
             </div>
           </div>

--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -16,6 +16,11 @@ import {
 interface UsageSettingsCardProps {
   workspaceId: string;
   hasPool: boolean;
+  // Whether any seat on the workspace's contract carries a built-in credit
+  // allowance. When it doesn't (e.g. pooled plans with no per-seat allowance),
+  // the pool limit is the user's whole monthly budget rather than a top-up, so
+  // the description drops the "on top of the seat allowance" wording.
+  seatsHaveBuiltInAllowance: boolean;
 }
 
 function validateDefaultLimit(value: string) {
@@ -26,6 +31,7 @@ function validateDefaultLimit(value: string) {
 export function UsageSettingsCard({
   workspaceId,
   hasPool,
+  seatsHaveBuiltInAllowance,
 }: UsageSettingsCardProps) {
   const { defaultUserSpendLimit, isDefaultUserSpendLimitLoading } =
     useDefaultUserSpendLimit({ workspaceId });
@@ -76,13 +82,22 @@ export function UsageSettingsCard({
           <SettingsList.Row
             title="Default per-user workspace credit pool monthly limit"
             description={
-              <>
-                Define the workspace credit pool credit limit for users per
-                month in your workspace. This limit is added on top of each
-                seat&apos;s built-in allowance. Can be overridden per user in
-                the members table.{" "}
-                <strong>Set to 0 to remove pool access.</strong>
-              </>
+              seatsHaveBuiltInAllowance ? (
+                <>
+                  Define the workspace credit pool credit limit for users per
+                  month in your workspace. This limit is added on top of each
+                  seat&apos;s built-in allowance. Can be overridden per user in
+                  the members table.{" "}
+                  <strong>Set to 0 to remove pool access.</strong>
+                </>
+              ) : (
+                <>
+                  Define the total amount of credits each user can consume from
+                  the workspace credit pool per month. Can be overridden per
+                  user in the members table.{" "}
+                  <strong>Set to 0 to remove pool access.</strong>
+                </>
+              )
             }
             action={
               <div className="w-60">

--- a/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
@@ -73,7 +73,7 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
         variant: "text",
         label: "Default per-user workspace credit pool monthly limit (credits)",
         description:
-          "Default per-user workspace credit pool monthly limit added on top of each seat's built-in allowance. Can be overridden per user in the members table. Set to 0 to remove pool access.",
+          "Default per-user monthly credit limit from the workspace credit pool. For plans whose seats carry a built-in allowance (pro/business), it is added on top of that allowance; enterprise pooled workspaces have no seat allowance, so it is the user's whole monthly budget. Can be overridden per user in the members table. Set to 0 to remove pool access.",
         async: true,
       },
       programmaticMonthlyCapCredits: {


### PR DESCRIPTION
## Description

The spending-policy copy on the Usage page hard-coded *"This limit is added on top of each seat's built-in allowance."* That is inaccurate for pooled workspaces whose seats carry no built-in allowance (e.g. pooled enterprise): there the per-user pool limit **is** the user's whole monthly budget, not a top-up.

This branches the copy on **real seat data** rather than the plan code — enterprise contracts exist both *with* and *without* a per-seat allowance, so the plan prefix is not a valid signal:

- **Workspace-level surfaces** (`UsageSettingsCard` default-limit setting, `BulkEditSpendLimitModal`) derive `seatsHaveBuiltInAllowance` from `seatPlans` (`SeatTypeInfo.awuCredits > 0` for any seat type), computed in `UsagePage` and threaded down.
- **Per-member modals** (`EditSpendLimitModal`, `EditMemberSpendLimitModal`) use the member's own seat allowance (`memberUsageLimit`), which is more precise per member.

When no allowance is present, the copy drops the "on top of the seat allowance" wording and states the pool limit is the whole budget. The Poke plugin's static field description (covers all plans) is reworded to state both cases.

Covers both usage-page variants (`enable_new_usage_page`) — the affected components render in both.

## Tests

Manual: no logic change beyond display copy. `npx tsgo --noEmit` and `biome check` pass on all changed files. No automated test covers this static copy.

## Risk

Low. Display-copy-only change gated on an already-fetched, contract-derived seat-allowance signal; no data mutation or API surface change.

## Deploy Plan

Standard deploy. No migration, feature flag, or config change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)