### PR TITLE
feat(frames): add an open-in-new-tab button next to the full screen button

### DIFF
--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.test.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.test.tsx
@@ -2,7 +2,7 @@ import { FrameRenderer } from "@app/components/assistant/conversation/interactiv
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { EditTextFn } from "@app/types/assistant/visualization";
 import type { LightWorkspaceType } from "@app/types/user";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { act } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -99,6 +99,9 @@ vi.mock("@app/lib/swr/files", () => ({
       version: 1,
     },
     mutateFileMetadata: vi.fn(),
+  }),
+  useShareInteractiveContentFile: () => ({
+    fileShare: { shareUrl: "https://dust.tt/share/frame/share-token" },
   }),
 }));
 vi.mock("@app/lib/swr/frames", () => ({
@@ -197,6 +200,29 @@ describe("FrameRenderer", () => {
         isEditable: false,
         onEditText: undefined,
       })
+    );
+  });
+
+  it("opens the frame's share URL in a new tab", () => {
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+
+    render(
+      <FrameRenderer
+        conversation={conversation}
+        fileId="frame_1"
+        projectId={null}
+        owner={owner}
+        contentHash="frame_1@42"
+        renderMode="v2"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open in a new tab" }));
+
+    expect(open).toHaveBeenCalledWith(
+      "https://dust.tt/share/frame/share-token",
+      "_blank",
+      "noopener,noreferrer"
     );
   });
 

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -15,7 +15,11 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useClientType } from "@app/lib/context/clientType";
 import { clientFetch } from "@app/lib/egress/client";
-import { useFileContent, useFileMetadata } from "@app/lib/swr/files";
+import {
+  useFileContent,
+  useFileMetadata,
+  useShareInteractiveContentFile,
+} from "@app/lib/swr/files";
 import { useEditFrameText, useFramePermissions } from "@app/lib/swr/frames";
 import { usePodFiles } from "@app/lib/swr/pods";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
@@ -29,6 +33,7 @@ import {
   CheckCircle,
   CodeBlock,
   Eye,
+  LinkExternal01,
   Maximize01,
   Minimize01,
   RefreshCw01,
@@ -141,6 +146,12 @@ export function FrameRenderer({
   const { fileMetadata, mutateFileMetadata } = useFileMetadata({
     fileId,
     owner,
+  });
+
+  const { fileShare } = useShareInteractiveContentFile({
+    fileId,
+    owner,
+    cacheKey: contentHash,
   });
 
   const sendNotification = useSendNotification();
@@ -487,6 +498,7 @@ export function FrameRenderer({
                 isFullScreen={isFullScreen}
                 exitFullScreen={exitFullScreen}
                 enterFullScreen={enterFullScreen}
+                shareUrl={fileShare?.shareUrl}
                 reloadFile={reloadFile}
               />
             )}
@@ -505,6 +517,7 @@ interface PreviewActionButtonsProps {
   isFullScreen: boolean;
   enterFullScreen: () => void;
   exitFullScreen: () => void;
+  shareUrl?: string;
   reloadFile: () => void;
 }
 
@@ -515,6 +528,7 @@ function PreviewActionButtons({
   isFullScreen,
   enterFullScreen,
   exitFullScreen,
+  shareUrl,
   reloadFile,
 }: PreviewActionButtonsProps) {
   const clientType = useClientType();
@@ -531,6 +545,25 @@ function PreviewActionButtons({
               variant="ghost"
               size="xs"
               onClick={isFullScreen ? exitFullScreen : enterFullScreen}
+            />
+          }
+        />
+      )}
+      {clientType !== "extension" && (
+        <Tooltip
+          label="Open in a new tab"
+          side="left"
+          tooltipTriggerAsChild
+          trigger={
+            <Button
+              aria-label="Open in a new tab"
+              icon={LinkExternal01}
+              variant="ghost"
+              size="xs"
+              disabled={!shareUrl}
+              onClick={() =>
+                window.open(shareUrl, "_blank", "noopener,noreferrer")
+              }
             />
           }
         />


### PR DESCRIPTION
## Description

Adds an "Open in a new tab" button to the frame preview action buttons, right below the full screen
toggle. It opens the current conversation URL in a new tab with the interactive content side panel
pointed at the same frame and full screen mode on, so a frame can be moved to its own browser tab
without going through sharing.

The button is hidden in the extension client, like the full screen toggle, since the extension side
panel has no dust.tt location to derive the URL from.

## Tests

Unit test in `FrameRenderer.test.tsx` covering the generated URL (origin/pathname/search preserved,
`spid` / `spt` / `fullScreen` hash params set).

Manually: open a frame in a conversation, click the new button, and check that the new tab lands on
the same frame, full screen.
