### PR TITLE
[front] Add changelog link to user menu

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -53,6 +53,7 @@ import type { UserTypeWithWorkspaces, WorkspaceType } from "@app/types/user";
 import { isOnlyAdmin, isOnlyManager, isOnlyUser } from "@app/types/user";
 import { datadogLogs } from "@datadog/browser-logs";
 import {
+  Announcement01,
   Avatar,
   BarChart01,
   Beaker02,
@@ -508,6 +509,14 @@ export function UserMenu({
                 onClick={() => trackUserMenuEvent("chrome_extension")}
               />
             ))}
+
+          <DropdownMenuItem
+            label="Changelog"
+            icon={Announcement01}
+            href="https://docs.dust.tt/docs/changelog"
+            target="_blank"
+            onClick={() => trackUserMenuEvent("changelog")}
+          />
 
           {subscription?.plan.limits.canUseProduct && (
             <>


### PR DESCRIPTION
## Description

Adds a "Changelog" item to the user menu, below the Chrome/Firefox extension link. Opens https://docs.dust.tt/docs/changelog in a new tab.

## Tests

Manually checked the menu locally.

## Risk

None.

## Deploy Plan

Deploy front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)