### PR TITLE
Show programmatic usage as % of total in credit pool cards

### DIFF
--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -55,6 +55,23 @@ function formatCycleDayLabel(
   return `Day ${elapsedDays}/${totalDays}`;
 }
 
+function formatProgrammaticUsageShare(
+  programmaticConsumedCredits: number | null,
+  consumedCredits: number | null
+): string | null {
+  if (
+    typeof programmaticConsumedCredits !== "number" ||
+    typeof consumedCredits !== "number" ||
+    consumedCredits <= 0
+  ) {
+    return null;
+  }
+  const percentage = Math.round(
+    Math.min(100, (programmaticConsumedCredits / consumedCredits) * 100)
+  );
+  return `${percentage}% of the usage`;
+}
+
 interface WorkspaceCreditUsageValueCardsProps {
   showPoolCard: boolean;
   totalRemainingCredits: number;
@@ -105,7 +122,10 @@ export function WorkspaceCreditUsageValueCards({
             ? formatCredits(programmaticConsumedCredits)
             : "—"
         }
-        hint={null}
+        hint={formatProgrammaticUsageShare(
+          programmaticConsumedCredits,
+          consumedCredits
+        )}
       />
     </div>
   );


### PR DESCRIPTION
## Description

Add a "% of this cycle usage" hint to the programmatic credit used this cycle card.

<img width="360" height="124" alt="Capture d’écran 2026-09-09 à 15 52 17" src="https://github.com/user-attachments/assets/27e09955-9a95-40ea-a584-13f66afb6401" />


## Tests


## Risk

Low small UI addition

## Deploy Plan

Deploy front
