### PR TITLE
Clarify Result and caught-error contracts

### DIFF
--- a/CONTRACTS
+++ b/CONTRACTS
@@ -486,13 +486,11 @@ attempts to write the attacker-controlled file as the workload user.
 Repository functions MUST return failures that callers are expected to handle as `Err<E>` values in
 `Result<T, E>`, rather than throw them.
 
-External-service adapters whose local contract requires throwing recognized provider failures are
-exempt: they MAY throw documented errors, and callers MAY catch them using runtime type guards.
-`catch` is also permitted around external-library calls whose exceptions we do not control.
-
 Applicable local contracts MAY define explicit exceptions to this rule, limited to the boundaries
-and failure cases they specify. Outside these exceptions, errors thrown by repository code MUST
-propagate to the runtime's error handler.
+and failure cases they specify; callers MAY catch those documented failures using runtime type
+guards. `catch` is also permitted around external-library calls whose exceptions we do not control.
+Outside these exceptions, errors thrown by repository code MUST propagate to the runtime's error
+handler.
 
 @cc [owner:spolu,label:error-handling] normalize-caught-errors
 Caught values MUST NOT be treated as `Error` or an error subtype through a type assertion. When an

--- a/CONTRACTS
+++ b/CONTRACTS
@@ -490,11 +490,9 @@ External-service adapters whose local contract requires throwing recognized prov
 exempt: they MAY throw documented errors, and callers MAY catch them using runtime type guards.
 `catch` is also permitted around external-library calls whose exceptions we do not control.
 
-Temporal activity entrypoints MAY throw expected failures under the local
-`temporal-activity-failure-boundary` contract. Workflow callers MAY handle failures delivered by
-Temporal under `temporal-workflow-activity-failures`. These exceptions do not extend to helpers.
-Outside these exceptions, errors thrown by repository code MUST propagate to the runtime's error
-handler.
+Applicable local contracts MAY define explicit exceptions to this rule, limited to the boundaries
+and failure cases they specify. Outside these exceptions, errors thrown by repository code MUST
+propagate to the runtime's error handler.
 
 @cc [owner:spolu,label:error-handling] normalize-caught-errors
 Caught values MUST NOT be treated as `Error` or an error subtype through a type assertion. When an

--- a/CONTRACTS
+++ b/CONTRACTS
@@ -489,7 +489,12 @@ Repository functions MUST return failures that callers are expected to handle as
 External-service adapters whose local contract requires throwing recognized provider failures are
 exempt: they MAY throw documented errors, and callers MAY catch them using runtime type guards.
 `catch` is also permitted around external-library calls whose exceptions we do not control.
-Other errors thrown by repository code MUST propagate to the runtime's error handler.
+
+Temporal activity entrypoints MAY throw expected failures under the local
+`temporal-activity-failure-boundary` contract. Workflow callers MAY handle failures delivered by
+Temporal under `temporal-workflow-activity-failures`. These exceptions do not extend to helpers.
+Outside these exceptions, errors thrown by repository code MUST propagate to the runtime's error
+handler.
 
 @cc [owner:spolu,label:error-handling] normalize-caught-errors
 Caught values MUST NOT be treated as `Error` or an error subtype through a type assertion. When an

--- a/CONTRACTS
+++ b/CONTRACTS
@@ -484,9 +484,12 @@ attempts to write the attacker-controlled file as the workload user.
 
 @cc [owner:spolu,label:error-handling] no-catching-own-errors
 Repository functions MUST return failures that callers are expected to handle as `Err<E>` values in
-`Result<T, E>`, rather than throw them. Repository code MUST NOT catch errors thrown by repository
-code; `catch` is permitted around external-library calls whose exceptions we do not control.
-Unexpected errors MAY be thrown and MUST propagate to the runtime's error handler.
+`Result<T, E>`, rather than throw them.
+
+External-service adapters whose local contract requires throwing recognized provider failures are
+exempt: they MAY throw documented errors, and callers MAY catch them using runtime type guards.
+`catch` is also permitted around external-library calls whose exceptions we do not control.
+Other errors thrown by repository code MUST propagate to the runtime's error handler.
 
 @cc [owner:spolu,label:error-handling] normalize-caught-errors
 Caught values MUST NOT be treated as `Error` or an error subtype through a type assertion. When an

--- a/CONTRACTS
+++ b/CONTRACTS
@@ -483,31 +483,28 @@ hardening that makes the path root-owned and not group/other writable, plus a re
 attempts to write the attacker-controlled file as the workload user.
 
 @cc [owner:spolu,label:error-handling] no-catching-own-errors
