### PR TITLE
Deploys and reverts name cells, not regions

### DIFF
--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -98,7 +98,7 @@ runs:
           channel: ${{ inputs.channel }}
           text: |
             ${{ inputs.is_revert == 'true' && '⏮️' || '🚀' }} ${{ inputs.is_revert == 'true' && 'Starting revert of' || 'Starting deployment of' }} ${{ inputs.component }} `${{ inputs.image_tag }}`
-            • Region: `${{ inputs.region }}`
+            • Cells: `${{ inputs.region }}`
             • Commit: <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ inputs.image_tag }}>
             • Workflow: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View build>
             • Author: ${{ steps.slack_user.outputs.id != '' && format('<@{0}>', steps.slack_user.outputs.id) || format('`{0}`', steps.author.outputs.name) }}
@@ -109,7 +109,7 @@ runs:
       shell: bash
       run: |
         # 1. Build Header Section
-        HEADER_TEXT="🔨 Build completed in ${{ inputs.region }} region"
+        HEADER_TEXT="🔨 Build completed for ${{ inputs.region }}"
         DETAILS_TEXT="• Image: \`${{ inputs.image_tag }}\`"
 
         if [ -n "${{ inputs.current_version }}" ]; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,17 +1,18 @@
 name: Deploy
-run-name: Deploy ${{ inputs.component }} to ${{ inputs.regions }}
+run-name: Deploy ${{ inputs.component }} to ${{ inputs.cells }}
 
 on:
   workflow_dispatch:
     inputs:
-      regions:
-        description: "Regions to deploy to"
+      cells:
+        description: "Cells to deploy to (cell-00000 is us-central1, cell-00001 europe-west1)"
         required: true
         default: "all"
         type: choice
         options:
-          - "us-central1"
-          - "europe-west1"
+          - "cell-00000"
+          - "cell-00001"
+          - "cell-00002"
           - "all"
       component:
         description: "Name of the component to deploy"
@@ -120,7 +121,7 @@ jobs:
           channel: ${{ secrets.SLACK_CHANNEL_ID }}
           component: ${{ inputs.component }}
           image_tag: ${{ needs.prepare.outputs.short_sha }}
