### PR TITLE
Disable triggers targeting a Pod when it is archived

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -1,9 +1,12 @@
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { ProjectFileFactory } from "@app/tests/utils/ProjectFileFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
 import { frameContentType } from "@app/types/files";
 import {
   DEFAULT_POD_FILE_TAB_ICON,
@@ -126,6 +129,37 @@ describe("PATCH /api/w/:wId/spaces/:spaceId/project_metadata", () => {
     expect(response.status).toBe(200);
     const data = await response.json();
     expect(data.projectMetadata.archivedAt).not.toBeNull();
+  });
+
+  it("disables triggers targeting the pod when archiving", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+
+    const projectSpace = await SpaceFactory.project(
+      workspace,
+      auth.getNonNullableUser().id
+    );
+    await ProjectMetadataResource.makeNew(auth, projectSpace, {
+      description: "Test description",
+      archivedAt: null,
+    });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await TriggerFactory.webhook(auth, {
+      agentConfigurationId: agent.sId,
+      status: "enabled",
+      spaceId: projectSpace.id,
+    });
+
+    const response = await patchMetadata(workspace, projectSpace.sId, {
+      archive: true,
+    });
+
+    expect(response.status).toBe(200);
+    const reloaded = await TriggerResource.fetchById(auth, trigger.sId);
+    expect(reloaded?.status).toBe("disabled");
+    expect(reloaded?.spaceId).toBe(projectSpace.id);
   });
 
   it("ignores tasks generation opt-in and returns hardcoded false", async () => {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -4,6 +4,7 @@ import { validatePinnedFramePath } from "@app/lib/api/projects/pinned_frame";
 import { hasFeatureFlag } from "@app/lib/auth";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import type {
   GetPodMetadataResponseBody,
   PatchPodMetadataResponseBody,
@@ -245,6 +246,10 @@ app.patch(
       if (refreshed) {
         metadata = refreshed;
       }
+    }
+
+    if (body.archive) {
+      await TriggerResource.disableAllForSpace(auth, space.id);
     }
 
     return ctx.json({ projectMetadata: metadata.toJSON() });

--- a/front/hooks/useArchivePod.tsx
+++ b/front/hooks/useArchivePod.tsx
@@ -19,7 +19,7 @@ export function useArchivePod({
     const confirmed = await confirm({
       title: "Archive Pod?",
       message:
-        "You'll no longer be able to create new conversations in this Pod and it will be hidden from the sidebar. However, existing content can still be used by agents. Unarchive it to get back access to it.",
+        "You'll no longer be able to create new conversations in this Pod and it will be hidden from the sidebar. Triggers targeting this Pod will be disabled. However, existing content can still be used by agents. Unarchive to restore access.",
       validateVariant: "warning",
     });
 

--- a/front/lib/resources/trigger_resource.test.ts
+++ b/front/lib/resources/trigger_resource.test.ts
@@ -6,6 +6,7 @@ import * as temporalClient from "@app/temporal/triggers/schedule_client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { Ok } from "@app/types/shared/result";
@@ -141,6 +142,63 @@ describe("TriggerResource", () => {
       // Clean up mocks
       mockCreateOrUpdateWorkflow.mockRestore();
       mockDeleteWorkflow.mockRestore();
+    });
+  });
+
+  describe("disableAllForSpace", () => {
+    it("disables enabled triggers on that pod and leaves others unchanged", async () => {
+      const { workspace, authenticator, user } = await createResourceTest({
+        plan: "creditPriced",
+        role: "admin",
+      });
+      const projectSpace = await SpaceFactory.project(workspace, user.id);
+      const otherSpace = await SpaceFactory.project(workspace, user.id);
+      await authenticator.refresh();
+
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        authenticator,
+        { name: "Test Agent" }
+      );
+
+      const enabledOnPod = await TriggerFactory.webhook(authenticator, {
+        agentConfigurationId: agentConfig.sId,
+        status: "enabled",
+        spaceId: projectSpace.id,
+      });
+      const alreadyDisabledOnPod = await TriggerFactory.webhook(authenticator, {
+        agentConfigurationId: agentConfig.sId,
+        status: "disabled",
+        spaceId: projectSpace.id,
+      });
+      const enabledOnOtherPod = await TriggerFactory.webhook(authenticator, {
+        agentConfigurationId: agentConfig.sId,
+        status: "enabled",
+        spaceId: otherSpace.id,
+      });
+
+      const result = await TriggerResource.disableAllForSpace(
+        authenticator,
+        projectSpace.id
+      );
+      expect(result.isOk()).toBe(true);
+
+      const reloadedEnabled = await TriggerResource.fetchById(
+        authenticator,
+        enabledOnPod.sId
+      );
+      const reloadedDisabled = await TriggerResource.fetchById(
+        authenticator,
+        alreadyDisabledOnPod.sId
+      );
+      const reloadedOther = await TriggerResource.fetchById(
+        authenticator,
+        enabledOnOtherPod.sId
+      );
+
+      expect(reloadedEnabled?.status).toBe("disabled");
+      expect(reloadedEnabled?.spaceId).toBe(projectSpace.id);
+      expect(reloadedDisabled?.status).toBe("disabled");
+      expect(reloadedOther?.status).toBe("enabled");
     });
   });
 

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -909,6 +909,40 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     );
   }
 
+  /**
+   * @cc [owner:aloia,label:product] archive-disables-pod-triggers
+   * Archiving a Pod disables enabled triggers that target it. Triggers stay
+   * attached to the Pod (not detached to personal conversations) and are not
+   * re-enabled on unarchive. Already-disabled or system-status triggers are
+   * left unchanged.
+   */
+  static async disableAllForSpace(
+    auth: Authenticator,
+    spaceModelId: ModelId
+  ): Promise<Result<undefined, Error>> {
+    const triggers = await this.listBySpace(auth, spaceModelId);
+    const enabled = triggers.filter((trigger) => trigger.status === "enabled");
+    if (enabled.length === 0) {
+      return new Ok(undefined);
+    }
+
+    const result = await this.disableMany(auth, enabled, "disabled");
+    if (result.isErr()) {
+      return result;
+    }
+
+    void emitBulkTriggerAuditLogEvents(auth, enabled, (trigger) => ({
+      action: "trigger.disabled",
+      metadata: {
+        trigger_type: trigger.kind,
+        agent_id: trigger.agentConfigurationId,
+        status: "disabled",
+      },
+    }));
+
+    return new Ok(undefined);
+  }
+
   static async disableAllForWorkspace(
     auth: Authenticator,
     targetStatus: Exclude<TriggerStatus, "enabled">


### PR DESCRIPTION
## Summary
- When a Pod is archived, disable enabled triggers that target it so they stop opening new conversations there.
- Leave those triggers attached to the Pod (do not retarget to personal conversations) and do not re-enable them on unarchive.
- Archive confirmation copy now tells editors that those triggers will be disabled.
- https://github.com/dust-tt/tasks/issues/10343

r? aubin-tchoi

## Testing
Validated disable locally

## Risk
Low

## Deploy Plan
1. Deploy front