### PR TITLE
Assign owners to coding and Resource contracts

### DIFF
--- a/CONTRACTS
+++ b/CONTRACTS
@@ -96,7 +96,7 @@ function handleStreamEvent(event: AgentMessageEvent): State {
 }
 ```
 
-@cc [label:coding] avoid-quadratic-loops
+@cc [owner:philipperolet,label:coding] avoid-quadratic-loops
 Loops with quadratic O(n²) or worse, cubic O(n³) complexity can severely hurt performance as data
 sizes grow. Common quadratic patterns include nested loops over related datasets, repeated searches
 within loops, and chained array operations that each iterate over the data.
@@ -353,7 +353,7 @@ const { name, count } = validation.data;
 Reviewer: If you see new `io-ts` imports or codecs introduced by a PR, require the author to
 rewrite them in `zod`.
 
-@cc [label:coding] batch-database-queries
+@cc [owner:flvndvd,label:coding] batch-database-queries
 Avoid database queries or database-only helpers inside loops, which would resolve in an unbounded
 number of SQL queries that will scale with the data (N+1 pattern).
 Also avoid them in `Promise.all` and `concurrentExecutor` if possible, they only make the queries
@@ -385,7 +385,7 @@ Reviewer: If you detect a DB-backed helper or query inside a loop, ask the autho
 No sensitive data should be sent to our servers through URL or query string parameters. HTTP body or
 headers only are acceptable for sensitive data.
 
-@cc [label:security] string-ids-in-api-interfaces
+@cc [owner:flvndvd,label:security] string-ids-in-api-interfaces
 Never expose or accept ModelId in URLs, API endpoints or POST/PATCH payloads. Use string identifiers
 (sId) instead. This applies to all routes, including GET, POST, PATCH, and DELETE methods. ModelIds
 should be strictly internal and never exposed to the client.
@@ -482,13 +482,13 @@ Reviewer: If sandbox code adds or depends on a root-consumed lookup path, requir
 hardening that makes the path root-owned and not group/other writable, plus a regression test that
 attempts to write the attacker-controlled file as the workload user.
 
-@cc [label:error-handling] no-catching-own-errors
+@cc [owner:spolu,label:error-handling] no-catching-own-errors
 Never catch your own errors. `catch` is authorized around external libraries (whose error handling
 we don't control), but otherwise errors that may alter the execution upstream should be returned
 using our `Result<>` pattern. It is OK to throw errors, since we can't catch them these are
 guaranteed to trigger an internal error (and return a 500).
 
-@cc [label:error-handling] normalize-caught-errors
+@cc [owner:spolu,label:error-handling] normalize-caught-errors
 Never catch and cast what was caught as `Error`. JS allows throwing anything (string, number,
 random object, ...), so the cast may be invalid and hides errors from the logs. Use `normalizeError`
 instead, this function properly checks the content of the caught object and always returns a valid

--- a/front/CONTRACTS
+++ b/front/CONTRACTS
@@ -254,7 +254,7 @@ must not build a wire shape by reading a Resource's fields, and must not spread 
 fields to it. If a caller needs a shape that no existing method produces, add a new
 `to<Audience>JSON` on the Resource next to the others.
 
-@cc [owner:spolu;flvndvd,label:backend] thin-api-handlers
+@cc [label:backend] thin-api-handlers
 API handlers must stay thin: non-trivial business logic must live in `lib/api/*` or the appropriate
 Resource, subject to the HTTP-coupling exceptions below.
 
@@ -304,7 +304,7 @@ authorize → validate → call business function → respond. But if the extrac
 HTTP status codes or `APIErrorWithStatusCode` into the lib, push back and keep the logic in
 the handler instead.
 
-@cc [owner:spolu,label:backend] transport-independent-business-results
+@cc [label:backend] transport-independent-business-results
 Functions in `lib/api/*` and other shared business-logic modules must not return HTTP error
 envelopes, `APIErrorWithStatusCode`, or values that encode HTTP status codes. HTTP response
 semantics belong in the handler layer.

--- a/front/CONTRACTS
+++ b/front/CONTRACTS
@@ -1,8 +1,8 @@
-@cc [label:backend] api-routes-use-resources
+@cc [owner:flvndvd,label:backend] api-routes-use-resources
 API routes must not interact with Sequelize models directly. Use `lib/api/*` interfaces (creating
 them if missing). Direct Resource interactions are acceptable.
 
-@cc [label:backend] business-interfaces-hide-models
+@cc [owner:flvndvd,label:backend] business-interfaces-hide-models
 Interfaces in `lib/api/*` must not expose ModelId or Sequelize model objects.
 
 Example:
@@ -17,16 +17,16 @@ function doWorkspace({ id }: { id: ModelId }) { }
 function doWorkspace({ workspace }: { workspace: WorkspaceType }) { }
 ```
 
-@cc [label:backend] models-behind-resources
+@cc [owner:flvndvd,label:backend] models-behind-resources
 Sequelize models must not be used directly outside Resources.
 
 Any new model should be abstracted to the rest of the codebase through a pre-existing or new
 `Resource`.
 
-@cc [label:backend] resource-interfaces-hide-models
+@cc [owner:flvndvd,label:backend] resource-interfaces-hide-models
 Resource interfaces must not expose Sequelize model objects; accept Resources or Types instead.
 
-@cc [label:backend] business-functions-use-resources
+@cc [owner:flvndvd,label:backend] business-functions-use-resources
 Any newly introduced function in `lib/api/*` should rely on Resources and not models directly.
 
 @cc [label:backend] use-concurrent-executor
@@ -67,7 +67,7 @@ if (isString(aId)) {
 const r = someFunction(aId);
 ```
 
-@cc [label:backend] resource-identifier-naming
+@cc [owner:flvndvd,label:backend] resource-identifier-naming
 Resource identifiers must follow this naming convention:
 
 - For the string identifier of a resource (`sId` field): use `<resourceName>Id` (e.g., `agentId`,
@@ -96,7 +96,7 @@ const agentModelId = agent.id;       // Numeric ModelId
 
 This naming convention also implies that no variable should follow the naming `xxxSId` or `<resourceName>sId`.
 
-@cc [label:backend] sequelize-model-suffix
+@cc [owner:flvndvd,label:backend] sequelize-model-suffix
 When creating a new Resource that wraps a Sequelize model, the model should be renamed to include
 the "Model" suffix for clarity (e.g., `Conversation` becomes `ConversationModel`).
 This naming convention helps distinguish between the Resource interface and
@@ -182,7 +182,7 @@ Follow these steps based on the type of change:
   - First: Update all client code to stop relying on the removed value
   - Stop returning the enum value from the backend only after a period of time
 
-@cc [label:backend] index-foreign-keys
+@cc [owner:flvndvd,label:backend] index-foreign-keys
 When adding a foreign key `B.a` on table `B` to a deletable object from table `A` (pretty much all
 objects in the context of scrubbing a workspace) make sure to add an index on `B.a` to avoid table
 scans when deleting objects from table `A`.
@@ -234,7 +234,7 @@ export type UserTypeWithWorkspaces = UserType & {
 };
 ```
 
-@cc [label:backend] resource-owned-serialization
+@cc [owner:flvndvd,label:backend] resource-owned-serialization
 Some objects have both a back-end (Resource class) and a front-end representation (Type interface).
 The back-end representation is a Resource class that wraps a Sequelize model.
 The front-end representation is a Type interface that is the result of serializing the back-end Resource, extracting the
@@ -254,7 +254,7 @@ must not build a wire shape by reading a Resource's fields, and must not spread 
 fields to it. If a caller needs a shape that no existing method produces, add a new
 `to<Audience>JSON` on the Resource next to the others.
 
-@cc [label:backend] thin-api-handlers
+@cc [owner:spolu;flvndvd,label:backend] thin-api-handlers
 API handlers must stay thin: non-trivial business logic must live in `lib/api/*` or the appropriate
 Resource, subject to the HTTP-coupling exceptions below.
 
@@ -304,7 +304,7 @@ authorize → validate → call business function → respond. But if the extrac
 HTTP status codes or `APIErrorWithStatusCode` into the lib, push back and keep the logic in
 the handler instead.
 
-@cc [label:backend] transport-independent-business-results
+@cc [owner:spolu,label:backend] transport-independent-business-results
 Functions in `lib/api/*` and other shared business-logic modules must not return HTTP error
 envelopes, `APIErrorWithStatusCode`, or values that encode HTTP status codes. HTTP response
 semantics belong in the handler layer.
@@ -494,11 +494,11 @@ When introducing new endpoints or modifying existing endpoints, introduce functi
 tests are functional and focus at the endpoint level for now. Unit tests are not required nor
 desired.
 
-@cc [label:testing] test-setup-through-factories
+@cc [owner:flvndvd,label:testing] test-setup-through-factories
 Test state setup should be done through factories. Factories should return Resources whenever
 possible.
 
-@cc [label:testing] tests-use-resources
+@cc [owner:flvndvd,label:testing] tests-use-resources
 Direct use of Sequelize models in tests should be avoided in favor of Resources. This includes test
 setup and assertions.
 

--- a/front/CONTRACTS
+++ b/front/CONTRACTS
@@ -494,7 +494,7 @@ When introducing new endpoints or modifying existing endpoints, introduce functi
 tests are functional and focus at the endpoint level for now. Unit tests are not required nor
 desired.
 
-@cc [owner:flvndvd,label:testing] test-setup-through-factories
+@cc [owner:Fraggle,label:testing] test-setup-through-factories
 Test state setup should be done through factories. Factories should return Resources whenever
 possible.
 


### PR DESCRIPTION
## Description

Assign @philipperolet  to `avoid-quadratic-loops`, @spolu  to Err/Result contracts, and @flvndvd  to Resource-related contracts in `CONTRACTS` and `front/CONTRACTS`.  Also @Fraggle to one test-related contract.

## Tests

Verified that only owner metadata changed, preserving all contract bodies, slugs, and labels.

## Risk

None. Ownership metadata only.

## Deploy Plan

Merge to main.
