### PR TITLE
chore: move requester at beginning of line in review action

### DIFF
--- a/.github/actions/review-bot/review-bot.ts
+++ b/.github/actions/review-bot/review-bot.ts
@@ -373,9 +373,10 @@ function escapeSlackText(text: string): string {
 
 /**
  * @cc [label:product] review-request-slack-format
- * Format each eligible `r?` line with trailing prose preserved, followed by the PR URL and
- * `(req:@requester)` on the same line. Resolve requester and reviewer mentions through `.authors`
- * emails and Slack user lookup; unresolved handles remain plain text.
+ * Format each eligible `r?` line with trailing prose preserved, prefixed by
+ * `from: @requester` and followed by the PR URL and on the same line. Resolve
+ * requester and reviewer mentions through `.authors` emails and Slack user
+ * lookup; unresolved handles remain plain text.
  */
 /**
  * @cc [label:error-handling] review-request-slack-delivery
@@ -470,7 +471,7 @@ export async function formatSlackNotification({
   return lines
     .map(
       (line) =>
-        `${line} ${escapeSlackText(notification.prUrl)} (req:${requester})`
+        `from ${requester}: ${line} ${escapeSlackText(notification.prUrl)}`
     )
     .join("\n");
 }


### PR DESCRIPTION
## Description

This PR edits the message output by the review bot in the review channel.
Puts the requester name at the beginning instead of the end.

Rationale is that the message is easier to parse at a glance if we know where to expect finding the requester name.

## Tests

- N/A

## Risk

- N/A

## Deploy Plan

- No deploy.
