### PR TITLE
Add pre-commit and CI checks blocking new moment usage

### DIFF
--- a/.github/workflows/run-dangerjs.yml
+++ b/.github/workflows/run-dangerjs.yml
@@ -28,10 +28,16 @@ jobs:
           echo "Checking for changed files..."
 
           # Define monitored paths
+          # MOMENT-BAN: front/components/ and front/hooks/ are included so the
+          # date-fns-over-moment dangerfile check (front/CONTRACTS:669) isn't
+          # skipped for PRs that only touch those directories. Remove this
+          # note (but keep the paths) once no file imports `moment` anymore.
           MONITORED_PATHS=(
             'front/lib/'
             'front/types/assistant/models/'
             'front/temporal/'
+            'front/components/'
+            'front/hooks/'
             'front-api/'
             'connectors/src/lib/models/'
             'connectors/src/resources/storage/models/'

--- a/.github/workflows/run-dangerjs.yml
+++ b/.github/workflows/run-dangerjs.yml
@@ -28,16 +28,10 @@ jobs:
           echo "Checking for changed files..."
 
           # Define monitored paths
-          # MOMENT-BAN: front/components/ and front/hooks/ are included so the
-          # date-fns-over-moment dangerfile check (front/CONTRACTS:669) isn't
-          # skipped for PRs that only touch those directories. Remove this
-          # note (but keep the paths) once no file imports `moment` anymore.
           MONITORED_PATHS=(
             'front/lib/'
             'front/types/assistant/models/'
             'front/temporal/'
-            'front/components/'
-            'front/hooks/'
             'front-api/'
             'connectors/src/lib/models/'
             'connectors/src/resources/storage/models/'

--- a/front/CONTRACTS
+++ b/front/CONTRACTS
@@ -665,3 +665,15 @@ usage still costs out.
 
 Reviewer: for a new image model, check the pricing entry exists and its numbers match the linked
 provider page.
+
+@cc [owner:avervaet,label:coding] date-fns-over-moment
+New code must not import `moment` (or `moment-timezone`). Use `date-fns` instead, extending the
+helpers in `lib/utils/timestamps.ts` for relative-time / calendar-style formatting when the
+existing ones don't cover a pattern. Files that already import `moment` may keep doing so; migrate
+them to `date-fns` opportunistically when touched for unrelated reasons, rather than as a
+dedicated migration.
+See https://github.com/dust-tt/decisions/issues/1009.
+This is enforced by a lefthook hook and a dangerfile check (grep the repo for "MOMENT-BAN"); once
+no file imports `moment` anymore, remove this contract along with those.
+
+Reviewer: if a file that did not previously import `moment` starts to, require `date-fns` instead.

--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -282,6 +282,50 @@ async function checkRawSqlRegistry(filePaths: string[]) {
 }
 
 /**
+ * MOMENT-BAN: delete this function and its call site, plus the lefthook hook,
+ * check script, and CONTRACTS entry (grep the repo for "MOMENT-BAN"), once no
+ * file imports `moment` anymore.
+ *
+ * Fail on files that start importing `moment` where they didn't before.
+ * See https://github.com/dust-tt/decisions/issues/1009: `moment` is being
+ * phased out in favor of `date-fns`; existing usage is migrated
+ * opportunistically, so only newly-introduced imports are blocked here.
+ */
+async function checkNoNewMomentUsage(filePaths: string[]) {
+  const momentImportPattern =
+    /((?:import|from)\s+["']moment(-timezone)?(\/[^"']*)?["']|require\(["']moment(-timezone)?(\/[^"']*)?["']\))/;
+
+  const filesWithNewMoment: string[] = [];
+
+  await Promise.all(
+    filePaths.map(async (file) => {
+      try {
+        const content = await danger.git.diffForFile(file);
+        if (
+          content !== null &&
+          momentImportPattern.test(content.after) &&
+          !momentImportPattern.test(content.before ?? "")
+        ) {
+          filesWithNewMoment.push(file);
+        }
+      } catch (error) {
+        console.error(`Error checking file ${file}:`, error);
+      }
+    })
+  );
+
+  if (filesWithNewMoment.length > 0) {
+    fail(
+      "`moment` is being phased out in favor of `date-fns` " +
+        "(see `front/lib/utils/timestamps.ts` and " +
+        "https://github.com/dust-tt/decisions/issues/1009). " +
+        "The following files newly import `moment`, please use `date-fns` instead:\n" +
+        filesWithNewMoment.map((f) => `- ${f}`).join("\n")
+    );
+  }
+}
+
+/**
  * Check if added lines contain new WorkspaceAwareModel definitions
  */
 async function checkWorkspaceAwareModels(filePaths: string[]) {
@@ -536,6 +580,14 @@ async function checkDiffFiles() {
   });
   if (modifiedFrontFiles.length > 0) {
     await checkRawSqlRegistry(modifiedFrontFiles);
+  }
+
+  // MOMENT-BAN: remove once no file imports `moment` anymore.
+  const modifiedFrontSourceFiles = diffFiles.filter((path) => {
+    return path.startsWith("front/") && /\.(ts|tsx|js|jsx)$/.test(path);
+  });
+  if (modifiedFrontSourceFiles.length > 0) {
+    await checkNoNewMomentUsage(modifiedFrontSourceFiles);
   }
 
   // Sparkle version consistency check

--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -26,6 +26,25 @@ const hasLabel = (label: string) => {
   return danger.github.issue.labels.some((l) => l.name === label);
 };
 
+// dangerfile.ts can't safely import `@app/*`-aliased modules (Danger's own
+// TypeScript transpiler doesn't resolve tsconfig path aliases at runtime), so
+// this stays a self-contained stand-in for `concurrentExecutor`.
+async function concurrentlyProcess<T>(
+  items: T[],
+  process: (item: T) => Promise<void>,
+  concurrency: number
+) {
+  const queue = [...items];
+  await Promise.all(
+    Array.from({ length: concurrency }, async () => {
+      let item: T | undefined;
+      while ((item = queue.shift()) !== undefined) {
+        await process(item);
+      }
+    })
+  );
+}
+
 function failMigrationAck() {
   fail(
     "Files in `**/models/` have been modified. " +
@@ -293,12 +312,13 @@ async function checkRawSqlRegistry(filePaths: string[]) {
  */
 async function checkNoNewMomentUsage(filePaths: string[]) {
   const momentImportPattern =
-    /((?:import|from)\s+["']moment(-timezone)?(\/[^"']*)?["']|require\(["']moment(-timezone)?(\/[^"']*)?["']\))/;
+    /((?:import|from)\s+["']moment(-timezone)?(\/[^"']*)?["']|(?:require|import)\(["']moment(-timezone)?(\/[^"']*)?["']\))/;
 
   const filesWithNewMoment: string[] = [];
 
-  await Promise.all(
-    filePaths.map(async (file) => {
+  await concurrentlyProcess(
+    filePaths,
+    async (file) => {
       try {
         const content = await danger.git.diffForFile(file);
         if (
@@ -309,9 +329,10 @@ async function checkNoNewMomentUsage(filePaths: string[]) {
           filesWithNewMoment.push(file);
         }
       } catch (error) {
-        console.error(`Error checking file ${file}:`, error);
+        warn(`Error checking file ${file} for new \`moment\` usage: ${error}`);
       }
-    })
+    },
+    8
   );
 
   if (filesWithNewMoment.length > 0) {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -65,6 +65,15 @@ pre-commit:
       run: scripts/check-package-lock-sync.sh
       priority: 1
 
+    # MOMENT-BAN: remove this block once no file imports `moment` anymore
+    # (grep the repo for "MOMENT-BAN" to find the rest).
+    # Block new `moment` usage; see https://github.com/dust-tt/decisions/issues/1009
+    # (skip with LEFTHOOK_EXCLUDE=no-new-moment-usage)
+    no-new-moment-usage:
+      glob: "*.{js,jsx,ts,tsx}"
+      run: scripts/check-no-new-moment-usage.sh {staged_files}
+      priority: 1
+
     # Optional: actionlint for GitHub Actions workflow files (skip with LEFTHOOK_EXCLUDE=actionlint)
     actionlint:
       glob: ".github/{workflows,actions}/**/*.{yml,yaml}"

--- a/scripts/check-no-new-moment-usage.sh
+++ b/scripts/check-no-new-moment-usage.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# MOMENT-BAN: delete this file, and its lefthook/dangerfile hooks and CONTRACTS
+# entry (grep the repo for "MOMENT-BAN"), once no file imports `moment` anymore.
+#
+# Blocks new usage of `moment` (staged) in files that didn't already import it
+# at HEAD. See https://github.com/dust-tt/decisions/issues/1009: `moment` is
+# being phased out in favor of `date-fns` (front/lib/utils/timestamps.ts);
+# existing usage is migrated opportunistically, not blocked.
+# Usage: ./check-no-new-moment-usage.sh <file>...
+
+set -euo pipefail
+
+moment_import_pattern=$'((import|from)[[:space:]]+["\x27]moment(-timezone)?(/[^"\x27]*)?["\x27]|require\\(["\x27]moment(-timezone)?(/[^"\x27]*)?["\x27]\\))'
+
+violations=()
+
+for f in "$@"; do
+  case "$f" in
+    *.ts|*.tsx|*.js|*.jsx) ;;
+    *) continue ;;
+  esac
+
+  staged_content=$(git show ":$f" 2>/dev/null || true)
+  if [ -z "$staged_content" ] || ! echo "$staged_content" | grep -qE "$moment_import_pattern"; then
+    continue
+  fi
+
+  if git cat-file -e "HEAD:$f" 2>/dev/null; then
+    head_content=$(git show "HEAD:$f")
+    if echo "$head_content" | grep -qE "$moment_import_pattern"; then
+      continue
+    fi
+  fi
+
+  violations+=("$f")
+done
+
+if [ ${#violations[@]} -gt 0 ]; then
+  echo "Error: new usage of 'moment' introduced in:"
+  for f in "${violations[@]}"; do
+    echo "  - $f"
+  done
+  echo ""
+  echo "moment is being phased out in favor of date-fns (see front/lib/utils/timestamps.ts"
+  echo "and https://github.com/dust-tt/decisions/issues/1009). Use date-fns instead."
+  echo "Skip with LEFTHOOK_EXCLUDE=no-new-moment-usage if this is a false positive."
+  exit 1
+fi
+
+exit 0

--- a/scripts/check-no-new-moment-usage.sh
+++ b/scripts/check-no-new-moment-usage.sh
@@ -11,7 +11,22 @@
 
 set -euo pipefail
 
-moment_import_pattern=$'((import|from)[[:space:]]+["\x27]moment(-timezone)?(/[^"\x27]*)?["\x27]|require\\(["\x27]moment(-timezone)?(/[^"\x27]*)?["\x27]\\))'
+moment_import_pattern=$'((import|from)[[:space:]]+["\x27]moment(-timezone)?(/[^"\x27]*)?["\x27]|(require|import)\\(["\x27]moment(-timezone)?(/[^"\x27]*)?["\x27]\\))'
+
+has_moment_import() {
+  # Collapse newlines (via `tr`, not bash's ${//} substitution, which is
+  # O(n^2) and hangs on large files) so a multi-line `from\n"moment"` still
+  # matches. Written to a temp file rather than piped into `grep -q`: with
+  # `pipefail`, grep's early exit on match can SIGPIPE the writing process,
+  # making the pipeline look like a failed match even though it matched.
+  local tmpfile
+  tmpfile=$(mktemp)
+  tr '\n' ' ' <<<"$1" >"$tmpfile"
+  local matched=0
+  grep -qE "$moment_import_pattern" "$tmpfile" || matched=1
+  rm -f "$tmpfile"
+  return "$matched"
+}
 
 violations=()
 
@@ -22,13 +37,13 @@ for f in "$@"; do
   esac
 
   staged_content=$(git show ":$f" 2>/dev/null || true)
-  if [ -z "$staged_content" ] || ! echo "$staged_content" | grep -qE "$moment_import_pattern"; then
+  if [ -z "$staged_content" ] || ! has_moment_import "$staged_content"; then
     continue
   fi
 
   if git cat-file -e "HEAD:$f" 2>/dev/null; then
     head_content=$(git show "HEAD:$f")
-    if echo "$head_content" | grep -qE "$moment_import_pattern"; then
+    if has_moment_import "$head_content"; then
       continue
     fi
   fi


### PR DESCRIPTION
## Description
Decision: https://github.com/dust-tt/decisions/issues/1009  phase out `moment` in favor of `date-fns`. This PR ships step 1 ("stop the spread"): a code contract plus enforcement, no migration of existing usage.


- `front/CONTRACTS`: new `date-fns-over-moment` contract, new code must not import `moment`/`moment-timezone`, existing usage is migrated opportunistically.
- Enforcement, both checking whether a file newly imports `moment` (files that already did are left alone): a `no-new-moment-usage` lefthook pre-commit hook (`scripts/check-no-new-moment-usage.sh`), and the same check in `front/dangerfile.ts` for CI/PRs where the hook isn't installed.
- All of it is tagged `MOMENT-BAN` (contract, script, lefthook entry, dangerfile function + call site) so it can be found and deleted in one grep once no file imports `moment` anymore.

## Tests

Manual: exercised `scripts/check-no-new-moment-usage.sh` in a scratch git repo editing an existing `moment`-using file passes, a new file importing `moment` fails. `npx tsgo --noEmit` and `npm run format:changed` pass on the dangerfile/lefthook/script changes.

## Risk

Low. Additive tooling only, no production code path touched. Can be skipped per-commit with `LEFTHOOK_EXCLUDE=no-new-moment-usage` if it ever false-positives.

## Deploy Plan

None — lefthook/dangerfile/CONTRACTS only, no deploy required.
