### PR TITLE
Update contract review action

### DIFF
--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -67,7 +67,7 @@ jobs:
       statuses: write
     steps:
       - name: Review contracts
-        uses: spolu/code-contracts/.github/actions/contract-review@9dcf575448dd88f0934e2862abf03093a00c3f27
+        uses: spolu/code-contracts/.github/actions/contract-review@c80b8e1afc7499184f84fd14a15da8d0d5406b27
         with:
           pull-request-number: ${{ inputs.pull-request-number || needs.request-reviews.outputs.pull-request-number }}
           request-run-id: ${{ inputs.request-run-id }}


### PR DESCRIPTION
## Description

Update the contract-review action pin to `c80b8e1`, including [spolu/code-contracts#36](https://github.com/spolu/code-contracts/pull/36). The new relevance rule limits pre-existing findings to violations directly connected to changed behavior, its assumptions, or introduced/modified contracts, and requires each finding to explain that connection. Review summaries now use `cc-check: LGTM` or `cc-check: violations found!`.

## Tests

Parsed the workflow YAML and verified the action ref. Confirmed the upstream action interface is unchanged.

## Risk

Low. Action revision update only.

## Deploy Plan

Merge to main.
