### PR TITLE
feat: add v1/wId/analytics/consumption/export

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -133,7 +133,7 @@
     "/api/v1/w/{wId}/analytics/consumption/export": {
       "post": {
         "summary": "Export consumption analytics",
-        "description": "Export per-call consumption analytics for the workspace identified by {wId}.\nEach row represents one unit of billed credit consumption (an LLM call or a tool call).\nThe export can be filtered by various dimensions (agents, users, API keys, groups, models, tools, skills, sources, tags).\nThe export is limited to a maximum of 30 days per request.\n",
+        "description": "Export per-call consumption analytics for the workspace identified by {wId}.\nEach row represents one unit of billed credit consumption (an LLM call or a tool call).\nThe export can be filtered by various dimensions (agents, users, API keys, groups, models, tools, skills, sources, tags).\nThe export is limited to a maximum of 30 days per request and times out after 10 seconds: reduce the time range\nor apply filters to reduce the number of rows if you encounter a timeout.\nResults are streamed, if an error occurs, an error message is appended and the stream is closed.\n",
         "tags": [
           "Analytics"
         ],

--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -186,68 +186,77 @@
                   },
                   "filter": {
                     "type": "object",
-                    "description": "Optional dimension filters. Each key maps to an array of string identifiers to include.",
+                    "description": "Optional dimension filters. Each key maps to an array of string identifiers to include.\nEach value must be at most 256 characters. The total number of values across all dimensions must not exceed 500.\n",
                     "properties": {
                       "agents": {
                         "type": "array",
                         "items": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 256
                         },
                         "description": "Agent sIds to filter on"
                       },
                       "users": {
                         "type": "array",
                         "items": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 256
                         },
                         "description": "User IDs to filter on"
                       },
                       "api_keys": {
                         "type": "array",
                         "items": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 256
                         },
                         "description": "API key names to filter on"
                       },
                       "groups": {
                         "type": "array",
                         "items": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 256
                         },
                         "description": "Group IDs to filter on"
                       },
                       "models": {
                         "type": "array",
                         "items": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 256
                         },
                         "description": "Model IDs to filter on"
                       },
                       "tools": {
                         "type": "array",
                         "items": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 256
                         },
                         "description": "Tool server names to filter on"
                       },
                       "skills": {
                         "type": "array",
                         "items": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 256
                         },
                         "description": "Skill IDs to filter on"
                       },
                       "sources": {
                         "type": "array",
                         "items": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 256
                         },
                         "description": "Context origins to filter on (e.g. \"web\", \"slack\", \"api\")"
                       },
                       "tags": {
                         "type": "array",
                         "items": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 256
                         },
                         "description": "Agent tag IDs to filter on"
                       }

--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -130,6 +130,163 @@
     }
   ],
   "paths": {
+    "/api/v1/w/{wId}/analytics/consumption/export": {
+      "post": {
+        "summary": "Export consumption analytics",
+        "description": "Export per-call consumption analytics for the workspace identified by {wId}.\nEach row represents one unit of billed credit consumption (an LLM call or a tool call).\nThe export can be filtered by various dimensions (agents, users, API keys, groups, models, tools, skills, sources, tags).\nThe export is limited to a maximum of 30 days per request.\n",
+        "tags": [
+          "Analytics"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "Unique string identifier for the workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "startDate",
+                  "endDate"
+                ],
+                "properties": {
+                  "startDate": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Start of the time range (inclusive), ISO 8601 datetime",
+                    "example": "2026-01-01T00:00:00Z"
+                  },
+                  "endDate": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "End of the time range (exclusive), ISO 8601 datetime. Must be after startDate, at most 30 days apart.",
+                    "example": "2026-01-15T00:00:00Z"
+                  },
+                  "format": {
+                    "type": "string",
+                    "enum": [
+                      "csv",
+                      "ndjson"
+                    ],
+                    "description": "Output format (defaults to csv)"
+                  },
+                  "filter": {
+                    "type": "object",
+                    "description": "Optional dimension filters. Each key maps to an array of string identifiers to include.",
+                    "properties": {
+                      "agents": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Agent sIds to filter on"
+                      },
+                      "users": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "User IDs to filter on"
+                      },
+                      "api_keys": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "API key names to filter on"
+                      },
+                      "groups": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Group IDs to filter on"
+                      },
+                      "models": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Model IDs to filter on"
+                      },
+                      "tools": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Tool server names to filter on"
+                      },
+                      "skills": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Skill IDs to filter on"
+                      },
+                      "sources": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Context origins to filter on (e.g. \"web\", \"slack\", \"api\")"
+                      },
+                      "tags": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Agent tag IDs to filter on"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The consumption data in CSV or NDJSON format",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/x-ndjson": {
+                "schema": {
+                  "type": "string",
+                  "description": "Newline-delimited JSON, one row object per line"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body (missing fields, invalid dates, range exceeds 30 days)"
+          },
+          "403": {
+            "description": "Requires an API key with admin scope"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
     "/api/v1/w/{wId}/analytics/export": {
       "get": {
         "summary": "Export workspace analytics",

--- a/front-api/routes/swagger-private.json
+++ b/front-api/routes/swagger-private.json
@@ -243,7 +243,7 @@
     "/api/v1/w/{wId}/analytics/consumption/export": {
       "post": {
         "summary": "Export consumption analytics",
-        "description": "Export per-call consumption analytics for the workspace identified by {wId}.\nEach row represents one unit of billed credit consumption (an LLM call or a tool call).\nThe export can be filtered by various dimensions (agents, users, API keys, groups, models, tools, skills, sources, tags).\nThe export is limited to a maximum of 30 days per request.\n",
+        "description": "Export per-call consumption analytics for the workspace identified by {wId}.\nEach row represents one unit of billed credit consumption (an LLM call or a tool call).\nThe export can be filtered by various dimensions (agents, users, API keys, groups, models, tools, skills, sources, tags).\nThe export is limited to a maximum of 30 days per request and times out after 10 seconds: reduce the time range\nor apply filters to reduce the number of rows if you encounter a timeout.\nResults are streamed, if an error occurs, an error message is appended and the stream is closed.\n",
         "tags": [
           "Analytics"
         ],
@@ -296,68 +296,77 @@
                   },
                   "filter": {
                     "type": "object",
-                    "description": "Optional dimension filters. Each key maps to an array of string identifiers to include.",
+                    "description": "Optional dimension filters. Each key maps to an array of string identifiers to include.\nEach value must be at most 256 characters. The total number of values across all dimensions must not exceed 500.\n",
                     "properties": {
                       "agents": {
                         "type": "array",
                         "items": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 256
                         },
                         "description": "Agent sIds to filter on"
                       },
                       "users": {
                         "type": "array",
                         "items": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 256
                         },
                         "description": "User IDs to filter on"
                       },
                       "api_keys": {
                         "type": "array",
                         "items": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 256
                         },
                         "description": "API key names to filter on"
                       },
                       "groups": {
                         "type": "array",
                         "items": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 256
                         },
                         "description": "Group IDs to filter on"
                       },
                       "models": {
                         "type": "array",
                         "items": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 256
                         },
                         "description": "Model IDs to filter on"
                       },
                       "tools": {
                         "type": "array",
                         "items": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 256
                         },
                         "description": "Tool server names to filter on"
                       },
                       "skills": {
                         "type": "array",
                         "items": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 256
                         },
                         "description": "Skill IDs to filter on"
                       },
                       "sources": {
                         "type": "array",
                         "items": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 256
                         },
                         "description": "Context origins to filter on (e.g. \"web\", \"slack\", \"api\")"
                       },
                       "tags": {
                         "type": "array",
                         "items": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 256
                         },
                         "description": "Agent tag IDs to filter on"
                       }

--- a/front-api/routes/swagger-private.json
+++ b/front-api/routes/swagger-private.json
@@ -240,6 +240,163 @@
         }
       }
     },
