### PR TITLE
public API: serialize an agent's skills on the agent endpoints

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -14619,6 +14619,47 @@
             "type": "array",
             "example": []
           },
+          "skills": {
+            "type": "array",
+            "description": "Skills attached to the agent. Returned by the agent GET endpoints (list and single-agent) whatever the requested variant. Empty both for an agent with no skill and for an agent whose details were redacted for the caller (canRead false).",
+            "items": {
+              "$ref": "#/components/schemas/AgentSkill"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "description": "Tags attached to the agent",
+            "items": {
+              "type": "object",
+              "properties": {
+                "sId": {
+                  "type": "string",
+                  "example": "3f9d1c7a5b"
+                },
+                "name": {
+                  "type": "string",
+                  "example": "Support"
+                },
+                "kind": {
+                  "type": "string",
+                  "enum": [
+                    "standard",
+                    "protected"
+                  ]
+                }
+              }
+            }
+          },
+          "requestedSpaceIds": {
+            "type": "array",
+            "description": "Identifiers of the spaces the agent needs access to",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "vlt_a1b2c3d4e5"
+            ]
+          },
           "maxStepsPerRun": {
             "type": "integer",
             "example": 10
@@ -14628,6 +14669,22 @@
             "nullable": true,
             "description": "ID of the template used for this configuration",
             "example": "b4e2f1a9c7"
+          }
+        }
+      },
+      "AgentSkill": {
+        "type": "object",
+        "description": "A skill attached to an agent configuration.",
+        "properties": {
+          "sId": {
+            "type": "string",
+            "description": "Unique string identifier for the skill",
+            "example": "skill_abc123"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the skill",
+            "example": "Customer Support"
           }
         }
       },

--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations.test.ts
@@ -2,9 +2,10 @@ import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentConfigurationWithSkillsType } from "@app/types/assistant/agent";
 import type { WorkspaceType } from "@app/types/user";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
