### PR TITLE
Normalize caught errors and guard provider failures

### DIFF
--- a/cli/dust-sandbox/e2e/smoke.ts
+++ b/cli/dust-sandbox/e2e/smoke.ts
@@ -184,9 +184,8 @@ async function startForward(): Promise<ForwardHandle> {
     await waitForListen(LISTEN_ADDR, FORWARD_READY_TIMEOUT_MS);
   } catch (err) {
     const stderr = await stop();
-    throw new Error(
-      `${(err as Error).message}\ndsbx forward stderr:\n${stderr}`
-    );
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`${message}\ndsbx forward stderr:\n${stderr}`);
   }
   return { stop };
 }

--- a/connectors/migrations/20240129_cleanup_orphaned_notion_cache.ts
+++ b/connectors/migrations/20240129_cleanup_orphaned_notion_cache.ts
@@ -1,4 +1,5 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
+import { normalizeError } from "@dust-tt/client";
 
 async function main() {
   await connectorsSequelize.query(`
@@ -14,7 +15,7 @@ main()
     process.exit(0);
   })
   .catch((err) => {
-    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+    console.error("\x1b[31m%s\x1b[0m", `Error: ${normalizeError(err).message}`);
     console.log(err);
     process.exit(1);
   });

--- a/connectors/migrations/20240129_drop_notion_connector_caches_indexes.ts
+++ b/connectors/migrations/20240129_drop_notion_connector_caches_indexes.ts
@@ -1,4 +1,5 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
+import { normalizeError } from "@dust-tt/client";
 
 async function main() {
   await connectorsSequelize.query(`
@@ -14,7 +15,7 @@ main()
     process.exit(0);
   })
   .catch((err) => {
-    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+    console.error("\x1b[31m%s\x1b[0m", `Error: ${normalizeError(err).message}`);
     console.log(err);
     process.exit(1);
   });

--- a/connectors/migrations/20240131_migrate_all_notion_connectors_to_dual_workflow.ts
+++ b/connectors/migrations/20240131_migrate_all_notion_connectors_to_dual_workflow.ts
@@ -1,4 +1,5 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
+import { normalizeError } from "@dust-tt/client";
 
 async function main() {
   await connectorsSequelize.query(`
@@ -12,7 +13,7 @@ main()
     process.exit(0);
   })
   .catch((err) => {
-    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+    console.error("\x1b[31m%s\x1b[0m", `Error: ${normalizeError(err).message}`);
     console.log(err);
     process.exit(1);
   });

--- a/connectors/migrations/20240216_make_notion_cache_tables_unlogged.ts
+++ b/connectors/migrations/20240216_make_notion_cache_tables_unlogged.ts
@@ -1,4 +1,5 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
+import { normalizeError } from "@dust-tt/client";
 
 async function main() {
   await connectorsSequelize.query(`
@@ -14,7 +15,7 @@ main()
     process.exit(0);
   })
   .catch((err) => {
-    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+    console.error("\x1b[31m%s\x1b[0m", `Error: ${normalizeError(err).message}`);
     console.log(err);
     process.exit(1);
   });

--- a/connectors/src/admin/cli.ts
+++ b/connectors/src/admin/cli.ts
@@ -1,5 +1,5 @@
 import { Argument, Command } from "@commander-js/extra-typings";
-import { AdminCommandSchema } from "@connectors/types";
+import { AdminCommandSchema, normalizeError } from "@connectors/types";
 import { fromError } from "zod-validation-error";
 
 process.env.INTERACTIVE_CLI = process.env.INTERACTIVE_CLI || "1";
@@ -471,7 +471,7 @@ program
     await dispatch("zendesk", subcommand, opts);
   });
 