-          region: ${{ inputs.regions }}
+          region: ${{ inputs.cells }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: Slack Check Deployment Blocked
@@ -139,11 +140,13 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          if [ "${{ inputs.regions }}" = "all" ]; then
-            echo "matrix=[\"us-central1\",\"europe-west1\"]" >> "$GITHUB_OUTPUT"
-          else
-            echo "matrix=[\"${{ inputs.regions }}\"]" >> "$GITHUB_OUTPUT"
-          fi
+          # Marketing builds per region, and only the legacy cells have one.
+          CELLS="${{ inputs.cells }}"
+          if [ "$CELLS" = "all" ]; then CELLS="cell-00000,cell-00001"; fi
+          REGIONS=$(tr ',' '\n' <<< "$CELLS" \
+            | sed -n 's/^cell-00000$/us-central1/p; s/^cell-00001$/europe-west1/p' \
+            | jq -R . | jq -sc 'unique')
+          echo "matrix=$REGIONS" >> "$GITHUB_OUTPUT"
 
   # Components on the build-once path: one build, pushed to the global registry.
   # Marketing stays on the regional matrix: next build inlines region-specific
@@ -190,7 +193,7 @@ jobs:
           thread_ts: ${{ needs.notify-start.outputs.thread_ts }}
           component: ${{ inputs.component }}
           image_tag: ${{ needs.prepare.outputs.short_sha }}
-          region: ${{ inputs.regions }}
+          region: ${{ inputs.cells }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
           current_version: ${{ steps.build.outputs.current_version }}
           commit_diff: ${{ steps.build.outputs.commit_diff }}
@@ -204,7 +207,7 @@ jobs:
           channel: ${{ secrets.SLACK_CHANNEL_ID }}
           component: ${{ inputs.component }}
           image_tag: ${{ needs.prepare.outputs.short_sha }}
-          region: ${{ inputs.regions }}
+          region: ${{ inputs.cells }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
           thread_ts: "${{ needs.notify-start.outputs.thread_ts }}"
 
@@ -277,7 +280,7 @@ jobs:
           channel: ${{ secrets.SLACK_CHANNEL_ID }}
           component: ${{ inputs.component }}
           image_tag: ${{ needs.prepare.outputs.short_sha }}
-          region: ${{ inputs.regions }}
+          region: ${{ inputs.cells }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
           thread_ts: "${{ needs.notify-start.outputs.thread_ts }}"
 
@@ -313,7 +316,7 @@ jobs:
         env:
           OWNER: ${{ github.repository_owner }}
           COMPONENT: ${{ inputs.component }}
-          REGIONS: ${{ inputs.regions }}
+          CELLS: ${{ inputs.cells }}
           IMAGE_TAG: ${{ needs.prepare.outputs.short_sha }}
           SLACK_THREAD_TS: ${{ needs.notify-start.outputs.thread_ts }}
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ID }}
@@ -332,7 +335,7 @@ jobs:
             const deploySpaAppPoke = process.env.DEPLOY_SPA_POKE === 'true';
 
             const payload = {
-              regions: process.env.REGIONS,
+              cells: process.env.CELLS,
               component,
               image_tag: process.env.IMAGE_TAG,
               slack_thread_ts: process.env.SLACK_THREAD_TS,
@@ -378,7 +381,7 @@ jobs:
           channel: ${{ secrets.SLACK_CHANNEL_ID }}
           component: ${{ inputs.component }}
           image_tag: ${{ needs.prepare.outputs.short_sha }}
-          region: ${{ inputs.regions }}
+          region: ${{ inputs.cells }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
           thread_ts: "${{ needs.notify-start.outputs.thread_ts }}"
 

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -1,17 +1,18 @@
 name: Revert Workflow
-run-name: Revert ${{ inputs.component }} in ${{ inputs.regions }}
+run-name: Revert ${{ inputs.component }} in ${{ inputs.cells }}
 
 on:
   workflow_dispatch:
     inputs:
-      regions:
-        description: "Regions to revert"
+      cells:
+        description: "Cells to revert (cell-00000 is us-central1, cell-00001 europe-west1)"
         required: true
         default: "all"
         type: choice
         options:
-          - "us-central1"
-          - "europe-west1"
+          - "cell-00000"
+          - "cell-00001"
+          - "cell-00002"
           - "all"
       image_tag:
         description: "The image tag/SHA to deploy"
@@ -66,7 +67,7 @@ jobs:
           channel: ${{ secrets.SLACK_CHANNEL_ID }}
           component: ${{ inputs.component }}
           image_tag: ${{ inputs.image_tag }}
-          region: ${{ inputs.regions }}
+          region: ${{ inputs.cells }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
           is_revert: true
 
@@ -123,7 +124,7 @@ jobs:
           channel: ${{ secrets.SLACK_CHANNEL_ID }}
           component: ${{ inputs.component }}
           image_tag: ${{ inputs.image_tag }}
-          region: ${{ inputs.regions }}
+          region: ${{ inputs.cells }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
           thread_ts: "${{ needs.notify-start.outputs.thread_ts }}"
           is_revert: true
@@ -153,7 +154,7 @@ jobs:
               repo: 'dust-infra',
               event_type: 'trigger-component-revert',
               client_payload: {
-                regions: '${{ inputs.regions }}',
+                cells: '${{ inputs.cells }}',
                 component: '${{ inputs.component }}',
                 image_tag: '${{ inputs.image_tag }}',
                 slack_thread_ts: "${{ needs.notify-start.outputs.thread_ts }}",
@@ -170,7 +171,7 @@ jobs:
           channel: ${{ secrets.SLACK_CHANNEL_ID }}
           component: ${{ inputs.component }}
           image_tag: ${{ inputs.image_tag }}
-          region: ${{ inputs.regions }}
+          region: ${{ inputs.cells }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
           thread_ts: "${{ needs.notify-start.outputs.thread_ts }}"
           is_revert: true


### PR DESCRIPTION
## Description

**Today.** Deploy and Revert ask for a region, `us-central1`, `europe-west1` or `all`, and send that to dust-infra, which runs the legacy clusters. cell-00002 is not reachable from here.

**After.** They ask for cells. `cell-00000` and `cell-00001` are the legacy clusters, `cell-00002` the first customer cell, `all` every one of them. The payload to dust-infra carries `cells`, and dust-infra (dust-tt/dust-infra#1081) turns each into a deploy target, records the tag in git and applies. The Slack thread names cells too.

The marketing build is the one job that still thinks in regions, its bundle inlines region specific values, so its matrix maps the two legacy cells to their region and skips any other. Nothing else in the build path changes.

## Tests

Read through and linted with actionlint. The cells to regions mapping for marketing was run locally for `all`, a single legacy cell, a mix with `cell-00002` and `cell-00002` alone, which yields an empty matrix as intended since marketing does not run on cells. A real deploy after both PRs are merged is the proof.

## Risk

dust-infra#1081 must merge first, it understands `cells` and refuses a payload without them. Merged in that order, the only window is between the two merges, during which a deploy from here stops in dust-infra before touching any cluster. Rollback is a revert of both.

## Deploy Plan

1. Merge dust-tt/dust-infra#1081.
2. Merge this.
3. Deploy any component to `cell-00001` from the Actions tab: one line in the thread for that cell, a commit in dust-infra under `versions/`.