@@ -24,7 +25,7 @@ function listAgents(
 async function agentNames(response: Response): Promise<string[]> {
   const {
     agentConfigurations,
-  }: { agentConfigurations: LightAgentConfigurationType[] } =
+  }: { agentConfigurations: AgentConfigurationWithSkillsType[] } =
     await response.json();
 
   return agentConfigurations.map((a) => a.name);
@@ -47,19 +48,37 @@ async function setupTestAgents(workspace: WorkspaceType) {
 
   const restrictedSpace = await SpaceFactory.regular(workspace);
 
-  await AgentConfigurationFactory.createTestAgent(agentOwnerAuth, {
-    name: "Published Agent",
-    scope: "visible",
-  });
+  const publishedAgent = await AgentConfigurationFactory.createTestAgent(
+    agentOwnerAuth,
+    {
+      name: "Published Agent",
+      scope: "visible",
+    }
+  );
   await AgentConfigurationFactory.createTestAgent(agentOwnerAuth, {
     name: "Unpublished Agent",
     scope: "hidden",
   });
-  await AgentConfigurationFactory.createTestAgent(agentOwnerAuth, {
-    name: "Restricted Space Agent",
-    scope: "visible",
-    requestedSpaceIds: [restrictedSpace.id],
+  const restrictedSpaceAgent = await AgentConfigurationFactory.createTestAgent(
+    agentOwnerAuth,
+    {
+      name: "Restricted Space Agent",
+      scope: "visible",
+      requestedSpaceIds: [restrictedSpace.id],
+    }
+  );
+
+  const skill = await SkillFactory.create(agentOwnerAuth, {
+    name: "Support Playbook",
   });
+  for (const agent of [publishedAgent, restrictedSpaceAgent]) {
+    await SkillFactory.linkToAgent(agentOwnerAuth, {
+      skillId: skill.id,
+      agentConfigurationId: agent.id,
+    });
+  }
+
+  return { skill };
 }
 
 describe("GET /api/v1/w/[wId]/assistant/agent_configurations", () => {
@@ -74,7 +93,7 @@ describe("GET /api/v1/w/[wId]/assistant/agent_configurations", () => {
     const response = await listAgents(workspace, key, { view: "all" });
     const {
       agentConfigurations,
-    }: { agentConfigurations: LightAgentConfigurationType[] } =
+    }: { agentConfigurations: AgentConfigurationWithSkillsType[] } =
       await response.json();
 
     expect(response.status).toBe(200);
@@ -101,7 +120,7 @@ describe("GET /api/v1/w/[wId]/assistant/agent_configurations", () => {
     expect(response.status).toBe(200);
     const {
       agentConfigurations,
-    }: { agentConfigurations: LightAgentConfigurationType[] } =
+    }: { agentConfigurations: AgentConfigurationWithSkillsType[] } =
       await response.json();
     expect(agentConfigurations).toEqual(
       expect.arrayContaining([
@@ -128,6 +147,33 @@ describe("GET /api/v1/w/[wId]/assistant/agent_configurations", () => {
     expect(names).toContain("Published Agent");
     expect(names).not.toContain("Unpublished Agent");
     expect(names).not.toContain("Restricted Space Agent");
+  });
+
+  it("returns the skills attached to each agent", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+    const { skill } = await setupTestAgents(workspace);
+
+    const response = await listAgents(workspace, key, { view: "all" });
+
+    expect(response.status).toBe(200);
+    const {
+      agentConfigurations,
+    }: { agentConfigurations: AgentConfigurationWithSkillsType[] } =
+      await response.json();
+
+    const publishedAgent = agentConfigurations.find(
+      (a) => a.name === "Published Agent"
+    );
+    expect(publishedAgent?.skills).toEqual([
+      { sId: skill.sId, name: "Support Playbook" },
+    ]);
+
+    // Every agent carries the field, so a client can tell "no skills" from "not serialized".
+    expect(agentConfigurations.every((a) => Array.isArray(a.skills))).toBe(
+      true
+    );
   });
 
   it("rejects the all_unrestricted view for non-admin keys", async () => {

--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations.ts
@@ -1,4 +1,4 @@
-import { serializeAgentConfigurationsWithSkills } from "@app/lib/api/assistant/configuration/helpers";
+import { toAgentConfigurationsWithSkills } from "@app/lib/api/assistant/configuration/helpers";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { getAgentsRecentAuthors } from "@app/lib/api/assistant/recent_authors";
 import { normalizeAgentView } from "@app/lib/api/v1/backward_compatibility";
@@ -161,7 +161,7 @@ app.get(
     }
 
     return ctx.json({
-      agentConfigurations: await serializeAgentConfigurationsWithSkills(
+      agentConfigurations: await toAgentConfigurationsWithSkills(
         auth,
         agentConfigurations
       ),

--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations.ts
@@ -1,3 +1,4 @@
+import { serializeAgentConfigurationsWithSkills } from "@app/lib/api/assistant/configuration/helpers";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { getAgentsRecentAuthors } from "@app/lib/api/assistant/recent_authors";
 import { normalizeAgentView } from "@app/lib/api/v1/backward_compatibility";
@@ -160,7 +161,10 @@ app.get(
     }
 
     return ctx.json({
-      agentConfigurations,
+      agentConfigurations: await serializeAgentConfigurationsWithSkills(
+        auth,
+        agentConfigurations
+      ),
     });
   }
 );

--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.test.ts
@@ -4,6 +4,7 @@ import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFa
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { honoApp } from "@front-api/app";
@@ -129,6 +130,43 @@ describe("GET /api/v1/w/[wId]/assistant/agent_configurations/[sId]", () => {
     expect(response.status).toBe(200);
     expect(data.agentConfiguration.canEdit).toBe(true);
     expect(data.agentConfiguration.instructions).toBe("Updated instructions");
+  });
+
+  it("returns the skills attached to the agent", async () => {
+    const { workspace, key, agentConfig, auth } = await setupTest("admin");
+    const skill = await SkillFactory.create(auth, {
+      name: "Support Playbook",
+    });
+    await SkillFactory.linkToAgent(auth, {
+      skillId: skill.id,
+      agentConfigurationId: agentConfig.id,
+    });
+
+    const response = await getAgentConfiguration(
+      workspace,
+      key,
+      agentConfig.sId
+    );
+    const data = await response.json();
+
+    expect(response.status, JSON.stringify(data)).toBe(200);
+    expect(data.agentConfiguration.skills).toEqual([
+      { sId: skill.sId, name: "Support Playbook" },
+    ]);
+  });
+
+  it("returns an empty skills array for an agent without skills", async () => {
+    const { workspace, key, agentConfig } = await setupTest("admin");
+
+    const response = await getAgentConfiguration(
+      workspace,
+      key,
+      agentConfig.sId
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.agentConfiguration.skills).toEqual([]);
   });
 
   it.each([

--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
@@ -2,7 +2,7 @@ import {
   archiveAgentConfiguration,
   getAgentConfiguration,
 } from "@app/lib/api/assistant/configuration/agent";
-import { serializeAgentConfigurationsWithSkills } from "@app/lib/api/assistant/configuration/helpers";
+import { toAgentConfigurationsWithSkills } from "@app/lib/api/assistant/configuration/helpers";
 import { patchAgentConfigurationFromJSON } from "@app/lib/api/assistant/configuration/yaml_import";
 import { isRetiredGlobalAgent } from "@app/lib/api/assistant/global_agents/global_agents";
 import { setAgentUserFavorite } from "@app/lib/api/assistant/user_relation";
@@ -314,7 +314,7 @@ app.get(
       });
     }
 
-    const [serialized] = await serializeAgentConfigurationsWithSkills(auth, [
+    const [serialized] = await toAgentConfigurationsWithSkills(auth, [
       agentConfiguration,
     ]);
 
@@ -382,7 +382,7 @@ app.patch(
         return apiError(ctx, patchResult.error);
       }
 
-      const [patched] = await serializeAgentConfigurationsWithSkills(auth, [
+      const [patched] = await toAgentConfigurationsWithSkills(auth, [
         patchResult.value.agentConfiguration,
       ]);
 
@@ -392,7 +392,7 @@ app.patch(
       });
     }
 
-    const [serialized] = await serializeAgentConfigurationsWithSkills(auth, [
+    const [serialized] = await toAgentConfigurationsWithSkills(auth, [
       agentConfiguration,
     ]);
 

--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
@@ -2,6 +2,7 @@ import {
   archiveAgentConfiguration,
   getAgentConfiguration,
 } from "@app/lib/api/assistant/configuration/agent";
+import { serializeAgentConfigurationsWithSkills } from "@app/lib/api/assistant/configuration/helpers";
 import { patchAgentConfigurationFromJSON } from "@app/lib/api/assistant/configuration/yaml_import";
 import { isRetiredGlobalAgent } from "@app/lib/api/assistant/global_agents/global_agents";
 import { setAgentUserFavorite } from "@app/lib/api/assistant/user_relation";
@@ -313,9 +314,11 @@ app.get(
       });
     }
 
-    return ctx.json({
+    const [serialized] = await serializeAgentConfigurationsWithSkills(auth, [
       agentConfiguration,
-    });
+    ]);
+
+    return ctx.json({ agentConfiguration: serialized });
   }
 );
 
@@ -379,15 +382,21 @@ app.patch(
         return apiError(ctx, patchResult.error);
       }
 
+      const [patched] = await serializeAgentConfigurationsWithSkills(auth, [
+        patchResult.value.agentConfiguration,
+      ]);
+
       return ctx.json({
-        agentConfiguration: patchResult.value.agentConfiguration,
+        agentConfiguration: patched,
         skippedActions: patchResult.value.skippedActions,
       });
     }
 
-    return ctx.json({
+    const [serialized] = await serializeAgentConfigurationsWithSkills(auth, [
       agentConfiguration,
-    });
+    ]);
+
+    return ctx.json({ agentConfiguration: serialized });
   }
 );
 

--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations/import.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations/import.ts
@@ -1,4 +1,4 @@
-import { serializeAgentConfigurationsWithSkills } from "@app/lib/api/assistant/configuration/helpers";
+import { toAgentConfigurationsWithSkills } from "@app/lib/api/assistant/configuration/helpers";
 import { importAgentConfigurationFromJSON } from "@app/lib/api/assistant/configuration/yaml_import";
 import type { ImportAgentConfigurationFromYAMLResponseType } from "@dust-tt/client";
 import { publicApiApp } from "@front-api/middlewares/ctx";
@@ -145,7 +145,7 @@ app.post(
     }
 
     const { agentConfiguration, skippedActions } = result.value;
-    const [serialized] = await serializeAgentConfigurationsWithSkills(auth, [
+    const [serialized] = await toAgentConfigurationsWithSkills(auth, [
       agentConfiguration,
     ]);
 

--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations/import.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations/import.ts
@@ -1,3 +1,4 @@
+import { serializeAgentConfigurationsWithSkills } from "@app/lib/api/assistant/configuration/helpers";
 import { importAgentConfigurationFromJSON } from "@app/lib/api/assistant/configuration/yaml_import";
 import type { ImportAgentConfigurationFromYAMLResponseType } from "@dust-tt/client";
 import { publicApiApp } from "@front-api/middlewares/ctx";
@@ -144,9 +145,12 @@ app.post(
     }
 
     const { agentConfiguration, skippedActions } = result.value;
+    const [serialized] = await serializeAgentConfigurationsWithSkills(auth, [
+      agentConfiguration,
+    ]);
 
     return ctx.json({
-      agentConfiguration,
+      agentConfiguration: serialized,
       skippedActions,
     });
   }

--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations/search.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations/search.ts
@@ -1,4 +1,5 @@
 import { searchAgentConfigurationsByName } from "@app/lib/api/assistant/configuration/agent";
+import { serializeAgentConfigurationsWithSkills } from "@app/lib/api/assistant/configuration/helpers";
 import { addBackwardCompatibleAgentConfigurationFields } from "@app/lib/api/v1/backward_compatibility";
 import type { GetAgentConfigurationsResponseType } from "@dust-tt/client";
 import { publicApiApp } from "@front-api/middlewares/ctx";
@@ -66,8 +67,13 @@ app.get(
     const { q } = ctx.req.valid("query");
 
     const agentConfigurations = await searchAgentConfigurationsByName(auth, q);
+    const serialized = await serializeAgentConfigurationsWithSkills(
+      auth,
+      agentConfigurations
+    );
+
     return ctx.json({
-      agentConfigurations: agentConfigurations.map((agentConfiguration) =>
+      agentConfigurations: serialized.map((agentConfiguration) =>
         addBackwardCompatibleAgentConfigurationFields(agentConfiguration)
       ),
     });

--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations/search.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations/search.ts
@@ -1,5 +1,5 @@
 import { searchAgentConfigurationsByName } from "@app/lib/api/assistant/configuration/agent";
-import { serializeAgentConfigurationsWithSkills } from "@app/lib/api/assistant/configuration/helpers";
+import { toAgentConfigurationsWithSkills } from "@app/lib/api/assistant/configuration/helpers";
 import { addBackwardCompatibleAgentConfigurationFields } from "@app/lib/api/v1/backward_compatibility";
 import type { GetAgentConfigurationsResponseType } from "@dust-tt/client";
 import { publicApiApp } from "@front-api/middlewares/ctx";
@@ -67,7 +67,7 @@ app.get(
     const { q } = ctx.req.valid("query");
 
     const agentConfigurations = await searchAgentConfigurationsByName(auth, q);
-    const serialized = await serializeAgentConfigurationsWithSkills(
+    const serialized = await toAgentConfigurationsWithSkills(
       auth,
       agentConfigurations
     );

--- a/front-api/routes/v1/w/[wId]/swagger_schemas.ts
+++ b/front-api/routes/v1/w/[wId]/swagger_schemas.ts
@@ -209,6 +209,35 @@
  *         actions:
  *           type: array
  *           example: []
+ *         skills:
+ *           type: array
+ *           description: >-
+ *             Skills attached to the agent. Returned by the agent GET endpoints (list and
+ *             single-agent) whatever the requested variant. Empty both for an agent with no skill
+ *             and for an agent whose details were redacted for the caller (canRead false).
+ *           items:
+ *             $ref: '#/components/schemas/AgentSkill'
+ *         tags:
+ *           type: array
+ *           description: Tags attached to the agent
+ *           items:
+ *             type: object
+ *             properties:
+ *               sId:
+ *                 type: string
+ *                 example: "3f9d1c7a5b"
+ *               name:
+ *                 type: string
+ *                 example: "Support"
+ *               kind:
+ *                 type: string
+ *                 enum: [standard, protected]
+ *         requestedSpaceIds:
+ *           type: array
+ *           description: Identifiers of the spaces the agent needs access to
+ *           items:
+ *             type: string
+ *           example: ["vlt_a1b2c3d4e5"]
  *         maxStepsPerRun:
  *           type: integer
  *           example: 10
@@ -217,6 +246,18 @@
  *           nullable: true
  *           description: ID of the template used for this configuration
  *           example: "b4e2f1a9c7"
+ *     AgentSkill:
+ *       type: object
+ *       description: A skill attached to an agent configuration.
+ *       properties:
+ *         sId:
+ *           type: string
+ *           description: Unique string identifier for the skill
+ *           example: "skill_abc123"
+ *         name:
+ *           type: string
+ *           description: Name of the skill
+ *           example: "Customer Support"
  *     Conversation:
  *       type: object
  *       properties:

--- a/front/lib/api/assistant/configuration/helpers.test.ts
+++ b/front/lib/api/assistant/configuration/helpers.test.ts
@@ -1,6 +1,6 @@
 import {
   redactPrivateAgentConfigurationFields,
-  serializeAgentConfigurationsWithSkills,
+  toAgentConfigurationsWithSkills,
 } from "@app/lib/api/assistant/configuration/helpers";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -8,7 +8,7 @@ import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { describe, expect, it } from "vitest";
 
-describe("serializeAgentConfigurationsWithSkills", () => {
+describe("toAgentConfigurationsWithSkills", () => {
   it("serializes the skills attached to each agent", async () => {
     const { authenticator } = await createResourceTest({ role: "builder" });
 
@@ -29,7 +29,7 @@ describe("serializeAgentConfigurationsWithSkills", () => {
     });
 
     const [serializedWithSkill, serializedWithoutSkill] =
-      await serializeAgentConfigurationsWithSkills(authenticator, [
+      await toAgentConfigurationsWithSkills(authenticator, [
         withSkill,
         withoutSkill,
       ]);
@@ -51,16 +51,13 @@ describe("serializeAgentConfigurationsWithSkills", () => {
       { name: "Stands in for a global agent" }
     );
 
-    const [serialized] = await serializeAgentConfigurationsWithSkills(
-      authenticator,
-      [
-        {
-          ...agent,
-          sId: GLOBAL_AGENTS_SID.DUST,
-          codeDefinedSkillIds: ["frames"],
-        },
-      ]
-    );
+    const [serialized] = await toAgentConfigurationsWithSkills(authenticator, [
+      {
+        ...agent,
+        sId: GLOBAL_AGENTS_SID.DUST,
+        codeDefinedSkillIds: ["frames"],
+      },
+    ]);
 
     expect(serialized.skills.map((skill) => skill.sId)).toEqual(["frames"]);
     // The raw ids are an internal detail, superseded by `skills`.
@@ -80,10 +77,9 @@ describe("serializeAgentConfigurationsWithSkills", () => {
       agentConfigurationId: agent.id,
     });
 
-    const [serialized] = await serializeAgentConfigurationsWithSkills(
-      authenticator,
-      [redactPrivateAgentConfigurationFields(agent)]
-    );
+    const [serialized] = await toAgentConfigurationsWithSkills(authenticator, [
+      redactPrivateAgentConfigurationFields(agent),
+    ]);
 
     expect(serialized.skills).toEqual([]);
   });

--- a/front/lib/api/assistant/configuration/helpers.test.ts
+++ b/front/lib/api/assistant/configuration/helpers.test.ts
@@ -1,0 +1,90 @@
+import {
+  redactPrivateAgentConfigurationFields,
+  serializeAgentConfigurationsWithSkills,
+} from "@app/lib/api/assistant/configuration/helpers";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { describe, expect, it } from "vitest";
+
+describe("serializeAgentConfigurationsWithSkills", () => {
+  it("serializes the skills attached to each agent", async () => {
+    const { authenticator } = await createResourceTest({ role: "builder" });
+
+    const [withSkill, withoutSkill] = await Promise.all([
+      AgentConfigurationFactory.createTestAgent(authenticator, {
+        name: "With skill",
+      }),
+      AgentConfigurationFactory.createTestAgent(authenticator, {
+        name: "Without skill",
+      }),
+    ]);
+    const skill = await SkillFactory.create(authenticator, {
+      name: "Support Playbook",
+    });
+    await SkillFactory.linkToAgent(authenticator, {
+      skillId: skill.id,
+      agentConfigurationId: withSkill.id,
+    });
+
+    const [serializedWithSkill, serializedWithoutSkill] =
+      await serializeAgentConfigurationsWithSkills(authenticator, [
+        withSkill,
+        withoutSkill,
+      ]);
+
+    expect(serializedWithSkill.skills).toEqual([
+      { sId: skill.sId, name: "Support Playbook" },
+    ]);
+    // Present but empty, so clients can tell "no skills" from "not serialized".
+    expect(serializedWithoutSkill.skills).toEqual([]);
+  });
+
+  it("serializes the code-defined skills a global agent declares", async () => {
+    const { authenticator } = await createResourceTest({ role: "builder" });
+
+    // Global agents hold no agent-skill row: they name their skills in code, and carry those
+    // ids on every variant of their configuration.
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Stands in for a global agent" }
+    );
+
+    const [serialized] = await serializeAgentConfigurationsWithSkills(
+      authenticator,
+      [
+        {
+          ...agent,
+          sId: GLOBAL_AGENTS_SID.DUST,
+          codeDefinedSkillIds: ["frames"],
+        },
+      ]
+    );
+
+    expect(serialized.skills.map((skill) => skill.sId)).toEqual(["frames"]);
+    // The raw ids are an internal detail, superseded by `skills`.
+    expect("codeDefinedSkillIds" in serialized).toBe(false);
+  });
+
+  it("serializes no skills for an agent whose details were redacted", async () => {
+    const { authenticator } = await createResourceTest({ role: "builder" });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Redacted" }
+    );
+    const skill = await SkillFactory.create(authenticator);
+    await SkillFactory.linkToAgent(authenticator, {
+      skillId: skill.id,
+      agentConfigurationId: agent.id,
+    });
+
+    const [serialized] = await serializeAgentConfigurationsWithSkills(
+      authenticator,
+      [redactPrivateAgentConfigurationFields(agent)]
+    );
+
+    expect(serialized.skills).toEqual([]);
+  });
+});

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -8,17 +8,30 @@ import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AgentResource } from "@app/lib/resources/agent_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { canReadRequestedSpaces } from "@app/lib/resources/permission_utils";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import type { SkillHydrationOptions } from "@app/lib/resources/skill/types";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { tagsSorter } from "@app/lib/utils";
 import type {
   AgentConfigurationType,
+  AgentConfigurationWithSkillsType,
   AgentFetchVariant,
   AgentModelConfigurationType,
   LightAgentConfigurationType,
 } from "@app/types/assistant/agent";
+import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { ModelId } from "@app/types/shared/model_id";
+import { removeNulls } from "@app/types/shared/utils/general";
+import partition from "lodash/partition";
+import uniq from "lodash/uniq";
+
+const LABELS_ONLY_FETCH_OPTIONS: SkillHydrationOptions = {
+  withInstructions: false,
+  withTools: false,
+  withFileAttachments: false,
+};
 
 export function getModelForAgentConfiguration(
   agent: AgentConfigurationModel
@@ -310,4 +323,69 @@ export function redactPrivateAgentConfigurationFields(
     codeDefinedSkillIds: [],
     canRead: false,
   };
+}
+
+/**
+ * @cc [owner:fabiencelier,label:security] no-skills-for-redacted-agents
+ * An agent whose details were redacted (`canRead === false`) MUST get an empty `skills` array:
+ * its skills are private, consistently with `redactPrivateAgentConfigurationFields`.
+ */
+export async function serializeAgentConfigurationsWithSkills<
+  // `codeDefinedSkillIds` is declared on the full configuration schema, but `getGlobalAgents`
+  // puts it on global agents in every variant, so light configurations carry it too.
+  T extends LightAgentConfigurationType & { codeDefinedSkillIds?: string[] },
+>(
+  auth: Authenticator,
+  agents: T[]
+): Promise<AgentConfigurationWithSkillsType<T>[]> {
+  const readableAgents = agents.filter((agent) => agent.canRead);
+
+  // Workspace agents hold `AgentSkillModel` rows; global agents declare their skills in code.
+  const [globalAgents, workspaceAgents] = partition(readableAgents, (agent) =>
+    isGlobalAgentId(agent.sId)
+  );
+
+  // Only `sId` and `name` reach the wire, so skip the instructions, tools and file attachments:
+  // see the `labels-only-skips-dynamic-instructions` contract.
+  const [workspaceAgentSkills, codeDefinedSkills] = await Promise.all([
+    SkillResource.listByAgentConfigurations(
+      auth,
+      workspaceAgents,
+      LABELS_ONLY_FETCH_OPTIONS
+    ),
+    SkillResource.listByCodeDefinedSkillIds(
+      auth,
+      uniq(globalAgents.flatMap((agent) => agent.codeDefinedSkillIds ?? [])),
+      LABELS_ONLY_FETCH_OPTIONS
+    ),
+  ]);
+
+  const skillsByAgentSId: Record<string, SkillResource[]> = {};
+  for (const { agentConfiguration, skill } of workspaceAgentSkills) {
+    skillsByAgentSId[agentConfiguration.sId] = [
+      ...(skillsByAgentSId[agentConfiguration.sId] ?? []),
+      skill,
+    ];
+  }
+
+  const codeDefinedSkillBySId = new Map(
+    codeDefinedSkills.map((skill) => [skill.sId, skill])
+  );
+  for (const agent of globalAgents) {
+    skillsByAgentSId[agent.sId] = removeNulls(
+      (agent.codeDefinedSkillIds ?? []).map(
+        (skillId) => codeDefinedSkillBySId.get(skillId) ?? null
+      )
+    );
+  }
+
+  // `codeDefinedSkillIds` does not reach the wire: the resolved `skills` replace it.
+  return agents.map(
+    ({ codeDefinedSkillIds: _codeDefinedSkillIds, ...agent }) => ({
+      ...agent,
+      skills: (skillsByAgentSId[agent.sId] ?? []).map((skill) =>
+        skill.toAgentSkillJSON()
+      ),
+    })
+  );
 }

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -325,6 +325,11 @@ export function redactPrivateAgentConfigurationFields(
   };
 }
 
+// Identifies one agent configuration: an agent id alone spans every version of that agent.
+const configurationKey = (
+  agent: Pick<LightAgentConfigurationType, "sId" | "version">
+): string => `${agent.sId}-${agent.version}`;
+
 /**
  * @cc [owner:fabiencelier,label:security] no-skills-for-redacted-agents
  * An agent whose details were redacted (`canRead === false`) MUST get an empty `skills` array:
@@ -360,21 +365,23 @@ export async function serializeAgentConfigurationsWithSkills<
     ),
   ]);
 
-  const skillsByAgentSId: Record<string, SkillResource[]> = {};
+  // Keyed per configuration, not per agent: an agent has one row per version and callers can
+  // pass several of them. `version` is unique within an agent id, and the
+  // version is a number, so the two parts cannot run together ambiguously.
+  const skillsByConfiguration: Record<string, SkillResource[]> = {};
   for (const { agentConfiguration, skill } of workspaceAgentSkills) {
-    skillsByAgentSId[agentConfiguration.sId] = [
-      ...(skillsByAgentSId[agentConfiguration.sId] ?? []),
-      skill,
-    ];
+    (skillsByConfiguration[configurationKey(agentConfiguration)] ??= []).push(
+      skill
+    );
   }
 
-  const codeDefinedSkillBySId = new Map(
+  const codeDefinedSkillById = new Map(
     codeDefinedSkills.map((skill) => [skill.sId, skill])
   );
   for (const agent of globalAgents) {
-    skillsByAgentSId[agent.sId] = removeNulls(
+    skillsByConfiguration[configurationKey(agent)] = removeNulls(
       (agent.codeDefinedSkillIds ?? []).map(
-        (skillId) => codeDefinedSkillBySId.get(skillId) ?? null
+        (skillId) => codeDefinedSkillById.get(skillId) ?? null
       )
     );
   }
@@ -383,9 +390,11 @@ export async function serializeAgentConfigurationsWithSkills<
   return agents.map(
     ({ codeDefinedSkillIds: _codeDefinedSkillIds, ...agent }) => ({
       ...agent,
-      skills: (skillsByAgentSId[agent.sId] ?? []).map((skill) =>
-        skill.toAgentSkillJSON()
-      ),
+      skills: agent.canRead
+        ? (skillsByConfiguration[configurationKey(agent)] ?? []).map((skill) =>
+            skill.toAgentSkillJSON()
+          )
+        : [],
     })
   );
 }

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -335,14 +335,12 @@ const configurationKey = (
  * An agent whose details were redacted (`canRead === false`) MUST get an empty `skills` array:
  * its skills are private, consistently with `redactPrivateAgentConfigurationFields`.
  */
-export async function serializeAgentConfigurationsWithSkills<
+export async function toAgentConfigurationsWithSkills(
+  auth: Authenticator,
   // `codeDefinedSkillIds` is declared on the full configuration schema, but `getGlobalAgents`
   // puts it on global agents in every variant, so light configurations carry it too.
-  T extends LightAgentConfigurationType & { codeDefinedSkillIds?: string[] },
->(
-  auth: Authenticator,
-  agents: T[]
-): Promise<AgentConfigurationWithSkillsType<T>[]> {
+  agents: (LightAgentConfigurationType & { codeDefinedSkillIds?: string[] })[]
+): Promise<AgentConfigurationWithSkillsType[]> {
   const readableAgents = agents.filter((agent) => agent.canRead);
 
   // Workspace agents hold `AgentSkillModel` rows; global agents declare their skills in code.
@@ -358,7 +356,7 @@ export async function serializeAgentConfigurationsWithSkills<
       workspaceAgents,
       LABELS_ONLY_FETCH_OPTIONS
     ),
-    SkillResource.listByCodeDefinedSkillIds(
+    SkillResource.fetchByIds(
       auth,
       uniq(globalAgents.flatMap((agent) => agent.codeDefinedSkillIds ?? [])),
       LABELS_ONLY_FETCH_OPTIONS

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1989,35 +1989,6 @@ describe("SkillResource", () => {
     });
   });
 
-  describe("listByCodeDefinedSkillIds", () => {
-    it("resolves the skills the given code-defined ids point to", async () => {
-      const skills = await SkillResource.listByCodeDefinedSkillIds(
-        testContext.authenticator,
-        ["frames"]
-      );
-
-      expect(skills.map((skill) => skill.sId)).toEqual(["frames"]);
-    });
-
-    it("returns nothing for no ids", async () => {
-      expect(
-        await SkillResource.listByCodeDefinedSkillIds(
-          testContext.authenticator,
-          []
-        )
-      ).toEqual([]);
-    });
-
-    it("skips ids that match no code-defined skill", async () => {
-      expect(
-        await SkillResource.listByCodeDefinedSkillIds(
-          testContext.authenticator,
-          ["not-a-code-defined-skill"]
-        )
-      ).toEqual([]);
-    });
-  });
-
   describe("listByMCPServerViewIds", () => {
     it("should return skills that use any of the given MCP server view IDs", async () => {
       const space = await SpaceFactory.regular(testContext.workspace);
@@ -2475,6 +2446,28 @@ describe("SkillResource", () => {
       });
       expect(fetchedSkill.mcpServerViews).toEqual([]);
       expect(fetchByModelIdsSpy).not.toHaveBeenCalled();
+    });
+
+    it("skips the dynamic instructions of a code-defined skill", async () => {
+      const [full] = await SkillResource.fetchByIds(testContext.authenticator, [
+        "frames",
+      ]);
+      const [labelsOnly] = await SkillResource.fetchByIds(
+        testContext.authenticator,
+        ["frames"],
+        {
+          withInstructions: false,
+          withTools: false,
+          withFileAttachments: false,
+        }
+      );
+
+      // `frames` builds its instructions through a callback, and some of those callbacks write
+      // (`discover_tools` ensures the workspace's auto MCP server views exist), so a read path
+      // that only needs to name a skill must not run them.
+      expect(full.instructions).not.toBe("");
+      expect(labelsOnly.instructions).toBe("");
+      expect(labelsOnly.name).toBe(full.name);
     });
 
     it("filters code-defined skills disabled for the current agent loop", async () => {

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1915,19 +1915,21 @@ describe("SkillResource", () => {
         [firstAgent, secondAgent, skillLessAgent]
       );
 
-      const skillIdsByAgentSId = new Map<string, number[]>();
+      const skillModelIdsByAgentId = new Map<string, number[]>();
       for (const { agentConfiguration, skill } of pairs) {
-        skillIdsByAgentSId.set(agentConfiguration.sId, [
-          ...(skillIdsByAgentSId.get(agentConfiguration.sId) ?? []),
-          skill.id,
-        ]);
+        const skillModelIds =
+          skillModelIdsByAgentId.get(agentConfiguration.sId) ?? [];
+        skillModelIds.push(skill.id);
+        skillModelIdsByAgentId.set(agentConfiguration.sId, skillModelIds);
       }
 
-      expect(skillIdsByAgentSId.get(firstAgent.sId)?.sort()).toEqual(
+      expect(skillModelIdsByAgentId.get(firstAgent.sId)?.sort()).toEqual(
         [firstSkill.id, sharedSkill.id].sort()
       );
-      expect(skillIdsByAgentSId.get(secondAgent.sId)).toEqual([sharedSkill.id]);
-      expect(skillIdsByAgentSId.has(skillLessAgent.sId)).toBe(false);
+      expect(skillModelIdsByAgentId.get(secondAgent.sId)).toEqual([
+        sharedSkill.id,
+      ]);
+      expect(skillModelIdsByAgentId.has(skillLessAgent.sId)).toBe(false);
     });
 
     it("resolves global skills attached to a workspace agent", async () => {

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1879,6 +1879,143 @@ describe("SkillResource", () => {
     });
   });
 
+  describe("listByAgentConfigurations", () => {
+    it("maps each agent to its own skills", async () => {
+      const [firstAgent, secondAgent, skillLessAgent] = await Promise.all([
+        AgentConfigurationFactory.createTestAgent(testContext.authenticator, {
+          name: "First Agent",
+        }),
+        AgentConfigurationFactory.createTestAgent(testContext.authenticator, {
+          name: "Second Agent",
+        }),
+        AgentConfigurationFactory.createTestAgent(testContext.authenticator, {
+          name: "Skill-less Agent",
+        }),
+      ]);
+
+      const [firstSkill, sharedSkill] = await Promise.all([
+        SkillFactory.create(testContext.authenticator, { name: "First Skill" }),
+        SkillFactory.create(testContext.authenticator, {
+          name: "Shared Skill",
+        }),
+      ]);
+      for (const [agent, skill] of [
+        [firstAgent, firstSkill],
+        [firstAgent, sharedSkill],
+        [secondAgent, sharedSkill],
+      ] as const) {
+        await SkillFactory.linkToAgent(testContext.authenticator, {
+          skillId: skill.id,
+          agentConfigurationId: agent.id,
+        });
+      }
+
+      const pairs = await SkillResource.listByAgentConfigurations(
+        testContext.authenticator,
+        [firstAgent, secondAgent, skillLessAgent]
+      );
+
+      const skillIdsByAgentSId = new Map<string, number[]>();
+      for (const { agentConfiguration, skill } of pairs) {
+        skillIdsByAgentSId.set(agentConfiguration.sId, [
+          ...(skillIdsByAgentSId.get(agentConfiguration.sId) ?? []),
+          skill.id,
+        ]);
+      }
+
+      expect(skillIdsByAgentSId.get(firstAgent.sId)?.sort()).toEqual(
+        [firstSkill.id, sharedSkill.id].sort()
+      );
+      expect(skillIdsByAgentSId.get(secondAgent.sId)).toEqual([sharedSkill.id]);
+      expect(skillIdsByAgentSId.has(skillLessAgent.sId)).toBe(false);
+    });
+
+    it("resolves global skills attached to a workspace agent", async () => {
+      const agent = await AgentConfigurationFactory.createTestAgent(
+        testContext.authenticator,
+        { name: "Agent With A Global Skill" }
+      );
+      await SkillFactory.linkGlobalSkillToAgent(testContext.authenticator, {
+        globalSkillId: "frames",
+        agentConfigurationId: agent.id,
+      });
+
+      const pairs = await SkillResource.listByAgentConfigurations(
+        testContext.authenticator,
+        [agent]
+      );
+
+      expect(pairs.map(({ skill }) => skill.sId)).toEqual(["frames"]);
+    });
+
+    it("returns nothing for no agents", async () => {
+      expect(
+        await SkillResource.listByAgentConfigurations(
+          testContext.authenticator,
+          []
+        )
+      ).toEqual([]);
+    });
+
+    it("does not return skills the caller cannot read", async () => {
+      const restrictedSpace = await SpaceFactory.regular(testContext.workspace);
+      const agent = await AgentConfigurationFactory.createTestAgent(
+        testContext.authenticator,
+        { name: "Agent With A Restricted Skill" }
+      );
+      const skill = await SkillFactory.create(testContext.authenticator, {
+        name: "Restricted Skill",
+        requestedSpaceIds: [restrictedSpace.id],
+      });
+      await SkillFactory.linkToAgent(testContext.authenticator, {
+        skillId: skill.id,
+        agentConfigurationId: agent.id,
+      });
+
+      const otherUser = await UserFactory.basic();
+      await MembershipFactory.associate(testContext.workspace, otherUser, {
+        role: "user",
+      });
+      const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherUser.sId,
+        testContext.workspace.sId
+      );
+
+      expect(
+        await SkillResource.listByAgentConfigurations(otherAuth, [agent])
+      ).toEqual([]);
+    });
+  });
+
+  describe("listByCodeDefinedSkillIds", () => {
+    it("resolves the skills the given code-defined ids point to", async () => {
+      const skills = await SkillResource.listByCodeDefinedSkillIds(
+        testContext.authenticator,
+        ["frames"]
+      );
+
+      expect(skills.map((skill) => skill.sId)).toEqual(["frames"]);
+    });
+
+    it("returns nothing for no ids", async () => {
+      expect(
+        await SkillResource.listByCodeDefinedSkillIds(
+          testContext.authenticator,
+          []
+        )
+      ).toEqual([]);
+    });
+
+    it("skips ids that match no code-defined skill", async () => {
+      expect(
+        await SkillResource.listByCodeDefinedSkillIds(
+          testContext.authenticator,
+          ["not-a-code-defined-skill"]
+        )
+      ).toEqual([]);
+    });
+  });
+
   describe("listByMCPServerViewIds", () => {
     it("should return skills that use any of the given MCP server view IDs", async () => {
       const space = await SpaceFactory.regular(testContext.workspace);

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -45,7 +45,10 @@ import type {
   SkillDefinition,
 } from "@app/lib/resources/skill/code_defined/shared";
 import { SystemSkillsRegistry } from "@app/lib/resources/skill/code_defined/system_registry";
-import type { SkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
+import type {
+  SkillConfigurationFindOptions,
+  SkillHydrationOptions,
+} from "@app/lib/resources/skill/types";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import {
@@ -78,6 +81,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import { isPodConversation } from "@app/types/assistant/conversation";
 import type {
+  AgentSkillType,
   SkillAvailability,
   SkillReinforcementMode,
   SkillSourceMetadata,
@@ -1259,16 +1263,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       withTools,
       withToolMetadata,
       withFileAttachments,
-    }: {
+    }: SkillHydrationOptions & {
       agentLoopData?: AgentLoopExecutionData;
       effectiveSpaceIds?: string[];
       permissionFiltering?: SkillPermissionFilteringMode;
       status?: SkillStatus | SkillStatus[];
       transaction?: Transaction;
-      withInstructions?: boolean;
-      withTools?: boolean;
-      withToolMetadata?: boolean;
-      withFileAttachments?: boolean;
     } = {}
   ): Promise<SkillResource[]> {
     const customSkillModelIds = removeNulls(refs.map((r) => r.customSkillId));
@@ -1435,17 +1435,16 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   /**
    * Batched version of listByAgentConfiguration. Performs 2 SQL queries.
-   * Does not support global agents as we rely on the ID for mapping.
+   * Does not support global agents as we rely on the ID for mapping: they all share the same
+   * model id and hold no `AgentSkillModel` row. Use `listByCodeDefinedSkillIds` for those.
    */
-  static async listByAgentConfigurations(
+  static async listByAgentConfigurations<
+    T extends Pick<LightAgentConfigurationType, "id" | "sId">,
+  >(
     auth: Authenticator,
-    agentConfigurations: AgentLoopExecutionData["agentConfiguration"][]
-  ): Promise<
-    {
-      agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
-      skill: SkillResource;
-    }[]
-  > {
+    agentConfigurations: T[],
+    fetchOptions?: SkillHydrationOptions
+  ): Promise<{ agentConfiguration: T; skill: SkillResource }[]> {
     assert(
       agentConfigurations.every((c) => !isGlobalAgentId(c.sId)),
       "Global agents are not supported"
@@ -1465,13 +1464,18 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       },
     });
 
+    if (agentSkills.length === 0) {
+      return [];
+    }
+
     // Fetch all unique skills in one batch.
     const allSkills = await this.fetchBySkillReferences(
       auth,
       agentSkills.map((s) => ({
         customSkillId: s.customSkillId,
         globalSkillId: s.globalSkillId,
-      }))
+      })),
+      fetchOptions
     );
 
     const skillByCustomId = new Map<ModelId, SkillResource>();
@@ -1504,6 +1508,31 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           }
         });
       })
+    );
+  }
+
+  /**
+   * Resolves the code-defined skills a global agent declares, in one SQL query. Global agents
+   * hold no `AgentSkillModel` row, so they cannot go through `listByAgentConfigurations`.
+   * Skills the caller cannot access are filtered out, so the result can be shorter than the
+   * requested ids.
+   */
+  static async listByCodeDefinedSkillIds(
+    auth: Authenticator,
+    codeDefinedSkillIds: string[],
+    fetchOptions?: SkillHydrationOptions
+  ): Promise<SkillResource[]> {
+    if (codeDefinedSkillIds.length === 0) {
+      return [];
+    }
+
+    return this.fetchBySkillReferences(
+      auth,
+      codeDefinedSkillIds.map((globalSkillId) => ({
+        customSkillId: null,
+        globalSkillId,
+      })),
+      fetchOptions
     );
   }
 
@@ -4539,6 +4568,19 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       canAdministrate: this.canAdministrate(auth),
       isDefault: isDefaultFromAvailability(this.availability),
       availability: this.availability,
+    };
+  }
+
+  /**
+   * @cc [owner:fabiencelier,label:security] no-private-skill-fields
+   * The returned object MUST only carry fields that are public to any actor who can see the
+   * skill: instructions, tools, files and space ids are redacted for some callers by `toJSON`
+   * and MUST NOT be added here.
+   */
+  toAgentSkillJSON(): AgentSkillType {
+    return {
+      sId: this.sId,
+      name: this.name,
     };
   }
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1436,11 +1436,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   /**
    * Batched version of listByAgentConfiguration. Performs 2 SQL queries.
    * Does not support global agents as we rely on the ID for mapping: they all share the same
-   * model id and hold no `AgentSkillModel` row. Use `listByCodeDefinedSkillIds` for those.
+   * model id and hold no `AgentSkillModel` row. Their skills are code-defined, so resolve them
+   * with `fetchByIds` on the ids their configuration declares.
    */
-  static async listByAgentConfigurations<
-    T extends Pick<LightAgentConfigurationType, "id" | "sId">,
-  >(
+  static async listByAgentConfigurations<T extends LightAgentConfigurationType>(
     auth: Authenticator,
     agentConfigurations: T[],
     fetchOptions?: SkillHydrationOptions
@@ -1508,31 +1507,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           }
         });
       })
-    );
-  }
-
-  /**
-   * Resolves the code-defined skills a global agent declares, in one SQL query. Global agents
-   * hold no `AgentSkillModel` row, so they cannot go through `listByAgentConfigurations`.
-   * Skills the caller cannot access are filtered out, so the result can be shorter than the
-   * requested ids.
-   */
-  static async listByCodeDefinedSkillIds(
-    auth: Authenticator,
-    codeDefinedSkillIds: string[],
-    fetchOptions?: SkillHydrationOptions
-  ): Promise<SkillResource[]> {
-    if (codeDefinedSkillIds.length === 0) {
-      return [];
-    }
-
-    return this.fetchBySkillReferences(
-      auth,
-      codeDefinedSkillIds.map((globalSkillId) => ({
-        customSkillId: null,
-        globalSkillId,
-      })),
-      fetchOptions
     );
   }
 

--- a/front/lib/resources/skill/types.ts
+++ b/front/lib/resources/skill/types.ts
@@ -26,14 +26,19 @@ type CustomSkillConfigurationFindOptions =
     onlyCustom: true; // Explicit: only custom skills.
   };
 
-// baseFetch controls the selected model attributes based on hydration options
-// such as withInstructions.
-export type SkillConfigurationFindOptions = (
-  | Omit<AllSkillConfigurationFindOptions, "attributes">
-  | Omit<CustomSkillConfigurationFindOptions, "attributes">
-) & {
+// Which satellite data a skill fetch loads. Everything but `withToolMetadata` defaults to true,
+// so a caller that needs less has to opt out.
+export type SkillHydrationOptions = {
   withTools?: boolean;
   withToolMetadata?: boolean;
   withInstructions?: boolean;
   withFileAttachments?: boolean;
 };
+
+// baseFetch controls the selected model attributes based on hydration options
+// such as withInstructions.
+export type SkillConfigurationFindOptions = (
+  | Omit<AllSkillConfigurationFindOptions, "attributes">
+  | Omit<CustomSkillConfigurationFindOptions, "attributes">
+) &
+  SkillHydrationOptions;

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -212,13 +212,12 @@ export type AgentConfigurationType = z.infer<typeof AgentConfigurationSchema>;
 
 /**
  * An agent configuration with its attached skills resolved, which is what the API serializes.
- * `codeDefinedSkillIds` is dropped: `skills` supersedes it, and the ids on their own are an
- * internal detail of how global agents declare theirs. Generic so a full configuration keeps
- * the fields a light one does not carry.
+ * `codeDefinedSkillIds` is stripped on the way out: `skills` supersedes it, and the ids on their
+ * own are an internal detail of how global agents declare theirs.
  */
-export type AgentConfigurationWithSkillsType<
-  T extends LightAgentConfigurationType = LightAgentConfigurationType,
-> = Omit<T, "codeDefinedSkillIds"> & { skills: AgentSkillType[] };
+export type AgentConfigurationWithSkillsType = LightAgentConfigurationType & {
+  skills: AgentSkillType[];
+};
 
 export type AgentConfigurationWithoutModelType = Omit<
   AgentConfigurationType,

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -11,6 +11,7 @@ import type {
 import type { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
 import { ORDERED_REASONING_EFFORTS } from "@app/types/assistant/models/reasoning";
 import type { ModelIdType } from "@app/types/assistant/models/types";
+import type { AgentSkillType } from "@app/types/assistant/skill_configuration";
 import { DbModelIdSchema } from "@app/types/shared/model_id";
 import type { TagType } from "@app/types/tag";
 import { TagSchema } from "@app/types/tag";
@@ -208,6 +209,16 @@ export const AgentConfigurationSchema = LightAgentConfigurationSchema.extend({
 });
 
 export type AgentConfigurationType = z.infer<typeof AgentConfigurationSchema>;
+
+/**
+ * An agent configuration with its attached skills resolved, which is what the API serializes.
+ * `codeDefinedSkillIds` is dropped: `skills` supersedes it, and the ids on their own are an
+ * internal detail of how global agents declare theirs. Generic so a full configuration keeps
+ * the fields a light one does not carry.
+ */
+export type AgentConfigurationWithSkillsType<
+  T extends LightAgentConfigurationType = LightAgentConfigurationType,
+> = Omit<T, "codeDefinedSkillIds"> & { skills: AgentSkillType[] };
 
 export type AgentConfigurationWithoutModelType = Omit<
   AgentConfigurationType,

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -112,6 +112,19 @@ export const SkillSchema = SkillWithoutInstructionsAndToolsSchema.extend({
 
 export type SkillType = z.infer<typeof SkillSchema>;
 
+// A skill as seen from the agent it is attached to: just enough to identify and label it. Kept
+// deliberately small because agent list endpoints serialize it for every agent of the workspace;
+// fetch the skill itself for its description, tools or instructions.
+const AgentSkillSchema = z.object({
+  sId: z.string(),
+  name: z.string(),
+});
+
+/**
+ * @swaggerschema AgentSkill (swagger_schemas.ts)
+ */
+export type AgentSkillType = z.infer<typeof AgentSkillSchema>;
+
 export type UsedBySkillType = {
   sId: string;
   name: string;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1071,6 +1071,12 @@ const AgentModelConfigurationSchema = z.object({
   temperature: z.number(),
 });
 
+// A skill attached to an agent, as returned by the agent GET endpoints.
+const AgentSkillSchema = z.object({
+  sId: z.string(),
+  name: z.string(),
+});
+
 const LightAgentConfigurationSchema = z.object({
   id: ModelIdSchema,
   versionCreatedAt: z.string().nullable(),
@@ -1094,6 +1100,9 @@ const LightAgentConfigurationSchema = z.object({
   groupIds: z.array(z.string()).optional(),
   requestedGroupIds: z.array(z.array(z.string())).optional(),
   requestedSpaceIds: z.array(z.string()).optional(),
+  // Only populated by the agent GET endpoints; empty for agents whose details were redacted
+  // (`canRead` false).
+  skills: z.array(AgentSkillSchema).optional(),
 });
 
 export type LightAgentConfigurationType = z.infer<


### PR DESCRIPTION
## Description

related to https://github.com/dust-tt/tasks/issues/9379 

The public `agent_configurations` endpoints serialize `actions`, `tags` and `requestedSpaceIds` but never the skills attached to an agent, so there is no way to build an agent -> skills mapping from JSON.

- Every public endpoint returning an agent configuration now serializes `skills` as`{ sId, name }` objects.
- `SkillResource.listByAgentConfigurationsBySId` resolves them in at most 2 queries regardless of agent count, and handles global agents, whose skills come from their in-code `globalSkillIds` rather than from `AgentSkillModel`.
- Agents whose details were redacted for the caller (`canRead` false) get an empty list, consistently with `redactPrivateAgentConfigurationFields`.

## Tests

 - added and updated unit test on public endpoint an resource

## Risk

Low. Additive on the response.

## Deploy Plan

- Deploy front