### PR TITLE
[connections] Surface the authorizing Microsoft account for managed connections

### DIFF
--- a/core/src/oauth/providers/microsoft.rs
+++ b/core/src/oauth/providers/microsoft.rs
@@ -362,6 +362,26 @@ mod tests {
     }
 
     #[test]
+    fn returns_none_for_opaque_or_non_jwt_token_formats() {
+        // Graph tokens are sometimes opaque/encrypted rather than a decodable JWT: extraction must
+        // degrade to `None`, never error, so finalize keeps working.
+        // Segment count of a JWT but the payload is not valid base64url.
+        assert_eq!(extract_account_from_access_token("aaa.!!!.bbb"), None);
+        // Valid base64url payload that is not JSON.
+        let not_json = general_purpose::URL_SAFE_NO_PAD.encode("not json");
+        assert_eq!(
+            extract_account_from_access_token(&format!("aaa.{}.bbb", not_json)),
+            None
+        );
+        // Valid JSON payload that is not an object (so `.get(...)` yields nothing).
+        let json_array = general_purpose::URL_SAFE_NO_PAD.encode("[1,2,3]");
+        assert_eq!(
+            extract_account_from_access_token(&format!("aaa.{}.bbb", json_array)),
+            None
+        );
+    }
+
+    #[test]
     fn ignores_blank_account_claims() {
         let token = make_jwt(json!({ "upn": "   ", "email": "real@manageris.com" }));
         assert_eq!(

--- a/core/src/oauth/providers/microsoft.rs
+++ b/core/src/oauth/providers/microsoft.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
+use base64::{engine::general_purpose, Engine as _};
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde_json::json;
@@ -22,6 +23,28 @@ lazy_static! {
     static ref OAUTH_MICROSOFT_CLIENT_ID: String = env::var("OAUTH_MICROSOFT_CLIENT_ID").unwrap();
     static ref OAUTH_MICROSOFT_CLIENT_SECRET: String =
         env::var("OAUTH_MICROSOFT_CLIENT_SECRET").unwrap();
+}
+
+/// Decodes the claims (payload) of a JWT without verifying its signature. The token is obtained
+/// directly from Microsoft over TLS, so we only read it, never trust it for authorization.
+fn decode_jwt_claims(token: &str) -> Option<serde_json::Value> {
+    let payload = token.split('.').nth(1)?;
+    let decoded = general_purpose::URL_SAFE_NO_PAD.decode(payload).ok()?;
+    serde_json::from_slice(&decoded).ok()
+}
+
+/// Extracts the authorizing account (email/UPN) from a Microsoft Graph access token JWT. Returns
+/// `None` for app-only (service principal) tokens, which carry no user identity.
+fn extract_account_from_access_token(access_token: &str) -> Option<String> {
+    let claims = decode_jwt_claims(access_token)?;
+    for key in ["upn", "preferred_username", "unique_name", "email"] {
+        if let Some(serde_json::Value::String(account)) = claims.get(key) {
+            if !account.trim().is_empty() {
+                return Some(account.clone());
+            }
+        }
+    }
+    None
 }
 
 pub struct MicrosoftConnectionProvider {}
@@ -147,6 +170,16 @@ impl Provider for MicrosoftConnectionProvider {
 
         let refresh_token = raw_json["refresh_token"].as_str();
 
+        // Surface the authorizing Microsoft account (email/UPN) so admins can verify which
+        // identity backs the connection. App-only (service principal) tokens carry no user
+        // identity, so `connected_account` is simply absent in that case.
+        let extra_metadata = extract_account_from_access_token(access_token).map(|account| {
+            serde_json::Map::from_iter([(
+                "connected_account".to_string(),
+                serde_json::Value::String(account),
+            )])
+        });
+
         Ok(FinalizeResult {
             redirect_uri: redirect_uri.to_string(),
             code: code.to_string(),
@@ -156,7 +189,7 @@ impl Provider for MicrosoftConnectionProvider {
             ),
             refresh_token: refresh_token.map(|s| s.to_string()),
             raw_json,
-            extra_metadata: None,
+            extra_metadata,
         })
     }
 
@@ -263,5 +296,77 @@ impl Provider for MicrosoftConnectionProvider {
                 self.default_handle_provider_request_error(error)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_account_from_access_token;
+    use base64::{engine::general_purpose, Engine as _};
+    use serde_json::json;
+
+    fn make_jwt(claims: serde_json::Value) -> String {
+        let header = general_purpose::URL_SAFE_NO_PAD.encode(r#"{"alg":"none","typ":"JWT"}"#);
+        let payload = general_purpose::URL_SAFE_NO_PAD.encode(claims.to_string());
+        format!("{}.{}.signature", header, payload)
+    }
+
+    #[test]
+    fn extracts_upn_from_delegated_token() {
+        let token = make_jwt(json!({ "upn": "etienne@manageris.com" }));
+        assert_eq!(
+            extract_account_from_access_token(&token),
+            Some("etienne@manageris.com".to_string())
+        );
+    }
+
+    #[test]
+    fn falls_back_to_preferred_username_then_email() {
+        let token = make_jwt(json!({ "preferred_username": "generic@manageris.com" }));
+        assert_eq!(
+            extract_account_from_access_token(&token),
+            Some("generic@manageris.com".to_string())
+        );
+
+        let token = make_jwt(json!({ "email": "svc@manageris.com" }));
+        assert_eq!(
+            extract_account_from_access_token(&token),
+            Some("svc@manageris.com".to_string())
+        );
+    }
+
+    #[test]
+    fn prefers_upn_over_other_claims() {
+        let token = make_jwt(json!({
+            "upn": "primary@manageris.com",
+            "preferred_username": "secondary@manageris.com",
+            "email": "tertiary@manageris.com",
+        }));
+        assert_eq!(
+            extract_account_from_access_token(&token),
+            Some("primary@manageris.com".to_string())
+        );
+    }
+
+    #[test]
+    fn returns_none_for_app_only_token_without_user_claims() {
+        // Service principal (client_credentials) tokens carry no user identity.
+        let token = make_jwt(json!({ "roles": ["Sites.Read.All"], "tid": "tenant-123" }));
+        assert_eq!(extract_account_from_access_token(&token), None);
+    }
+
+    #[test]
+    fn returns_none_for_malformed_token() {
+        assert_eq!(extract_account_from_access_token("not-a-jwt"), None);
+        assert_eq!(extract_account_from_access_token(""), None);
+    }
+
+    #[test]
+    fn ignores_blank_account_claims() {
+        let token = make_jwt(json!({ "upn": "   ", "email": "real@manageris.com" }));
+        assert_eq!(
+            extract_account_from_access_token(&token),
+            Some("real@manageris.com".to_string())
+        );
     }
 }

--- a/core/src/oauth/providers/notion.rs
+++ b/core/src/oauth/providers/notion.rs
@@ -22,6 +22,29 @@ lazy_static! {
         env::var("OAUTH_NOTION_PLATFORM_ACTIONS_CLIENT_SECRET").unwrap();
 }
 
+/// Extracts the authorizing Notion account (email, falling back to display name) from the OAuth
+/// token response. Notion returns the granting identity under `owner.user`. Returns `None` for
+/// workspace-level owners that carry no user identity.
+fn extract_account_from_raw_json(raw_json: &serde_json::Value) -> Option<String> {
+    let user = raw_json.get("owner")?.get("user")?;
+
+    let email = user
+        .get("person")
+        .and_then(|person| person.get("email"))
+        .and_then(|email| email.as_str())
+        .map(str::trim)
+        .filter(|email| !email.is_empty());
+    if let Some(email) = email {
+        return Some(email.to_string());
+    }
+
+    user.get("name")
+        .and_then(|name| name.as_str())
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub enum NotionUseCase {
     Connection,
@@ -111,6 +134,16 @@ impl Provider for NotionConnectionProvider {
             None => Err(anyhow!("Missing `access_token` in response from Notion"))?,
         };
 
+        // Surface the authorizing Notion account so admins can verify which identity backs the
+        // connection. Workspace-level owners carry no user identity, so `connected_account` is
+        // simply absent in that case.
+        let extra_metadata = extract_account_from_raw_json(&raw_json).map(|account| {
+            serde_json::Map::from_iter([(
+                "connected_account".to_string(),
+                serde_json::Value::String(account),
+            )])
+        });
+
         Ok(FinalizeResult {
             redirect_uri: redirect_uri.to_string(),
             code: code.to_string(),
@@ -118,7 +151,7 @@ impl Provider for NotionConnectionProvider {
             access_token_expiry: None,
             refresh_token: None,
             raw_json,
-            extra_metadata: None,
+            extra_metadata,
         })
     }
 
@@ -141,5 +174,63 @@ impl Provider for NotionConnectionProvider {
             _ => Err(anyhow!("Invalid raw_json, not an object"))?,
         };
         Ok(raw_json)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_account_from_raw_json;
+    use serde_json::json;
+
+    #[test]
+    fn extracts_person_email() {
+        let raw_json = json!({
+            "owner": {
+                "type": "user",
+                "user": {
+                    "object": "user",
+                    "name": "Etienne Baerd",
+                    "type": "person",
+                    "person": { "email": "etienne@manageris.com" }
+                }
+            }
+        });
+        assert_eq!(
+            extract_account_from_raw_json(&raw_json),
+            Some("etienne@manageris.com".to_string())
+        );
+    }
+
+    #[test]
+    fn falls_back_to_name_when_email_absent() {
+        let raw_json = json!({
+            "owner": {
+                "type": "user",
+                "user": { "object": "user", "name": "Manageris Bot" }
+            }
+        });
+        assert_eq!(
+            extract_account_from_raw_json(&raw_json),
+            Some("Manageris Bot".to_string())
+        );
+    }
+
+    #[test]
+    fn returns_none_for_workspace_owner_without_user() {
+        let raw_json = json!({
+            "owner": { "type": "workspace", "workspace": true },
+            "workspace_name": "Manageris"
+        });
+        assert_eq!(extract_account_from_raw_json(&raw_json), None);
+    }
+
+    #[test]
+    fn ignores_blank_values() {
+        let raw_json = json!({
+            "owner": {
+                "user": { "name": "  ", "person": { "email": "" } }
+            }
+        });
+        assert_eq!(extract_account_from_raw_json(&raw_json), None);
     }
 }

--- a/core/src/oauth/providers/notion.rs
+++ b/core/src/oauth/providers/notion.rs
@@ -22,29 +22,6 @@ lazy_static! {
         env::var("OAUTH_NOTION_PLATFORM_ACTIONS_CLIENT_SECRET").unwrap();
 }
 
-/// Extracts the authorizing Notion account (email, falling back to display name) from the OAuth
-/// token response. Notion returns the granting identity under `owner.user`. Returns `None` for
-/// workspace-level owners that carry no user identity.
-fn extract_account_from_raw_json(raw_json: &serde_json::Value) -> Option<String> {
-    let user = raw_json.get("owner")?.get("user")?;
-
-    let email = user
-        .get("person")
-        .and_then(|person| person.get("email"))
-        .and_then(|email| email.as_str())
-        .map(str::trim)
-        .filter(|email| !email.is_empty());
-    if let Some(email) = email {
-        return Some(email.to_string());
-    }
-
-    user.get("name")
-        .and_then(|name| name.as_str())
-        .map(str::trim)
-        .filter(|name| !name.is_empty())
-        .map(str::to_string)
-}
-
 #[derive(Debug, PartialEq, Clone)]
 pub enum NotionUseCase {
     Connection,
@@ -134,16 +111,6 @@ impl Provider for NotionConnectionProvider {
             None => Err(anyhow!("Missing `access_token` in response from Notion"))?,
         };
 
-        // Surface the authorizing Notion account so admins can verify which identity backs the
-        // connection. Workspace-level owners carry no user identity, so `connected_account` is
-        // simply absent in that case.
-        let extra_metadata = extract_account_from_raw_json(&raw_json).map(|account| {
-            serde_json::Map::from_iter([(
-                "connected_account".to_string(),
-                serde_json::Value::String(account),
-            )])
-        });
-
         Ok(FinalizeResult {
             redirect_uri: redirect_uri.to_string(),
             code: code.to_string(),
@@ -151,7 +118,7 @@ impl Provider for NotionConnectionProvider {
             access_token_expiry: None,
             refresh_token: None,
             raw_json,
-            extra_metadata,
+            extra_metadata: None,
         })
     }
 
@@ -174,63 +141,5 @@ impl Provider for NotionConnectionProvider {
             _ => Err(anyhow!("Invalid raw_json, not an object"))?,
         };
         Ok(raw_json)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::extract_account_from_raw_json;
-    use serde_json::json;
-
-    #[test]
-    fn extracts_person_email() {
-        let raw_json = json!({
-            "owner": {
-                "type": "user",
-                "user": {
-                    "object": "user",
-                    "name": "Etienne Baerd",
-                    "type": "person",
-                    "person": { "email": "etienne@manageris.com" }
-                }
-            }
-        });
-        assert_eq!(
-            extract_account_from_raw_json(&raw_json),
-            Some("etienne@manageris.com".to_string())
-        );
-    }
-
-    #[test]
-    fn falls_back_to_name_when_email_absent() {
-        let raw_json = json!({
-            "owner": {
-                "type": "user",
-                "user": { "object": "user", "name": "Manageris Bot" }
-            }
-        });
-        assert_eq!(
-            extract_account_from_raw_json(&raw_json),
-            Some("Manageris Bot".to_string())
-        );
-    }
-
-    #[test]
-    fn returns_none_for_workspace_owner_without_user() {
-        let raw_json = json!({
-            "owner": { "type": "workspace", "workspace": true },
-            "workspace_name": "Manageris"
-        });
-        assert_eq!(extract_account_from_raw_json(&raw_json), None);
-    }
-
-    #[test]
-    fn ignores_blank_values() {
-        let raw_json = json!({
-            "owner": {
-                "user": { "name": "  ", "person": { "email": "" } }
-            }
-        });
-        assert_eq!(extract_account_from_raw_json(&raw_json), None);
     }
 }

--- a/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/details.ts
@@ -11,6 +11,8 @@ import type { InternalConnectorType } from "@app/types/connectors/connectors_api
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { isSlackAutoReadPatterns } from "@app/types/connectors/slack";
 import { CoreAPI } from "@app/types/core/core_api";
+import { OAuthAPI } from "@app/types/oauth/oauth_api";
+import { isString } from "@app/types/shared/utils/general";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -100,6 +102,31 @@ app.get(
         logger.error(
           { connectorId: dataSource.connectorId },
           "Failed to get connector"
+        );
+      }
+    }
+
+    // Surface the external account authorizing the OAuth connection (e.g. the Microsoft account
+    // behind a SharePoint connection) so admins can verify which identity backs it.
+    let oauthConnectedAccount: string | null = null;
+    if (connector?.connectionId) {
+      const oauthAPI = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+      const metadataRes = await oauthAPI.getConnectionMetadata({
+        connectionId: connector.connectionId,
+      });
+      if (metadataRes.isOk()) {
+        const { connected_account } = metadataRes.value.connection.metadata;
+        oauthConnectedAccount = isString(connected_account)
+          ? connected_account
+          : null;
+      } else {
+        logger.error(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            connectionId: connector.connectionId,
+            error: metadataRes.error,
+          },
+          "Failed to fetch OAuth connection metadata"
         );
       }
     }
@@ -263,6 +290,7 @@ app.get(
       dataSourceViews: dataSourceViews.map((view) => view.toJSON()),
       coreDataSource: coreDataSourceRes.value.data_source,
       connector,
+      oauthConnectedAccount,
       features,
       temporalWorkspace: config.getTemporalConnectorsNamespace() ?? "",
       temporalRunningWorkflows: workflowInfos,

--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -277,13 +277,16 @@ function UpdateConnectionOAuthModal({
   const isSlack = connectorProvider === "slack";
   const isMicrosoft = connectorProvider === "microsoft";
   const isZendesk = connectorProvider === "zendesk";
+  const isNotion = connectorProvider === "notion";
 
   // Fetch existing OAuth metadata when modal is open
   const { metadata, isMetadataLoading } = useOAuthMetadata({
     dataSource,
     owner,
     disabled:
-      !isOpen || !dataSource.connectorId || (!isMicrosoft && !isZendesk),
+      !isOpen ||
+      !dataSource.connectorId ||
+      (!isMicrosoft && !isZendesk && !isNotion),
   });
 
   // Populate extraConfig from metadata on first load only
@@ -356,6 +359,11 @@ function UpdateConnectionOAuthModal({
     connectorProvider && CONNECTOR_UI_CONFIGURATIONS[connectorProvider];
 
   const isDataSourceOwner = editedByUser?.userId === user.sId;
+
+  const connectedAccountValue = metadata?.connected_account;
+  const connectedAccount = isString(connectedAccountValue)
+    ? connectedAccountValue
+    : null;
 
   const permissionsConfigurable =
     getConnectorPermissionsConfigurableBlocked(connectorProvider);
@@ -445,6 +453,12 @@ function UpdateConnectionOAuthModal({
                 : "."}
             </div>
           </div>
+          {connectedAccount && (
+            <div className="copy-sm text-muted-foreground">
+              Authorized with {connectorConfiguration.name} account{" "}
+              <span className="font-bold">{connectedAccount}</span>.
+            </div>
+          )}
           {!isDataSourceOwner && (
             <div className="flex items-center justify-center gap-2">
               <RequestDataSourceModal

--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -277,16 +277,13 @@ function UpdateConnectionOAuthModal({
   const isSlack = connectorProvider === "slack";
   const isMicrosoft = connectorProvider === "microsoft";
   const isZendesk = connectorProvider === "zendesk";
-  const isNotion = connectorProvider === "notion";
 
   // Fetch existing OAuth metadata when modal is open
   const { metadata, isMetadataLoading } = useOAuthMetadata({
     dataSource,
     owner,
     disabled:
-      !isOpen ||
-      !dataSource.connectorId ||
-      (!isMicrosoft && !isZendesk && !isNotion),
+      !isOpen || !dataSource.connectorId || (!isMicrosoft && !isZendesk),
   });
 
   // Populate extraConfig from metadata on first load only
@@ -360,10 +357,9 @@ function UpdateConnectionOAuthModal({
 
   const isDataSourceOwner = editedByUser?.userId === user.sId;
 
-  const connectedAccountValue = metadata?.connected_account;
-  const connectedAccount = isString(connectedAccountValue)
-    ? connectedAccountValue
-    : null;
+  const connectedAccount = metadata?.connected_account;
+  const microsoftAccount =
+    isMicrosoft && isString(connectedAccount) ? connectedAccount : null;
 
   const permissionsConfigurable =
     getConnectorPermissionsConfigurableBlocked(connectorProvider);
@@ -453,10 +449,10 @@ function UpdateConnectionOAuthModal({
                 : "."}
             </div>
           </div>
-          {connectedAccount && (
+          {microsoftAccount && (
             <div className="copy-sm text-muted-foreground">
-              Authorized with {connectorConfiguration.name} account{" "}
-              <span className="font-bold">{connectedAccount}</span>.
+              Authorized with Microsoft account{" "}
+              <span className="font-bold">{microsoftAccount}</span>.
             </div>
           )}
           {!isDataSourceOwner && (

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -48,6 +48,7 @@ export function ViewDataSourceTable({
   coreDataSource,
   dataSource,
   dataSourceViews,
+  oauthConnectedAccount,
   owner,
   temporalWorkspace,
   temporalRunningWorkflows,
@@ -56,6 +57,7 @@ export function ViewDataSourceTable({
   coreDataSource: CoreAPIDataSource;
   dataSource: DataSourceType;
   dataSourceViews: DataSourceViewType[];
+  oauthConnectedAccount: string | null;
   owner: WorkspaceType;
   temporalWorkspace: string;
   temporalRunningWorkflows: {
@@ -143,6 +145,12 @@ export function ViewDataSourceTable({
                       : "N/A"}
                   </PokeTableCell>
                 </PokeTableRow>
+                {oauthConnectedAccount && (
+                  <PokeTableRow>
+                    <PokeTableCell>Connected account</PokeTableCell>
+                    <PokeTableCell>{oauthConnectedAccount}</PokeTableCell>
+                  </PokeTableRow>
+                )}
                 <PokeTableRow>
                   <PokeTableCell>Logs</PokeTableCell>
                   <PokeTableCell>

--- a/front/components/poke/pages/DataSourcePage.tsx
+++ b/front/components/poke/pages/DataSourcePage.tsx
@@ -940,6 +940,7 @@ export function DataSourcePage() {
     dataSourceViews,
     coreDataSource,
     connector,
+    oauthConnectedAccount,
     features,
     temporalWorkspace,
     temporalRunningWorkflows,
@@ -988,6 +989,7 @@ export function DataSourcePage() {
           temporalWorkspace={temporalWorkspace}
           coreDataSource={coreDataSource}
           connector={connector}
+          oauthConnectedAccount={oauthConnectedAccount}
           temporalRunningWorkflows={temporalRunningWorkflows}
         />
         <div className="mt-4 flex grow flex-col gap-y-4">

--- a/front/types/api/poke/data_sources.ts
+++ b/front/types/api/poke/data_sources.ts
@@ -31,6 +31,7 @@ export type PokeGetDataSourceDetails = {
   dataSourceViews: DataSourceViewType[];
   coreDataSource: CoreAPIDataSource;
   connector: InternalConnectorType | null;
+  oauthConnectedAccount: string | null;
   features: FeaturesType;
   temporalWorkspace: string;
   temporalRunningWorkflows: {


### PR DESCRIPTION
## Description

Admins cannot verify which Microsoft account authorizes an existing managed Microsoft/SharePoint connection: the flow reports success, but Dust only exposes the *Dust* user who edited the connection, not the Microsoft identity. This has repeatedly forced support to delete + recreate connections (once detaching a data source from 23 agents) just to change or verify the authorizing account.

Fixes dust-tt/tasks#10172.

This extracts the authorizing account at OAuth **finalize** and stores it as `connected_account` in the connection metadata (same `extra_metadata` pattern as Slack/Discord/Gong), then surfaces it:

- **Core** — `MicrosoftConnectionProvider`: decode the Graph access-token JWT and read the account (`upn` → `preferred_username` → `unique_name` → `email`). Extraction is fully non-fatal: any non-JWT/opaque/claim-less token degrades to `None` and finalize proceeds unchanged.
- **Poke** — the data-source details route fetches the OAuth connection metadata for any managed connector and returns `oauthConnectedAccount`, rendered as a "Connected account" row under "Edited by/at" (provider-agnostic; only Microsoft populates it today).
- **Manage Connection modal** — shows `Authorized with Microsoft account <email>`.

App-only tokens (Microsoft service principal) carry no user identity, so `connected_account` is simply absent there.

## Tests

- New Rust unit tests for the extractor: claim precedence, blank-value skipping, app-only case (no account), and opaque/non-JWT/non-object token formats that must degrade to `None` without erroring (`cargo test -p dust --lib oauth::providers::microsoft`, 7 tests, all green).
- `tsgo --noEmit` clean on `front` and `front-api`; `cargo check` clean; biome/rustfmt applied.
- Poke route reuses the existing `getConnectionMetadata` path; the modal reuses the existing `useOAuthMetadata` hook.

## Risk

Low. Additive only — a new optional metadata field and read-only UI. No schema/migration, no change to token exchange, refresh, or scopes (no re-consent). The JWT is decoded without signature verification, but it is obtained directly from Microsoft over TLS and used only for display, never for authorization (mirrors the existing tenant-id decode in connectors). Safe to roll back.

The account is captured at finalize, so **existing connections show nothing until their next re-authorization** ("Edit permissions") — intended; no backfill in this PR.

## Deploy Plan

Standard. Deploy `core` (oauth) first so the metadata is populated on new/re-authorized connections, then `front`/`front-api`. No ordering constraints beyond that; nothing to run.