### PR TITLE
Add ui_host so the PostHog toolbar can authenticate

### DIFF
--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -178,6 +178,11 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
 
     posthog.init(POSTHOG_KEY, {
       api_host: `${config.getApiBaseUrl()}/subtle1`,
+      // Direct PostHog app URL (EU region). Required because api_host points
+      // at our own /subtle1 reverse proxy: the toolbar (heatmaps, inspect mode)
+      // authenticates against ui_host, and without it tries to reach the
+      // PostHog app at dust.tt and fails.
+      ui_host: "https://eu.posthog.com",
       person_profiles: "identified_only",
       defaults: "2025-05-24",
       persistence,

--- a/marketing/components/app/PostHogTracker.tsx
+++ b/marketing/components/app/PostHogTracker.tsx
@@ -136,6 +136,11 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
       // /subtle1 is rewritten to PostHog by marketing's own next.config.js.
       // Use a relative path so requests hit marketing's origin (not front).
       api_host: "/subtle1",
+      // Direct PostHog app URL (EU region). Required because api_host points
+      // at our own /subtle1 reverse proxy: the toolbar (heatmaps, inspect mode)
+      // authenticates against ui_host, and without it tries to reach the
+      // PostHog app at dust.tt and fails.
+      ui_host: "https://eu.posthog.com",
       person_profiles: "identified_only",
       defaults: "2025-05-24",
       persistence,


### PR DESCRIPTION
### Problem

Opening the PostHog toolbar (heatmaps, inspect mode) on dust.tt fails with:

> The toolbar tried to connect to the PostHog app at https://dust.tt but could not reach it. This happens when you use a reverse proxy for api_host — the toolbar needs to know the direct URL of the PostHog app to authenticate.

We reverse-proxy PostHog ingestion through our own obfuscated `/subtle1` path (`front-api/routes/subtle1.ts` and the rewrites in `marketing/next.config.js`) so analytics requests aren't flagged by ad blockers. That means `api_host` is our own domain. The toolbar assumes `api_host` is also the PostHog app URL, so it tries to authenticate against dust.tt and fails.

### Fix

Set `ui_host: "https://eu.posthog.com"` in both `posthog.init` call sites, matching the `eu.i.posthog.com` upstream our proxy already targets:

- `front/components/app/PostHogTracker.tsx` — app.dust.tt, and the SPA (`front-spa` wraps both `App.tsx` and `ShareApp.tsx` in this component)
- `marketing/components/app/PostHogTracker.tsx` — the marketing site

`ui_host` only tells the client where the PostHog app lives for toolbar auth; ingestion still goes through `/subtle1` and is unaffected.

### Notes

- The toolbar reads this config from the running page, so heatmaps won't work on production until this ships.
- Viewing heatmaps is separate from capturing them — `$heatmap` collection still depends on the heatmaps toggle in PostHog project settings.

### Testing

- `biome check` clean on both files.
- Pre-commit hooks were skipped (worktree without `node_modules`); biome was run manually against the repo config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)