### PR TITLE
Admin access: show the restricted access message instead of the editor for redacted agents and skills

### DIFF
--- a/front/components/pages/builder/agents/EditAgentPage.tsx
+++ b/front/components/pages/builder/agents/EditAgentPage.tsx
@@ -1,5 +1,6 @@
 import AgentBuilder from "@app/components/agent_builder/AgentBuilder";
 import { AgentBuilderProvider } from "@app/components/agent_builder/AgentBuilderContext";
+import { RedactedAgentMessage } from "@app/components/assistant/details/tabs/AgentInfoTab/RedactedAgentMessage";
 import { NotAvailableErrorPage } from "@app/components/pages/builder/agents/NotAvailableErrorPage";
 import Custom404 from "@app/components/pages/Custom404";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
@@ -51,7 +52,7 @@ export function EditAgentPage() {
     throw new Error("Cannot edit archived agent");
   }
 
-  return (
+  const builder = (
     <AgentBuilderProvider
       owner={owner}
       user={user}
@@ -64,4 +65,30 @@ export function EditAgentPage() {
       />
     </AgentBuilderProvider>
   );
+
+  // The API redacts the private fields of the agents an admin cannot read (`canRead` false): the
+  // builder would show an empty prompt. Keep it as a blurred, inert backdrop and show the details
+  // panel's message and actions on top. Once access is granted, the refetch lifts the overlay.
+  if (!agentConfiguration.canRead) {
+    return (
+      <div className="relative">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none select-none blur-sm"
+        >
+          {builder}
+        </div>
+        <div className="absolute inset-0 z-10 flex items-start justify-center p-8">
+          <div className="w-full max-w-2xl">
+            <RedactedAgentMessage
+              agentConfiguration={agentConfiguration}
+              owner={owner}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return builder;
 }

--- a/front/components/pages/builder/skills/EditSkillPage.tsx
+++ b/front/components/pages/builder/skills/EditSkillPage.tsx
@@ -1,6 +1,7 @@
 import Custom404 from "@app/components/pages/Custom404";
 import SkillBuilder from "@app/components/skill_builder/SkillBuilder";
 import { SkillBuilderProvider } from "@app/components/skill_builder/SkillBuilderContext";
+import { RedactedSkillMessage } from "@app/components/skills/RedactedSkillMessage";
 import { useDocumentTitle } from "@app/hooks/useDocumentTitle";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { useRequiredPathParam } from "@app/lib/platform";
@@ -37,7 +38,7 @@ export function EditSkillPage() {
     );
   }
 
-  return (
+  const builder = (
     <SkillBuilderProvider
       key={skill.sId}
       owner={owner}
@@ -47,4 +48,27 @@ export function EditSkillPage() {
       <SkillBuilder skill={skill} onSaved={mutateSkill} />
     </SkillBuilderProvider>
   );
+
+  // The API redacts the private fields of the skills an admin cannot read (`canRead` false): the
+  // builder would show empty guidelines. Keep it as a blurred, inert backdrop and show the details
+  // panel's message and actions on top. Once access is granted, the refetch lifts the overlay.
+  if (!skill.canRead) {
+    return (
+      <div className="relative">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none select-none blur-sm"
+        >
+          {builder}
+        </div>
+        <div className="absolute inset-0 z-10 flex items-start justify-center p-8">
+          <div className="w-full max-w-2xl">
+            <RedactedSkillMessage skill={skill} owner={owner} />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return builder;
 }

--- a/front/components/skills/RedactedSkillMessage.tsx
+++ b/front/components/skills/RedactedSkillMessage.tsx
@@ -32,7 +32,7 @@ export function RedactedSkillMessage({
   const { spaces: allSpaces } = useSpacesAsAdmin({ workspaceId: owner.sId });
   const { user } = useAuth();
   const addSpaceMembers = useAddSpaceMembers({ owner });
-  const { mutateSkill } = useSkill({
+  const { mutateSkillRegardlessOfQueryParams: mutateSkill } = useSkill({
     workspaceId: owner.sId,
     skillId: skill.sId,
     disabled: true, // We only use the hook to mutate the cache

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -47,6 +47,8 @@ export function useSkill(options: {
   isSkillLoading: boolean;
   isSkillError: boolean;
   mutateSkill: () => void;
+  // Also refreshes the other variants of the skill fetch (with/without relations).
+  mutateSkillRegardlessOfQueryParams: () => void;
 };
 export function useSkill(options: {
   workspaceId: string;
@@ -58,6 +60,8 @@ export function useSkill(options: {
   isSkillLoading: boolean;
   isSkillError: boolean;
   mutateSkill: () => void;
+  // Also refreshes the other variants of the skill fetch (with/without relations).
+  mutateSkillRegardlessOfQueryParams: () => void;
 };
 export function useSkill({
   workspaceId,
@@ -74,6 +78,8 @@ export function useSkill({
   isSkillLoading: boolean;
   isSkillError: boolean;
   mutateSkill: () => void;
+  // Also refreshes the other variants of the skill fetch (with/without relations).
+  mutateSkillRegardlessOfQueryParams: () => void;
 } {
   const { fetcher } = useFetcher();
   const skillFetcher: Fetcher<
@@ -84,17 +90,15 @@ export function useSkill({
     ? `/api/w/${workspaceId}/skills/${skillId}${withRelations ? "?withRelations=true" : ""}`
     : null;
 
-  const { data, error, isLoading, mutate } = useSWRWithDefaults(
-    url,
-    skillFetcher,
-    { disabled }
-  );
+  const { data, error, isLoading, mutate, mutateRegardlessOfQueryParams } =
+    useSWRWithDefaults(url, skillFetcher, { disabled });
 
   return {
     skill: data?.skill ?? null,
     isSkillLoading: isLoading,
     isSkillError: !!error,
     mutateSkill: mutate,
+    mutateSkillRegardlessOfQueryParams: mutateRegardlessOfQueryParams,
   };
 }
 


### PR DESCRIPTION
## Description

Prevent seeing the editor page when trying to access a private agent/skill as an admin
Instead show a call to action to become an editor and join spaces.
This make it consistent with what admin can see all over the app.
Before this PR they would just see a half-filled editor

<img width="3834" height="1870" alt="image" src="https://github.com/user-attachments/assets/39208a50-581b-4ef7-b090-552c767fdf72" />

<img width="3820" height="1854" alt="image" src="https://github.com/user-attachments/assets/aae81401-acea-4524-9e38-1a51451b8b8c" />


## Tests

tested locally


https://github.com/user-attachments/assets/2537b393-f240-441f-b0fd-b0cabd4f50e4



## Risk

low

## Deploy Plan

deploy front
