### PR TITLE
[Admin Governance] Align Poke agent permission reporting with grants

### DIFF
--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -43,7 +43,10 @@ import assert from "assert";
 import { describe, expect, it, vi } from "vitest";
 
 describe("getAgentConfigurations", () => {
-  it("reports system-key edit access without a permission shadow mismatch", async () => {
+  it.each([
+    "system key",
+    "Poke",
+  ] as const)("reports %s edit access without a permission shadow mismatch", async (caller) => {
     const { authenticator, workspace, systemGroup } = await createResourceTest({
       role: "admin",
     });
@@ -54,8 +57,16 @@ describe("getAgentConfigurations", () => {
       }
     );
     await FeatureFlagFactory.basic(authenticator, "group_permissions_shadow");
-    const key = await KeyFactory.system(systemGroup);
-    const auth = await Authenticator.fromKey(key, workspace.sId);
+    const auth =
+      caller === "system key"
+        ? await Authenticator.fromKey(
+            await KeyFactory.system(systemGroup),
+            workspace.sId
+          )
+        : await Authenticator.fromDustSuperUser({
+            wId: workspace.sId,
+            pokePrincipal: { email: "operator@dust.tt", name: "Operator" },
+          });
     const warn = vi.spyOn(logger, "warn");
     try {
       const configuration = await getAgentConfiguration(auth, {

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -166,7 +166,7 @@ async function shadowAgentPermissions(
  */
 /**
  * @cc [owner:philipperolet,label:security] agent-editability
- * For user and system-key callers, `canEdit` allows legacy authors/editors or user-less system-key
+ * Outside regular API keys, `canEdit` allows legacy authors/editors or user-less system-key/Poke
  * callers with agent write permission; workspace admin role alone does not grant it.
  */
 export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
@@ -230,18 +230,18 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
 
     const isAuthor = agent.authorId === auth.user()?.id;
     const isMember = editorIds.includes(agent.id);
-    const canEditAsSystem =
+    const canEditWithoutUser =
       !user &&
-      auth.isSystemKey() &&
+      (auth.isSystemKey() || auth.isDustSuperUser()) &&
       auth.can("write", AgentResource.fromAgentConfigurationModel(agent));
 
     const canRead =
-      isAuthor || isMember || canEditAsSystem || agent.scope === "visible";
+      isAuthor || isMember || canEditWithoutUser || agent.scope === "visible";
     const canEdit = isRegularApiKey
       ? auth.isAdmin() &&
         agent.status === "active" &&
         canReadRequestedSpaces(auth, spaceById, agent.requestedSpaceIds)
-      : isAuthor || isMember || canEditAsSystem;
+      : isAuthor || isMember || canEditWithoutUser;
     const agentConfigurationType: AgentConfigurationType = {
       id: agent.id,
       sId: agent.sId,


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/32083 and https://github.com/dust-tt/dust/pull/32056.

Poke sessions authenticated through Cloudflare Access have no Dust user attached. Although their workspace groups grant agent edit access, the legacy permission calculation only handles user-less system keys. Poke therefore reports `canEdit: false` where the grant-based shadow check reports `true`.

Extend that fallback to user-less Poke super-users, still requiring `auth.can("write", agent)`. This makes Poke's reported agent access match its existing grants. Human admins and user-backed impersonation keep their current permissions; no resource ACL changes.

## Risks

Blast radius: Agent permission reporting for user-less Poke sessions.
Risk: low

## Deploy Plan

- Deploy front.

## Tests

- [x] New Poke regression case fails before the fix and passes afterward.
- [x] Agent configuration, resource ACL, and permission shadow suites (48 tests), including human-admin and scoped-system-key boundaries.
- [x] Public API agent list and single-agent suites (16 tests), including regular API key behavior.
