### PR TITLE
feat(analytics): open the analyst panel on a live conversation

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -125,6 +125,8 @@ interface ConversationViewerProps {
   owner: WorkspaceType;
   user: UserType;
   clientSideMCPServerIds?: string[];
+  /** Set while the viewer is mounted but not shown, to skip its fetches. */
+  disabled?: boolean;
 }
 
 function easeOutQuint(x: number): number {
@@ -257,6 +259,7 @@ export const ConversationViewer = ({
   setLimitReachedCode,
   limitReachedCode,
   clientSideMCPServerIds,
+  disabled = false,
 }: ConversationViewerProps) => {
   const virtuosoMessageListRef =
     useRef<
@@ -282,6 +285,7 @@ export const ConversationViewer = ({
     conversationId,
     workspaceId: owner.sId,
     options: {
+      disabled,
       refreshInterval: (data) =>
         data?.conversation.forkingData?.forkedFrom?.fileCopyStatus === "pending"
           ? FORK_PREPARATION_POLL_INTERVAL_MS
@@ -340,6 +344,7 @@ export const ConversationViewer = ({
     conversationId,
     workspaceId: owner.sId,
     limit: DEFAULT_PAGE_LIMIT,
+    disabled,
   });
 
   const { mutateConversationParticipants } = useConversationParticipants({

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -266,7 +266,7 @@ export function AnalyticsConsumptionPage() {
               owner={owner}
               user={user}
               onClose={closePanel}
-              disabled={!isOpen}
+              isOpen={isOpen}
             />
           }
         >

--- a/front/components/workspace/analytics/AnalyticsConversationPanel.tsx
+++ b/front/components/workspace/analytics/AnalyticsConversationPanel.tsx
@@ -7,28 +7,12 @@ import {
 import { ConversationViewer } from "@app/components/assistant/conversation/ConversationViewer";
 import { FilePreviewProvider } from "@app/components/assistant/conversation/FilePreviewContext";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
-import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import type { VirtuosoMessageListContext } from "@app/components/assistant/conversation/types";
 import { useAnalyticsConversation } from "@app/hooks/useAnalyticsConversation";
-import { useAgentConfiguration } from "@app/lib/swr/assistants";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { ConversationType } from "@app/types/assistant/conversation";
-import type { RichMention } from "@app/types/assistant/mentions";
-import { toRichAgentMentionType } from "@app/types/assistant/mentions";
 import type { UserType, WorkspaceType } from "@app/types/user";
-import {
-  Button,
-  ConversationMessageAvatar,
-  ConversationMessageContainer,
-  ConversationMessageContent,
-  ConversationMessageTitle,
-  Icon,
-  Robot,
-  Spinner,
-  XClose,
-} from "@dust-tt/sparkle";
-import { useMemo } from "react";
+import { Button, Icon, Robot, Spinner, XClose } from "@dust-tt/sparkle";
+import { useCallback, useEffect, useMemo } from "react";
 
 interface AnalyticsConversationPanelHeaderProps {
   onClose: () => void;
@@ -54,69 +38,28 @@ function AnalyticsConversationPanelHeader({
   );
 }
 
-interface AnalyticsConversationGreetingProps {
-  agentConfiguration: LightAgentConfigurationType;
-}
-
-function AnalyticsConversationGreeting({
-  agentConfiguration,
-}: AnalyticsConversationGreetingProps) {
-  return (
-    <ConversationMessageContainer messageType="agent" type="agent">
-      <ConversationMessageAvatar
-        type="agent"
-        name={agentConfiguration.name}
-        avatarUrl={agentConfiguration.pictureUrl}
-      />
-      <div className="flex flex-col gap-2">
-        <ConversationMessageTitle
-          name={agentConfiguration.name}
-          renderName={(name) => name}
-        />
-        <ConversationMessageContent type="agent">
-          I can help you understand your workspace usage and costs across your
-          analytics data.
-        </ConversationMessageContent>
-      </div>
-    </ConversationMessageContainer>
-  );
-}
-
 interface AnalyticsConversationPanelBodyProps {
   owner: WorkspaceType;
   user: UserType;
   conversation: ConversationType | null;
-  createConversation: ReturnType<
-    typeof useAnalyticsConversation
-  >["createConversation"];
+  isOpen: boolean;
+  isCreatingConversation: boolean;
+  creationFailed: boolean;
+  onRetry: () => void;
   resetConversation: () => void;
-  disabled: boolean;
 }
 
 function AnalyticsConversationPanelBody({
   owner,
   user,
   conversation,
-  createConversation,
+  isOpen,
+  isCreatingConversation,
+  creationFailed,
+  onRetry,
   resetConversation,
-  disabled,
 }: AnalyticsConversationPanelBodyProps) {
-  const { agentConfiguration: analystAgentConfiguration } =
-    useAgentConfiguration({
-      workspaceId: owner.sId,
-      agentConfigurationId: GLOBAL_AGENTS_SID.ANALYST,
-      disabled,
-    });
-
   const { currentPanel } = useConversationSidePanelContext();
-
-  const stickyMentions = useMemo<RichMention[]>(
-    () =>
-      analystAgentConfiguration
-        ? [toRichAgentMentionType(analystAgentConfiguration)]
-        : [],
-    [analystAgentConfiguration]
-  );
 
   // Stub reuse of ConversationViewer's agentBuilderContext slot, whose only
   // fields we need are disableAgentMentions/actionsToShow.
@@ -133,10 +76,31 @@ function AnalyticsConversationPanelBody({
     [resetConversation]
   );
 
-  if (!analystAgentConfiguration) {
+  if (creationFailed) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <Spinner size="md" />
+      <div className="flex h-full min-h-0 items-center justify-center">
+        <div className="flex flex-col items-center gap-3 px-4 text-center">
+          <div className="text-lg font-medium text-foreground">
+            Unable to start Analyst
+          </div>
+          <div className="max-w-sm text-muted-foreground">
+            The Analyst session could not be started.
+          </div>
+          <Button variant="outline" label="Try again" onClick={onRetry} />
+        </div>
+      </div>
+    );
+  }
+
+  if (isCreatingConversation || !conversation) {
+    return (
+      <div className="flex h-full min-h-0 items-center justify-center">
+        <div className="flex items-center gap-3">
+          <Spinner size="md" />
+          <span className="text-muted-foreground">
+            Starting Analyst session...
+          </span>
+        </div>
       </div>
     );
   }
@@ -149,49 +113,22 @@ function AnalyticsConversationPanelBody({
         }
       >
         <div className="min-h-0 flex-1 overflow-y-auto">
-          {conversation ? (
-            <ConversationViewer
-              owner={owner}
-              user={user}
-              conversationId={conversation.sId}
-              agentBuilderContext={analystAgentContext}
-              key={conversation.sId}
-            />
-          ) : (
-            <div className="mx-auto w-full max-w-conversation px-5 pt-6 md:pt-10">
-              <AnalyticsConversationGreeting
-                agentConfiguration={analystAgentConfiguration}
-              />
-            </div>
-          )}
+          <ConversationViewer
+            owner={owner}
+            user={user}
+            conversationId={conversation.sId}
+            disabled={!isOpen}
+            agentBuilderContext={analystAgentContext}
+            key={conversation.sId}
+          />
         </div>
-
-        {!conversation && (
-          <div className="relative z-20 mx-auto flex w-full flex-shrink-0 flex-col px-5 pt-4 pb-6 md:max-w-[calc(var(--container-conversation)+0.5rem)] md:px-1">
-            <InputBar
-              owner={owner}
-              user={user}
-              onSubmit={createConversation}
-              stickyMentions={stickyMentions}
-              draftKey="analytics-conversation-panel"
-              placeholder="Ask about your workspace usage and costs"
-              actions={[]}
-              disableAgentMentions
-              disableUserMentions
-              disableAutoFocus
-              isFloating={false}
-            />
-          </div>
-        )}
       </div>
 
-      {conversation && (
-        <ConversationSidePanelContent
-          conversation={conversation}
-          owner={owner}
-          currentPanel={currentPanel}
-        />
-      )}
+      <ConversationSidePanelContent
+        conversation={conversation}
+        owner={owner}
+        currentPanel={currentPanel}
+      />
     </>
   );
 }
@@ -200,8 +137,7 @@ export interface AnalyticsConversationPanelProps {
   owner: WorkspaceType;
   user: UserType;
   onClose: () => void;
-  /** Skips fetching the agent configuration while the panel is closed. */
-  disabled?: boolean;
+  isOpen: boolean;
 }
 
 /**
@@ -212,10 +148,28 @@ export function AnalyticsConversationPanel({
   owner,
   user,
   onClose,
-  disabled = false,
+  isOpen,
 }: AnalyticsConversationPanelProps) {
-  const { conversation, createConversation, resetConversation } =
-    useAnalyticsConversation({ owner, user });
+  const {
+    conversation,
+    isCreatingConversation,
+    creationFailed,
+    startConversation,
+    resetConversation,
+  } = useAnalyticsConversation({ owner, user });
+
+  // `ResizableSidePanel` keeps this panel mounted while closed, so a mount effect would bootstrap
+  // a conversation on every Analytics page load.
+  useEffect(() => {
+    if (isOpen) {
+      void startConversation();
+    }
+  }, [isOpen, startConversation]);
+
+  const handleRetry = useCallback(() => {
+    resetConversation();
+    void startConversation();
+  }, [resetConversation, startConversation]);
 
   return (
     <div className="flex h-full w-full flex-col overflow-hidden">
@@ -234,9 +188,11 @@ export function AnalyticsConversationPanel({
                   owner={owner}
                   user={user}
                   conversation={conversation}
-                  createConversation={createConversation}
+                  isOpen={isOpen}
+                  isCreatingConversation={isCreatingConversation}
+                  creationFailed={creationFailed}
+                  onRetry={handleRetry}
                   resetConversation={resetConversation}
-                  disabled={disabled}
                 />
               </GenerationContextProvider>
             </BlockedActionsProvider>

--- a/front/hooks/conversations/useConversationMessages.ts
+++ b/front/hooks/conversations/useConversationMessages.ts
@@ -15,11 +15,13 @@ export function useConversationMessages({
   conversationId,
   workspaceId,
   limit,
+  disabled = false,
 }: {
   conversationId?: string | null;
   workspaceId: string;
   limit: number;
   startAtRank?: number;
+  disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
   const messagesFetcher: Fetcher<FetchConversationMessagesResponse> = fetcher;
@@ -27,7 +29,7 @@ export function useConversationMessages({
   const { data, error, mutate, size, setSize, isLoading, isValidating } =
     useSWRInfiniteWithDefaults(
       (pageIndex: number, previousPageData) => {
-        if (!conversationId) {
+        if (disabled || !conversationId) {
           return null;
         }
 

--- a/front/hooks/useAnalyticsConversation.ts
+++ b/front/hooks/useAnalyticsConversation.ts
@@ -1,22 +1,25 @@
-import { useConversations } from "@app/hooks/conversations/useConversations";
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { DustError } from "@app/lib/error";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { ConversationType } from "@app/types/assistant/conversation";
-import type { RichMention } from "@app/types/assistant/mentions";
-import type { ContentFragmentsType } from "@app/types/content_fragment";
-import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
+
+// Hidden in the panel by its origin, so what the user sees first is @analyst's reply to it.
+const OPENING_MESSAGE = `<dust_system>
+The user just opened the @analyst panel on the workspace Analytics page.
+Do NOT call any tools. Greet briefly and offer 2-3 example questions they could ask.
+</dust_system>`;
 
 /**
  * Creates and holds the single conversation for the Analytics conversation
- * panel, always mentioning `@analyst` on the first message. Creation is eager
- * on submit with the first message deferred, so `ConversationViewer` mounts
- * right away and renders its own optimistic placeholders (see
- * useCreateConversationWithMessage).
+ * panel. Creation is eager on panel opening, so the panel shows a live
+ * conversation from the start rather than a mocked greeting.
+ *
+ * At most one conversation is created per hook instance: `startConversation` is
+ * a no-op after the first call until `resetConversation` runs. Callers must
+ * gate the first call on the panel being open, since it stays mounted while
+ * closed.
  */
 export function useAnalyticsConversation({
   owner,
@@ -26,70 +29,68 @@ export function useAnalyticsConversation({
   user: UserType | null;
 }) {
   const sendNotification = useSendNotification();
+
   const [conversation, setConversation] = useState<ConversationType | null>(
     null
   );
-
-  const { mutateConversations } = useConversations({
-    workspaceId: owner.sId,
-    options: { disabled: true },
-  });
+  const [isCreatingConversation, setIsCreatingConversation] = useState(false);
+  const [creationFailed, setCreationFailed] = useState(false);
+  const hasStartedRef = useRef(false);
 
   const createConversationWithMessage = useCreateConversationWithMessage({
     owner,
     user,
   });
 
-  const createConversation = useCallback(
-    async (
-      input: string,
-      mentions: RichMention[],
-      contentFragments: ContentFragmentsType
-    ): Promise<Result<undefined, DustError>> => {
-      const result = await createConversationWithMessage({
-        messageData: {
-          input,
-          mentions: mentions.map((mention) => ({
-            configurationId: mention.id,
-          })),
-          contentFragments,
-          richMentions: mentions,
-        },
-        title: `Ask ${GLOBAL_AGENTS_SID.ANALYST}`,
-        deferMessage: true,
+  const startConversation = useCallback(async () => {
+    if (hasStartedRef.current) {
+      return;
+    }
+    hasStartedRef.current = true;
+
+    setIsCreatingConversation(true);
+
+    const result = await createConversationWithMessage({
+      messageData: {
+        input: OPENING_MESSAGE,
+        mentions: [{ configurationId: GLOBAL_AGENTS_SID.ANALYST }],
+        contentFragments: { uploaded: [], contentNodes: [] },
+        origin: "analytics_panel",
+      },
+      // `test` is the hidden state. Becomes visible (`unlisted`) once the user writes, see
+      // `promoteAnalyticsPanelConversation`.
+      visibility: "test",
+      // Without a title, `ensureConversationTitle` would name the conversation after the
+      // opening message.
+      title: `Ask ${GLOBAL_AGENTS_SID.ANALYST}`,
+    });
+
+    if (result.isErr()) {
+      setCreationFailed(true);
+      setIsCreatingConversation(false);
+      sendNotification({
+        title: result.error.title,
+        description: result.error.message,
+        type: "error",
       });
+      return;
+    }
 
-      if (result.isErr()) {
-        sendNotification({
-          title: result.error.title,
-          description: result.error.message,
-          type: "error",
-        });
-        return new Err({
-          code: "internal_error",
-          name: result.error.title,
-          message: result.error.message,
-        });
-      }
-
-      setConversation(result.value);
-      await mutateConversations(
-        (currentData) => [result.value, ...(currentData ?? [])],
-        { revalidate: false }
-      );
-
-      return new Ok(undefined);
-    },
-    [createConversationWithMessage, mutateConversations, sendNotification]
-  );
+    setConversation(result.value);
+    setIsCreatingConversation(false);
+  }, [createConversationWithMessage, sendNotification]);
 
   const resetConversation = useCallback(() => {
+    hasStartedRef.current = false;
     setConversation(null);
+    setCreationFailed(false);
   }, []);
 
   return {
     conversation,
-    createConversation,
+    isCreatingConversation,
+    creationFailed,
+    startConversation,
     resetConversation,
   };
 }


### PR DESCRIPTION
## Description

The Ask @analyst panel opens on a hardcoded greeting bubble and only creates a conversation once the user submits. This stack makes it open on a real conversation instead.

Stack, merges in order:

1. `hide-bootstrapped-opening-message` hides an opening message the user did not write
2. `promote-on-first-write` adds the conversation to history on first write
3. `open-panel-on-conversation` opens the Ask @analyst panel on it

**This PR (3).**
The panel creates its conversation when it first opens, sending the opening message the way the agent builder sidekick does and tagging it with the `analytics_panel` origin so PR#1 hides it. The empty state, its input bar and its sticky mentions are deleted.

`ResizableSidePanel` keeps the panel mounted while closed, so creation is keyed on the panel being open rather than on mount. The `disabled` prop becomes `isOpen` to kill the double negative.

## Tests

No automated coverage, this is UI wiring. Checked manually:

- loading the Analytics page without opening the panel issues no `POST /assistant/conversations`
- opening it issues exactly one, then shows @analyst's greeting with no gap above it
- the conversation stays out of the sidebar until the first real question
- closing and reopening reuses the same conversation

## Risk

Connects the rest of the stack but still behind the `analytics_conversation_panel` flag.

The regression it is most exposed to is the first item above: the panel stays mounted while closed, so a mount-keyed effect would create a conversation on every Analytics page load.

## Deploy Plan

Standard, merges last in the stack.
