### PR TITLE
fix(marketing): server-render marketing pages so meta tags reach crawlers

### DIFF
--- a/marketing/components/app/PostHogTracker.tsx
+++ b/marketing/components/app/PostHogTracker.tsx
@@ -15,7 +15,6 @@ import {
 } from "@marketing/lib/utils/utm";
 import { isString } from "@marketing/types/shared/utils/general";
 import posthog from "posthog-js";
-import { PostHogProvider } from "posthog-js/react";
 import { useEffect, useMemo, useRef } from "react";
 import { useCookies } from "react-cookie";
 
@@ -35,39 +34,15 @@ function isTrackablePathname(pathname: string): boolean {
   );
 }
 
-interface PostHogTrackerProps {
-  children: React.ReactNode;
+interface PostHogTrackerEffectsProps {
   // When true, assume cookies are accepted (logged in users).
   // Use in authenticated contexts (e.g. SPA) where the user is always logged in.
   authenticated?: boolean;
 }
 
-export function PostHogTracker({
-  children,
+export function PostHogTrackerEffects({
   authenticated,
-}: PostHogTrackerProps) {
-  // Always render PostHogProvider to avoid unmounting/remounting the entire
-  // tree when tracking state changes. Tracking is controlled via
-  // posthog.opt_in_capturing() / posthog.opt_out_capturing() instead.
-  return (
-    <PostHogProvider client={posthog}>
-      <PostHogTrackerInner authenticated={authenticated} />
-      {children}
-    </PostHogProvider>
-  );
-}
-
-/**
- * Inner component that handles all PostHog side-effects (initialization,
- * identification, opt-in/opt-out, workspace grouping, pageview tracking).
- * Separated from PostHogTracker so that user/subscription loading never
- * affects the children tree structure.
- */
-interface PostHogTrackerInnerProps {
-  authenticated?: boolean;
-}
-
-function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
+}: PostHogTrackerEffectsProps) {
   const router = useAppRouter();
   const [cookies] = useCookies([DUST_COOKIES_ACCEPTED]);
 

--- a/marketing/pages/_app.tsx
+++ b/marketing/pages/_app.tsx
@@ -18,12 +18,11 @@ const COMMIT_HASH = process.env.NEXT_PUBLIC_COMMIT_HASH;
 
 const CONSOLE_MESSAGE_SHOWN_KEY = "dust_console_message_shown";
 
-// PostHogTracker calls useRouter at the top level, which throws during static
-// prerendering. Load it client-side only.
-const PostHogTracker = dynamic(
+// Client-only: as a wrapper this would strip the page tree from the SSR output.
+const PostHogTrackerEffects = dynamic(
   () =>
     import("@marketing/components/app/PostHogTracker").then(
-      (m) => m.PostHogTracker
+      (m) => m.PostHogTrackerEffects
     ),
   { ssr: false }
 );
@@ -34,6 +33,8 @@ import { SignUpModalProvider } from "@marketing/hooks/useSignUpModal";
 import { fetcher, fetcherWithBody } from "@marketing/lib/swr/fetcher";
 import { initDatadogLogs } from "@marketing/logger/datadogLogger";
 import { SparkleContext } from "@dust-tt/sparkle";
+import posthog from "posthog-js";
+import { PostHogProvider } from "posthog-js/react";
 import { useMemo } from "react";
 
 if (DATADOG_CLIENT_TOKEN) {
@@ -123,14 +124,15 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
 
   return (
     <FetcherProvider fetcher={fetcher} fetcherWithBody={fetcherWithBody}>
-      <PostHogTracker>
+      <PostHogProvider client={posthog}>
+        <PostHogTrackerEffects />
         <SparkleContext.Provider value={sparkleContextValue}>
           <SignUpModalProvider>
             {getLayout(<Component {...pageProps} />, pageProps)}
             <RegionSelectionModal />
           </SignUpModalProvider>
         </SparkleContext.Provider>
-      </PostHogTracker>
+      </PostHogProvider>
     </FetcherProvider>
   );
 }

--- a/marketing/pages/academy/[slug].tsx
+++ b/marketing/pages/academy/[slug].tsx
@@ -153,7 +153,7 @@ export default function CoursePage({
         </div>
       )}
       <Head>
-        <title>{course.title} | Dust Academy</title>
+        <title>{`${course.title} | Dust Academy`}</title>
         {preview && <meta name="robots" content="noindex, nofollow" />}
         {course.description && (
           <meta name="description" content={course.description} />

--- a/marketing/pages/academy/[slug]/chapter/[chapterSlug].tsx
+++ b/marketing/pages/academy/[slug]/chapter/[chapterSlug].tsx
@@ -204,9 +204,7 @@ export default function ChapterPage({
         </div>
       )}
       <Head>
-        <title>
-          {chapter.title} | {courseTitle} | Dust Academy
-        </title>
+        <title>{`${chapter.title} | ${courseTitle} | Dust Academy`}</title>
         {preview && <meta name="robots" content="noindex, nofollow" />}
         {chapter.description && (
           <meta name="description" content={chapter.description} />

--- a/marketing/pages/academy/lessons/[slug].tsx
+++ b/marketing/pages/academy/lessons/[slug].tsx
@@ -129,7 +129,7 @@ export default function LessonPage({
         </div>
       )}
       <Head>
-        <title>{lesson.title} | Dust Academy</title>
+        <title>{`${lesson.title} | Dust Academy`}</title>
         {preview && <meta name="robots" content="noindex, nofollow" />}
         {lesson.description && (
           <meta name="description" content={lesson.description} />

--- a/marketing/pages/blog/[slug].tsx
+++ b/marketing/pages/blog/[slug].tsx
@@ -125,7 +125,7 @@ export default function BlogPost({
         </div>
       )}
       <Head>
-        <title>{post.title} | Dust Blog</title>
+        <title>{`${post.title} | Dust Blog`}</title>
         {preview && <meta name="robots" content="noindex, nofollow" />}
         {post.description && (
           <meta name="description" content={post.description} />

--- a/marketing/pages/blog/index.tsx
+++ b/marketing/pages/blog/index.tsx
@@ -133,7 +133,7 @@ export default function BlogListing({ posts }: BlogListingPageProps) {
   return (
     <>
       <Head>
-        <title>{selectedTag ? `${selectedTag} | ` : ""}Blog | Dust</title>
+        <title>{`${selectedTag ? `${selectedTag} | ` : ""}Blog | Dust`}</title>
         <meta
           name="description"
           content="Insights, tutorials, and updates from the Dust team on AI agents, enterprise productivity, and building with AI."

--- a/marketing/pages/blog/page/[page].tsx
+++ b/marketing/pages/blog/page/[page].tsx
@@ -135,7 +135,7 @@ export default function BlogPage({
   return (
     <>
       <Head>
-        <title>Blog - Page {currentPage} | Dust</title>
+        <title>{`Blog - Page ${currentPage} | Dust`}</title>
         <meta
           name="description"
           content="Insights, tutorials, and updates from the Dust team on AI agents, enterprise productivity, and building with AI."

--- a/marketing/pages/customers/[slug].tsx
+++ b/marketing/pages/customers/[slug].tsx
@@ -110,9 +110,7 @@ export default function CustomerStoryPage({
         </div>
       )}
       <Head>
-        <title>
-          {story.companyName}: {story.title} | Dust Customer Story
-        </title>
+        <title>{`${story.companyName}: ${story.title} | Dust Customer Story`}</title>
         {preview && <meta name="robots" content="noindex, nofollow" />}
         {story.description && (
           <meta name="description" content={story.description} />


### PR DESCRIPTION
## Description

No marketing page was server-rendered. Crawlers got `next-head-count=2` and an empty `<div id=\"__next\">` on `/`, `/home`, `/pricing`, `/blog`, `/customers`, `/security`, so none of the OG, Twitter or `article:*` tags we write in the page components ever reached the HTML. Link previews and indexing worked off nothing.

Cause: `_app.tsx` loaded `PostHogTracker` via `dynamic(..., { ssr: false })` and wrapped the whole app in it. That combination does not hide children on the server, it discards them, so every page, layout and `<Head>` was dropped from the server output. Introduced in d67604229a (#26962).

Fix: the tracker no longer wraps anything. `PostHogProvider` renders normally, and the client-only effects render as a null sibling next to the page tree.

While in there, seven pages built `<title>` from several JSX children. `<title>` is RCDATA, so React's `<!-- -->` separators are parsed as literal text and end up visible in the tab and in search results. Each is now a single template string.

## Tests

Ran the marketing app locally and checked the served HTML (not the hydrated DOM) on the six routes above: head count went from 2 to 21-35 and the `__next` body from 0 to 55-119 KB. The customer story page serves 6 OG and 4 Twitter tags. No `<!-- -->` left in any title. `next build` prerenders 39/39 pages and First Load JS shared is unchanged at 339 kB.

PostHog capture is not verified locally: `NEXT_PUBLIC_POSTHOG_KEY` is unset in my environment so `posthog.init` short-circuits. Worth a look at pageview events on the preview deploy.

## Risk

Low on the rendering side, the build prerenders every page and the pages themselves are untouched. The one thing to watch is PostHog: the provider now mounts during SSR instead of being skipped, and the effects mount as a sibling rather than a parent. Any regression shows up as missing pageview events, not as a broken page.

## Deploy Plan

Deploy marketing.