### PR TITLE
Show transferred-asset counts after merging user identities

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/user_identity_merge.ts
+++ b/front/lib/api/poke/plugins/workspaces/user_identity_merge.ts
@@ -3,8 +3,25 @@ import {
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
 import { createPlugin } from "@app/lib/api/poke/types";
+import type { UserIdentityMergeTransferCounts } from "@app/lib/iam/users";
 import { mergeUserIdentities } from "@app/lib/iam/users";
 import { Err, Ok } from "@app/types/shared/result";
+
+// Labels for the transferred-asset summary shown after a merge, in display order.
+const TRANSFER_COUNT_LABELS: [keyof UserIdentityMergeTransferCounts, string][] =
+  [
+    ["conversations", "Conversations"],
+    ["userMessages", "Messages"],
+    ["agentConfigurations", "Agents (authored)"],
+    ["agentUserRelations", "Agent relations"],
+    ["groupMemberships", "Group memberships"],
+    ["triggers", "Triggers"],
+    ["files", "Files"],
+    ["contentFragments", "Content fragments"],
+    ["agentMemories", "Agent memories"],
+    ["keys", "API keys"],
+    ["dustAppSecrets", "Dust app secrets"],
+  ];
 
 export const userIdentityMergePlugin = createPlugin({
   manifest: {
@@ -84,9 +101,23 @@ export const userIdentityMergePlugin = createPlugin({
       },
     });
 
+    const { primaryUser, secondaryUser, transferCounts } = mergeResult.value;
+
+    const transferRows = TRANSFER_COUNT_LABELS.map(
+      ([key, label]) => `| ${label} | ${transferCounts[key]} |`
+    ).join("\n");
+
     return new Ok({
-      display: "text",
-      value: `User identities successfully merged into primary identity with email: ${mergeResult.value.primaryUser.email}`,
+      display: "markdown",
+      value: `
+User identities successfully merged into primary identity with email: ${primaryUser.email}
+
+Transferred from secondary (${secondaryUser.sId}) to primary (${primaryUser.sId}):
+
+| Asset | Transferred |
+|-------|-------------|
+${transferRows}
+      `,
     });
   },
 });

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -238,6 +238,25 @@ export async function createOrUpdateUser({
   return { user: resultUser, created };
 }
 
+// Number of each asset transferred from the secondary user to the primary user during an identity
+// merge. Surfaced by the "merge user identities" poke plugin so support can confirm, in real time,
+// that the secondary user's data moved onto the primary user without waiting for a data warehouse
+// refresh. Counts reflect rows actually re-pointed to the primary user (duplicates that the primary
+// already owned are discarded, not transferred).
+export interface UserIdentityMergeTransferCounts {
+  agentConfigurations: number;
+  conversations: number;
+  userMessages: number;
+  contentFragments: number;
+  files: number;
+  dustAppSecrets: number;
+  agentMemories: number;
+  groupMemberships: number;
+  agentUserRelations: number;
+  keys: number;
+  triggers: number;
+}
+
 export async function mergeUserIdentities({
   auth,
   primaryUserId,
@@ -251,7 +270,14 @@ export async function mergeUserIdentities({
   enforceEmailMatch?: boolean;
   revokeSecondaryUser?: boolean;
 }): Promise<
-  Result<{ primaryUser: UserResource; secondaryUser: UserResource }, Error>
+  Result<
+    {
+      primaryUser: UserResource;
+      secondaryUser: UserResource;
+      transferCounts: UserIdentityMergeTransferCounts;
+    },
+    Error
+  >
 > {
   if (primaryUserId === secondaryUserId) {
     return new Err(new Error("Primary and secondary user IDs are the same."));
@@ -292,7 +318,7 @@ export async function mergeUserIdentities({
   }
 
   // Migrate authorship of agent configurations from the secondary user to the primary user.
-  await AgentConfigurationModel.update(
+  const [agentConfigurationsCount] = await AgentConfigurationModel.update(
     {
       authorId: primaryUser.id,
     },
@@ -315,25 +341,43 @@ export async function mergeUserIdentities({
   };
 
   // Merge conversation participations from secondary user to primary user.
-  await ConversationResource.mergeUserParticipations(workspaceId, {
-    primaryUserId: primaryUser.id,
-    secondaryUserId: secondaryUser.id,
-  });
+  const conversationsCount = await ConversationResource.mergeUserParticipations(
+    workspaceId,
+    {
+      primaryUserId: primaryUser.id,
+      secondaryUserId: secondaryUser.id,
+    }
+  );
   // Migrate authorship of user messages from the secondary user to the primary user.
-  await UserMessageModel.update(userIdValues, userIdOptions);
+  const [userMessagesCount] = await UserMessageModel.update(
+    userIdValues,
+    userIdOptions
+  );
   // Migrate authorship of content fragments from the secondary user to the primary user.
-  await ContentFragmentModel.update(userIdValues, userIdOptions);
+  const [contentFragmentsCount] = await ContentFragmentModel.update(
+    userIdValues,
+    userIdOptions
+  );
   // Migrate authorship of files from the secondary user to the primary user.
-  await FileModel.update(userIdValues, userIdOptions);
-  await DustAppSecretModel.update(userIdValues, userIdOptions);
+  const [filesCount] = await FileModel.update(userIdValues, userIdOptions);
+  const [dustAppSecretsCount] = await DustAppSecretModel.update(
+    userIdValues,
+    userIdOptions
+  );
   // Migrate authorship of agent memories from the secondary user to the primary user.
-  await AgentMemoryModel.update(userIdValues, userIdOptions);
+  const [agentMemoriesCount] = await AgentMemoryModel.update(
+    userIdValues,
+    userIdOptions
+  );
 
   // Migrate group memberships from secondary user to primary user
-  await GroupResource.migrateUserMemberships(auth, {
-    primaryUser,
-    secondaryUser,
-  });
+  const groupMembershipsCount = await GroupResource.migrateUserMemberships(
+    auth,
+    {
+      primaryUser,
+      secondaryUser,
+    }
+  );
 
   // Delete all agent-user relations for the secondary user that already have a relation.
   const agentConfigurations = await AgentUserRelationModel.findAll({
@@ -351,10 +395,13 @@ export async function mergeUserIdentities({
     },
   });
   // Migrate agent-user relations from the secondary user to the primary user.
-  await AgentUserRelationModel.update(userIdValues, userIdOptions);
+  const [agentUserRelationsCount] = await AgentUserRelationModel.update(
+    userIdValues,
+    userIdOptions
+  );
 
   // Migrate authorship of keys from the secondary user to the primary user.
-  await KeyModel.update(userIdValues, userIdOptions);
+  const [keysCount] = await KeyModel.update(userIdValues, userIdOptions);
 
   // Migrate trigger editorship from the secondary user to the primary user. Must run before the
   // revocation below, which deletes every trigger still owned by the secondary user.
@@ -365,6 +412,7 @@ export async function mergeUserIdentities({
   if (triggerTransferResult.isErr()) {
     return new Err(triggerTransferResult.error);
   }
+  const triggersCount = triggerTransferResult.value;
 
   if (
     primaryUser.email === secondaryUser.email &&
@@ -383,5 +431,18 @@ export async function mergeUserIdentities({
   return new Ok({
     primaryUser,
     secondaryUser,
+    transferCounts: {
+      agentConfigurations: agentConfigurationsCount,
+      conversations: conversationsCount,
+      userMessages: userMessagesCount,
+      contentFragments: contentFragmentsCount,
+      files: filesCount,
+      dustAppSecrets: dustAppSecretsCount,
+      agentMemories: agentMemoriesCount,
+      groupMemberships: groupMembershipsCount,
+      agentUserRelations: agentUserRelationsCount,
+      keys: keysCount,
+      triggers: triggersCount,
+    },
   });
 }

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -5363,7 +5363,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       primaryUserId: ModelId;
       secondaryUserId: ModelId;
     }
-  ): Promise<void> {
+  ): Promise<number> {
     // Find conversations where primary user is already a participant
     const primaryUserParticipations =
       await ConversationParticipantModel.findAll({
@@ -5389,8 +5389,10 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       });
     }
 
-    // Update remaining secondary user participations to point to primary user
-    await ConversationParticipantModel.update(
+    // Update remaining secondary user participations to point to primary user. The affected-row
+    // count is the number of conversations actually transferred (duplicates the primary already
+    // participated in were deleted above, not transferred).
+    const [transferredCount] = await ConversationParticipantModel.update(
       { userId: primaryUserId },
       {
         where: {
@@ -5399,6 +5401,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         },
       }
     );
+
+    return transferredCount;
   }
 
   toListItem(): ConversationListItemType {

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -657,10 +657,14 @@ describe("GroupResource", () => {
       });
       expect(membershipBefore).not.toBeNull();
 
-      await GroupResource.migrateUserMemberships(authenticator, {
-        primaryUser: user,
-        secondaryUser: secondaryUser,
-      });
+      const transferredCount = await GroupResource.migrateUserMemberships(
+        authenticator,
+        {
+          primaryUser: user,
+          secondaryUser: secondaryUser,
+        }
+      );
+      expect(transferredCount).toBe(1);
 
       const membershipAfter = await GroupMembershipModel.findOne({
         where: {
@@ -700,10 +704,15 @@ describe("GroupResource", () => {
         users: [secondaryUser.toJSON()],
       });
 
-      await GroupResource.migrateUserMemberships(authenticator, {
-        primaryUser: user,
-        secondaryUser: secondaryUser,
-      });
+      // The membership the primary already had is deleted, not transferred, so nothing is counted.
+      const transferredCount = await GroupResource.migrateUserMemberships(
+        authenticator,
+        {
+          primaryUser: user,
+          secondaryUser: secondaryUser,
+        }
+      );
+      expect(transferredCount).toBe(0);
 
       const primaryMembership = await GroupMembershipModel.findOne({
         where: {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -313,7 +313,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       primaryUser: UserResource;
       secondaryUser: UserResource;
     }
-  ): Promise<void> {
+  ): Promise<number> {
     const workspace = auth.getNonNullableWorkspace();
     const primaryMemberships = await GroupMembershipModel.findAll({
       where: { userId: primaryUser.id, workspaceId: workspace.id },
@@ -331,7 +331,9 @@ export class GroupResource extends BaseResource<GroupModel> {
       });
     }
 
-    await GroupMembershipModel.update(
+    // The affected-row count is the number of group memberships actually transferred (memberships
+    // the primary already had were deleted above, not transferred).
+    const [transferredCount] = await GroupMembershipModel.update(
       { userId: primaryUser.id },
       { where: { userId: secondaryUser.id, workspaceId: workspace.id } }
     );
@@ -341,6 +343,8 @@ export class GroupResource extends BaseResource<GroupModel> {
       [{ user: { id: primaryUser.id }, workspace: { id: workspace.id } }],
       [{ user: { id: secondaryUser.id }, workspace: { id: workspace.id } }],
     ]);
+
+    return transferredCount;
   }
 
   static async makeNew(

--- a/front/lib/resources/trigger_resource.test.ts
+++ b/front/lib/resources/trigger_resource.test.ts
@@ -708,6 +708,8 @@ describe("TriggerResource", () => {
       });
 
       expect(result.isOk()).toBe(true);
+      // Both the enabled and disabled triggers are re-pointed to the primary user.
+      expect(result.isOk() && result.value).toBe(2);
       for (const trigger of [enabledTrigger, disabledTrigger]) {
         const reloaded = await TriggerResource.fetchById(
           authenticator,
@@ -761,6 +763,8 @@ describe("TriggerResource", () => {
       });
 
       expect(result.isOk()).toBe(true);
+      // The secondary user owns no triggers, so nothing is transferred.
+      expect(result.isOk() && result.value).toBe(0);
       const reloaded = await TriggerResource.fetchById(
         authenticator,
         adminTrigger.sId

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -783,7 +783,7 @@ export class TriggerResource extends BaseResource<TriggerModel> {
       fromUser: UserResource;
       toUser: UserResource;
     }
-  ): Promise<Result<undefined, Error>> {
+  ): Promise<Result<number, Error>> {
     assert(
       auth.isAdmin(),
       "Trigger editorship can only be transferred by admins."
@@ -802,7 +802,7 @@ export class TriggerResource extends BaseResource<TriggerModel> {
       }
     );
     if (updatedRows.length === 0) {
-      return new Ok(undefined);
+      return new Ok(0);
     }
 
     const transferred = updatedRows.map(
@@ -854,7 +854,7 @@ export class TriggerResource extends BaseResource<TriggerModel> {
       );
     }
 
-    return new Ok(undefined);
+    return new Ok(transferred.length);
   }
 
   static async deleteAllForUser(


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8920.

After running the **Merge user identities** poke plugin (e.g. to fix duplicate accounts from an SSO/email change), support had no quick way to confirm the merge actually worked — the only signal was a periodically-refreshed Snowflake `DIM_USERS` snapshot, which is stale right after the merge.

The plugin now reports, right after the merge, **how many of each asset were transferred from the secondary user onto the primary**, as a markdown table:

<img width="516" height="557" alt="Screenshot 2026-09-09 at 15 54 19" src="https://github.com/user-attachments/assets/73bccc6f-e0b4-45b5-ac7c-a32f9a8baf99" />

Counts reflect rows genuinely re-pointed to the primary user; assets the primary already owned are deduped/deleted, so they are correctly **not** counted as transferred.

Implementation: `mergeUserIdentities` now returns a `transferCounts` object built from the affected-row count of each migration. To make those counts available, three helpers (each with only `mergeUserIdentities` as a non-test caller) now surface their transfer count:
- `ConversationResource.mergeUserParticipations` → `Promise<number>`
- `GroupResource.migrateUserMemberships` → `Promise<number>`
- `TriggerResource.transferEditor` → `Result<number, Error>` (was `Result<undefined, Error>`)

## Tests

- Extended the existing `migrateUserMemberships` and `transferEditor` resource tests to assert the returned counts, including the dedup case (primary already owned the asset → count 0). `group_resource.test.ts` + `trigger_resource.test.ts`: 52/52 pass.
- `tsgo --noEmit` clean; Biome format clean.

## Risk

Low. The change is additive — it only adds a return value (counts) to functions and enriches the poke plugin output; the merge behavior itself is unchanged. The three helpers changed signature but all non-test callers were updated in this PR, and callers only ever checked `isOk()`/ignored the return. Safe to roll back.

## Deploy Plan

Standard `front` deploy. No migration, no config, no ordering constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)