### PR TITLE
[front] fix: surface legacy per-member credit cap + rate-limiter state in poke

### DIFF
--- a/front/components/poke/credits/PokeMembersUsageTable.tsx
+++ b/front/components/poke/credits/PokeMembersUsageTable.tsx
@@ -163,6 +163,11 @@ interface PokeMembersUsageTableProps {
   // columns (user cap, seat balance/allowance, credit state), which are
   // meaningless for non-credit workspaces.
   isCreditBased: boolean;
+  // Reveals the "User cap" column on non-credit-priced (legacy) workspaces that
+  // enforce a per-member credit limit — the Redis rate-limiter cap still
+  // applies there even though the Metronome credit columns don't. Defaults to
+  // `false`; ignored (superseded) when `isCreditBased` is true.
+  showUserCap?: boolean;
 }
 
 function makeColumns({
@@ -173,6 +178,7 @@ function makeColumns({
   onToggleSort,
   showFairUse,
   showCreditColumns,
+  showUserCap,
 }: {
   owner: WorkspaceType;
   onReconciled: () => void;
@@ -181,6 +187,7 @@ function makeColumns({
   onToggleSort: (column: OrderColumn) => void;
   showFairUse: boolean;
   showCreditColumns: boolean;
+  showUserCap: boolean;
 }): ColumnDef<MemberUsageType>[] {
   const columns: ColumnDef<MemberUsageType>[] = [
     {
@@ -446,11 +453,13 @@ function makeColumns({
     if (key === "fairUse") {
       return showFairUse;
     }
-    if (
-      key === "spendLimitAwuCredits" ||
-      key === "memberUsageLimit" ||
-      key === "creditState"
-    ) {
+    // The user cap applies to credit-priced workspaces and to legacy
+    // workspaces that set a per-member credit limit; the remaining credit
+    // columns are Metronome-only.
+    if (key === "spendLimitAwuCredits") {
+      return showCreditColumns || showUserCap;
+    }
+    if (key === "memberUsageLimit" || key === "creditState") {
       return showCreditColumns;
     }
     return true;
@@ -460,6 +469,7 @@ function makeColumns({
 export function PokeMembersUsageTable({
   owner,
   isCreditBased,
+  showUserCap = false,
 }: PokeMembersUsageTableProps) {
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
@@ -550,6 +560,7 @@ export function PokeMembersUsageTable({
         onToggleSort: toggleSort,
         showFairUse,
         showCreditColumns: isCreditBased,
+        showUserCap: isCreditBased || showUserCap,
       }),
     [
       owner,
@@ -559,6 +570,7 @@ export function PokeMembersUsageTable({
       toggleSort,
       showFairUse,
       isCreditBased,
+      showUserCap,
     ]
   );
 

--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -267,6 +267,36 @@ function PokeDefaultAlertsCard({ defaultAlerts }: PokeDefaultAlertsCardProps) {
   );
 }
 
+interface PokeLegacyPerMemberCapCardProps {
+  capAwuCredits: number | null;
+}
+
+// Non-credit-priced (legacy) workspaces have no Metronome credit-state machine,
+// but can still enforce a single workspace-wide per-member credit cap via the
+// "Set Per-Member Credit Limit (Legacy Plans)" poke plugin. Enforcement runs off
+// a UTC-calendar-month Redis rate-limiter counter (see
+// `isNonCreditPricedUserSpendLimitReached`); this card surfaces the configured
+// cap so it isn't invisible in poke.
+function PokeLegacyPerMemberCapCard({
+  capAwuCredits,
+}: PokeLegacyPerMemberCapCardProps) {
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-border p-4">
+      <span className="text-sm font-medium text-foreground">
+        Per-member credit limit (legacy)
+      </span>
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-muted-foreground">Cap</span>
+        <span className="text-sm font-medium text-foreground">
+          {capAwuCredits !== null
+            ? `${formatCredits(capAwuCredits)} credits / member / month`
+            : "No limit set"}
+        </span>
+      </div>
+    </div>
+  );
+}
+
 interface PokeCreditPoolCardProps {
   owner: WorkspaceType;
 }
@@ -351,13 +381,24 @@ export function PokeUsageTab({
     // Non-credit-based workspaces (no Metronome contract) have no credit
     // diagnostics, but fair-use AWU limits still apply to them (free/trial), so
     // the members table — which surfaces per-user fair-use usage — is shown
-    // alongside the activity chart.
+    // alongside the activity chart. Legacy plans may also enforce a
+    // workspace-wide per-member credit cap (`defaultPoolCapAwuCredits`), so its
+    // configured value and the per-member rate-limiter state are surfaced too.
+    const legacyPerMemberCapAwuCredits =
+      creditUsageConfig?.defaultPoolCapAwuCredits &&
+      creditUsageConfig.defaultPoolCapAwuCredits > 0
+        ? creditUsageConfig.defaultPoolCapAwuCredits
+        : null;
     return (
       <div className="flex flex-col gap-4">
         <PokeWorkspaceUsageChart workspaceId={owner.sId} period={30} />
+        <PokeLegacyPerMemberCapCard
+          capAwuCredits={legacyPerMemberCapAwuCredits}
+        />
         <PokeMembersUsageTable
           owner={owner}
           isCreditBased={hasMetronomeBillingUsage}
+          showUserCap={legacyPerMemberCapAwuCredits !== null}
         />
       </div>
     );

--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -30,6 +30,7 @@ import {
   ContentMessage,
   ProgressBar,
   Spinner,
+  ValueCard,
 } from "@dust-tt/sparkle";
 
 interface PokeUsageTabProps {
@@ -281,19 +282,17 @@ function PokeLegacyPerMemberCapCard({
   capAwuCredits,
 }: PokeLegacyPerMemberCapCardProps) {
   return (
-    <div className="flex flex-col gap-2 rounded-lg border border-border p-4">
-      <span className="text-sm font-medium text-foreground">
-        Per-member credit limit (legacy)
-      </span>
-      <div className="flex items-center gap-2">
-        <span className="text-xs text-muted-foreground">Cap</span>
-        <span className="text-sm font-medium text-foreground">
+    <ValueCard
+      title="Per-member credit limit (legacy)"
+      subtitle="Enforced per member, per calendar month"
+      content={
+        <span className="heading-lg text-foreground">
           {capAwuCredits !== null
-            ? `${formatCredits(capAwuCredits)} credits / member / month`
+            ? `${formatCredits(capAwuCredits)} credits`
             : "No limit set"}
         </span>
-      </div>
-    </div>
+      }
+    />
   );
 }
 

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -2092,6 +2092,16 @@ export async function getMembersUsage({
   const subscription = auth.subscription();
   const { metronomeCustomerId } = workspace;
   const metronomeContractId = subscription?.metronomeContractId ?? null;
+  // Mirrors the enforcement branch in `lib/api/assistant/conversation.ts`:
+  // credit-priced workspaces resolve the per-user cap from the seat allowance +
+  // override/group/default; non-credit-priced (legacy) workspaces instead
+  // enforce a single workspace-wide per-member cap on a UTC-calendar-month
+  // window (`isNonCreditPricedUserSpendLimitReached`).
+  const isCreditPricedWorkspace = Boolean(
+    metronomeCustomerId &&
+      subscription?.plan &&
+      isCreditPricedPlan(subscription.plan)
+  );
 
   // Resolved up front (Redis-cached) so even empty pages carry the reset date
   // for the table header.
@@ -2133,6 +2143,19 @@ export async function getMembersUsage({
   // configuration row (created lazily; absent → no default configured).
   const creditUsageConfig =
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+
+  // Non-credit-priced (legacy) per-member cap: the raw pool default, applied
+  // uniformly to every member with no per-member/group override and no seat
+  // allowance (matching `getNonCreditPricedDefaultUserSpendLimit`). `0` means
+  // "no limit". Poke-only (`includeAlertLinks`): surfaces the enforced legacy
+  // cap in the admin members table without altering the customer usage page,
+  // whose unblock/override affordances don't apply on legacy plans.
+  const nonCreditPricedCapAwuCredits =
+    includeAlertLinks &&
+    !isCreditPricedWorkspace &&
+    (creditUsageConfig?.defaultPoolCapAwuCredits ?? 0) > 0
+      ? (creditUsageConfig?.defaultPoolCapAwuCredits ?? 0)
+      : null;
 
   // Memberships are needed up front to split consumed credits on seat type:
   // free-seat users are counted from `is_free_seat: true` usage, everyone else
@@ -2257,10 +2280,24 @@ export async function getMembersUsage({
   if (periodResult.isOk() && periodResult.value) {
     billingCycle = periodResult.value;
   }
-  const cycleBounds = billingCycle
+  // The per-cycle spend-cap counter is bucketed on the same window the
+  // enforcement writer accrues into: the UTC calendar month for
+  // non-credit-priced workspaces (no Metronome contract to anchor on), the
+  // Metronome billing period otherwise. Mirror `spendLimitCycleOverrideForAuth`
+  // so the poke counter read lands on the same Redis key. Poke-only
+  // (`includeAlertLinks`): only the admin members table surfaces the legacy
+  // rate-limiter state, and this leaves the customer usage page unchanged
+  // (`spendLimitCycleOverrideForAuth` is a no-op for credit-priced workspaces,
+  // so it only diverges on legacy plans). `billingCycle` stays Metronome-only
+  // below — the seat-usage pace classification only applies to credit-priced
+  // seats.
+  const spendCapCycle = includeAlertLinks
+    ? (spendLimitCycleOverrideForAuth(auth) ?? billingCycle)
+    : billingCycle;
+  const cycleBounds = spendCapCycle
     ? makeSpendLimitCycleWindowBounds(
-        billingCycle.cycleStart,
-        billingCycle.cycleEnd
+        spendCapCycle.cycleStart,
+        spendCapCycle.cycleEnd
       )
     : null;
   const lifetimeBounds = makeSpendLimitLifetimeWindowBounds();
@@ -2454,16 +2491,30 @@ export async function getMembersUsage({
           (seatAllowanceBySeatType[normalizedSeatType] ?? 0)
         : null;
 
-    const spendLimitSource = resolveEffectiveSpendLimitSource({
-      overrideAwuCredits,
-      groupCapAwuCredits,
-      defaultAwuCredits: effectiveDefaultAwuCredits,
-    });
-    const effectiveSpendLimitAwuCredits = resolveEffectiveSpendLimitAwuCredits({
-      overrideAwuCredits,
-      groupCapAwuCredits,
-      defaultAwuCredits: effectiveDefaultAwuCredits,
-    });
+    // Non-credit-priced (legacy) workspaces ignore the seat-allowance /
+    // override / group resolution above: enforcement applies the uniform
+    // workspace default to every member, so surface that same cap here to
+    // match. Poke-only (`nonCreditPricedCapAwuCredits` is gated on
+    // `includeAlertLinks`); the customer usage page keeps the original
+    // resolution untouched.
+    const useLegacyUniformCap = includeAlertLinks && !isCreditPricedWorkspace;
+    const spendLimitResolverInput = useLegacyUniformCap
+      ? {
+          overrideAwuCredits: null,
+          groupCapAwuCredits: null,
+          defaultAwuCredits: nonCreditPricedCapAwuCredits,
+        }
+      : {
+          overrideAwuCredits,
+          groupCapAwuCredits,
+          defaultAwuCredits: effectiveDefaultAwuCredits,
+        };
+    const spendLimitSource = resolveEffectiveSpendLimitSource(
+      spendLimitResolverInput
+    );
+    const effectiveSpendLimitAwuCredits = resolveEffectiveSpendLimitAwuCredits(
+      spendLimitResolverInput
+    );
     const effectiveCapAlert =
       spendLimitSource === "override"
         ? (perUserOverrideAlerts.get(userId) ?? null)


### PR DESCRIPTION
## Description

For non-credit-priced (legacy) plans, poke did not show the per-member credit cap or the per-member rate-limiter state — even though the cap **is** enforced (`isNonCreditPricedUserSpendLimitReached` → `403 user_cap_reached`, a workspace-wide default applied uniformly on a UTC-calendar-month Redis window).

Two backend gaps made the data wrong for legacy in `getMembersUsage`:
- the per-member cap was resolved via `fetchEffectivePerUserSpendLimits`, which short-circuits to empty maps when there is no `metronomeCustomerId` → cap showed `null`;
- the rate-limiter counter was read against the (null) Metronome billing period instead of the calendar-month window enforcement actually writes → rate-limiter state was always `ok`/`—`.

This PR, **scoped poke-only** (gated on `includeAlertLinks`):
- resolves the legacy cap from the raw `defaultPoolCapAwuCredits` (uniform across members, `0` = no limit), matching `getNonCreditPricedDefaultUserSpendLimit`;
- reads the counter on the calendar-month window via `spendLimitCycleOverrideForAuth`, so poke reads the same Redis key enforcement accrues into;
- adds a **"Per-member credit limit (legacy)"** card and reveals the **User cap** column in the poke members table (the Rate limiter state column already rendered).

The customer usage page is intentionally left byte-for-byte unchanged: its Unblock affordance raises a per-member *override*, which legacy enforcement ignores — so surfacing an accurate `isSpendCapped` there would offer a non-functional action.

## Tests

- `npx tsgo --noEmit` clean (only a pre-existing unrelated `archiver` module error).
- `biome check` clean on changed files.
- `npm run test -- lib/api/credits/members_usage.test.ts` passes (5/5).
- Manual: verified the corrected values only flow through the poke path (`includeAlertLinks`), leaving the customer `members-usage` route output unchanged.

## Risk

Low. Behavior change is confined to the poke admin members table (read-only display). No customer-facing surface changes; no enforcement changes. Credit-priced workspaces are unaffected (`spendLimitCycleOverrideForAuth` is a no-op for them and the resolver input is identical to before).

## Deploy Plan

Standard front deploy. No migration, no config, no feature flag.