### PR TITLE
Open EditMemberSpendLimitModal from the usage table on the new usage page

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -379,9 +379,13 @@ export function UsagePage() {
   const handleEditSpendLimitFromTable = useCallback(
     (member: MemberUsageType) => {
       setPendingApproveRequestId(null);
-      setEditSpendLimitMember(member);
+      if (isNewUsagePage) {
+        setSpendLimitRecapMember(member);
+      } else {
+        setEditSpendLimitMember(member);
+      }
     },
-    []
+    [isNewUsagePage]
   );
   const { setUserAllowedModelTier, clearUserAllowedModelTier } =
     useUserAllowedModelTierMutations({ owner });
@@ -500,6 +504,7 @@ export function UsagePage() {
     isMembersUsageLoading,
     isMembersUsageRefreshing,
     totalMembersUsage,
+    mutateMembersUsage,
   } = useMembersUsage({
     workspaceId: owner.sId,
     searchTerm,
@@ -1061,32 +1066,28 @@ export function UsagePage() {
             />
           ) : (
             <div className="flex items-center justify-between">
-              <Page.Header
-                title={
-                  <div className="flex w-full items-center gap-4">
-                    <Page.H variant="h3">Usage</Page.H>
+              <Page.Header title="Usage" />
+              <div className="flex items-center gap-4">
+                <Button
+                  label="Breakdown in analytics"
+                  iconRight={LinkExternal01}
+                  size="xs"
+                  variant="highlight-ghost"
+                  href={`/w/${owner.sId}/analytics/consumption`}
+                />
+                {!isNewUsagePage &&
+                  isCreditPriced &&
+                  usageSettings.topUpEnabled &&
+                  isWorkspaceAdmin && (
                     <Button
-                      label="Breakdown in analytics"
-                      iconRight={LinkExternal01}
-                      size="xs"
-                      variant="highlight-ghost"
-                      href={`/w/${owner.sId}/analytics/consumption`}
+                      label="Top up"
+                      icon={ArrowUp}
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setShowBuyCreditDialog(true)}
                     />
-                  </div>
-                }
-              />
-              {!isNewUsagePage &&
-                isCreditPriced &&
-                usageSettings.topUpEnabled &&
-                isWorkspaceAdmin && (
-                  <Button
-                    label="Top up"
-                    icon={ArrowUp}
-                    size="sm"
-                    variant="outline"
-                    onClick={() => setShowBuyCreditDialog(true)}
-                  />
-                )}
+                  )}
+              </div>
             </div>
           )}
 
@@ -1432,10 +1433,15 @@ export function UsagePage() {
         <EditMemberSpendLimitModal
           isOpen={spendLimitRecapMember !== null}
           onClose={() => setSpendLimitRecapMember(null)}
+          onSaved={() => {
+            // Refreshes the member row (limit, source, isSpendCapped) so the
+            // table and the Unblock button reflect the edit without a reload.
+            void mutateMembersUsage();
+          }}
           member={spendLimitRecapMember}
           owner={owner}
           groups={groups}
-          readOnly
+          readOnly={!isWorkspaceAdmin}
         />
 
         <BulkEditSpendLimitModal

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -94,7 +94,7 @@ import {
   isCreditPricedPlan,
   isSubscriptionCancellationScheduled,
 } from "@app/types/plan";
-import { isAdmin } from "@app/types/user";
+import { isAdmin, isManager } from "@app/types/user";
 import {
   AlertCircle,
   ArrowUp,
@@ -504,7 +504,6 @@ export function UsagePage() {
     isMembersUsageLoading,
     isMembersUsageRefreshing,
     totalMembersUsage,
-    mutateMembersUsage,
   } = useMembersUsage({
     workspaceId: owner.sId,
     searchTerm,
@@ -991,7 +990,7 @@ export function UsagePage() {
       onRemoveSeat={onRemoveSeat}
       onEditSpendLimit={handleEditSpendLimitFromTable}
       onOpenChangeSeatRecap={handleChangeSeatFromTable}
-      onOpenSpendLimitRecap={setSpendLimitRecapMember}
+      onOpenSpendLimitRecap={handleEditSpendLimitFromTable}
       canUpgradeSeat={canUpgradeSeat}
       onSetUserModelTier={handleSetUserModelTier}
       pagination={pagination}
@@ -1065,30 +1064,34 @@ export function UsagePage() {
               description="Control credit consumption across your workspace."
             />
           ) : (
-            <div className="flex items-center justify-between">
-              <Page.Header title="Usage" />
-              <div className="flex items-center gap-4">
-                <Button
-                  label="Breakdown in analytics"
-                  iconRight={LinkExternal01}
-                  size="xs"
-                  variant="highlight-ghost"
-                  href={`/w/${owner.sId}/analytics/consumption`}
-                />
-                {!isNewUsagePage &&
-                  isCreditPriced &&
-                  usageSettings.topUpEnabled &&
-                  isWorkspaceAdmin && (
+            <Page.Header
+              title={
+                <div className="flex w-full items-center justify-between gap-4">
+                  <Page.H variant="h3">Usage</Page.H>
+                  <div className="flex items-center gap-4">
                     <Button
-                      label="Top up"
-                      icon={ArrowUp}
-                      size="sm"
-                      variant="outline"
-                      onClick={() => setShowBuyCreditDialog(true)}
+                      label="Breakdown in analytics"
+                      iconRight={LinkExternal01}
+                      size="xs"
+                      variant="highlight-ghost"
+                      href={`/w/${owner.sId}/analytics/consumption`}
                     />
-                  )}
-              </div>
-            </div>
+                    {!isNewUsagePage &&
+                      isCreditPriced &&
+                      usageSettings.topUpEnabled &&
+                      isWorkspaceAdmin && (
+                        <Button
+                          label="Top up"
+                          icon={ArrowUp}
+                          size="sm"
+                          variant="outline"
+                          onClick={() => setShowBuyCreditDialog(true)}
+                        />
+                      )}
+                  </div>
+                </div>
+              }
+            />
           )}
 
           {isCreditPricedFreePlan(subscription.plan.code) && (
@@ -1433,15 +1436,10 @@ export function UsagePage() {
         <EditMemberSpendLimitModal
           isOpen={spendLimitRecapMember !== null}
           onClose={() => setSpendLimitRecapMember(null)}
-          onSaved={() => {
-            // Refreshes the member row (limit, source, isSpendCapped) so the
-            // table and the Unblock button reflect the edit without a reload.
-            void mutateMembersUsage();
-          }}
           member={spendLimitRecapMember}
           owner={owner}
           groups={groups}
-          readOnly={!isWorkspaceAdmin}
+          readOnly={!isManager(owner)}
         />
 
         <BulkEditSpendLimitModal

--- a/front/components/workspace/EditMemberSpendLimitModal.tsx
+++ b/front/components/workspace/EditMemberSpendLimitModal.tsx
@@ -31,9 +31,6 @@ import { useEffect, useMemo, useRef, useState } from "react";
 interface EditMemberSpendLimitModalProps {
   isOpen: boolean;
   onClose: () => void;
-  // Called only once a change has actually been persisted, distinct from
-  // `onClose` which also fires on cancel or a read-only dismiss.
-  onSaved?: () => void;
   member: MemberUsageType | null;
   owner: LightWorkspaceType;
   groups: GroupType[];
@@ -46,7 +43,6 @@ interface MemberSpendLimitFormProps {
   groups: GroupType[];
   readOnly: boolean;
   onClose: () => void;
-  onSaved?: () => void;
 }
 
 function MemberSpendLimitForm({
@@ -55,7 +51,6 @@ function MemberSpendLimitForm({
   groups,
   readOnly,
   onClose,
-  onSaved,
 }: MemberSpendLimitFormProps) {
   const { doUpdateSpendLimit } = useUpdateUserSpendLimit({
     workspaceId: owner.sId,
@@ -176,7 +171,6 @@ function MemberSpendLimitForm({
         concurrency: 8,
       });
       if (results.every((result) => result !== null)) {
-        onSaved?.();
         onClose();
       }
     } finally {
@@ -255,7 +249,6 @@ function MemberSpendLimitForm({
 export function EditMemberSpendLimitModal({
   isOpen,
   onClose,
-  onSaved,
   member,
   owner,
   groups,
@@ -286,7 +279,6 @@ export function EditMemberSpendLimitModal({
           groups={groups}
           readOnly={readOnly}
           onClose={onClose}
-          onSaved={onSaved}
         />
       </DialogContent>
     </Dialog>

--- a/front/components/workspace/EditMemberSpendLimitModal.tsx
+++ b/front/components/workspace/EditMemberSpendLimitModal.tsx
@@ -31,6 +31,9 @@ import { useEffect, useMemo, useRef, useState } from "react";
 interface EditMemberSpendLimitModalProps {
   isOpen: boolean;
   onClose: () => void;
+  // Called only once a change has actually been persisted, distinct from
+  // `onClose` which also fires on cancel or a read-only dismiss.
+  onSaved?: () => void;
   member: MemberUsageType | null;
   owner: LightWorkspaceType;
   groups: GroupType[];
@@ -43,6 +46,7 @@ interface MemberSpendLimitFormProps {
   groups: GroupType[];
   readOnly: boolean;
   onClose: () => void;
+  onSaved?: () => void;
 }
 
 function MemberSpendLimitForm({
@@ -51,6 +55,7 @@ function MemberSpendLimitForm({
   groups,
   readOnly,
   onClose,
+  onSaved,
 }: MemberSpendLimitFormProps) {
   const { doUpdateSpendLimit } = useUpdateUserSpendLimit({
     workspaceId: owner.sId,
@@ -171,6 +176,7 @@ function MemberSpendLimitForm({
         concurrency: 8,
       });
       if (results.every((result) => result !== null)) {
+        onSaved?.();
         onClose();
       }
     } finally {
@@ -249,6 +255,7 @@ function MemberSpendLimitForm({
 export function EditMemberSpendLimitModal({
   isOpen,
   onClose,
+  onSaved,
   member,
   owner,
   groups,
@@ -279,6 +286,7 @@ export function EditMemberSpendLimitModal({
           groups={groups}
           readOnly={readOnly}
           onClose={onClose}
+          onSaved={onSaved}
         />
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Description

Stack 2/4 for #32027.
- On the new usage page, "Edit spend limit" and "Unblock" open `EditMemberSpendLimitModal`. It is editable for managers and admins, matching the route guard and the spend-limit API (both manager-gated). Poke keeps it read-only.
- "Breakdown in analytics" button moves next to "Top up", both inside the page header so they stay aligned with the title.

The members table refreshes after a save through the existing cache invalidation in the spend-limit mutation hooks; no extra callback is needed.

## Tests

Manual with the new usage page flag: edit a personal or group limit as admin and as manager, row updates without reload.

## Risk

Low, behind the new usage page flag.

## Deploy Plan

Deploy front.