-program.parseAsync(process.argv).catch((err: Error) => {
-  console.error(`\x1b[31mError: ${err.message}\x1b[0m`);
+program.parseAsync(process.argv).catch((err: unknown) => {
+  console.error(`\x1b[31mError: ${normalizeError(err).message}\x1b[0m`);
   process.exit(1);
 });

--- a/connectors/src/connectors/google_drive/lib/google_drive_api.ts
+++ b/connectors/src/connectors/google_drive/lib/google_drive_api.ts
@@ -5,7 +5,8 @@ import {
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import type { GoogleDriveObjectType, ModelId } from "@connectors/types";
 import { cacheWithRedis, FILE_ATTRIBUTES_TO_FETCH } from "@connectors/types";
-import type { GaxiosError, OAuth2Client } from "googleapis-common";
+import type { OAuth2Client } from "googleapis-common";
+import { GaxiosError } from "googleapis-common";
 
 interface CacheKey {
   connectorId: number;
@@ -38,10 +39,10 @@ async function _getGoogleDriveObject({
 
     return await driveObjectToDustType(connectorId, file, authCredentials);
   } catch (e) {
-    if ((e as GaxiosError).response?.status === 401) {
+    if (e instanceof GaxiosError && e.response?.status === 401) {
       throw new ExternalOAuthTokenError();
     }
-    if ((e as GaxiosError).response?.status === 404) {
+    if (e instanceof GaxiosError && e.response?.status === 404) {
       return null;
     }
     throw e;

--- a/connectors/src/connectors/google_drive/temporal/utils.ts
+++ b/connectors/src/connectors/google_drive/temporal/utils.ts
@@ -24,7 +24,7 @@ async function _getMyDriveId(auth_credentials: OAuth2Client) {
   try {
     myDriveRes = await drive.files.get({ fileId: "root", fields: "id" });
   } catch (e) {
-    if ((e as GaxiosError).response?.status === 401) {
+    if (e instanceof GaxiosError && e.response?.status === 401) {
       throw new ExternalOAuthTokenError();
     }
     throw e;

--- a/connectors/src/connectors/slack/lib/errors.test.ts
+++ b/connectors/src/connectors/slack/lib/errors.test.ts
@@ -1,7 +1,7 @@
 import { ErrorCode } from "@slack/web-api";
 import { describe, expect, it } from "vitest";
 
-import { isSlackPostingPermissionError } from "./errors";
+import { isSlackPostingPermissionError, isWebAPIPlatformError } from "./errors";
 
 function makePlatformError(error: string) {
   return {
@@ -9,6 +9,35 @@ function makePlatformError(error: string) {
     data: { ok: false, error },
   };
 }
+
+describe("isWebAPIPlatformError", () => {
+  it("recognizes the platform errors handled by sync and permission retrieval", () => {
+    for (const error of [
+      "account_inactive",
+      "not_in_channel",
+      "thread_not_found",
+    ]) {
+      expect(isWebAPIPlatformError(makePlatformError(error))).toBe(true);
+    }
+  });
+
+  it("rejects non-platform and malformed errors without throwing", () => {
+    for (const error of [
+      null,
+      undefined,
+      "not_in_channel",
+      new Error("not_in_channel"),
+      {},
+      { code: ErrorCode.PlatformError },
+      { code: ErrorCode.PlatformError, data: null },
+      { code: ErrorCode.PlatformError, data: {} },
+      { code: ErrorCode.PlatformError, data: { error: 123 } },
+      { code: ErrorCode.HTTPError, data: { error: "not_in_channel" } },
+    ]) {
+      expect(isWebAPIPlatformError(error)).toBe(false);
+    }
+  });
+});
 
 describe("isSlackPostingPermissionError", () => {
   it("returns true for channel posting restriction errors", () => {

--- a/connectors/src/connectors/slack/lib/retrieve_permissions.ts
+++ b/connectors/src/connectors/slack/lib/retrieve_permissions.ts
@@ -1,5 +1,6 @@
 import type { RetrievePermissionsErrorCode } from "@connectors/connectors/interface";
 import { ConnectorManagerError } from "@connectors/connectors/interface";
+import { isWebAPIPlatformError } from "@connectors/connectors/slack/lib/errors";
 import { slackChannelInternalIdFromSlackChannelId } from "@connectors/connectors/slack/lib/utils";
 import {
   ExternalOAuthTokenError,
@@ -12,7 +13,6 @@ import type { ConnectorPermission, ContentNode } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
 import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
-import type { WebAPIPlatformError } from "@slack/web-api";
 
 export async function retrievePermissions({
   connectorId,
@@ -105,11 +105,7 @@ export async function retrievePermissions({
       );
     }
 
-    const maybeSlackPlatformError = e as WebAPIPlatformError;
-    if (
-      maybeSlackPlatformError.code === "slack_webapi_platform_error" &&
-      maybeSlackPlatformError.data?.error === "account_inactive"
-    ) {
+    if (isWebAPIPlatformError(e) && e.data.error === "account_inactive") {
       logger.error(
         { connectorId, error: e },
         "Slack account inactive when retrieving permissions."

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -72,13 +72,7 @@ import {
 } from "@connectors/types";
 import type { DataSourceViewType } from "@dust-tt/client";
 import { DustAPI, Err, Ok } from "@dust-tt/client";
-import type {
-  CodedError,
-  ConversationsInfoResponse,
-  WebAPIPlatformError,
-  WebClient,
-} from "@slack/web-api";
-import { ErrorCode } from "@slack/web-api";
+import type { ConversationsInfoResponse, WebClient } from "@slack/web-api";
 import type { Channel } from "@slack/web-api/dist/types/response/ChannelsInfoResponse";
 import type {
   ConversationsHistoryResponse,
@@ -515,11 +509,7 @@ export async function syncNonThreaded({
         { source: "syncNonThreaded" }
       );
     } catch (e) {
-      const maybeSlackPlatformError = e as WebAPIPlatformError;
-      if (
-        maybeSlackPlatformError.code === "slack_webapi_platform_error" &&
-        maybeSlackPlatformError.data?.error === "not_in_channel"
-      ) {
+      if (isWebAPIPlatformError(e) && e.data.error === "not_in_channel") {
         // If the bot is no longer in the channel, we don't upsert anything.
         return;
       }
@@ -889,19 +879,13 @@ export async function syncThread(
     );
     allMessages = allMessages.filter((m) => !!m.user);
   } catch (e) {
-    const slackError = e as CodedError;
-    if (slackError.code === ErrorCode.PlatformError) {
-      const platformError = slackError as WebAPIPlatformError;
-
-      if (platformError.data.error === "thread_not_found") {
+    if (isWebAPIPlatformError(e)) {
+      if (e.data.error === "thread_not_found") {
         // If the thread is not found we just return and don't upsert anything.
         return;
       }
 
-      if (
-        platformError.code === "slack_webapi_platform_error" &&
-        platformError.data?.error === "not_in_channel"
-      ) {
+      if (e.data.error === "not_in_channel") {
         // If the bot is no longer in the channel, we don't upsert anything.
         return;
       }

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -21,7 +21,7 @@ import type {
   UpsertDatabaseTableRequestType,
   UpsertTableFromCsvRequestType,
 } from "@dust-tt/client";
-import type { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
+import type { AxiosRequestConfig, AxiosResponse } from "axios";
 import axios from "axios";
 import tracer from "dd-trace";
 import http from "http";
@@ -1366,8 +1366,7 @@ async function _getDataSourceTable({
       dustRequestConfig
     );
   } catch (e) {
-    const axiosError = e as AxiosError;
-    if (axiosError?.response?.status === 404) {
+    if (axios.isAxiosError(e) && e.response?.status === 404) {
       localLogger.info("Table doesn't exist on Dust. Ignoring.");
       return;
     }
@@ -1502,8 +1501,7 @@ export async function _getDataSourceFolder({
   try {
     dustRequestResult = await axiosWithTimeout.get(endpoint, dustRequestConfig);
   } catch (e) {
-    const axiosError = e as AxiosError;
-    if (axiosError?.response?.status === 404) {
+    if (axios.isAxiosError(e) && e.response?.status === 404) {
       localLogger.info("Folder doesn't exist on Dust. Ignoring.");
       return;
     }

--- a/connectors/src/logger/withlogging.ts
+++ b/connectors/src/logger/withlogging.ts
@@ -3,6 +3,7 @@ import type {
   ConnectorsAPIErrorWithStatusCode,
   WithConnectorsAPIErrorReponse,
 } from "@connectors/types";
+import { normalizeError } from "@dust-tt/client";
 import type { Request, Response } from "express";
 import StatsD from "hot-shots";
 
@@ -22,8 +23,7 @@ export const withLogging = (handler: any) => {
           url: req.url,
           durationMs: elapsed,
           error: err,
-          // @ts-expect-error we can't really know what the error is
-          error_stack: err?.stack,
+          error_stack: normalizeError(err).stack,
           headers: req.headers,
         },
         "Unhandled API Error"

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -38,6 +38,7 @@ import { REGISTERED_CHECKS } from "@app/temporal/production_checks/activities";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { labsTranscriptsProviders } from "@app/types/labs";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { isAssignableRoleType } from "@app/types/user";
 import fs from "fs/promises";
@@ -1015,7 +1016,7 @@ main()
     process.exit(0);
   })
   .catch((err) => {
-    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+    console.error("\x1b[31m%s\x1b[0m", `Error: ${normalizeError(err).message}`);
     console.log(err);
     process.exit(1);
   });

--- a/front/lib/api/assistant/global_agents/configurations/dust/utils.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/utils.ts
@@ -1,6 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import memoizer from "lru-memoizer";
 
 const DEEP_DIVE_DISABLED_TTL_MS = 3 * 1000; // 3 seconds
@@ -19,7 +20,7 @@ const _isDeepDiveDisabledByAdmin = memoizer<Authenticator, boolean>({
       .then((settings) =>
         callback(null, settings?.status === "disabled_by_admin")
       )
-      .catch((err: Error) => callback(err));
+      .catch((err: unknown) => callback(normalizeError(err)));
   },
 
   hash: (auth: Authenticator) =>

--- a/front/lib/api/triggers/built-in-webhooks/github/service.ts
+++ b/front/lib/api/triggers/built-in-webhooks/github/service.ts
@@ -7,6 +7,7 @@ import logger from "@app/logger/logger";
 import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 import type { RemoteWebhookService } from "@app/types/triggers/remote_webhook_service";
 import { Octokit } from "@octokit/core";
@@ -151,9 +152,9 @@ export class GitHubWebhookService implements RemoteWebhookService<"github"> {
           );
 
           webhookIds[fullName] = String(webhook.id);
-        } catch (error: any) {
+        } catch (error) {
           errors.push(
-            `Failed to create webhook for ${fullName}: ${error.message}`
+            `Failed to create webhook for ${fullName}: ${normalizeError(error).message}`
           );
         }
       }
@@ -179,9 +180,9 @@ export class GitHubWebhookService implements RemoteWebhookService<"github"> {
           );
 
           webhookIds[orgName] = String(webhook.id);
-        } catch (error: any) {
+        } catch (error) {
           errors.push(
-            `Failed to create webhook for organization ${orgName}: ${error.message}`
+            `Failed to create webhook for organization ${orgName}: ${normalizeError(error).message}`
           );
         }
       }
@@ -202,10 +203,12 @@ export class GitHubWebhookService implements RemoteWebhookService<"github"> {
         },
         errors: errors.length > 0 ? errors : undefined,
       });
-    } catch (error: any) {
+    } catch (error) {
       return new Err(
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        new Error(error.message || "Failed to create GitHub webhooks")
+        new Error(
+          normalizeError(error).message || "Failed to create GitHub webhooks"
+        )
       );
     }
   }
@@ -313,8 +316,10 @@ export class GitHubWebhookService implements RemoteWebhookService<"github"> {
               hook_id: parseInt(webhookId, 10),
             });
           }
-        } catch (error: any) {
-          errors.push(`Failed to delete webhook for ${key}: ${error.message}`);
+        } catch (error) {
+          errors.push(
+            `Failed to delete webhook for ${key}: ${normalizeError(error).message}`
+          );
         }
       }
 
@@ -324,10 +329,13 @@ export class GitHubWebhookService implements RemoteWebhookService<"github"> {
       }
 
       return new Ok(undefined);
-    } catch (error: any) {
+    } catch (error) {
       return new Err(
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        new Error(error.message || "Failed to delete webhook from GitHub")
+        new Error(
+          normalizeError(error).message ||
+            "Failed to delete webhook from GitHub"
+        )
       );
     }
   }

--- a/front/lib/providers.ts
+++ b/front/lib/providers.ts
@@ -1,5 +1,6 @@
 import { clientFetch } from "@app/lib/egress/client";
 import type { GetProvidersCheckResponseBody } from "@app/types/api/provider_credentials";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { WorkspaceType } from "@app/types/user";
 
 import type { useProviders } from "./swr/apps";
@@ -136,8 +137,8 @@ export async function checkProvider(
       }
     );
     return await result.json();
-  } catch (e: any) {
-    return { ok: false, error: e.message };
+  } catch (e) {
+    return { ok: false, error: normalizeError(e).message };
   }
 }
 

--- a/front/lib/resources/webhook_request_resource.ts
+++ b/front/lib/resources/webhook_request_resource.ts
@@ -16,6 +16,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type {
   Attributes,
   CreationAttributes,
@@ -537,7 +538,7 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
 
       return new Ok(affectedCount);
     } catch (error) {
-      return new Err(error as Error);
+      return new Err(normalizeError(error));
     }
   }
 

--- a/front/lib/triggers/admin/cli.ts
+++ b/front/lib/triggers/admin/cli.ts
@@ -1,4 +1,5 @@
 import { createOrUpdateWebhookCleanupSchedule } from "@app/temporal/triggers_garbage_collect/client";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import parseArgs from "minimist";
 
 const main = async () => {
@@ -24,7 +25,7 @@ main()
     process.exit(0);
   })
   .catch((err) => {
-    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+    console.error("\x1b[31m%s\x1b[0m", `Error: ${normalizeError(err).message}`);
     console.log(err);
     process.exit(1);
   });

--- a/front/temporal/activation_scheduler/admin/cli.ts
+++ b/front/temporal/activation_scheduler/admin/cli.ts
@@ -7,6 +7,7 @@ import {
   stopEnsureActivationSchedulesWorkflow,
   triggerActivationWorkspaceWorkflow,
 } from "@app/temporal/activation_scheduler/client";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import parseArgs from "minimist";
 
 function usage() {
@@ -83,7 +84,7 @@ main()
     process.exit(0);
   })
   .catch((err) => {
-    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+    console.error("\x1b[31m%s\x1b[0m", `Error: ${normalizeError(err).message}`);
     console.log(err);
     process.exit(1);
   });

--- a/front/temporal/data_retention/admin/cli.ts
+++ b/front/temporal/data_retention/admin/cli.ts
@@ -6,6 +6,7 @@ import {
 import { QUEUE_NAME } from "@app/temporal/data_retention/config";
 import { runSignal } from "@app/temporal/data_retention/signals";
 import { dataRetentionWorkflow } from "@app/temporal/data_retention/workflows";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import parseArgs from "minimist";
 
 const main = async () => {
@@ -41,7 +42,7 @@ main()
     process.exit(0);
   })
   .catch((err) => {
-    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+    console.error("\x1b[31m%s\x1b[0m", `Error: ${normalizeError(err).message}`);
     console.log(err);
     process.exit(1);
   });

--- a/front/temporal/production_checks/admin/cli.ts
+++ b/front/temporal/production_checks/admin/cli.ts
@@ -1,4 +1,5 @@
 import { launchProductionChecksWorkflow } from "@app/temporal/production_checks/client";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import parseArgs from "minimist";
 
 const main = async () => {
@@ -22,7 +23,7 @@ main()
     process.exit(0);
   })
   .catch((err) => {
-    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+    console.error("\x1b[31m%s\x1b[0m", `Error: ${normalizeError(err).message}`);
     console.log(err);
     process.exit(1);
   });

--- a/front/temporal/reinforcement/admin/cli.ts
+++ b/front/temporal/reinforcement/admin/cli.ts
@@ -7,6 +7,7 @@ import {
   stopAllReinforcementWorkspaceSchedules as stopAllReinforcementWorkspaceSchedules,
   stopEnsureReinforcementSchedulesWorkflow as stopEnsureReinforcementSchedulesWorkflow,
 } from "@app/temporal/reinforcement/client";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import parseArgs from "minimist";
 
 function usage() {
@@ -111,7 +112,7 @@ main()
     process.exit(0);
   })
   .catch((err) => {
-    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+    console.error("\x1b[31m%s\x1b[0m", `Error: ${normalizeError(err).message}`);
     console.log(err);
     process.exit(1);
   });

--- a/front/temporal/remote_tools/admin/cli.ts
+++ b/front/temporal/remote_tools/admin/cli.ts
@@ -1,4 +1,5 @@
 import { createRemoteMCPServersSyncSchedule } from "@app/temporal/remote_tools/client";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import parseArgs from "minimist";
 
 const main = async () => {
@@ -22,7 +23,7 @@ main()
     process.exit(0);
   })
   .catch((err) => {
-    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+    console.error("\x1b[31m%s\x1b[0m", `Error: ${normalizeError(err).message}`);
     console.log(err);
     process.exit(1);
   });

--- a/front/temporal/scrub_workspace/admin/cli.ts
+++ b/front/temporal/scrub_workspace/admin/cli.ts
@@ -3,6 +3,7 @@ import {
   launchDowngradeFreeEndedWorkspacesWorkflow,
   stopDowngradeFreeEndedWorkspacesWorkflow,
 } from "@app/temporal/scrub_workspace/client";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import parseArgs from "minimist";
 
 const main = async () => {
@@ -37,7 +38,7 @@ main()
     process.exit(0);
   })
   .catch((err) => {
-    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+    console.error("\x1b[31m%s\x1b[0m", `Error: ${normalizeError(err).message}`);
     console.log(err);
     process.exit(1);
   });

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -2353,7 +2353,10 @@ export class CoreAPI {
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         (init && init.signal && (init.signal as AbortSignal).aborted) ||
         // Some environments throw an AbortError with name property.
-        (e as any)?.name === "AbortError";
+        (typeof e === "object" &&
+          e !== null &&
+          "name" in e &&
+          e.name === "AbortError");
       const err: CoreAPIError = isAbort
         ? {
             code: "request_timeout",

--- a/tools/datadog-log-exporter/src/index.ts
+++ b/tools/datadog-log-exporter/src/index.ts
@@ -414,6 +414,6 @@ async function main(): Promise<void> {
 
 // Execute
 main().catch((err) => {
-  console.error(err?.stack || String(err));
+  console.error((err instanceof Error && err.stack) || String(err));
   process.exit(1);
 });

--- a/x/henry/dust-hive/src/forward-daemon.ts
+++ b/x/henry/dust-hive/src/forward-daemon.ts
@@ -210,7 +210,8 @@ function createForwarder(listenPort: number, targetPort: number, name: string) {
           },
         }).catch((error) => {
           clearTimeout(timeoutId);
-          console.error(`[${name}] Connection error: ${error.message}`);
+          const message = error instanceof Error ? error.message : String(error);
+          console.error(`[${name}] Connection error: ${message}`);
           if (!client.data.closed) {
             client.end();
           }

--- a/x/spolu/research/evals/index.ts
+++ b/x/spolu/research/evals/index.ts
@@ -35,7 +35,8 @@ main()
     process.exit(0);
   })
   .catch((err) => {
-    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("\x1b[31m%s\x1b[0m", `Error: ${message}`);
     console.log(err);
     process.exit(1);
   });


### PR DESCRIPTION
## Description

Caught values were cast to error types or accessed without runtime validation, which could mask the original failure with another exception. Fix 34 direct `normalize-caught-errors` violations across 28 files: 23 sites use `normalizeError`, and 11 use runtime guards. Provider-specific handlers validate Google, Axios, and Slack errors before inspecting their fields.

## Tests

- Five Slack error guard tests passed, including recognized sync/permission errors and malformed inputs, using an isolated Node test configuration.
- Re-scanned all 34 targeted sites to verify normalization or runtime guards.
- The WebhookRequestResource suite could not load because the local environment lacks `@novu/framework`. Full hive validation is also blocked by missing `bun-types`.

## Risk

Low. Changes are limited to error handling. Known provider failures retain their existing handling; unexpected values are normalized or propagated.

## Deploy Plan

Deploy `connectors`, `front-api`, `front-spa`, and front workers. Tooling changes take effect when those tools are next run.
