### PR TITLE
Rename top up to "Add credits" on the new usage page and refresh the credit cards after a purchase

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -290,9 +290,7 @@ export function UsagePage() {
     sort?.id === "email" || sort?.id === "seatUsage"
       ? sort.id
       : sort?.id === "consumedFromPoolAwuCredits"
-        ? isNewUsagePage
-          ? "consumedFromPoolAwuCredits"
-          : "consumedAwuCredits"
+        ? "consumedAwuCredits"
         : "name";
   const membersOrderDirection = sort?.desc ? "desc" : "asc";
 

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -118,6 +118,7 @@ import {
   LinkExternal01,
   LoadingBlock,
   Page,
+  Plus,
   ProgressBar,
   SearchInput,
   Spinner,
@@ -919,7 +920,7 @@ export function UsagePage() {
   const topUpButton = isWorkspaceAdmin ? (
     <Button
       label={isNewUsagePage ? "Add credits" : "Top up"}
-      icon={ArrowUp}
+      icon={isNewUsagePage ? Plus : ArrowUp}
       size="sm"
       variant="outline"
       disabled={!isCreditPriced || !usageSettings.topUpEnabled}
@@ -1267,11 +1268,12 @@ export function UsagePage() {
           ) : null}
 
           {isNewUsagePage && isCreditPriced ? (
-            <CreditPoolCards
-              owner={owner}
-              disabled={!isCreditPriced}
-              headerAction={usageSettings.topUpEnabled ? topUpButton : null}
-            />
+            <div className="flex flex-col items-stretch gap-4">
+              <CreditPoolCards owner={owner} disabled={!isCreditPriced} />
+              {usageSettings.topUpEnabled && (
+                <div className="flex justify-end">{topUpButton}</div>
+              )}
+            </div>
           ) : null}
 
           {!isNewUsagePage &&

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -511,9 +511,9 @@ export function UsagePage() {
     disabled: !isCreditPriced,
   });
 
-  // The new usage page cards read the pool from the cycle endpoints, so a
-  // purchase must revalidate those too. Disabled here: the cards own the
-  // fetch, we only borrow the mutate functions.
+  // The pool cards read the cycle endpoints, so a purchase must revalidate
+  // those too. Disabled here: the cards own the fetch, we only borrow the
+  // mutate functions.
   const { mutateAwuPoolCurrentCycle } = useAwuPoolCurrentCycle({
     workspaceId: owner.sId,
     disabled: true,
@@ -1079,10 +1079,8 @@ export function UsagePage() {
           onClose={() => setShowBuyCreditDialog(false)}
           onPurchaseSuccess={() => {
             void mutateAwuPoolSummary();
-            if (isNewUsagePage) {
-              void mutateAwuPoolCurrentCycle();
-              void mutateAwuPoolCycleHistory();
-            }
+            void mutateAwuPoolCurrentCycle();
+            void mutateAwuPoolCycleHistory();
           }}
           workspaceId={owner.sId}
           awuPurchaseInfo={awuPurchaseInfo}
@@ -1269,10 +1267,8 @@ export function UsagePage() {
 
           {isNewUsagePage && isCreditPriced ? (
             <div className="flex flex-col items-stretch gap-4">
+              <div className="flex justify-end">{topUpButton}</div>
               <CreditPoolCards owner={owner} disabled={!isCreditPriced} />
-              {usageSettings.topUpEnabled && (
-                <div className="flex justify-end">{topUpButton}</div>
-              )}
             </div>
           ) : null}
 

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -1340,8 +1340,9 @@ export function UsagePage() {
                   : "members"
               )
             }
+            className="flex flex-col gap-4"
           >
-            <TabsList className="mb-4">
+            <TabsList>
               <TabsTrigger value="members" label="Members" />
               <TabsTrigger value="groups" label="Groups" />
               {isWorkspaceAdmin && isCreditPriced && (
@@ -1353,7 +1354,7 @@ export function UsagePage() {
             </TabsList>
 
             <TabsContent value="members" className={TAB_CONTENT_CLASS}>
-              <Page.Vertical gap="sm" align="stretch">
+              <div className="flex flex-col items-stretch gap-4">
                 {searchRow}
                 <div className="flex flex-col gap-2">
                   <div className="flex flex-row items-center justify-between gap-2">
@@ -1412,7 +1413,7 @@ export function UsagePage() {
                     )}
                   </div>
                 </div>
-              </Page.Vertical>
+              </div>
             </TabsContent>
             <TabsContent value="groups" className={TAB_CONTENT_CLASS}>
               <GroupsUsageTable

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -904,7 +904,7 @@ export function UsagePage() {
 
   const topUpButton = isWorkspaceAdmin ? (
     <Button
-      label="Top up"
+      label={isNewUsagePage ? "Add credits" : "Top up"}
       icon={ArrowUp}
       size="sm"
       variant="outline"
@@ -1249,12 +1249,11 @@ export function UsagePage() {
           ) : null}
 
           {isNewUsagePage && isCreditPriced ? (
-            <div className="flex flex-col items-stretch gap-4">
-              <CreditPoolCards owner={owner} disabled={!isCreditPriced} />
-              {usageSettings.topUpEnabled && (
-                <div className="flex justify-end">{topUpButton}</div>
-              )}
-            </div>
+            <CreditPoolCards
+              owner={owner}
+              disabled={!isCreditPriced}
+              headerAction={usageSettings.topUpEnabled ? topUpButton : null}
+            />
           ) : null}
 
           {!isNewUsagePage &&

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -53,6 +53,8 @@ import {
 } from "@app/lib/plans/plan_codes";
 import { useSearchParam } from "@app/lib/platform";
 import {
+  useAwuPoolCurrentCycle,
+  useAwuPoolCycleHistory,
   useAwuPoolSummary,
   useAwuPurchaseInfo,
   useMyUsage,
@@ -506,6 +508,18 @@ export function UsagePage() {
   } = useAwuPoolSummary({
     workspaceId: owner.sId,
     disabled: !isCreditPriced,
+  });
+
+  // The new usage page cards read the pool from the cycle endpoints, so a
+  // purchase must revalidate those too. Disabled here: the cards own the
+  // fetch, we only borrow the mutate functions.
+  const { mutateAwuPoolCurrentCycle } = useAwuPoolCurrentCycle({
+    workspaceId: owner.sId,
+    disabled: true,
+  });
+  const { mutateAwuPoolCycleHistory } = useAwuPoolCycleHistory({
+    workspaceId: owner.sId,
+    disabled: true,
   });
 
   // TODO(2026-08-24): add back logic to show consumption here.
@@ -1064,6 +1078,10 @@ export function UsagePage() {
           onClose={() => setShowBuyCreditDialog(false)}
           onPurchaseSuccess={() => {
             void mutateAwuPoolSummary();
+            if (isNewUsagePage) {
+              void mutateAwuPoolCurrentCycle();
+              void mutateAwuPoolCycleHistory();
+            }
           }}
           workspaceId={owner.sId}
           awuPurchaseInfo={awuPurchaseInfo}

--- a/front/components/workspace/EditMemberSpendLimitModal.tsx
+++ b/front/components/workspace/EditMemberSpendLimitModal.tsx
@@ -320,7 +320,7 @@ function MemberSpendLimitForm({
                   ? "Only workspace admins can edit the workspace default limit."
                   : undefined
               }
-              isActive={false}
+              isActive={isDefaultActive}
               validationMessage={
                 defaultUserSpendLimit.status === "error"
                   ? "The workspace default limit could not be loaded."

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -18,7 +18,6 @@ import {
   ContentMessage,
   cn,
   DataTable,
-  Page,
   Spinner,
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
@@ -290,7 +289,7 @@ export function WorkspaceCreditPoolSection({
   }
 
   return (
-    <Page.Vertical gap="xs" align="stretch">
+    <div className="flex flex-col items-stretch gap-10">
       {cardsStatus === "error" ? (
         <ContentMessage
           title="Failed to load Workspace Credits Pool"
@@ -321,7 +320,7 @@ export function WorkspaceCreditPoolSection({
           />
         </>
       )}
-    </Page.Vertical>
+    </div>
   );
 }
 

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -23,6 +23,7 @@ import {
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useCallback, useState } from "react";
+import type { ReactNode } from "react";
 
 export type CreditPoolFetchStatus = "loading" | "error" | "ready";
 
@@ -265,6 +266,7 @@ interface WorkspaceCreditPoolSectionProps {
   cycleBreakdown: AwuPoolCycleBreakdown[];
   programmaticConsumedCredits: number | null;
   cycleHistoryLoadMore: CycleHistoryLoadMore;
+  headerAction?: ReactNode;
 }
 
 export function WorkspaceCreditPoolSection({
@@ -279,6 +281,7 @@ export function WorkspaceCreditPoolSection({
   cycleBreakdown,
   programmaticConsumedCredits,
   cycleHistoryLoadMore,
+  headerAction,
 }: WorkspaceCreditPoolSectionProps) {
   if (cardsStatus === "ready" && !isVisible) {
     return null;
@@ -286,7 +289,10 @@ export function WorkspaceCreditPoolSection({
 
   return (
     <Page.Vertical gap="xs" align="stretch">
-      <Page.H variant="h4">Credit consumption</Page.H>
+      <div className="flex items-center justify-between">
+        <Page.H variant="h4">Credit consumption</Page.H>
+        {headerAction}
+      </div>
 
       {cardsStatus === "error" ? (
         <ContentMessage
@@ -347,6 +353,7 @@ interface CreditPoolCardsFromCycleDataProps {
   excessCycleBreakdown: AwuPoolCycleBreakdown[];
   tableStatus: CreditPoolFetchStatus;
   cycleHistoryLoadMore: CycleHistoryLoadMore;
+  headerAction?: ReactNode;
 }
 export function CreditPoolCardsFromCycleData({
   awuPoolCurrentCycle,
@@ -355,6 +362,7 @@ export function CreditPoolCardsFromCycleData({
   excessCycleBreakdown,
   tableStatus,
   cycleHistoryLoadMore,
+  headerAction,
 }: CreditPoolCardsFromCycleDataProps) {
   const {
     totalRemainingCredits,
@@ -393,6 +401,7 @@ export function CreditPoolCardsFromCycleData({
       cycleBreakdown={hasPool ? poolCycleBreakdown : excessCycleBreakdown}
       programmaticConsumedCredits={programmaticConsumedCredits}
       cycleHistoryLoadMore={cycleHistoryLoadMore}
+      headerAction={headerAction}
     />
   );
 }
@@ -400,8 +409,13 @@ export function CreditPoolCardsFromCycleData({
 interface CreditPoolCardsProps {
   owner: LightWorkspaceType;
   disabled: boolean;
+  headerAction?: ReactNode;
 }
-export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
+export function CreditPoolCards({
+  owner,
+  disabled,
+  headerAction,
+}: CreditPoolCardsProps) {
   const { cycleHistoryLimit, onLoadMoreCycleHistory } = useCycleHistoryLimit();
   const {
     awuPoolCurrentCycle,
@@ -440,6 +454,7 @@ export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
           isAwuPoolCycleHistoryValidating && !isAwuPoolCycleHistoryLoading,
         onLoadMore: onLoadMoreCycleHistory,
       }}
+      headerAction={headerAction}
     />
   );
 }

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -22,7 +22,6 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
-import type { ReactNode } from "react";
 import { useCallback, useState } from "react";
 
 export type CreditPoolFetchStatus = "loading" | "error" | "ready";
@@ -195,7 +194,6 @@ export function WorkspaceCreditPoolCycleHistoryTable({
 
   return (
     <>
-      <Page.H variant="h5">Previous cycles</Page.H>
       <DataTable
         data={rows}
         columns={CYCLE_HISTORY_COLUMNS}
@@ -266,7 +264,6 @@ interface WorkspaceCreditPoolSectionProps {
   cycleBreakdown: AwuPoolCycleBreakdown[];
   programmaticConsumedCredits: number | null;
   cycleHistoryLoadMore: CycleHistoryLoadMore;
-  headerAction?: ReactNode;
 }
 
 export function WorkspaceCreditPoolSection({
@@ -281,7 +278,6 @@ export function WorkspaceCreditPoolSection({
   cycleBreakdown,
   programmaticConsumedCredits,
   cycleHistoryLoadMore,
-  headerAction,
 }: WorkspaceCreditPoolSectionProps) {
   if (cardsStatus === "ready" && !isVisible) {
     return null;
@@ -289,11 +285,6 @@ export function WorkspaceCreditPoolSection({
 
   return (
     <Page.Vertical gap="xs" align="stretch">
-      <div className="flex items-center justify-between">
-        <Page.H variant="h4">Credit consumption</Page.H>
-        {headerAction}
-      </div>
-
       {cardsStatus === "error" ? (
         <ContentMessage
           title="Failed to load Workspace Credits Pool"
@@ -353,7 +344,6 @@ interface CreditPoolCardsFromCycleDataProps {
   excessCycleBreakdown: AwuPoolCycleBreakdown[];
   tableStatus: CreditPoolFetchStatus;
   cycleHistoryLoadMore: CycleHistoryLoadMore;
-  headerAction?: ReactNode;
 }
 export function CreditPoolCardsFromCycleData({
   awuPoolCurrentCycle,
@@ -362,7 +352,6 @@ export function CreditPoolCardsFromCycleData({
   excessCycleBreakdown,
   tableStatus,
   cycleHistoryLoadMore,
-  headerAction,
 }: CreditPoolCardsFromCycleDataProps) {
   const {
     totalRemainingCredits,
@@ -401,7 +390,6 @@ export function CreditPoolCardsFromCycleData({
       cycleBreakdown={hasPool ? poolCycleBreakdown : excessCycleBreakdown}
       programmaticConsumedCredits={programmaticConsumedCredits}
       cycleHistoryLoadMore={cycleHistoryLoadMore}
-      headerAction={headerAction}
     />
   );
 }
@@ -409,13 +397,8 @@ export function CreditPoolCardsFromCycleData({
 interface CreditPoolCardsProps {
   owner: LightWorkspaceType;
   disabled: boolean;
-  headerAction?: ReactNode;
 }
-export function CreditPoolCards({
-  owner,
-  disabled,
-  headerAction,
-}: CreditPoolCardsProps) {
+export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
   const { cycleHistoryLimit, onLoadMoreCycleHistory } = useCycleHistoryLimit();
   const {
     awuPoolCurrentCycle,
@@ -454,7 +437,6 @@ export function CreditPoolCards({
           isAwuPoolCycleHistoryValidating && !isAwuPoolCycleHistoryLoading,
         onLoadMore: onLoadMoreCycleHistory,
       }}
-      headerAction={headerAction}
     />
   );
 }

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -22,8 +22,8 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
-import { useCallback, useState } from "react";
 import type { ReactNode } from "react";
+import { useCallback, useState } from "react";
 
 export type CreditPoolFetchStatus = "loading" | "error" | "ready";
 

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -81,7 +81,7 @@ interface WorkspaceCreditUsageValueCardsProps {
   currentCycleStartMs: number | null;
   currentCycleEndMs: number | null;
   programmaticConsumedCredits: number | null;
-  isLoading: boolean;
+  isRefreshing: boolean;
 }
 
 export function WorkspaceCreditUsageValueCards({
@@ -91,7 +91,7 @@ export function WorkspaceCreditUsageValueCards({
   currentCycleStartMs,
   currentCycleEndMs,
   programmaticConsumedCredits,
-  isLoading,
+  isRefreshing,
 }: WorkspaceCreditUsageValueCardsProps) {
   const cycleDayLabel = formatCycleDayLabel(
     currentCycleStartMs,
@@ -106,6 +106,7 @@ export function WorkspaceCreditUsageValueCards({
           label="Remaining credits in the pool"
           value={formatCredits(totalRemainingCredits)}
           hint={null}
+          isRefreshing={isRefreshing}
         />
       )}
       <SummaryCard
@@ -116,6 +117,7 @@ export function WorkspaceCreditUsageValueCards({
             : "—"
         }
         hint={cycleDayLabel}
+        isRefreshing={isRefreshing}
       />
       <SummaryCard
         label="Programmatic usage this cycle"
@@ -128,6 +130,7 @@ export function WorkspaceCreditUsageValueCards({
           programmaticConsumedCredits,
           consumedCredits
         )}
+        isRefreshing={isRefreshing}
       />
     </div>
   );
@@ -254,6 +257,8 @@ function WorkspaceCreditPoolHistory({
 
 interface WorkspaceCreditPoolSectionProps {
   cardsStatus: CreditPoolFetchStatus;
+  // Background refresh of already displayed cards (e.g. right after a purchase).
+  isCardsRefreshing: boolean;
   tableStatus: CreditPoolFetchStatus;
   showPoolCard: boolean;
   isVisible: boolean;
@@ -268,6 +273,7 @@ interface WorkspaceCreditPoolSectionProps {
 
 export function WorkspaceCreditPoolSection({
   cardsStatus,
+  isCardsRefreshing,
   tableStatus,
   showPoolCard,
   isVisible,
@@ -306,7 +312,7 @@ export function WorkspaceCreditPoolSection({
             currentCycleStartMs={currentCycleStartMs}
             currentCycleEndMs={currentCycleEndMs}
             programmaticConsumedCredits={programmaticConsumedCredits}
-            isLoading={false}
+            isRefreshing={isCardsRefreshing}
           />
           <WorkspaceCreditPoolHistory
             tableStatus={tableStatus}
@@ -340,6 +346,7 @@ export function useCycleHistoryLimit() {
 interface CreditPoolCardsFromCycleDataProps {
   awuPoolCurrentCycle: AwuPoolCurrentCycleResponseBody | null;
   cardsStatus: CreditPoolFetchStatus;
+  isCardsRefreshing?: boolean;
   poolCycleBreakdown: AwuPoolCycleBreakdown[];
   excessCycleBreakdown: AwuPoolCycleBreakdown[];
   tableStatus: CreditPoolFetchStatus;
@@ -348,6 +355,7 @@ interface CreditPoolCardsFromCycleDataProps {
 export function CreditPoolCardsFromCycleData({
   awuPoolCurrentCycle,
   cardsStatus,
+  isCardsRefreshing = false,
   poolCycleBreakdown,
   excessCycleBreakdown,
   tableStatus,
@@ -378,6 +386,7 @@ export function CreditPoolCardsFromCycleData({
   return (
     <WorkspaceCreditPoolSection
       cardsStatus={cardsStatus}
+      isCardsRefreshing={isCardsRefreshing}
       tableStatus={tableStatus}
       showPoolCard={hasPool}
       isVisible={hasPool || hasExcessData}
@@ -404,6 +413,7 @@ export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
     awuPoolCurrentCycle,
     isAwuPoolCurrentCycleLoading,
     isAwuPoolCurrentCycleError,
+    isAwuPoolCurrentCycleValidating,
   } = useAwuPoolCurrentCycle({ workspaceId: owner.sId, disabled });
   const {
     cycleBreakdown: poolCycleBreakdown,
@@ -425,6 +435,9 @@ export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
         isAwuPoolCurrentCycleLoading,
         !!isAwuPoolCurrentCycleError
       )}
+      isCardsRefreshing={
+        isAwuPoolCurrentCycleValidating && !isAwuPoolCurrentCycleLoading
+      }
       poolCycleBreakdown={poolCycleBreakdown}
       excessCycleBreakdown={excessCycleBreakdown}
       tableStatus={toCreditPoolFetchStatus(

--- a/front/components/workspace/analytics/SummaryCard.tsx
+++ b/front/components/workspace/analytics/SummaryCard.tsx
@@ -1,10 +1,12 @@
-import { cn } from "@dust-tt/sparkle";
+import { cn, Spinner } from "@dust-tt/sparkle";
 
 interface SummaryCardProps {
   className?: string;
   label: string;
   value: string;
   hint: string | null;
+  // Shows the value is being refreshed while keeping the previous one visible.
+  isRefreshing?: boolean;
 }
 
 export function SummaryCard({
@@ -12,6 +14,7 @@ export function SummaryCard({
   label,
   value,
   hint,
+  isRefreshing = false,
 }: SummaryCardProps) {
   return (
     <div
@@ -25,8 +28,9 @@ export function SummaryCard({
         {label}
       </span>
       <div className="flex flex-col">
-        <span className="truncate text-base font-semibold text-foreground">
-          {value}
+        <span className="flex items-center gap-2 text-base font-semibold text-foreground">
+          <span className="truncate">{value}</span>
+          {isRefreshing && <Spinner size="xs" />}
         </span>
         {hint && <span className="text-xs text-muted-foreground">{hint}</span>}
       </div>

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -24,7 +24,11 @@ import {
   getProductSeatTypes,
   getSeatTypesByProductIdFromContract,
 } from "@app/lib/metronome/seat_types";
-import { cacheWithRedis } from "@app/lib/utils/cache";
+import {
+  batchInvalidateCacheWithRedis,
+  cacheWithRedis,
+  invalidateCacheWithRedis,
+} from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type {
   AwuPoolCurrentCycleResponseBody,
@@ -381,6 +385,42 @@ const getCachedAwuPoolCycleHistoryOutcome = cacheWithRedis(
     ttlMs: AWU_POOL_CYCLE_HISTORY_CACHE_TTL_MS,
   }
 );
+
+const invalidateCachedAwuPoolCurrentCycleOutcome = invalidateCacheWithRedis(
+  computeAwuPoolCurrentCycleOutcome,
+  (auth) => auth.getNonNullableWorkspace().sId,
+  { cacheId: AWU_POOL_CURRENT_CYCLE_CACHE_ID }
+);
+
+const batchInvalidateCachedAwuPoolCycleHistoryOutcome =
+  batchInvalidateCacheWithRedis(
+    computeAwuPoolCycleHistoryOutcome,
+    (auth, cycleHistoryLimit) =>
+      cacheResolverKeyWithHistoryLimit(
+        auth.getNonNullableWorkspace().sId,
+        cycleHistoryLimit
+      ),
+    { cacheId: AWU_POOL_CYCLE_HISTORY_CACHE_ID }
+  );
+
+/**
+ * @cc [owner:arthurvervaet,label:product;performance] pool-cache-dropped-after-grant
+ * After this resolves, no cached current-cycle or cycle-history entry for the workspace remains,
+ * for any `cycleHistoryLimit` in `[1, MAX_CYCLE_HISTORY_LIMIT]`. Any code path that changes the
+ * workspace's pool balance outside a cycle rollover (credit purchase settlement, coupon redemption)
+ * MUST call it once the grant is effective, so the next read reflects the new balance instead of
+ * waiting for the cache TTL.
+ */
+export async function invalidateAwuPoolCaches(
+  auth: Authenticator
+): Promise<void> {
+  await Promise.all([
+    invalidateCachedAwuPoolCurrentCycleOutcome(auth),
+    batchInvalidateCachedAwuPoolCycleHistoryOutcome(
+      Array.from({ length: MAX_CYCLE_HISTORY_LIMIT }, (_, i) => [auth, i + 1])
+    ),
+  ]);
+}
 
 export async function getAwuPoolCycleHistory(
   auth: Authenticator,

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -2,6 +2,7 @@ import {
   getEsConsumedAwuCreditsForWorkspace,
   resolveMetronomeCycle,
 } from "@app/lib/api/credits/members_usage";
+import { getRedisCacheClient } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
 import { MAX_CYCLE_HISTORY_LIMIT } from "@app/lib/credits/awu_purchase_constants";
 import { amountCents } from "@app/lib/metronome/amounts";
@@ -24,11 +25,7 @@ import {
   getProductSeatTypes,
   getSeatTypesByProductIdFromContract,
 } from "@app/lib/metronome/seat_types";
-import {
-  batchInvalidateCacheWithRedis,
-  cacheWithRedis,
-  invalidateCacheWithRedis,
-} from "@app/lib/utils/cache";
+import { buildCacheWithRedisKey, cacheWithRedis } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type {
   AwuPoolCurrentCycleResponseBody,
@@ -386,27 +383,13 @@ const getCachedAwuPoolCycleHistoryOutcome = cacheWithRedis(
   }
 );
 
-const invalidateCachedAwuPoolCurrentCycleOutcome = invalidateCacheWithRedis(
-  computeAwuPoolCurrentCycleOutcome,
-  (auth) => auth.getNonNullableWorkspace().sId,
-  { cacheId: AWU_POOL_CURRENT_CYCLE_CACHE_ID }
-);
-
-const batchInvalidateCachedAwuPoolCycleHistoryOutcome =
-  batchInvalidateCacheWithRedis(
-    computeAwuPoolCycleHistoryOutcome,
-    (auth, cycleHistoryLimit) =>
-      cacheResolverKeyWithHistoryLimit(
-        auth.getNonNullableWorkspace().sId,
-        cycleHistoryLimit
-      ),
-    { cacheId: AWU_POOL_CYCLE_HISTORY_CACHE_ID }
-  );
-
 /**
  * @cc [owner:arthurvervaet,label:product;performance] pool-cache-dropped-after-grant
- * After this resolves, no cached current-cycle or cycle-history entry for the workspace remains,
- * for any `cycleHistoryLimit` in `[1, MAX_CYCLE_HISTORY_LIMIT]`. Any code path that changes the
+ * Deletes, in a single Redis command, every cached current-cycle and cycle-history entry of the
+ * workspace (for any `cycleHistoryLimit` in `[1, MAX_CYCLE_HISTORY_LIMIT]`) that exists when the
+ * command runs, so a reader never observes one cache refreshed and the other still stale. A read
+ * whose recompute started before the grant became effective can still write its pre-grant result
+ * after the deletion; that stale entry lives at most one cache TTL. Any code path that changes the
  * workspace's pool balance outside a cycle rollover (credit purchase settlement, coupon redemption)
  * MUST call it once the grant is effective, so the next read reflects the new balance instead of
  * waiting for the cache TTL.
@@ -414,12 +397,18 @@ const batchInvalidateCachedAwuPoolCycleHistoryOutcome =
 export async function invalidateAwuPoolCaches(
   auth: Authenticator
 ): Promise<void> {
-  await Promise.all([
-    invalidateCachedAwuPoolCurrentCycleOutcome(auth),
-    batchInvalidateCachedAwuPoolCycleHistoryOutcome(
-      Array.from({ length: MAX_CYCLE_HISTORY_LIMIT }, (_, i) => [auth, i + 1])
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+  const keys = [
+    buildCacheWithRedisKey(AWU_POOL_CURRENT_CYCLE_CACHE_ID, workspaceId),
+    ...Array.from({ length: MAX_CYCLE_HISTORY_LIMIT }, (_, i) =>
+      buildCacheWithRedisKey(
+        AWU_POOL_CYCLE_HISTORY_CACHE_ID,
+        cacheResolverKeyWithHistoryLimit(workspaceId, i + 1)
+      )
     ),
-  ]);
+  ];
+  const redisCli = await getRedisCacheClient({ origin: "cache_with_redis" });
+  await redisCli.del(keys);
 }
 
 export async function getAwuPoolCycleHistory(

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -2,6 +2,7 @@ import {
   handleSubscriptionActivationFailure,
   handleSubscriptionActivationSuccess,
 } from "@app/lib/api/checkout/business_activation";
+import { invalidateAwuPoolCaches } from "@app/lib/api/credits/awu_pool_summary";
 import {
   maybeClearAdminsBalanceThresholdReached,
   maybeNotifyAdminsBalanceThresholdReached,
@@ -948,6 +949,12 @@ export async function processMetronomeWebhook({
             paymentStatus,
           },
           "[Metronome Webhook] Payment-gated commit paid"
+        );
+        // Metronome has already activated the commit, so the cached pool
+        // reads are stale. Drop them before the UI learns the purchase
+        // succeeded and refetches.
+        await invalidateAwuPoolCaches(
+          await Authenticator.internalAdminForWorkspace(workspace.sId)
         );
         // Resolve the AWU purchase attempt the UI is polling for. The
         // store ignores the call if no attempt is pending on this

--- a/front/lib/metronome/coupons.ts
+++ b/front/lib/metronome/coupons.ts
@@ -2,6 +2,7 @@ import {
   buildAuditLogTarget,
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
+import { invalidateAwuPoolCaches } from "@app/lib/api/credits/awu_pool_summary";
 import type { Authenticator } from "@app/lib/auth";
 import { metronomeAmount } from "@app/lib/metronome/amounts";
 import {
@@ -328,6 +329,7 @@ export async function redeemPoolTopupCoupon(
   }
 
   await redemption.markActive(creditResult.value);
+  await invalidateAwuPoolCaches(auth);
 
   void emitAuditLogEvent({
     auth,

--- a/front/lib/metronome/coupons.ts
+++ b/front/lib/metronome/coupons.ts
@@ -39,6 +39,7 @@ import { isSupportedCurrency } from "@app/types/currency";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { addMonths } from "date-fns";
 
 async function getCreditTypeFromRateCardId(
@@ -329,8 +330,8 @@ export async function redeemPoolTopupCoupon(
   }
 
   await redemption.markActive(creditResult.value);
-  await invalidateAwuPoolCaches(auth);
 
+  // The redemption is complete at this point: audit it before anything that can still fail.
   void emitAuditLogEvent({
     auth,
     action: "coupon.redeemed",
@@ -341,6 +342,20 @@ export async function redeemPoolTopupCoupon(
       amount: String(coupon.amount),
     },
   });
+
+  // A cache failure must not turn a completed redemption into an error the user would retry.
+  try {
+    await invalidateAwuPoolCaches(auth);
+  } catch (err) {
+    logger.warn(
+      {
+        err: normalizeError(err),
+        couponId: coupon.sId,
+        workspaceId: workspace.sId,
+      },
+      "[Metronome] Failed to invalidate pool caches after coupon redemption"
+    );
+  }
 
   return new Ok(redemption);
 }

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -329,8 +329,6 @@ export function useAwuPoolCycleHistory({
     isAwuPoolCycleHistoryLoading: !error && !data && !disabled,
     isAwuPoolCycleHistoryError: error,
     isAwuPoolCycleHistoryValidating: isValidating,
-    // The key carries the current "Load more" limit, so revalidate every
-    // cached page rather than only the default one.
     mutateAwuPoolCycleHistory: mutateRegardlessOfQueryParams,
   };
 }

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -303,15 +303,16 @@ export function useAwuPoolCycleHistory({
   const { fetcher } = useFetcher();
   const awuFetcher: Fetcher<AwuPoolCycleHistoryResponseBody> = fetcher;
 
-  const { data, error, isValidating, mutate } = useSWRWithDefaults(
-    `/api/w/${workspaceId}/credits/awu-pool-cycle-history${
-      cycleHistoryLimit ? `?cycleHistoryLimit=${cycleHistoryLimit}` : ""
-    }`,
-    awuFetcher,
-    // Keep rows on screen while a larger limit is fetched so "Load more"
-    // appends instead of swapping the table for a spinner.
-    { disabled, keepPreviousData: true }
-  );
+  const { data, error, isValidating, mutateRegardlessOfQueryParams } =
+    useSWRWithDefaults(
+      `/api/w/${workspaceId}/credits/awu-pool-cycle-history${
+        cycleHistoryLimit ? `?cycleHistoryLimit=${cycleHistoryLimit}` : ""
+      }`,
+      awuFetcher,
+      // Keep rows on screen while a larger limit is fetched so "Load more"
+      // appends instead of swapping the table for a spinner.
+      { disabled, keepPreviousData: true }
+    );
 
   const isUsable = !error && !disabled;
 
@@ -328,7 +329,9 @@ export function useAwuPoolCycleHistory({
     isAwuPoolCycleHistoryLoading: !error && !data && !disabled,
     isAwuPoolCycleHistoryError: error,
     isAwuPoolCycleHistoryValidating: isValidating,
-    mutateAwuPoolCycleHistory: mutate,
+    // The key carries the current "Load more" limit, so revalidate every
+    // cached page rather than only the default one.
+    mutateAwuPoolCycleHistory: mutateRegardlessOfQueryParams,
   };
 }
 


### PR DESCRIPTION
## Description

- Rename the "Top up" button to "Add credits" on the new usage page and render it above the credit cards. It is now greyed out rather than hidden when top-up is disabled for the workspace.
- Revalidate the pool current-cycle and cycle-history endpoints from the purchase dialog success handler so the new credit cards refresh after a purchase or coupon redemption.
- Invalidate the Redis-cached current-cycle and cycle-history reads when a payment-gated commit is paid or a pool top-up coupon is redeemed. Without this the client refetch got the pre-grant balance back for up to 60s.
- Remove the "Credit consumption" and "Previous cycles" titles from the shared credit pool section (seen with @ClementAupiais). This also applies to the Poke credits page.

## Tests

- `lib/api/metronome/process_webhook.test.ts` and `lib/metronome/coupons.test.ts` pass.
- Manual: purchase flow on the new usage page not exercised end to end in a browser.

## Risk

Low

## Deploy Plan

Deploy front