+    "/api/v1/w/{wId}/analytics/consumption/export": {
+      "post": {
+        "summary": "Export consumption analytics",
+        "description": "Export per-call consumption analytics for the workspace identified by {wId}.\nEach row represents one unit of billed credit consumption (an LLM call or a tool call).\nThe export can be filtered by various dimensions (agents, users, API keys, groups, models, tools, skills, sources, tags).\nThe export is limited to a maximum of 30 days per request.\n",
+        "tags": [
+          "Analytics"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "Unique string identifier for the workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "startDate",
+                  "endDate"
+                ],
+                "properties": {
+                  "startDate": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Start of the time range (inclusive), ISO 8601 datetime",
+                    "example": "2026-01-01T00:00:00Z"
+                  },
+                  "endDate": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "End of the time range (exclusive), ISO 8601 datetime. Must be after startDate, at most 30 days apart.",
+                    "example": "2026-01-15T00:00:00Z"
+                  },
+                  "format": {
+                    "type": "string",
+                    "enum": [
+                      "csv",
+                      "ndjson"
+                    ],
+                    "description": "Output format (defaults to csv)"
+                  },
+                  "filter": {
+                    "type": "object",
+                    "description": "Optional dimension filters. Each key maps to an array of string identifiers to include.",
+                    "properties": {
+                      "agents": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Agent sIds to filter on"
+                      },
+                      "users": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "User IDs to filter on"
+                      },
+                      "api_keys": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "API key names to filter on"
+                      },
+                      "groups": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Group IDs to filter on"
+                      },
+                      "models": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Model IDs to filter on"
+                      },
+                      "tools": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Tool server names to filter on"
+                      },
+                      "skills": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Skill IDs to filter on"
+                      },
+                      "sources": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Context origins to filter on (e.g. \"web\", \"slack\", \"api\")"
+                      },
+                      "tags": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Agent tag IDs to filter on"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The consumption data in CSV or NDJSON format",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/x-ndjson": {
+                "schema": {
+                  "type": "string",
+                  "description": "Newline-delimited JSON, one row object per line"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body (missing fields, invalid dates, range exceeds 30 days)"
+          },
+          "403": {
+            "description": "Requires an API key with admin scope"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
     "/api/v1/w/{wId}/analytics/export": {
       "get": {
         "summary": "Export workspace analytics",

--- a/front-api/routes/v1/w/[wId]/analytics/consumption/export.test.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/consumption/export.test.ts
@@ -1,0 +1,283 @@
+import { Authenticator } from "@app/lib/auth";
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { ENSURE_IS_ADMIN_ERROR_MESSAGE } from "@front-api/middlewares/ensure_role";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const MOCK_ROWS = [
+  {
+    completedAt: "2024-06-15T10:00:00.000Z",
+    conversationId: "conv-1",
+    spaceId: "space-1",
+    agentMessageId: "msg-1",
+    consumptionType: "llm",
+    agentId: "agent-1",
+    agentName: "TestAgent",
+    agentVersion: "1",
+    agentTagIds: "",
+    agentRootId: "",
+    agentParentId: "",
+    agentDepth: 0,
+    modelProviderId: "openai",
+    modelId: "gpt-4",
+    modelName: "GPT-4",
+    modelReasoningEffort: "",
+    modelResolutionMethod: "",
+    userId: "user-1",
+    userName: "Alice",
+    userGroupIds: "",
+    userGroupNames: "",
+    triggerId: "",
+    contextOrigin: "web",
+    apiKeyName: "",
+    toolName: "",
+    toolServerName: "",
+    toolDisplayName: "",
+    toolParentServerName: "",
+    toolActionId: "",
+    attributedSkillIds: "",
+    attributedSkillNames: "",
+    creditsSystem: 0.01,
+    creditsInput: 0.02,
+    creditsOutput: 0.03,
+    creditsReasoning: 0,
+    creditsDirect: 0,
+    totalCredits: 0.06,
+    usageType: "chat",
+    status: "completed",
+    stepIndex: 0,
+    executionTimeMs: 1200,
+  },
+];
+
+vi.mock(
+  "@app/lib/api/analytics/consumption/export_lines",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@app/lib/api/analytics/consumption/export_lines")
+    >()),
+    fetchConsumptionExportRows: vi.fn(async () => new Ok(MOCK_ROWS)),
+  })
+);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function enableFeatureFlag() {
+  vi.spyOn(Authenticator.prototype, "hasFeatureFlag").mockResolvedValue(true);
+}
+
+function disableFeatureFlag() {
+  vi.spyOn(Authenticator.prototype, "hasFeatureFlag").mockResolvedValue(false);
+}
+
+function consumptionExportRequest({
+  workspace,
+  key,
+  body,
+  method = "POST",
+}: {
+  workspace: { sId: string };
+  key: { secret: string };
+  body?: Record<string, unknown>;
+  method?: string;
+}) {
+  return honoApp.request(
+    `/api/v1/w/${workspace.sId}/analytics/consumption/export`,
+    {
+      method,
+      headers: {
+        authorization: `Bearer ${key.secret}`,
+        "content-type": "application/json",
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    }
+  );
+}
+
+describe("POST /api/v1/w/[wId]/analytics/consumption/export", () => {
+  it("returns 200 CSV for admin API key with feature flag", async () => {
+    enableFeatureFlag();
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+
+    const response = await consumptionExportRequest({
+      workspace,
+      key,
+      body: {
+        startDate: "2024-06-01T00:00:00Z",
+        endDate: "2024-06-15T00:00:00Z",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/csv");
+    expect(response.headers.get("Content-Disposition")).toContain(
+      "dust_consumption_2024-06-01T00:00:00Z_2024-06-15T00:00:00Z.csv"
+    );
+    const csv = await response.text();
+    expect(csv).toContain("completedAt");
+    expect(csv).toContain("conv-1");
+  });
+
+  it("returns 200 NDJSON when format=ndjson", async () => {
+    enableFeatureFlag();
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+
+    const response = await consumptionExportRequest({
+      workspace,
+      key,
+      body: {
+        startDate: "2024-06-01T00:00:00Z",
+        endDate: "2024-06-15T00:00:00Z",
+        format: "ndjson",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/x-ndjson");
+    const text = await response.text();
+    const parsed = JSON.parse(text.trim());
+    expect(parsed.conversationId).toBe("conv-1");
+    expect(parsed.totalCredits).toBe(0.06);
+  });
+
+  it("returns 403 when feature flag is not enabled", async () => {
+    disableFeatureFlag();
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+
+    const response = await consumptionExportRequest({
+      workspace,
+      key,
+      body: {
+        startDate: "2024-06-01T00:00:00Z",
+        endDate: "2024-06-15T00:00:00Z",
+      },
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "workspace_auth_error",
+        message:
+          "The workspace does not have access to the consumption export API.",
+      },
+    });
+  });
+
+  it("returns 403 for read-only API key", async () => {
+    enableFeatureFlag();
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "user",
+    });
+
+    const response = await consumptionExportRequest({
+      workspace,
+      key,
+      body: {
+        startDate: "2024-06-01T00:00:00Z",
+        endDate: "2024-06-15T00:00:00Z",
+      },
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "workspace_auth_error",
+        message: ENSURE_IS_ADMIN_ERROR_MESSAGE,
+      },
+    });
+  });
+
+  it("returns 400 when time range exceeds 30 days", async () => {
+    enableFeatureFlag();
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+
+    const response = await consumptionExportRequest({
+      workspace,
+      key,
+      body: {
+        startDate: "2024-06-01T00:00:00Z",
+        endDate: "2024-08-01T00:00:00Z",
+      },
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when startDate is after endDate", async () => {
+    enableFeatureFlag();
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+
+    const response = await consumptionExportRequest({
+      workspace,
+      key,
+      body: {
+        startDate: "2024-06-30T00:00:00Z",
+        endDate: "2024-06-01T00:00:00Z",
+      },
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for missing required fields", async () => {
+    enableFeatureFlag();
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+
+    const response = await consumptionExportRequest({
+      workspace,
+      key,
+      body: {},
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 405 for GET", async () => {
+    enableFeatureFlag();
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+
+    const response = await consumptionExportRequest({
+      workspace,
+      key,
+      method: "GET",
+    });
+
+    expect(response.status).toBe(405);
+  });
+
+  it("accepts optional filter parameter", async () => {
+    enableFeatureFlag();
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+
+    const response = await consumptionExportRequest({
+      workspace,
+      key,
+      body: {
+        startDate: "2024-06-01T00:00:00Z",
+        endDate: "2024-06-15T00:00:00Z",
+        filter: { agents: ["agent-1"] },
+      },
+    });
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/front-api/routes/v1/w/[wId]/analytics/consumption/export.test.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/consumption/export.test.ts
@@ -1,69 +1,105 @@
+import {
+  ElasticsearchError,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
 import { Authenticator } from "@app/lib/auth";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
-import { Ok } from "@app/types/shared/result";
+import type { AgentMessageConsumptionAnalyticsData } from "@app/types/assistant/analytics";
+import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import { ENSURE_IS_ADMIN_ERROR_MESSAGE } from "@front-api/middlewares/ensure_role";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-const MOCK_ROWS = [
-  {
-    completedAt: "2024-06-15T10:00:00.000Z",
-    conversationId: "conv-1",
-    spaceId: "space-1",
-    agentMessageId: "msg-1",
-    consumptionType: "llm",
-    agentId: "agent-1",
-    agentName: "TestAgent",
-    agentVersion: "1",
-    agentTagIds: "",
-    agentRootId: "",
-    agentParentId: "",
-    agentDepth: 0,
-    modelProviderId: "openai",
-    modelId: "gpt-4",
-    modelName: "GPT-4",
-    modelReasoningEffort: "",
-    modelResolutionMethod: "",
-    userId: "user-1",
-    userName: "Alice",
-    userGroupIds: "",
-    userGroupNames: "",
-    triggerId: "",
-    contextOrigin: "web",
-    apiKeyName: "",
-    toolName: "",
-    toolServerName: "",
-    toolDisplayName: "",
-    toolParentServerName: "",
-    toolActionId: "",
-    attributedSkillIds: "",
-    attributedSkillNames: "",
-    creditsSystem: 0.01,
-    creditsInput: 0.02,
-    creditsOutput: 0.03,
-    creditsReasoning: 0,
-    creditsDirect: 0,
-    totalCredits: 0.06,
-    usageType: "chat",
-    status: "completed",
-    stepIndex: 0,
-    executionTimeMs: 1200,
-  },
-];
-
-vi.mock(
-  "@app/lib/api/analytics/consumption/export_lines",
-  async (importOriginal) => ({
-    ...(await importOriginal<
-      typeof import("@app/lib/api/analytics/consumption/export_lines")
-    >()),
-    fetchConsumptionExportRows: vi.fn(async () => new Ok(MOCK_ROWS)),
-  })
+const mockedSearchConsumptionAnalytics = vi.mocked(
+  searchConsumptionAnalytics<AgentMessageConsumptionAnalyticsData>
 );
 
-afterEach(() => {
-  vi.restoreAllMocks();
+vi.mock(import("@app/lib/api/elasticsearch"), async (orig) => {
+  const mod = await orig();
+  return { ...mod, searchConsumptionAnalytics: vi.fn() };
 });
+
+vi.mock(import("@app/lib/api/analytics/consumption/labels"), async (orig) => {
+  const mod = await orig();
+  return { ...mod, resolveDimensionLabels: vi.fn(async () => new Map()) };
+});
+
+const MOCK_ES_DOC: AgentMessageConsumptionAnalyticsData = {
+  workspace_id: "ws-1",
+  agent: {
+    attributed_id: "agent-1",
+    id: "agent-1",
+    version: "1",
+    tag_ids: [],
+    parent_ids: [],
+    direct_parent_id: null,
+    root_id: "agent-1",
+    depth: 0,
+  },
+  agent_message_id: "msg-1",
+  api_key_name: null,
+  attribution_version: 1,
+  completed_at: "2024-06-15T10:00:00.000Z",
+  consumption_key: "run-usage:1",
+  context_origin: "web",
+  normalized_origin: "web",
+  conversation_id: "conv-1",
+  credit_micro: 6000,
+  execution_time_ms: 1200,
+  micro_usd: 3000,
+  message_version: "1",
+  parent_message_id: null,
+  model: {
+    provider_id: "openai",
+    model_id: "gpt-5.6-luna",
+    reasoning_effort: "high",
+    resolution_method: null,
+  },
+  run_usage_id: "123",
+  space_id: "space-1",
+  status: "completed",
+  step_index: 0,
+  trigger_id: null,
+  usage_type: "user",
+  user: { id: "user-1", group_ids: [], seat_type: "pro" },
+  consumption_type: "llm",
+  gross_credit_micro: {
+    system: 0,
+    input: 2000,
+    result_footprint: null,
+    output: 4000,
+    reasoning: 0,
+    direct: 0,
+    total: 6000,
+  },
+  tokens: {
+    system: 0,
+    input: 10,
+    result_footprint: null,
+    output: 20,
+    reasoning: 0,
+  },
+  tool: null,
+};
+
+function mockEsSuccess() {
+  mockedSearchConsumptionAnalytics.mockResolvedValueOnce(
+    new Ok({
+      took: 0,
+      timed_out: false,
+      _shards: { failed: 0, successful: 1, total: 1 },
+      hits: {
+        hits: [
+          {
+            _index: "consumption_analytics",
+            _source: MOCK_ES_DOC,
+            sort: [],
+          },
+        ],
+      },
+    })
+  );
+}
 
 function enableFeatureFlag() {
   vi.spyOn(Authenticator.prototype, "hasFeatureFlag").mockResolvedValue(true);
@@ -100,6 +136,7 @@ function consumptionExportRequest({
 describe("POST /api/v1/w/[wId]/analytics/consumption/export", () => {
   it("returns 200 CSV for admin API key with feature flag", async () => {
     enableFeatureFlag();
+    mockEsSuccess();
     const { workspace, key } = await createPublicApiMockRequest({
       role: "admin",
     });
@@ -125,6 +162,7 @@ describe("POST /api/v1/w/[wId]/analytics/consumption/export", () => {
 
   it("returns 200 NDJSON when format=ndjson", async () => {
     enableFeatureFlag();
+    mockEsSuccess();
     const { workspace, key } = await createPublicApiMockRequest({
       role: "admin",
     });
@@ -144,7 +182,6 @@ describe("POST /api/v1/w/[wId]/analytics/consumption/export", () => {
     const text = await response.text();
     const parsed = JSON.parse(text.trim());
     expect(parsed.conversationId).toBe("conv-1");
-    expect(parsed.totalCredits).toBe(0.06);
   });
 
   it("returns 403 when feature flag is not enabled", async () => {
@@ -264,6 +301,7 @@ describe("POST /api/v1/w/[wId]/analytics/consumption/export", () => {
 
   it("accepts optional filter parameter", async () => {
     enableFeatureFlag();
+    mockEsSuccess();
     const { workspace, key } = await createPublicApiMockRequest({
       role: "admin",
     });
@@ -279,5 +317,68 @@ describe("POST /api/v1/w/[wId]/analytics/consumption/export", () => {
     });
 
     expect(response.status).toBe(200);
+  });
+
+  it("returns 400 when total filter values exceed 500", async () => {
+    enableFeatureFlag();
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+
+    const response = await consumptionExportRequest({
+      workspace,
+      key,
+      body: {
+        startDate: "2024-06-01T00:00:00Z",
+        endDate: "2024-06-15T00:00:00Z",
+        filter: {
+          agents: Array.from({ length: 501 }, (_, i) => `agent-${i}`),
+        },
+      },
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when a filter value exceeds 256 characters", async () => {
+    enableFeatureFlag();
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+
+    const response = await consumptionExportRequest({
+      workspace,
+      key,
+      body: {
+        startDate: "2024-06-01T00:00:00Z",
+        endDate: "2024-06-15T00:00:00Z",
+        filter: { agents: ["a".repeat(257)] },
+      },
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("appends error to stream body on ES failure", async () => {
+    enableFeatureFlag();
+    mockedSearchConsumptionAnalytics.mockResolvedValueOnce(
+      new Err(new ElasticsearchError("query_error", "shard failure"))
+    );
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+
+    const response = await consumptionExportRequest({
+      workspace,
+      key,
+      body: {
+        startDate: "2024-06-01T00:00:00Z",
+        endDate: "2024-06-15T00:00:00Z",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toBe("ERROR: Internal server error.");
   });
 });

--- a/front-api/routes/v1/w/[wId]/analytics/consumption/export.test.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/consumption/export.test.ts
@@ -153,7 +153,7 @@ describe("POST /api/v1/w/[wId]/analytics/consumption/export", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("text/csv");
     expect(response.headers.get("Content-Disposition")).toContain(
-      "dust_consumption_2024-06-01T00:00:00Z_2024-06-15T00:00:00Z.csv"
+      "dust_consumption_2024-06-01T00:00:00.000Z_2024-06-15T00:00:00.000Z.csv"
     );
     const csv = await response.text();
     expect(csv).toContain("completedAt");
@@ -202,7 +202,7 @@ describe("POST /api/v1/w/[wId]/analytics/consumption/export", () => {
     expect(response.status).toBe(403);
     expect(await response.json()).toEqual({
       error: {
-        type: "workspace_auth_error",
+        type: "feature_flag_not_found",
         message:
           "The workspace does not have access to the consumption export API.",
       },
@@ -249,6 +249,9 @@ describe("POST /api/v1/w/[wId]/analytics/consumption/export", () => {
     });
 
     expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error.type).toBe("invalid_request_error");
+    expect(json.error.message).toContain("Time range must not exceed 30 days");
   });
 
   it("returns 400 when startDate is after endDate", async () => {
@@ -267,6 +270,11 @@ describe("POST /api/v1/w/[wId]/analytics/consumption/export", () => {
     });
 
     expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error.type).toBe("invalid_request_error");
+    expect(json.error.message).toContain(
+      "startDate must be strictly before endDate"
+    );
   });
 
   it("returns 400 for missing required fields", async () => {
@@ -282,6 +290,9 @@ describe("POST /api/v1/w/[wId]/analytics/consumption/export", () => {
     });
 
     expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error.type).toBe("invalid_request_error");
+    expect(json.error.message).toContain("startDate");
   });
 
   it("returns 405 for GET", async () => {
@@ -297,6 +308,12 @@ describe("POST /api/v1/w/[wId]/analytics/consumption/export", () => {
     });
 
     expect(response.status).toBe(405);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
   });
 
   it("accepts optional filter parameter", async () => {
@@ -319,7 +336,7 @@ describe("POST /api/v1/w/[wId]/analytics/consumption/export", () => {
     expect(response.status).toBe(200);
   });
 
-  it("returns 400 when total filter values exceed 500", async () => {
+  it("returns 400 when filter values exceed 500 dimensions", async () => {
     enableFeatureFlag();
     const { workspace, key } = await createPublicApiMockRequest({
       role: "admin",
@@ -338,6 +355,38 @@ describe("POST /api/v1/w/[wId]/analytics/consumption/export", () => {
     });
 
     expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error.type).toBe("invalid_request_error");
+    expect(json.error.message).toContain(
+      "Filter must not exceed 500 values total"
+    );
+  });
+
+  it("returns 400 when filter values exceed 500 across all dimensions", async () => {
+    enableFeatureFlag();
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+
+    const response = await consumptionExportRequest({
+      workspace,
+      key,
+      body: {
+        startDate: "2024-06-01T00:00:00Z",
+        endDate: "2024-06-15T00:00:00Z",
+        filter: {
+          agents: Array.from({ length: 250 }, (_, i) => `agent-${i}`),
+          tags: Array.from({ length: 251 }, (_, i) => `tag-${i}`),
+        },
+      },
+    });
+
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error.type).toBe("invalid_request_error");
+    expect(json.error.message).toContain(
+      "Filter must not exceed 500 values total"
+    );
   });
 
   it("returns 400 when a filter value exceeds 256 characters", async () => {
@@ -357,9 +406,12 @@ describe("POST /api/v1/w/[wId]/analytics/consumption/export", () => {
     });
 
     expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error.type).toBe("invalid_request_error");
+    expect(json.error.message).toContain("256");
   });
 
-  it("appends error to stream body on ES failure", async () => {
+  it("returns 500 with API error on ES failure", async () => {
     enableFeatureFlag();
     mockedSearchConsumptionAnalytics.mockResolvedValueOnce(
       new Err(new ElasticsearchError("query_error", "shard failure"))
@@ -377,8 +429,12 @@ describe("POST /api/v1/w/[wId]/analytics/consumption/export", () => {
       },
     });
 
-    expect(response.status).toBe(200);
-    const body = await response.text();
-    expect(body).toBe("ERROR: Internal server error.");
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "internal_server_error",
+        message: "Failed to export consumption analytics.",
+      },
+    });
   });
 });

--- a/front-api/routes/v1/w/[wId]/analytics/consumption/export.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/consumption/export.ts
@@ -1,0 +1,99 @@
+/** @ignoreswagger */
+
+import {
+  fetchConsumptionExportRows,
+  rowsToCsvString,
+  rowsToNdjson,
+} from "@app/lib/api/analytics/consumption/export_lines";
+import logger from "@app/logger/logger";
+import { PostConsumptionExportRequestSchema } from "@dust-tt/client";
+import { publicApiApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+
+// Mounted at /api/v1/w/:wId/analytics/consumption/export.
+const app = publicApiApp();
+
+// No swagger doc while this endpoint is under feature flag.
+app.post(
+  "/",
+  ensureIsAdmin(),
+  validate("json", PostConsumptionExportRequestSchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+
+    if (!(await auth.hasFeatureFlag("consumption_export_api"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "The workspace does not have access to the consumption export API.",
+        },
+      });
+    }
+
+    const body = ctx.req.valid("json");
+    const format = body.format ?? "csv";
+
+    const startDate = new Date(body.startDate).toISOString();
+    const endDate = new Date(body.endDate).toISOString();
+
+    const owner = auth.getNonNullableWorkspace();
+
+    logger.info(
+      {
+        workspaceId: owner.sId,
+        startDate,
+        endDate,
+        format,
+        hasFilter: !!body.filter,
+      },
+      "Consumption export requested."
+    );
+
+    const result = await fetchConsumptionExportRows(auth, {
+      period: { startDate, endDate },
+      filter: body.filter,
+    });
+
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: result.error.message,
+        },
+      });
+    }
+
+    if (format === "ndjson") {
+      ctx.header("Content-Type", "application/x-ndjson");
+      ctx.header(
+        "Content-Disposition",
+        `attachment; filename="dust_consumption_${body.startDate}_${body.endDate}.ndjson"`
+      );
+      return ctx.body(rowsToNdjson(result.value));
+    }
+
+    ctx.header("Content-Type", "text/csv");
+    ctx.header(
+      "Content-Disposition",
+      `attachment; filename="dust_consumption_${body.startDate}_${body.endDate}.csv"`
+    );
+    return ctx.body(rowsToCsvString(result.value));
+  }
+);
+
+app.all("/", (ctx) =>
+  apiError(ctx, {
+    status_code: 405,
+    api_error: {
+      type: "method_not_supported_error",
+      message: "The method passed is not supported, POST is expected.",
+    },
+  })
+);
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/analytics/consumption/export.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/consumption/export.ts
@@ -1,14 +1,12 @@
-import {
-  fetchConsumptionExportRows,
-  rowsToCsvString,
-  rowsToNdjson,
-} from "@app/lib/api/analytics/consumption/export_lines";
+import { streamConsumptionExport } from "@app/lib/api/analytics/consumption/export_lines";
 import logger from "@app/logger/logger";
 import { PostConsumptionExportRequestSchema } from "@dust-tt/client";
 import { publicApiApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+
+const EXPORT_TIMEOUT_MS = 10_000;
 
 // Mounted at /api/v1/w/:wId/analytics/consumption/export.
 const app = publicApiApp();
@@ -22,7 +20,9 @@ const app = publicApiApp();
  *       Export per-call consumption analytics for the workspace identified by {wId}.
  *       Each row represents one unit of billed credit consumption (an LLM call or a tool call).
  *       The export can be filtered by various dimensions (agents, users, API keys, groups, models, tools, skills, sources, tags).
- *       The export is limited to a maximum of 30 days per request.
+ *       The export is limited to a maximum of 30 days per request and times out after 10 seconds: reduce the time range
+ *       or apply filters to reduce the number of rows if you encounter a timeout.
+ *       Results are streamed, if an error occurs, an error message is appended and the stream is closed.
  *     tags:
  *       - Analytics
  *     security:
@@ -143,6 +143,17 @@ app.post(
       });
     }
 
+    if (!auth.isKey()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "Workspace analytics export requires API key authentication.",
+        },
+      });
+    }
+
     const body = ctx.req.valid("json");
     const format = body.format ?? "csv";
 
@@ -162,36 +173,26 @@ app.post(
       "Consumption export requested."
     );
 
-    const result = await fetchConsumptionExportRows(auth, {
+    const abortController = new AbortController();
+    setTimeout(() => abortController.abort(), EXPORT_TIMEOUT_MS);
+
+    const stream = streamConsumptionExport(auth, {
       period: { startDate, endDate },
       filter: body.filter,
+      format,
+      signal: abortController.signal,
     });
 
-    if (result.isErr()) {
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: result.error.message,
-        },
-      });
-    }
+    const contentType =
+      format === "ndjson" ? "application/x-ndjson" : "text/csv";
+    const ext = format === "ndjson" ? "ndjson" : "csv";
 
-    if (format === "ndjson") {
-      ctx.header("Content-Type", "application/x-ndjson");
-      ctx.header(
-        "Content-Disposition",
-        `attachment; filename="dust_consumption_${body.startDate}_${body.endDate}.ndjson"`
-      );
-      return ctx.body(rowsToNdjson(result.value));
-    }
-
-    ctx.header("Content-Type", "text/csv");
+    ctx.header("Content-Type", contentType);
     ctx.header(
       "Content-Disposition",
-      `attachment; filename="dust_consumption_${body.startDate}_${body.endDate}.csv"`
+      `attachment; filename="dust_consumption_${body.startDate}_${body.endDate}.${ext}"`
     );
-    return ctx.body(rowsToCsvString(result.value));
+    return ctx.body(stream);
   }
 );
 

--- a/front-api/routes/v1/w/[wId]/analytics/consumption/export.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/consumption/export.ts
@@ -1,5 +1,3 @@
-/** @ignoreswagger */
-
 import {
   fetchConsumptionExportRows,
   rowsToCsvString,
@@ -15,7 +13,118 @@ import { validate } from "@front-api/middlewares/validator";
 // Mounted at /api/v1/w/:wId/analytics/consumption/export.
 const app = publicApiApp();
 
-// No swagger doc while this endpoint is under feature flag.
+/**
+ * @swagger
+ * /api/v1/w/{wId}/analytics/consumption/export:
+ *   post:
+ *     summary: Export consumption analytics
+ *     description: |
+ *       Export per-call consumption analytics for the workspace identified by {wId}.
+ *       Each row represents one unit of billed credit consumption (an LLM call or a tool call).
+ *       The export can be filtered by various dimensions (agents, users, API keys, groups, models, tools, skills, sources, tags).
+ *       The export is limited to a maximum of 30 days per request.
+ *     tags:
+ *       - Analytics
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: Unique string identifier for the workspace
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - startDate
+ *               - endDate
+ *             properties:
+ *               startDate:
+ *                 type: string
+ *                 format: date-time
+ *                 description: Start of the time range (inclusive), ISO 8601 datetime
+ *                 example: "2026-01-01T00:00:00Z"
+ *               endDate:
+ *                 type: string
+ *                 format: date-time
+ *                 description: End of the time range (exclusive), ISO 8601 datetime. Must be after startDate, at most 30 days apart.
+ *                 example: "2026-01-15T00:00:00Z"
+ *               format:
+ *                 type: string
+ *                 enum: [csv, ndjson]
+ *                 description: Output format (defaults to csv)
+ *               filter:
+ *                 type: object
+ *                 description: Optional dimension filters. Each key maps to an array of string identifiers to include.
+ *                 properties:
+ *                   agents:
+ *                     type: array
+ *                     items:
+ *                       type: string
+ *                     description: Agent sIds to filter on
+ *                   users:
+ *                     type: array
+ *                     items:
+ *                       type: string
+ *                     description: User IDs to filter on
+ *                   api_keys:
+ *                     type: array
+ *                     items:
+ *                       type: string
+ *                     description: API key names to filter on
+ *                   groups:
+ *                     type: array
+ *                     items:
+ *                       type: string
+ *                     description: Group IDs to filter on
+ *                   models:
+ *                     type: array
+ *                     items:
+ *                       type: string
+ *                     description: Model IDs to filter on
+ *                   tools:
+ *                     type: array
+ *                     items:
+ *                       type: string
+ *                     description: Tool server names to filter on
+ *                   skills:
+ *                     type: array
+ *                     items:
+ *                       type: string
+ *                     description: Skill IDs to filter on
+ *                   sources:
+ *                     type: array
+ *                     items:
+ *                       type: string
+ *                     description: Context origins to filter on (e.g. "web", "slack", "api")
+ *                   tags:
+ *                     type: array
+ *                     items:
+ *                       type: string
+ *                     description: Agent tag IDs to filter on
+ *     responses:
+ *       200:
+ *         description: The consumption data in CSV or NDJSON format
+ *         content:
+ *           text/csv:
+ *             schema:
+ *               type: string
+ *           application/x-ndjson:
+ *             schema:
+ *               type: string
+ *               description: Newline-delimited JSON, one row object per line
+ *       400:
+ *         description: Invalid request body (missing fields, invalid dates, range exceeds 30 days)
+ *       403:
+ *         description: Requires an API key with admin scope
+ *       500:
+ *         description: Internal Server Error
+ */
 app.post(
   "/",
   ensureIsAdmin(),

--- a/front-api/routes/v1/w/[wId]/analytics/consumption/export.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/consumption/export.ts
@@ -60,52 +60,63 @@ const app = publicApiApp();
  *                 description: Output format (defaults to csv)
  *               filter:
  *                 type: object
- *                 description: Optional dimension filters. Each key maps to an array of string identifiers to include.
+ *                 description: |
+ *                   Optional dimension filters. Each key maps to an array of string identifiers to include.
+ *                   Each value must be at most 256 characters. The total number of values across all dimensions must not exceed 500.
  *                 properties:
  *                   agents:
  *                     type: array
  *                     items:
  *                       type: string
+ *                       maxLength: 256
  *                     description: Agent sIds to filter on
  *                   users:
  *                     type: array
  *                     items:
  *                       type: string
+ *                       maxLength: 256
  *                     description: User IDs to filter on
  *                   api_keys:
  *                     type: array
  *                     items:
  *                       type: string
+ *                       maxLength: 256
  *                     description: API key names to filter on
  *                   groups:
  *                     type: array
  *                     items:
  *                       type: string
+ *                       maxLength: 256
  *                     description: Group IDs to filter on
  *                   models:
  *                     type: array
  *                     items:
  *                       type: string
+ *                       maxLength: 256
  *                     description: Model IDs to filter on
  *                   tools:
  *                     type: array
  *                     items:
  *                       type: string
+ *                       maxLength: 256
  *                     description: Tool server names to filter on
  *                   skills:
  *                     type: array
  *                     items:
  *                       type: string
+ *                       maxLength: 256
  *                     description: Skill IDs to filter on
  *                   sources:
  *                     type: array
  *                     items:
  *                       type: string
+ *                       maxLength: 256
  *                     description: Context origins to filter on (e.g. "web", "slack", "api")
  *                   tags:
  *                     type: array
  *                     items:
  *                       type: string
+ *                       maxLength: 256
  *                     description: Agent tag IDs to filter on
  *     responses:
  *       200:
@@ -132,17 +143,6 @@ app.post(
   async (ctx) => {
     const auth = ctx.get("auth");
 
-    if (!(await auth.hasFeatureFlag("consumption_export_api"))) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message:
-            "The workspace does not have access to the consumption export API.",
-        },
-      });
-    }
-
     if (!auth.isKey()) {
       return apiError(ctx, {
         status_code: 403,
@@ -150,6 +150,17 @@ app.post(
           type: "workspace_auth_error",
           message:
             "Workspace analytics export requires API key authentication.",
+        },
+      });
+    }
+
+    if (!(await auth.hasFeatureFlag("consumption_export_api"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "feature_flag_not_found",
+          message:
+            "The workspace does not have access to the consumption export API.",
         },
       });
     }
@@ -174,14 +185,38 @@ app.post(
     );
 
     const abortController = new AbortController();
-    setTimeout(() => abortController.abort(), EXPORT_TIMEOUT_MS);
+    const timer = setTimeout(() => abortController.abort(), EXPORT_TIMEOUT_MS);
 
-    const stream = streamConsumptionExport(auth, {
+    const result = await streamConsumptionExport(auth, {
       period: { startDate, endDate },
       filter: body.filter,
       format,
       signal: abortController.signal,
     });
+
+    if (result.isErr()) {
+      clearTimeout(timer);
+      return apiError(
+        ctx,
+        {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to export consumption analytics.",
+          },
+        },
+        result.error
+      );
+    }
+
+    const stream = result.value;
+    const monitored = stream.pipeThrough(
+      new TransformStream({
+        flush() {
+          clearTimeout(timer);
+        },
+      })
+    );
 
     const contentType =
       format === "ndjson" ? "application/x-ndjson" : "text/csv";
@@ -190,9 +225,9 @@ app.post(
     ctx.header("Content-Type", contentType);
     ctx.header(
       "Content-Disposition",
-      `attachment; filename="dust_consumption_${body.startDate}_${body.endDate}.${ext}"`
+      `attachment; filename="dust_consumption_${startDate}_${endDate}.${ext}"`
     );
-    return ctx.body(stream);
+    return ctx.body(monitored);
   }
 );
 

--- a/front-api/routes/v1/w/[wId]/analytics/consumption/index.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/consumption/index.ts
@@ -1,12 +1,10 @@
 import { publicApiApp } from "@front-api/middlewares/ctx";
 
-import consumption from "./consumption";
 import exportRoute from "./export";
 
-// Mounted at /api/v1/w/:wId/analytics.
+// Mounted at /api/v1/w/:wId/analytics/consumption.
 const app = publicApiApp();
 
-app.route("/consumption", consumption);
 app.route("/export", exportRoute);
 
 export default app;

--- a/front/lib/api/analytics/consumption/export_lines.ts
+++ b/front/lib/api/analytics/consumption/export_lines.ts
@@ -13,7 +13,8 @@ import { microCreditsToCredits } from "@app/lib/credits/units";
 import logger from "@app/logger/logger";
 import type { AgentMessageConsumptionAnalyticsData } from "@app/types/assistant/analytics";
 import type { Result } from "@app/types/shared/result";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { estypes } from "@elastic/elasticsearch";
 
@@ -293,7 +294,7 @@ export function buildConsumptionLineExportCsvHeader(): string {
   return rowsToCsv(CONSUMPTION_LINE_EXPORT_HEADERS, []);
 }
 
-export async function fetchConsumptionExportRows(
+async function fetchConsumptionExportRows(
   auth: Authenticator,
   {
     period,
@@ -330,7 +331,14 @@ export function rowsToCsvString(rows: ConsumptionLineExportRow[]): string {
   return rowsToCsv(CONSUMPTION_LINE_EXPORT_HEADERS, rows);
 }
 
-export function streamConsumptionExport(
+/**
+ * Streams consumption export data page by page. The first ES page is fetched
+ * eagerly: if it fails, an Err is returned so the caller can respond with a
+ * proper API error. Once streaming has started (Ok), mid-stream failures are
+ * appended as a raw error line (intentionally not valid CSV/NDJSON so parsers
+ * break loudly) and the stream is closed.
+ */
+export async function streamConsumptionExport(
   auth: Authenticator,
   opts: {
     period: ConsumptionPeriod;
@@ -338,7 +346,7 @@ export function streamConsumptionExport(
     format: "csv" | "ndjson";
     signal?: AbortSignal;
   }
-): ReadableStream<Uint8Array> {
+): Promise<Result<ReadableStream<Uint8Array>, ElasticsearchError>> {
   const encoder = new TextEncoder();
   const { period, filter, format, signal } = opts;
 
@@ -349,16 +357,51 @@ export function streamConsumptionExport(
     filter,
   });
 
+  // Fetch the first page eagerly so failures surface as a Result before
+  // the caller commits to a streaming 200 response.
+  const firstResult =
+    await searchConsumptionAnalytics<AgentMessageConsumptionAnalyticsData>(
+      query,
+      { size: EXPORT_PAGE_SIZE, sort: ES_SORT }
+    );
+
+  if (firstResult.isErr()) {
+    return new Err(firstResult.error);
+  }
+
+  const firstPageHits = firstResult.value.hits.hits;
   let cancelled = false;
 
   async function* pages(): AsyncGenerator<Uint8Array> {
-    let searchAfter: estypes.SortResults | undefined;
-    let pageSize: number;
+    // Yield the first (already-fetched) page, then continue paginating.
+    let currentHits = firstPageHits;
     let isFirst = true;
 
-    do {
+    while (true) {
+      const docs: AgentMessageConsumptionAnalyticsData[] = [];
+      for (const hit of currentHits) {
+        if (hit._source) {
+          docs.push(hit._source);
+        }
+      }
+
+      const rows = await buildConsumptionLineExportRows(auth, docs);
+
+      const chunk =
+        format === "csv"
+          ? rowsToCsv(CONSUMPTION_LINE_EXPORT_HEADERS, rows, {
+              includeHeader: isFirst,
+            })
+          : rowsToNdjson(rows);
+
+      isFirst = false;
+      yield encoder.encode(chunk);
+
+      if (currentHits.length < EXPORT_PAGE_SIZE) {
+        break;
+      }
+
       if (cancelled) {
-        // Cancelled by the client, stop streaming.
         return;
       }
       if (signal?.aborted) {
@@ -366,6 +409,7 @@ export function streamConsumptionExport(
         return;
       }
 
+      const searchAfter = currentHits[currentHits.length - 1]?.sort;
       const result =
         await searchConsumptionAnalytics<AgentMessageConsumptionAnalyticsData>(
           query,
@@ -391,35 +435,12 @@ export function streamConsumptionExport(
         return;
       }
 
-      const { hits } = result.value.hits;
-      const docs: AgentMessageConsumptionAnalyticsData[] = [];
-      // Accumulate hits to call buildConsumptionLineExportRows once per page,
-      // since it needs to resolve labels.
-      for (const hit of hits) {
-        if (hit._source) {
-          docs.push(hit._source);
-        }
-      }
-
-      const rows = await buildConsumptionLineExportRows(auth, docs);
-
-      const chunk =
-        format === "csv"
-          ? rowsToCsv(CONSUMPTION_LINE_EXPORT_HEADERS, rows, {
-              includeHeader: isFirst,
-            })
-          : rowsToNdjson(rows);
-
-      isFirst = false;
-      yield encoder.encode(chunk);
-
-      pageSize = hits.length;
-      searchAfter = hits[hits.length - 1]?.sort;
-    } while (pageSize === EXPORT_PAGE_SIZE);
+      currentHits = result.value.hits.hits;
+    }
   }
 
   const gen = pages();
-  return new ReadableStream({
+  const stream = new ReadableStream<Uint8Array>({
     async pull(controller) {
       try {
         const { value, done } = await gen.next();
@@ -431,12 +452,16 @@ export function streamConsumptionExport(
       } catch (err) {
         if (!cancelled) {
           logger.error({ err }, "[Consumption Export] Unexpected stream error");
+          controller.error(normalizeError(err));
+        } else {
+          controller.close();
         }
-        controller.close();
       }
     },
     cancel() {
       cancelled = true;
     },
   });
+
+  return new Ok(stream);
 }

--- a/front/lib/api/analytics/consumption/export_lines.ts
+++ b/front/lib/api/analytics/consumption/export_lines.ts
@@ -10,6 +10,7 @@ import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import { microCreditsToCredits } from "@app/lib/credits/units";
+import logger from "@app/logger/logger";
 import type { AgentMessageConsumptionAnalyticsData } from "@app/types/assistant/analytics";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
@@ -106,6 +107,12 @@ const CONSUMPTION_LINE_EXPORT_HEADERS: (keyof ConsumptionLineExportRow)[] = [
   "executionTimeMs",
 ];
 
+const ES_SORT: estypes.Sort = [
+  { completed_at: "asc" },
+  { agent_message_id: "asc" },
+  { consumption_key: "asc" },
+];
+
 // One document per unit of billed credit consumption
 async function fetchAllConsumptionDocuments(
   query: estypes.QueryDslQueryContainer
@@ -120,11 +127,7 @@ async function fetchAllConsumptionDocuments(
         query,
         {
           size: EXPORT_PAGE_SIZE,
-          sort: [
-            { completed_at: "asc" },
-            { agent_message_id: "asc" },
-            { consumption_key: "asc" },
-          ],
+          sort: ES_SORT,
           search_after: searchAfter,
         }
       );
@@ -325,4 +328,115 @@ export function rowsToNdjson(rows: ConsumptionLineExportRow[]): string {
 
 export function rowsToCsvString(rows: ConsumptionLineExportRow[]): string {
   return rowsToCsv(CONSUMPTION_LINE_EXPORT_HEADERS, rows);
+}
+
+export function streamConsumptionExport(
+  auth: Authenticator,
+  opts: {
+    period: ConsumptionPeriod;
+    filter?: ConsumptionScopeFilter;
+    format: "csv" | "ndjson";
+    signal?: AbortSignal;
+  }
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  const { period, filter, format, signal } = opts;
+
+  const query = buildConsumptionScopeQuery({
+    auth,
+    startDate: period.startDate,
+    endDate: period.endDate,
+    filter,
+  });
+
+  let cancelled = false;
+
+  async function* pages(): AsyncGenerator<Uint8Array> {
+    let searchAfter: estypes.SortResults | undefined;
+    let pageSize: number;
+    let isFirst = true;
+
+    do {
+      if (cancelled) {
+        // Cancelled by the client, stop streaming.
+        return;
+      }
+      if (signal?.aborted) {
+        yield encoder.encode("ERROR: Export timed out.");
+        return;
+      }
+
+      const result =
+        await searchConsumptionAnalytics<AgentMessageConsumptionAnalyticsData>(
+          query,
+          {
+            size: EXPORT_PAGE_SIZE,
+            sort: ES_SORT,
+            search_after: searchAfter,
+          }
+        );
+
+      if (result.isErr()) {
+        logger.error(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            startDate: period.startDate,
+            endDate: period.endDate,
+            filter,
+            error: result.error.message,
+          },
+          "[Consumption Export] Failed to stream consumption lines"
+        );
+        yield encoder.encode("ERROR: Internal server error.");
+        return;
+      }
+
+      const { hits } = result.value.hits;
+      const docs: AgentMessageConsumptionAnalyticsData[] = [];
+      // Accumulate hits to call buildConsumptionLineExportRows once per page,
+      // since it needs to resolve labels.
+      for (const hit of hits) {
+        if (hit._source) {
+          docs.push(hit._source);
+        }
+      }
+
+      const rows = await buildConsumptionLineExportRows(auth, docs);
+
+      const chunk =
+        format === "csv"
+          ? rowsToCsv(CONSUMPTION_LINE_EXPORT_HEADERS, rows, {
+              includeHeader: isFirst,
+            })
+          : rowsToNdjson(rows);
+
+      isFirst = false;
+      yield encoder.encode(chunk);
+
+      pageSize = hits.length;
+      searchAfter = hits[hits.length - 1]?.sort;
+    } while (pageSize === EXPORT_PAGE_SIZE);
+  }
+
+  const gen = pages();
+  return new ReadableStream({
+    async pull(controller) {
+      try {
+        const { value, done } = await gen.next();
+        if (done) {
+          controller.close();
+        } else {
+          controller.enqueue(value);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          logger.error({ err }, "[Consumption Export] Unexpected stream error");
+        }
+        controller.close();
+      }
+    },
+    cancel() {
+      cancelled = true;
+    },
+  });
 }

--- a/front/lib/api/analytics/consumption/export_lines.ts
+++ b/front/lib/api/analytics/consumption/export_lines.ts
@@ -274,6 +274,32 @@ export async function fetchConsumptionExportBucketCsv(
     filter?: ConsumptionScopeFilter;
   }
 ): Promise<Result<string, ElasticsearchError>> {
+  const rows = await fetchConsumptionExportRows(auth, { period, filter });
+  if (rows.isErr()) {
+    return rows;
+  }
+
+  return new Ok(
+    rowsToCsv(CONSUMPTION_LINE_EXPORT_HEADERS, rows.value, {
+      includeHeader: false,
+    })
+  );
+}
+
+export function buildConsumptionLineExportCsvHeader(): string {
+  return rowsToCsv(CONSUMPTION_LINE_EXPORT_HEADERS, []);
+}
+
+export async function fetchConsumptionExportRows(
+  auth: Authenticator,
+  {
+    period,
+    filter,
+  }: {
+    period: ConsumptionPeriod;
+    filter?: ConsumptionScopeFilter;
+  }
+): Promise<Result<ConsumptionLineExportRow[], ElasticsearchError>> {
   const query = buildConsumptionScopeQuery({
     auth,
     startDate: period.startDate,
@@ -287,12 +313,16 @@ export async function fetchConsumptionExportBucketCsv(
   }
 
   const rows = await buildConsumptionLineExportRows(auth, docsResult.value);
+  return new Ok(rows);
+}
 
-  return new Ok(
-    rowsToCsv(CONSUMPTION_LINE_EXPORT_HEADERS, rows, { includeHeader: false })
+export function rowsToNdjson(rows: ConsumptionLineExportRow[]): string {
+  return (
+    rows.map((row) => JSON.stringify(row)).join("\n") +
+    (rows.length > 0 ? "\n" : "")
   );
 }
 
-export function buildConsumptionLineExportCsvHeader(): string {
-  return rowsToCsv(CONSUMPTION_LINE_EXPORT_HEADERS, []);
+export function rowsToCsvString(rows: ConsumptionLineExportRow[]): string {
+  return rowsToCsv(CONSUMPTION_LINE_EXPORT_HEADERS, rows);
 }

--- a/front/lib/api/analytics/consumption/export_lines.ts
+++ b/front/lib/api/analytics/consumption/export_lines.ts
@@ -1,6 +1,10 @@
+import type { DimensionLabel } from "@app/lib/api/analytics/consumption/labels";
 import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
-import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import type {
+  ConsumptionScopeFilter,
+  ConsumptionTopDimension,
+} from "@app/lib/api/analytics/consumption/scope";
 import { buildConsumptionScopeQuery } from "@app/lib/api/analytics/consumption/scope";
 import {
   roundToTwoDecimals,
@@ -114,6 +118,38 @@ const ES_SORT: estypes.Sort = [
   { consumption_key: "asc" },
 ];
 
+type DimensionLabelCache = Map<
+  ConsumptionTopDimension,
+  Map<string, DimensionLabel>
+>;
+
+function newDimensionLabelCache(): DimensionLabelCache {
+  return new Map();
+}
+
+async function resolveAndCache(
+  auth: Authenticator,
+  cache: DimensionLabelCache,
+  dimension: ConsumptionTopDimension,
+  keys: string[]
+): Promise<Map<string, DimensionLabel>> {
+  let cached = cache.get(dimension);
+  if (!cached) {
+    cached = new Map();
+    cache.set(dimension, cached);
+  }
+
+  const uncached = keys.filter((k) => !cached.has(k));
+  if (uncached.length > 0) {
+    const resolved = await resolveDimensionLabels(auth, dimension, uncached);
+    for (const [k, v] of resolved) {
+      cached.set(k, v);
+    }
+  }
+
+  return cached;
+}
+
 // One document per unit of billed credit consumption
 async function fetchAllConsumptionDocuments(
   query: estypes.QueryDslQueryContainer
@@ -153,8 +189,15 @@ async function fetchAllConsumptionDocuments(
 
 async function buildConsumptionLineExportRows(
   auth: Authenticator,
-  docs: AgentMessageConsumptionAnalyticsData[]
+  docs: AgentMessageConsumptionAnalyticsData[],
+  labelCache?: DimensionLabelCache
 ): Promise<ConsumptionLineExportRow[]> {
+  const resolve = labelCache
+    ? (dimension: ConsumptionTopDimension, keys: string[]) =>
+        resolveAndCache(auth, labelCache, dimension, keys)
+    : (dimension: ConsumptionTopDimension, keys: string[]) =>
+        resolveDimensionLabels(auth, dimension, keys);
+
   const [
     agentLabels,
     userLabels,
@@ -164,25 +207,21 @@ async function buildConsumptionLineExportRows(
     groupLabels,
     sourceLabels,
   ] = await Promise.all([
-    resolveDimensionLabels(auth, "agent", [
-      ...new Set(docs.map((doc) => doc.agent.attributed_id)),
-    ]),
-    resolveDimensionLabels(auth, "user", [
-      ...new Set(removeNulls(docs.map((doc) => doc.user?.id))),
-    ]),
-    resolveDimensionLabels(auth, "model", [
+    resolve("agent", [...new Set(docs.map((doc) => doc.agent.attributed_id))]),
+    resolve("user", [...new Set(removeNulls(docs.map((doc) => doc.user?.id)))]),
+    resolve("model", [
       ...new Set(removeNulls(docs.map((doc) => doc.model?.model_id))),
     ]),
-    resolveDimensionLabels(auth, "tool", [
+    resolve("tool", [
       ...new Set(removeNulls(docs.map((doc) => doc.tool?.server_name))),
     ]),
-    resolveDimensionLabels(auth, "skill", [
+    resolve("skill", [
       ...new Set(docs.flatMap((doc) => doc.tool?.attributed_skill_ids ?? [])),
     ]),
-    resolveDimensionLabels(auth, "group", [
+    resolve("group", [
       ...new Set(docs.flatMap((doc) => doc.user?.group_ids ?? [])),
     ]),
-    resolveDimensionLabels(auth, "source", [
+    resolve("source", [
       ...new Set(removeNulls(docs.map((doc) => doc.context_origin))),
     ]),
   ]);
@@ -374,6 +413,8 @@ export async function streamConsumptionExport(
 
   async function* pages(): AsyncGenerator<Uint8Array> {
     // Yield the first (already-fetched) page, then continue paginating.
+    // Labels resolved on earlier pages are cached and reused.
+    const labelCache = newDimensionLabelCache();
     let currentHits = firstPageHits;
     let isFirst = true;
 
@@ -385,7 +426,7 @@ export async function streamConsumptionExport(
         }
       }
 
-      const rows = await buildConsumptionLineExportRows(auth, docs);
+      const rows = await buildConsumptionLineExportRows(auth, docs, labelCache);
 
       const chunk =
         format === "csv"

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -434,7 +434,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   consumption_export_api: {
     description:
       "Enable the public API endpoint for raw consumption analytics export (POST /api/v1/w/:wId/analytics/consumption/export).",
-    stage: "dust_only",
+    stage: "ask_owner",
     owner: "sylvain",
   },
 } as const satisfies Record<string, FeatureFlag>;

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -423,7 +423,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description:
       "Use the consumption analytics ES index instead of the message analytics index for message exports.",
     stage: "ask_owner",
-    owner: "sylvain",
+    owner: "sfriquet",
   },
   enable_new_usage_page: {
     description:
@@ -435,7 +435,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description:
       "Enable the public API endpoint for raw consumption analytics export (POST /api/v1/w/:wId/analytics/consumption/export).",
     stage: "ask_owner",
-    owner: "sylvain",
+    owner: "sfriquet",
   },
 } as const satisfies Record<string, FeatureFlag>;
 

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -431,6 +431,12 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "ask_owner",
     owner: "avervaet",
   },
+  consumption_export_api: {
+    description:
+      "Enable the public API endpoint for raw consumption analytics export (POST /api/v1/w/:wId/analytics/consumption/export).",
+    stage: "dust_only",
+    owner: "sylvain",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "ask_owner" | "self_serve";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -3277,7 +3277,7 @@ export const PostConsumptionExportRequestSchema = z
     endDate: IsoDateTimeSchema,
     format: z.enum(["csv", "ndjson"]).optional(),
     filter: z
-      .record(ConsumptionExportFilterKeySchema, z.string().array())
+      .record(ConsumptionExportFilterKeySchema, z.string().max(256).array())
       .optional(),
   })
   .refine(
@@ -3291,6 +3291,20 @@ export const PostConsumptionExportRequestSchema = z
       return diffMs <= 30 * 24 * 60 * 60 * 1000;
     },
     { message: "Time range must not exceed 30 days" }
+  )
+  .refine(
+    (d) => {
+      if (!d.filter) {
+        return true;
+      }
+      const total = Object.values(d.filter).reduce(
+        (sum, arr) => sum + arr.length,
+        0
+      );
+      // Aligned with CONSUMPTION_FILTER_MAX_VALUES_PER_DIMENSION in front.
+      return total <= 500;
+    },
+    { message: "Filter must not exceed 500 values total across all dimensions" }
   );
 
 export type PostConsumptionExportRequestType = z.infer<

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -899,6 +899,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "xai_feature"
   | "conversations_slack_notifications"
   | "collapsible_messages"
+  | "consumption_export_api"
   | "conversation_consumption_details"
   | "use_dust_keys"
   | "sensitivity_labels"
@@ -3250,6 +3251,50 @@ export const GetAnalyticsExportRequestSchema = z
 
 export type GetAnalyticsExportRequestType = z.infer<
   typeof GetAnalyticsExportRequestSchema
+>;
+
+const ConsumptionExportFilterKeySchema = z.enum([
+  "agents",
+  "users",
+  "api_keys",
+  "groups",
+  "models",
+  "tools",
+  "skills",
+  "sources",
+  "tags",
+]);
+
+const IsoDateTimeSchema = z
+  .string()
+  .refine((s): s is string => !isNaN(new Date(s).getTime()), {
+    message: "Must be a valid ISO 8601 datetime (e.g. 2026-01-15T00:00:00Z)",
+  });
+
+export const PostConsumptionExportRequestSchema = z
+  .object({
+    startDate: IsoDateTimeSchema,
+    endDate: IsoDateTimeSchema,
+    format: z.enum(["csv", "ndjson"]).optional(),
+    filter: z
+      .record(ConsumptionExportFilterKeySchema, z.string().array())
+      .optional(),
+  })
+  .refine(
+    (d) => new Date(d.startDate).getTime() < new Date(d.endDate).getTime(),
+    { message: "startDate must be strictly before endDate" }
+  )
+  .refine(
+    (d) => {
+      const diffMs =
+        new Date(d.endDate).getTime() - new Date(d.startDate).getTime();
+      return diffMs <= 30 * 24 * 60 * 60 * 1000;
+    },
+    { message: "Time range must not exceed 30 days" }
+  );
+
+export type PostConsumptionExportRequestType = z.infer<
+  typeof PostConsumptionExportRequestSchema
 >;
 
 export const FileUploadUrlRequestSchema = z.object({


### PR DESCRIPTION
## Description

Refs https://github.com/dust-tt/tasks/issues/9988, https://github.com/dust-tt/tasks/issues/10156

Add a public API to fetch consumption analytics data, to get granular and filtered export.
Supports `csv` and `ndjson` format to ease programmatic usage.
Unlike the private `export-raw` endpoint, this endpoint is synchronous and meant to be consumed programmatically. 
Results are streamed. The time range is arbitrarily capped at 30 days and there's a 10s timeout.
Under feature flag for now.

## Tests

added tests + tested locally for now.

## Risk

Low while under feature flag.

## Deploy Plan

Front + Docs