### PR TITLE
A deploy thread that reads at a glance

### DIFF
--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -96,12 +96,7 @@ runs:
         token: ${{ inputs.slack_token }}
         payload: |
           channel: ${{ inputs.channel }}
-          text: |
-            ${{ inputs.is_revert == 'true' && '⏮️' || '🚀' }} ${{ inputs.is_revert == 'true' && 'Starting revert of' || 'Starting deployment of' }} ${{ inputs.component }} `${{ inputs.image_tag }}`
-            • Cells: `${{ inputs.region }}`
-            • Commit: <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ inputs.image_tag }}>
-            • Workflow: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View build>
-            • Author: ${{ steps.slack_user.outputs.id != '' && format('<@{0}>', steps.slack_user.outputs.id) || format('`{0}`', steps.author.outputs.name) }}
+          text: "${{ inputs.is_revert == 'true' && '⏮️ revert' || '🚀' }} `${{ inputs.component }}` <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|`${{ inputs.image_tag }}`> → ${{ inputs.region }} · ${{ steps.slack_user.outputs.id != '' && format('<@{0}>', steps.slack_user.outputs.id) || format('`{0}`', steps.author.outputs.name) }} · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow>"
 
     - name: Format and Build Payload
       if: inputs.step == 'build_success'
@@ -109,8 +104,12 @@ runs:
       shell: bash
       run: |
         # 1. Build Header Section
-        HEADER_TEXT="🔨 Build completed for ${{ inputs.region }}"
-        DETAILS_TEXT="• Image: \`${{ inputs.image_tag }}\`"
+        # Region builds (marketing) say where, cell deploys build once.
+        case "${{ inputs.region }}" in
+          cell-*|all) HEADER_TEXT="🔨 \`${{ inputs.image_tag }}\` built" ;;
+          *) HEADER_TEXT="🔨 \`${{ inputs.image_tag }}\` built for ${{ inputs.region }}" ;;
+        esac
+        DETAILS_TEXT=""
 
         if [ -n "${{ inputs.current_version }}" ]; then
           DETAILS_TEXT="${DETAILS_TEXT}

--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -109,16 +109,10 @@ runs:
           cell-*|all) HEADER_TEXT="🔨 \`${{ inputs.image_tag }}\` built" ;;
           *) HEADER_TEXT="🔨 \`${{ inputs.image_tag }}\` built for ${{ inputs.region }}" ;;
         esac
-        DETAILS_TEXT=""
-
+        MAIN_BLOCK_TEXT="$HEADER_TEXT"
         if [ -n "${{ inputs.current_version }}" ]; then
-          DETAILS_TEXT="${DETAILS_TEXT}
-        • Changes: \`${{ inputs.current_version }}\` → \`${{ inputs.image_tag }}\` (${{ inputs.commit_count }} commits)"
+          MAIN_BLOCK_TEXT="${HEADER_TEXT} · \`${{ inputs.current_version }}\` → \`${{ inputs.image_tag }}\`, ${{ inputs.commit_count }} commits"
         fi
-
-        # Combine for the first block
-        MAIN_BLOCK_TEXT="$HEADER_TEXT
-        $DETAILS_TEXT"
 
         # 2. Build Changelog Section
         CHANGELOG_TEXT=""


### PR DESCRIPTION
## Description

**Today** the deploy thread opens with a four bullet header that names the commit twice, and the build message says "Build completed for all", "all" being the cell list.

**After** the header is one line, `🚀 front b6cf5d9 → all · @flavien · workflow`, the tag linking to the commit, and the build line is `🔨 b6cf5d9 built · 8384b67 → b6cf5d9, 3 commits`. Region builds, marketing, still say which region. The cell lines and the recap that follow come from dust-tt/dust-infra#1082.

## Tests

Read through, actionlint clean. Visual proof on the next deploy.

## Risk

Slack text only.

## Deploy Plan

Merge with dust-tt/dust-infra#1082, any order.
