### PR TITLE
[sparkle] DataTable: add a "Load more" footer with an animated row reveal

### DIFF
--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -16,6 +16,7 @@ import {
 } from "@sparkle/components/Dropdown";
 import { Icon } from "@sparkle/components/Icon";
 import { IconButton } from "@sparkle/components/IconButton";
+import { LoadMore } from "@sparkle/components/LoadMore";
 import { Pagination } from "@sparkle/components/Pagination";
 import {
   radioIndicatorStyles,
@@ -51,7 +52,13 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import React, { type ReactNode, useEffect, useRef, useState } from "react";
+import React, {
+  type ReactNode,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { breakpoints, useWindowSize } from "./WindowUtility";
 
 const cellHeight = "h-12";
@@ -105,6 +112,10 @@ interface DataTableProps<TData extends TBaseData> {
   pagination?: PaginationState;
   /** Called with the new pagination state when the user changes page. */
   setPagination?: (pagination: PaginationState) => void;
+  /** Shows a clickable "Load more" footer, as an alternative to pagination. Ignored when pagination is set. */
+  onLoadMore?: () => void;
+  /** Swaps the "Load more" label for an animated "Loading" and disables it. */
+  isLoadingMore?: boolean;
   /** Minimum breakpoint per column id below which the column is hidden. */
   columnsBreakpoints?: ColumnBreakpoint;
   /** Controlled sorting state. */
@@ -145,6 +156,91 @@ interface DataTableProps<TData extends TBaseData> {
  * ScrollableDataTable, which virtualizes rows and supports onLoadMore.
  * @summary Sortable, filterable, paginated data table.
  */
+const ROW_REVEAL_DURATION_MS = 300;
+
+/**
+ * Reveals appended rows by animating the table's height, so the rows slide into
+ * view at exactly the rate the footer below them moves down. Animating the
+ * footer instead would let the rows pop in ahead of it.
+ */
+function useRowRevealAnimation(rowCount: number, enabled: boolean) {
+  const ref = useRef<HTMLDivElement>(null);
+  const previousHeightRef = useRef<number | null>(null);
+  const previousRowCountRef = useRef(rowCount);
+
+  // Keep the last laid-out height current through every layout change, not just
+  // row changes. Cells are skipped on the first commit (the window size is not
+  // measured yet), so a height recorded only on mount would be the height of a
+  // table with no columns, and the first reveal would animate from ~nothing.
+  // ResizeObserver callbacks run after layout effects, so the value read below
+  // is always the height from before the new rows landed.
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element || !enabled) {
+      return;
+    }
+
+    previousHeightRef.current = element.scrollHeight;
+
+    const observer = new ResizeObserver(() => {
+      previousHeightRef.current = element.scrollHeight;
+    });
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, [enabled]);
+
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element) {
+      return;
+    }
+
+    // `scrollHeight` reports the content height even while we pin `height`
+    // mid-animation, so this stays correct if rows land back to back.
+    const height = element.scrollHeight;
+    const previousHeight = previousHeightRef.current;
+    const grew = rowCount > previousRowCountRef.current;
+
+    previousRowCountRef.current = rowCount;
+
+    if (
+      !enabled ||
+      !grew ||
+      previousHeight === null ||
+      previousHeight >= height ||
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      return;
+    }
+
+    const clear = () => {
+      element.style.transition = "";
+      element.style.height = "";
+      element.style.overflow = "";
+    };
+
+    element.style.overflow = "hidden";
+    element.style.transition = "none";
+    element.style.height = `${previousHeight}px`;
+
+    const frame = requestAnimationFrame(() => {
+      element.style.transition = `height ${ROW_REVEAL_DURATION_MS}ms ease-out`;
+      element.style.height = `${height}px`;
+    });
+
+    element.addEventListener("transitionend", clear, { once: true });
+
+    return () => {
+      cancelAnimationFrame(frame);
+      element.removeEventListener("transitionend", clear);
+      clear();
+    };
+  }, [rowCount, enabled]);
+
+  return ref;
+}
+
 export function DataTable<TData extends TBaseData>({
   data,
   totalRowCount,
@@ -157,6 +253,8 @@ export function DataTable<TData extends TBaseData>({
   columnsBreakpoints = {},
   pagination,
   setPagination,
+  onLoadMore,
+  isLoadingMore = false,
   sorting,
   setSorting,
   isServerSideSorting = false,
@@ -250,9 +348,17 @@ export function DataTable<TData extends TBaseData>({
     }
   }, [filter, filterColumn]);
 
+  const rows = table.getRowModel().rows;
+  // Uses the rendered row count, not `data.length`, so filtering keeps the
+  // measured height in sync.
+  const rowRevealRef = useRowRevealAnimation(
+    rows.length,
+    !!onLoadMore && !pagination
+  );
+
   return (
     <div className={cn("flex flex-col gap-2", className, widthClassName)}>
-      <DataTable.Root>
+      <DataTable.Root containerRef={rowRevealRef}>
         <DataTable.Header>
           {table.getHeaderGroups().map((headerGroup) => (
             <DataTable.Row key={headerGroup.id} widthClassName={widthClassName}>
@@ -313,7 +419,7 @@ export function DataTable<TData extends TBaseData>({
           ))}
         </DataTable.Header>
         <DataTable.Body>
-          {table.getRowModel().rows.map((row) => {
+          {rows.map((row) => {
             const handleRowClick = () => {
               if (enableRowSelection && row.getCanSelect()) {
                 row.toggleSelected(!enableMultiRowSelection ? true : undefined);
@@ -371,12 +477,23 @@ export function DataTable<TData extends TBaseData>({
           />
         </div>
       )}
+      {!pagination && onLoadMore && (
+        <div className="p-1">
+          <LoadMore
+            onLoadMore={onLoadMore}
+            isLoading={isLoadingMore}
+            rowCount={data.length}
+            totalRowCount={totalRowCount}
+            totalRowCountIsCapped={rowCountIsCapped}
+          />
+        </div>
+      )}
     </div>
   );
 }
 
 export interface ScrollableDataTableProps<TData extends TBaseData>
-  extends DataTableProps<TData> {
+  extends Omit<DataTableProps<TData>, "onLoadMore" | "isLoadingMore"> {
   /** Height of the scroll container: a max-height class name, true to fill the parent (flex-1), or unset for the default max-h-100. */
   maxHeight?: string | boolean;
   /** Called when the user scrolls near the bottom — use it for infinite loading. */
@@ -778,6 +895,8 @@ interface DataTableRootProps extends React.HTMLAttributes<HTMLTableElement> {
   children: ReactNode;
   containerClassName?: string;
   containerProps?: React.HTMLAttributes<HTMLDivElement>;
+  /** Ref to the container wrapping the table element. */
+  containerRef?: React.Ref<HTMLDivElement>;
 }
 
 /** The underlying table element with its container-query wrapper. */
@@ -786,10 +905,12 @@ DataTable.Root = function DataTableRoot({
   className,
   containerClassName,
   containerProps,
+  containerRef,
   ...props
 }: DataTableRootProps) {
   return (
     <div
+      ref={containerRef}
       className={cn("@container/table", containerClassName)}
       {...containerProps}
     >

--- a/sparkle/src/components/LoadMore.tsx
+++ b/sparkle/src/components/LoadMore.tsx
@@ -1,0 +1,86 @@
+import { cn } from "@sparkle/lib/utils";
+import React from "react";
+
+const LOADING_DOT_DELAYS = ["0ms", "250ms", "500ms"];
+
+interface LoadMoreProps {
+  showDetails?: boolean;
+  /** Number of rows currently loaded. */
+  rowCount: number;
+  /** Total number of rows available, when known. */
+  totalRowCount?: number;
+  totalRowCountIsCapped?: boolean;
+  isLoading?: boolean;
+  onLoadMore: () => void;
+  label?: string;
+  loadingLabel?: string;
+}
+
+export function LoadMore({
+  showDetails = true,
+  rowCount,
+  totalRowCount,
+  totalRowCountIsCapped = false,
+  isLoading = false,
+  onLoadMore,
+  label = "Load more",
+  loadingLabel = "Loading",
+}: LoadMoreProps) {
+  // When the total is known and everything is loaded, there is nothing left to
+  // fetch: keep the details, hide the control (same behavior as Pagination).
+  const controlIsHidden =
+    totalRowCount !== undefined &&
+    !totalRowCountIsCapped &&
+    rowCount >= totalRowCount;
+
+  return (
+    <div
+      className={cn(
+        "flex w-full items-center",
+        controlIsHidden ? "justify-end" : "justify-between"
+      )}
+    >
+      <button
+        className={cn(
+          "text-xs font-medium",
+          "transition-colors duration-200",
+          "text-primary-400 hover:text-foreground disabled:hover:text-primary-400",
+          controlIsHidden ? "invisible" : "visible"
+        )}
+        onClick={onLoadMore}
+        disabled={isLoading || controlIsHidden}
+      >
+        {isLoading ? (
+          <span>
+            {loadingLabel}
+            {LOADING_DOT_DELAYS.map((delay) => (
+              <span
+                key={delay}
+                className="animate-loading-dot opacity-100 motion-reduce:animate-none"
+                style={{ animationDelay: delay }}
+              >
+                .
+              </span>
+            ))}
+          </span>
+        ) : (
+          label
+        )}
+      </button>
+
+      <span
+        className={cn(
+          "text-xs",
+          "text-muted-foreground",
+          showDetails ? "visible" : "collapse"
+        )}
+      >
+        {totalRowCount === undefined
+          ? `${rowCount} item${rowCount === 1 ? "" : "s"}`
+          : `Showing ${rowCount} of ${totalRowCount}${
+              totalRowCountIsCapped ? "+" : ""
+            } item${totalRowCount === 1 ? "" : "s"}`}
+      </span>
+    </div>
+  );
+}

--- a/sparkle/src/components/LoadMore.tsx
+++ b/sparkle/src/components/LoadMore.tsx
@@ -41,6 +41,7 @@ export function LoadMore({
       )}
     >
       <button
+        type="button"
         className={cn(
           "text-xs font-medium",
           "transition-colors duration-200",

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -201,6 +201,7 @@ export type { LinkWrapperProps } from "./LinkWrapper";
 export { LinkWrapper } from "./LinkWrapper";
 export { ListGroup, ListItem, ListItemSection } from "./ListItem";
 export { LoadingBlock } from "./LoadingBlock";
+export { LoadMore } from "./LoadMore";
 export { MessageCard } from "./MessageCard";
 export type {
   MultiPageDialogFooterProps,

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -614,6 +614,45 @@ export const ServerSidePagination = () => {
   );
 };
 
+export const DataTableLoadMoreExample = () => {
+  const [visibleCount, setVisibleCount] = React.useState(2);
+  const [isLoadingMore, setIsLoadingMore] = React.useState(false);
+  const [filter, setFilter] = React.useState<string>("");
+
+  const rows = useMemo(() => data.slice(0, visibleCount), [visibleCount]);
+
+  const handleLoadMore = () => {
+    setIsLoadingMore(true);
+    // Simulate a server round-trip.
+    setTimeout(() => {
+      setVisibleCount((count) => Math.min(count + 2, data.length));
+      setIsLoadingMore(false);
+    }, 600);
+  };
+
+  return (
+    <div className="w-full max-w-4xl overflow-x-auto">
+      <Input
+        name="filter"
+        placeholder="Filter"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+      />
+      <DataTable
+        className="w-full max-w-4xl overflow-x-auto"
+        data={rows}
+        totalRowCount={data.length}
+        filter={filter}
+        filterColumn="name"
+        onLoadMore={handleLoadMore}
+        isLoadingMore={isLoadingMore}
+        columns={columns}
+        columnsBreakpoints={{ lastUpdated: "sm" }}
+      />
+    </div>
+  );
+};
+
 const createData = (start: number, count: number): TransformedData[] => {
   return Array.from({ length: count }, (_, i) => {
     const index = start + i;

--- a/sparkle/src/styles/sparkle-theme.css
+++ b/sparkle/src/styles/sparkle-theme.css
@@ -17,6 +17,7 @@
   --animate-background-position-spin: background-position-spin 2000ms infinite
     alternate;
   --animate-rainbow: rainbow var(--speed, 16s) infinite linear;
+  --animate-loading-dot: loading-dot 1.2s infinite;
   --animate-collapse-down: collapse-down 150ms ease-out;
   --animate-collapse-up: collapse-up 150ms ease-out;
 }
@@ -88,6 +89,16 @@
   }
   50% {
     opacity: 0.5;
+  }
+}
+@keyframes loading-dot {
+  0%,
+  20% {
+    opacity: 0;
+  }
+  40%,
+  100% {
+    opacity: 1;
   }
 }
 @keyframes background-position-spin {


### PR DESCRIPTION
## Description

Adds a "Load more" footer to `DataTable`, as an alternative to `pagination` for tables that append rows instead of swapping pages.

```tsx
<DataTable
  data={rows}
  totalRowCount={total}
  onLoadMore={handleLoadMore}
  isLoadingMore={isLoadingMore}
  columns={columns}
/>
```

`onLoadMore` renders the control in the same footer slot `Pagination` uses, and is ignored when `pagination` is set, so the two can't double up.

### `LoadMore`

A new component that mirrors `Pagination`'s layout and typography:

- the label carries the same `text-xs font-medium` as the page numbers, in `text-primary-400` with a `hover:text-foreground`
- the item count sits on the right, in the same spot and the same muted style
- once every row is loaded the control hides and the count remains — the way `Pagination` behaves when there's only one page

While loading, the label animates three dots (new `--animate-loading-dot`) instead of showing a spinner, which sat too heavily next to the small type. It falls back to a static `Loading...` under `prefers-reduced-motion`.

### Row reveal

Appended rows are revealed by animating the **table's height**, so they slide into view at exactly the rate the footer moves down. Animating the footer instead — the first thing I tried — let the rows pop in at full height while the line took 300ms to catch up.

Two details worth a reviewer's eye:

- A `ResizeObserver` keeps the measured height current through every layout change, not just row changes. `DataTable` renders no cells on the first commit (`useWindowSize` hasn't measured yet), so a height recorded only on mount is the height of a table with **no columns** — the first reveal then animates up from nothing. `ResizeObserver` callbacks run after layout effects, so the value read during the reveal is reliably the height from before the new rows landed.
- The reveal is keyed on the *rendered* row count, not `data.length`, so filtering keeps the measurement in sync.

It's gated on `!!onLoadMore && !pagination`, so paginated and plain tables are untouched. `DataTable.Root` gains a `containerRef` prop to carry the ref — this avoids a wrapper div, and kept the diff off ~200 lines of re-indented JSX.

### Risk

- `overflow: hidden` sits on the table container for the 300ms the animation runs, cleared on `transitionend`. A row dropdown opened during that window would clip.
- `ScrollableDataTable` already had its own `onLoadMore` meaning "infinite scroll on intersection". Its props now `Omit` the two new ones so the meanings can't collide.

## Tests

Typecheck and biome pass. New story: `DataTable / Data Table Load More Example` — loads 2 rows at a time behind a simulated 600ms round-trip.

Checked by hand in Storybook: first click and subsequent clicks (the first was the case the stale baseline broke), and the fully-loaded end state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)