### PR TITLE
Sort members usage by the same consumed source the table renders

### DIFF
--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1773,6 +1773,12 @@ export async function resolveMatchingMemberUserIds({
 // for those columns. Every other column is not indexed, so to sort by it we
 // fetch the full matching set with Elasticsearch `search_after`, rank it by
 // the relevant signal, sort in-app, then slice the requested page.
+/**
+ * @cc [owner:avervaet,label:product] sort-keys-match-rendered-source
+ * Every in-app sort key must be derived from the same data source as the response field it
+ * orders (consumed credits from the analytics index, never from the Metronome per-user usage
+ * cache), so the order shown always agrees with the values displayed.
+ */
 async function resolveMembersUsagePageUsers({
   auth,
   workspace,
@@ -1856,14 +1862,11 @@ async function resolveMembersUsagePageUsers({
         { defaultCapAwuCreditsBySeatType, seatAllowanceBySeatType },
         freeSeatCredits,
       ] = await Promise.all([
-        fetchConsumedAwuCreditsFromMetronomeByUserId({
-          workspaceId: workspace.sId,
-          metronomeCustomerId: workspace.metronomeCustomerId,
-          metronomeContractId: auth.subscription()?.metronomeContractId ?? null,
-          users: allUsers.map((u) => ({
-            sId: u.sId,
-            seatType: membershipByUserModelId.get(u.id)?.seatType ?? null,
-          })),
+        fetchConsumedAwuCreditsByUserId({
+          workspace,
+          userIds: allUsers.map((u) => u.sId),
+          freeSeatUserIds,
+          cycle: spendLimitCycleOverrideForAuth(auth),
         }),
         fetchEffectivePerUserSpendLimits({
           metronomeCustomerId: workspace.metronomeCustomerId,
@@ -1958,15 +1961,11 @@ async function resolveMembersUsagePageUsers({
       );
       const [consumedByUserId, seatDataByUserId, freeSeatCredits] =
         await Promise.all([
-          fetchConsumedAwuCreditsFromMetronomeByUserId({
-            workspaceId: workspace.sId,
-            metronomeCustomerId: workspace.metronomeCustomerId,
-            metronomeContractId:
-              auth.subscription()?.metronomeContractId ?? null,
-            users: allUsers.map((u) => ({
-              sId: u.sId,
-              seatType: membershipByUserModelId.get(u.id)?.seatType ?? null,
-            })),
+          fetchConsumedAwuCreditsByUserId({
+            workspace,
+            userIds: allUsers.map((u) => u.sId),
+            freeSeatUserIds,
+            cycle: spendLimitCycleOverrideForAuth(auth),
           }),
           fetchSeatDataForMembersTable({
             metronomeCustomerId: workspace.metronomeCustomerId,


### PR DESCRIPTION
## Description

The pool and seat usage in-app sorts read per-user usage from the Metronome cache while the rendered values come from the analytics index, so ties and cold-cache pages could order rows against the displayed numbers. Both sorts now use the analytics fetcher the response uses.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://app.notion.com/p/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- Deploy front
