### PR TITLE
Run contract reviews for every review request

### DIFF
--- a/.github/actions/review-bot/README.md
+++ b/.github/actions/review-bot/README.md
@@ -1,7 +1,7 @@
 # Review bot
 
-Start a line in a PR description or message with `r?`, followed by GitHub user mentions or bare `cc`
-for a contract review:
+Start a line in a PR description or message with `r?`, followed by GitHub user mentions to request
+their reviews and a contract review. Use `r? cc` to request only a contract review:
 
 ```text
 r? @spolu @flvndvd
@@ -47,9 +47,10 @@ The bot also adds the `PMRR` label whenever an eligible description or message c
 (case-insensitively), on open, closed, or merged PRs. Labeling runs before review requests, does not
 require an `r?` command or requester write access, and never removes labels.
 
-Each eligible event with `cc` in a reviewer list triggers one contract review, even if `cc` appears
-multiple times. Description edits retaining `cc` request another review, just like human reviewers.
-Bare `cc` stays plain text in Slack and is never sent to GitHub as a reviewer.
+Each eligible event containing an `r?` request triggers one contract review, regardless of whether
+`cc` appears in the reviewer list or how many request lines it contains. Description edits retaining
+the request trigger another review, just like human reviewers. Bare `cc` stays plain text in Slack
+and is never sent to GitHub as a reviewer.
 
 The workflow calls the pinned
 [`spolu/code-contracts` contract-review action](https://github.com/spolu/code-contracts/tree/main/.github/actions/contract-review)

--- a/.github/actions/review-bot/action.yml
+++ b/.github/actions/review-bot/action.yml
@@ -11,7 +11,7 @@ inputs:
 
 outputs:
   pull-request-number:
-    description: PR number when an authorized reviewer list includes bare cc; empty otherwise.
+    description: PR number for an authorized review request; empty otherwise.
     value: ${{ steps.request.outputs.pull-request-number }}
 
 runs:
@@ -32,9 +32,7 @@ runs:
           await labelPmrr({ github, context });
           const notification = await requestReviews({ github, context, core });
           if (notification) {
-            if (notification.requests.some((request) => request.contractReview)) {
-              core.setOutput('pull-request-number', notification.pullNumber);
-            }
+            core.setOutput('pull-request-number', notification.pullNumber);
             const text = await formatSlackNotification({
               notification,
               authors: readFileSync('.authors', 'utf8'),

--- a/.github/actions/review-bot/review-bot.ts
+++ b/.github/actions/review-bot/review-bot.ts
@@ -230,14 +230,14 @@ export async function labelPmrr({
  */
 /**
  * @cc [label:product] contract-review-delivery
- * Each eligible event with bare `cc` in a reviewer list requests one contract review, including
- * description edits retaining `cc`. Callers emit `pull-request-number` before Slack delivery and
- * invoke the pinned `spolu/code-contracts` contract-review action in a separate job even if Slack
- * delivery fails. Description and conversation-comment requests require `review-bot.yml` to be
- * registered on the default branch and present on the PR head with `workflow_dispatch` and its
- * review inputs; missing prerequisites can fail dispatch. Inline comments and review summaries
- * invoke the action directly. That action reviews only open PRs with heads in this repository and
- * publishes a COMMENT review pinned to the inspected head.
+ * Each eligible event with a parsed `r?` request MUST request one contract review, including
+ * description edits retaining the request. Bare `cc` is optional. Callers emit `pull-request-number`
+ * before Slack delivery and invoke the pinned `spolu/code-contracts` contract-review action in a
+ * separate job even if Slack delivery fails. Description and conversation-comment requests require
+ * `review-bot.yml` to be registered on the default branch and present on the PR head with
+ * `workflow_dispatch` and its review inputs; missing prerequisites can fail dispatch. Inline comments
+ * and review summaries invoke the action directly. That action reviews only open PRs with heads in
+ * this repository and publishes a COMMENT review pinned to the inspected head.
  */
 /**
  * @cc [label:security] review-automation-source
@@ -311,7 +311,7 @@ export async function requestReviews({
 
 /**
  * @cc [label:security] contract-review-dispatch-access
- * Callers supply only PR numbers emitted for an authorized `cc` request. Skip closed and fork PRs.
+ * Callers supply only PR numbers emitted for an authorized `r?` request. Skip closed and fork PRs.
  * The imported action rechecks the human requester's access using the originating run ID.
  */
 /**


### PR DESCRIPTION
## Description

Make every eligible `r?` request trigger one contract review, so `r? @reviewer` requests both human and contract reviews without requiring `cc`. Keep `r? cc` support and the parsed `contractReview` flag, and update the documentation and contracts to match.

## Tests

Passed 16 local tests exercising the actual action scripts with mocked APIs: supported request events, repeated request lines, explicit `cc`, permissions, PR eligibility, and Slack/reviewer failure handling.

## Risk

Low. More contract reviews will run; existing authorization and PR eligibility checks still apply.

## Deploy Plan

Merge into main to activate the updated review bot.