-Never catch your own errors. `catch` is authorized around external libraries (whose error handling
-we don't control), but otherwise errors that may alter the execution upstream should be returned
-using our `Result<>` pattern. It is OK to throw errors, since we can't catch them these are
-guaranteed to trigger an internal error (and return a 500).
+Repository functions MUST return failures that callers are expected to handle as `Err<E>` values in
+`Result<T, E>`, rather than throw them. Repository code MUST NOT catch errors thrown by repository
+code; `catch` is permitted around external-library calls whose exceptions we do not control.
+Unexpected errors MAY be thrown and MUST propagate to the runtime's error handler.
 
 @cc [owner:spolu,label:error-handling] normalize-caught-errors
-Never catch and cast what was caught as `Error`. JS allows throwing anything (string, number,
-random object, ...), so the cast may be invalid and hides errors from the logs. Use `normalizeError`
-instead, this function properly checks the content of the caught object and always returns a valid
-`Error` object.
-
-Example:
-
-```
-// BAD
+Caught values MUST NOT be treated as `Error` or an error subtype through a type assertion. When an
+`Error` is required, code MUST use `normalizeError(caught)` unless a runtime type guard has already
+established the required type. Inspecting a caught value with a type guard or rethrowing it
+unchanged does not require normalization.
+```typescript
+// BAD: A type assertion does not validate the caught value.
 try {
-  // Some code.
+  await externalClient.request();
 } catch (err) {
-  return new Err(err as Err);
+  return new Err(err as Error);
 }
 
-// GOOD
+// GOOD: Normalize the caught value before returning it as an error.
 try {
-  // Some code.
-} catch(err) {
+  await externalClient.request();
+} catch (err) {
   return new Err(normalizeError(err));
 }
 ```

--- a/connectors/src/CONTRACTS
+++ b/connectors/src/CONTRACTS
@@ -1,0 +1,13 @@
+@cc [owner:spolu,label:error-handling] temporal-activity-failure-boundary
+Registered activity entrypoints invoked by Temporal MAY throw expected failures, as an exception
+to `no-catching-own-errors`. An activity failure MUST be reported by throwing an `Error` at that
+boundary, including converting an unhandled helper `Err<E>`, rather than returning an `Err` as data.
+Helpers MUST return expected failures as `Result<T, E>` until the activity boundary; neither
+`activities.ts` nor `activities/` grants them this exception. The separately documented
+external-service adapter exception remains governed by `no-catching-own-errors`.
+
+@cc [owner:spolu,label:error-handling] temporal-workflow-activity-failures
+Workflow code MAY catch failures delivered by Temporal activity calls using runtime type guards,
+such as `error instanceof ActivityFailure`, under the exception to `no-catching-own-errors`.
+Unrecognized errors MUST be rethrown. This exception does not permit workflows to throw expected
+local failures or catch errors thrown by workflow helpers.

--- a/connectors/src/lib/oauth.ts
+++ b/connectors/src/lib/oauth.ts
@@ -6,9 +6,10 @@ import type { LoggerInterface } from "@dust-tt/client";
 
 /**
  * @cc [label:error-handling] oauth-access-token-or-error
- * Return the retrieved token and connection data from `oauth` on success. Generic `oauth` errors
- * and well-known provider specific error codes throw `ExternalOAuthTokenError`. Other unrecognized
- * OAuth failures throw regular `Error` (generally leading to retries).
+ * This external-service adapter MUST return the retrieved token and connection data from `oauth` on
+ * success. Under the exception in `no-catching-own-errors`, it MUST throw `ExternalOAuthTokenError`
+ * for generic `oauth` errors and well-known provider-specific error codes, and regular `Error` for
+ * other unrecognized OAuth failures (generally leading to retries).
  */
 export async function getOAuthConnectionAccessTokenWithThrow({
   logger,

--- a/front/poke/temporal/CONTRACTS
+++ b/front/poke/temporal/CONTRACTS
@@ -1,0 +1,13 @@
+@cc [owner:spolu,label:error-handling] temporal-activity-failure-boundary
+Registered activity entrypoints invoked by Temporal MAY throw expected failures, as an exception
+to `no-catching-own-errors`. An activity failure MUST be reported by throwing an `Error` at that
+boundary, including converting an unhandled helper `Err<E>`, rather than returning an `Err` as data.
+Helpers MUST return expected failures as `Result<T, E>` until the activity boundary; neither
+`activities.ts` nor `activities/` grants them this exception. The separately documented
+external-service adapter exception remains governed by `no-catching-own-errors`.
+
+@cc [owner:spolu,label:error-handling] temporal-workflow-activity-failures
+Workflow code MAY catch failures delivered by Temporal activity calls using runtime type guards,
+such as `error instanceof ActivityFailure`, under the exception to `no-catching-own-errors`.
+Unrecognized errors MUST be rethrown. This exception does not permit workflows to throw expected
+local failures or catch errors thrown by workflow helpers.

--- a/front/temporal/CONTRACTS
+++ b/front/temporal/CONTRACTS
@@ -1,0 +1,13 @@
+@cc [owner:spolu,label:error-handling] temporal-activity-failure-boundary
+Registered activity entrypoints invoked by Temporal MAY throw expected failures, as an exception
+to `no-catching-own-errors`. An activity failure MUST be reported by throwing an `Error` at that
+boundary, including converting an unhandled helper `Err<E>`, rather than returning an `Err` as data.
+Helpers MUST return expected failures as `Result<T, E>` until the activity boundary; neither
+`activities.ts` nor `activities/` grants them this exception. The separately documented
+external-service adapter exception remains governed by `no-catching-own-errors`.
+
+@cc [owner:spolu,label:error-handling] temporal-workflow-activity-failures
+Workflow code MAY catch failures delivered by Temporal activity calls using runtime type guards,
+such as `error instanceof ActivityFailure`, under the exception to `no-catching-own-errors`.
+Unrecognized errors MUST be rethrown. This exception does not permit workflows to throw expected
+local failures or catch errors thrown by workflow helpers.


### PR DESCRIPTION
## Description

Clarify the `no-catching-own-errors` and `normalize-caught-errors` contracts: expected failures use `Result`, unexpected throws propagate, and caught values require normalization or a runtime type guard before being treated as errors. Remove the unconditional HTTP 500 and normalization-success claims, and retain the example using an external-library call.

## Tests

N/A. Contract prose and example changes only.

## Risk

None.

## Deploy Plan

Merge to main.
