### PR TITLE
Add Load more to credit pool cycle history table

### DIFF
--- a/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.test.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.test.ts
@@ -22,16 +22,19 @@ function awuPoolCycleHistoryUrl(wId: string, query = "") {
   return `/api/w/${wId}/credits/awu-pool-cycle-history${query}`;
 }
 
-// Only the fields the breakdown reads; the SDK type is far larger.
 function finalizedInvoice(index: number): Invoice {
   const end = Date.UTC(2026, 0, 1) - index * 31 * 24 * 60 * 60 * 1000;
   return {
     id: `inv-${index}`,
+    customer_id: "m-customer",
+    status: "FINALIZED",
+    type: "USAGE",
+    total: 0,
     start_timestamp: new Date(end - 31 * 24 * 60 * 60 * 1000).toISOString(),
     end_timestamp: new Date(end).toISOString(),
     credit_type: { id: "2714e483-4ff1-48e4-9e25-ac732e8f24f2", name: "USD" },
     line_items: [],
-  } as unknown as Invoice;
+  };
 }
 
 async function requestAsManager(query = "") {

--- a/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.test.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.test.ts
@@ -3,6 +3,7 @@ import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_ap
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
+import type { Invoice } from "@metronome/sdk/resources/v1/customers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/metronome/client", async () => {
@@ -17,8 +18,30 @@ vi.mock("@app/lib/metronome/client", async () => {
   };
 });
 
-function awuPoolCycleHistoryUrl(wId: string) {
-  return `/api/w/${wId}/credits/awu-pool-cycle-history`;
+function awuPoolCycleHistoryUrl(wId: string, query = "") {
+  return `/api/w/${wId}/credits/awu-pool-cycle-history${query}`;
+}
+
+// Only the fields the breakdown reads; the SDK type is far larger.
+function finalizedInvoice(index: number): Invoice {
+  const end = Date.UTC(2026, 0, 1) - index * 31 * 24 * 60 * 60 * 1000;
+  return {
+    id: `inv-${index}`,
+    start_timestamp: new Date(end - 31 * 24 * 60 * 60 * 1000).toISOString(),
+    end_timestamp: new Date(end).toISOString(),
+    credit_type: { id: "2714e483-4ff1-48e4-9e25-ac732e8f24f2", name: "USD" },
+    line_items: [],
+  } as unknown as Invoice;
+}
+
+async function requestAsManager(query = "") {
+  const workspace = await WorkspaceFactory.creditPriced();
+  await createPrivateApiMockRequest({
+    method: "GET",
+    role: "manager",
+    workspace,
+  });
+  return honoApp.request(awuPoolCycleHistoryUrl(workspace.sId, query));
 }
 
 beforeEach(() => {
@@ -67,7 +90,53 @@ describe("GET /api/w/[wId]/credits/awu-pool-cycle-history", () => {
     expect(await response.json()).toEqual({
       cycleBreakdown: [],
       excessCycleBreakdown: [],
+      hasMoreCycleHistory: false,
     });
     expect(metronomeClient.listMetronomeFinalizedInvoices).toHaveBeenCalled();
+  });
+
+  it("fetches one invoice past the limit to detect older cycles", async () => {
+    vi.mocked(metronomeClient.listMetronomeFinalizedInvoices).mockResolvedValue(
+      new Ok([finalizedInvoice(0), finalizedInvoice(1), finalizedInvoice(2)])
+    );
+
+    const response = await requestAsManager("?cycleHistoryLimit=2");
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).hasMoreCycleHistory).toBe(true);
+    expect(metronomeClient.listMetronomeFinalizedInvoices).toHaveBeenCalledWith(
+      expect.any(String),
+      { limit: 3 }
+    );
+  });
+
+  it("reports no more history when the invoices run out", async () => {
+    vi.mocked(metronomeClient.listMetronomeFinalizedInvoices).mockResolvedValue(
+      new Ok([finalizedInvoice(0), finalizedInvoice(1)])
+    );
+
+    const response = await requestAsManager("?cycleHistoryLimit=2");
+
+    expect((await response.json()).hasMoreCycleHistory).toBe(false);
+  });
+
+  it("caps the limit at 24 cycles", async () => {
+    const response = await requestAsManager("?cycleHistoryLimit=24");
+
+    expect(response.status).toBe(200);
+    expect(metronomeClient.listMetronomeFinalizedInvoices).toHaveBeenCalledWith(
+      expect.any(String),
+      { limit: 25 }
+    );
+  });
+
+  it("falls back to the default limit when the requested one is out of range", async () => {
+    const response = await requestAsManager("?cycleHistoryLimit=25");
+
+    expect(response.status).toBe(200);
+    expect(metronomeClient.listMetronomeFinalizedInvoices).toHaveBeenCalledWith(
+      expect.any(String),
+      { limit: 6 }
+    );
   });
 });

--- a/front-api/routes/w/[wId]/credits/awu-pool-summary.test.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-summary.test.ts
@@ -33,6 +33,7 @@ const EMPTY_POOL_SUMMARY = {
   cycleBreakdown: [],
   excessConsumedCredits: null,
   excessCycleBreakdown: [],
+  hasMoreCycleHistory: false,
   programmaticConsumedCredits: null,
 };
 

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -106,11 +106,12 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
         isAwuPoolCycleHistoryLoading,
         !!isAwuPoolCycleHistoryError
       )}
-      hasMoreCycleHistory={hasMoreCycleHistory}
-      onLoadMoreCycleHistory={onLoadMoreCycleHistory}
-      isLoadingMoreCycleHistory={
-        isAwuPoolCycleHistoryValidating && !isAwuPoolCycleHistoryLoading
-      }
+      cycleHistoryLoadMore={{
+        hasMore: hasMoreCycleHistory,
+        isLoading:
+          isAwuPoolCycleHistoryValidating && !isAwuPoolCycleHistoryLoading,
+        onLoadMore: onLoadMoreCycleHistory,
+      }}
     />
   );
 }

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -10,6 +10,7 @@ import { getSeatIconColorClass } from "@app/components/workspace/seat_styles";
 import {
   CreditPoolCardsFromCycleData,
   toCreditPoolFetchStatus,
+  useCycleHistoryLimit,
 } from "@app/components/workspace/WorkspaceCreditPoolCards";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
@@ -77,6 +78,7 @@ interface PoolCreditCardProps {
 }
 
 function PoolCreditCard({ owner }: PoolCreditCardProps) {
+  const { cycleHistoryLimit, onLoadMoreCycleHistory } = useCycleHistoryLimit();
   const {
     awuPoolCurrentCycle,
     isAwuPoolCurrentCycleLoading,
@@ -87,7 +89,8 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
     excessCycleBreakdown,
     isAwuPoolCycleHistoryLoading,
     isAwuPoolCycleHistoryError,
-  } = usePokeAwuPoolCycleHistory({ owner });
+    isAwuPoolCycleHistoryValidating,
+  } = usePokeAwuPoolCycleHistory({ owner, cycleHistoryLimit });
 
   return (
     <CreditPoolCardsFromCycleData
@@ -102,6 +105,11 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
         isAwuPoolCycleHistoryLoading,
         !!isAwuPoolCycleHistoryError
       )}
+      cycleHistoryLimit={cycleHistoryLimit}
+      onLoadMoreCycleHistory={onLoadMoreCycleHistory}
+      isLoadingMoreCycleHistory={
+        isAwuPoolCycleHistoryValidating && !isAwuPoolCycleHistoryLoading
+      }
     />
   );
 }

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -87,6 +87,7 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
   const {
     cycleBreakdown: poolCycleBreakdown,
     excessCycleBreakdown,
+    hasMoreCycleHistory,
     isAwuPoolCycleHistoryLoading,
     isAwuPoolCycleHistoryError,
     isAwuPoolCycleHistoryValidating,
@@ -105,7 +106,7 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
         isAwuPoolCycleHistoryLoading,
         !!isAwuPoolCycleHistoryError
       )}
-      cycleHistoryLimit={cycleHistoryLimit}
+      hasMoreCycleHistory={hasMoreCycleHistory}
       onLoadMoreCycleHistory={onLoadMoreCycleHistory}
       isLoadingMoreCycleHistory={
         isAwuPoolCycleHistoryValidating && !isAwuPoolCycleHistoryLoading

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -1,8 +1,8 @@
 import { SummaryCard } from "@app/components/workspace/analytics/SummaryCard";
 import { formatConsumptionDate } from "@app/lib/analytics/consumption_period";
 import { ONE_DAY_MS } from "@app/lib/api/analytics/time_utils";
-import { MAX_CYCLE_HISTORY_LIMIT } from "@app/lib/api/credits/awu_pool_summary";
 import { formatCredits } from "@app/lib/client/credits";
+import { MAX_CYCLE_HISTORY_LIMIT } from "@app/lib/credits/awu_purchase_constants";
 import {
   useAwuPoolCurrentCycle,
   useAwuPoolCycleHistory,

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -1,6 +1,7 @@
 import { SummaryCard } from "@app/components/workspace/analytics/SummaryCard";
 import { formatConsumptionDate } from "@app/lib/analytics/consumption_period";
 import { ONE_DAY_MS } from "@app/lib/api/analytics/time_utils";
+import { MAX_CYCLE_HISTORY_LIMIT } from "@app/lib/api/credits/awu_pool_summary";
 import { formatCredits } from "@app/lib/client/credits";
 import {
   useAwuPoolCurrentCycle,
@@ -21,7 +22,7 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 export type CreditPoolFetchStatus = "loading" | "error" | "ready";
 
@@ -134,6 +135,9 @@ export function WorkspaceCreditUsageValueCards({
 
 interface WorkspaceCreditPoolCycleHistoryTableProps {
   cycleBreakdown: AwuPoolCycleBreakdown[];
+  onLoadMore: () => void;
+  hasMoreCycleHistory: boolean;
+  isLoadingMoreCycleHistory: boolean;
 }
 
 type CycleHistoryRowData = {
@@ -164,29 +168,26 @@ const CYCLE_HISTORY_COLUMNS: ColumnDef<CycleHistoryRowData, string>[] = [
   },
 ];
 
-const INITIAL_CYCLE_HISTORY_ROW_COUNT = 2;
-const CYCLE_HISTORY_LOAD_MORE_COUNT = 5;
+export const INITIAL_CYCLE_HISTORY_ROW_COUNT = 2;
+export const CYCLE_HISTORY_LOAD_MORE_COUNT = 5;
 
 export function WorkspaceCreditPoolCycleHistoryTable({
   cycleBreakdown,
+  onLoadMore,
+  hasMoreCycleHistory,
+  isLoadingMoreCycleHistory,
 }: WorkspaceCreditPoolCycleHistoryTableProps) {
-  const [visibleRowCount, setVisibleRowCount] = useState(
-    INITIAL_CYCLE_HISTORY_ROW_COUNT
-  );
-
   if (cycleBreakdown.length === 0) {
     return null;
   }
 
-  const rows: CycleHistoryRowData[] = cycleBreakdown
-    .slice(0, visibleRowCount)
-    .map((cycle) => ({
-      cycle:
-        cycle.cycleStartMs && cycle.cycleEndMs
-          ? `${formatConsumptionDate(cycle.cycleStartMs)} – ${formatConsumptionDate(cycle.cycleEndMs)}`
-          : "Unknown cycle",
-      consumedCredits: formatCredits(Math.round(cycle.consumedCredits)),
-    }));
+  const rows: CycleHistoryRowData[] = cycleBreakdown.map((cycle) => ({
+    cycle:
+      cycle.cycleStartMs && cycle.cycleEndMs
+        ? `${formatConsumptionDate(cycle.cycleStartMs)} – ${formatConsumptionDate(cycle.cycleEndMs)}`
+        : "Unknown cycle",
+    consumedCredits: formatCredits(Math.round(cycle.consumedCredits)),
+  }));
 
   return (
     <>
@@ -195,9 +196,9 @@ export function WorkspaceCreditPoolCycleHistoryTable({
         data={rows}
         columns={CYCLE_HISTORY_COLUMNS}
         totalRowCount={cycleBreakdown.length}
-        onLoadMore={() =>
-          setVisibleRowCount((count) => count + CYCLE_HISTORY_LOAD_MORE_COUNT)
-        }
+        rowCountIsCapped={hasMoreCycleHistory}
+        onLoadMore={onLoadMore}
+        isLoadingMore={isLoadingMoreCycleHistory}
       />
     </>
   );
@@ -206,6 +207,9 @@ export function WorkspaceCreditPoolCycleHistoryTable({
 interface WorkspaceCreditPoolHistoryProps {
   tableStatus: CreditPoolFetchStatus;
   cycleBreakdown: AwuPoolCycleBreakdown[];
+  onLoadMore: () => void;
+  hasMoreCycleHistory: boolean;
+  isLoadingMoreCycleHistory: boolean;
 }
 
 // Table area rendered under the value cards. Kept separate so a slow cycle
@@ -213,6 +217,9 @@ interface WorkspaceCreditPoolHistoryProps {
 function WorkspaceCreditPoolHistory({
   tableStatus,
   cycleBreakdown,
+  onLoadMore,
+  hasMoreCycleHistory,
+  isLoadingMoreCycleHistory,
 }: WorkspaceCreditPoolHistoryProps) {
   switch (tableStatus) {
     case "error":
@@ -233,7 +240,12 @@ function WorkspaceCreditPoolHistory({
       );
     case "ready":
       return (
-        <WorkspaceCreditPoolCycleHistoryTable cycleBreakdown={cycleBreakdown} />
+        <WorkspaceCreditPoolCycleHistoryTable
+          cycleBreakdown={cycleBreakdown}
+          onLoadMore={onLoadMore}
+          hasMoreCycleHistory={hasMoreCycleHistory}
+          isLoadingMoreCycleHistory={isLoadingMoreCycleHistory}
+        />
       );
     default:
       assertNeverAndIgnore(tableStatus);
@@ -252,6 +264,9 @@ interface WorkspaceCreditPoolSectionProps {
   currentCycleEndMs: number | null;
   cycleBreakdown: AwuPoolCycleBreakdown[];
   programmaticConsumedCredits: number | null;
+  onLoadMoreCycleHistory: () => void;
+  hasMoreCycleHistory: boolean;
+  isLoadingMoreCycleHistory: boolean;
 }
 
 export function WorkspaceCreditPoolSection({
@@ -265,6 +280,9 @@ export function WorkspaceCreditPoolSection({
   currentCycleEndMs,
   cycleBreakdown,
   programmaticConsumedCredits,
+  onLoadMoreCycleHistory,
+  hasMoreCycleHistory,
+  isLoadingMoreCycleHistory,
 }: WorkspaceCreditPoolSectionProps) {
   if (cardsStatus === "ready" && !isVisible) {
     return null;
@@ -300,10 +318,44 @@ export function WorkspaceCreditPoolSection({
           <WorkspaceCreditPoolHistory
             tableStatus={tableStatus}
             cycleBreakdown={cycleBreakdown}
+            onLoadMore={onLoadMoreCycleHistory}
+            hasMoreCycleHistory={hasMoreCycleHistory}
+            isLoadingMoreCycleHistory={isLoadingMoreCycleHistory}
           />
         </>
       )}
     </Page.Vertical>
+  );
+}
+
+// Reveals cycle history a page at a time, re-fetching a growing
+// `cycleHistoryLimit` from the backend rather than paginating client-side,
+// since the backend itself caps how many cycles it will ever return
+// (`MAX_CYCLE_HISTORY_LIMIT`).
+export function useCycleHistoryLimit() {
+  const [cycleHistoryLimit, setCycleHistoryLimit] = useState(
+    INITIAL_CYCLE_HISTORY_ROW_COUNT
+  );
+
+  const onLoadMoreCycleHistory = useCallback(() => {
+    setCycleHistoryLimit((limit) =>
+      Math.min(MAX_CYCLE_HISTORY_LIMIT, limit + CYCLE_HISTORY_LOAD_MORE_COUNT)
+    );
+  }, []);
+
+  return { cycleHistoryLimit, onLoadMoreCycleHistory };
+}
+
+// A fetched count matching the requested limit means the backend may be
+// truncating rather than reporting the true total, so there could be more
+// left to reveal — unless the limit is already at the backend's own cap.
+export function computeHasMoreCycleHistory(
+  fetchedCount: number,
+  cycleHistoryLimit: number
+): boolean {
+  return (
+    fetchedCount === cycleHistoryLimit &&
+    cycleHistoryLimit < MAX_CYCLE_HISTORY_LIMIT
   );
 }
 
@@ -313,6 +365,9 @@ interface CreditPoolCardsFromCycleDataProps {
   poolCycleBreakdown: AwuPoolCycleBreakdown[];
   excessCycleBreakdown: AwuPoolCycleBreakdown[];
   tableStatus: CreditPoolFetchStatus;
+  cycleHistoryLimit: number;
+  onLoadMoreCycleHistory: () => void;
+  isLoadingMoreCycleHistory: boolean;
 }
 export function CreditPoolCardsFromCycleData({
   awuPoolCurrentCycle,
@@ -320,6 +375,9 @@ export function CreditPoolCardsFromCycleData({
   poolCycleBreakdown,
   excessCycleBreakdown,
   tableStatus,
+  cycleHistoryLimit,
+  onLoadMoreCycleHistory,
+  isLoadingMoreCycleHistory,
 }: CreditPoolCardsFromCycleDataProps) {
   const {
     totalRemainingCredits,
@@ -342,6 +400,7 @@ export function CreditPoolCardsFromCycleData({
   const hasPool = totalActiveCredits > 0;
   const hasExcessData =
     excessConsumedCredits !== null || excessCycleBreakdown.length > 0;
+  const cycleBreakdown = hasPool ? poolCycleBreakdown : excessCycleBreakdown;
 
   return (
     <WorkspaceCreditPoolSection
@@ -355,8 +414,14 @@ export function CreditPoolCardsFromCycleData({
       }
       currentCycleStartMs={currentCycleStartMs}
       currentCycleEndMs={currentCycleEndMs}
-      cycleBreakdown={hasPool ? poolCycleBreakdown : excessCycleBreakdown}
+      cycleBreakdown={cycleBreakdown}
       programmaticConsumedCredits={programmaticConsumedCredits}
+      onLoadMoreCycleHistory={onLoadMoreCycleHistory}
+      hasMoreCycleHistory={computeHasMoreCycleHistory(
+        cycleBreakdown.length,
+        cycleHistoryLimit
+      )}
+      isLoadingMoreCycleHistory={isLoadingMoreCycleHistory}
     />
   );
 }
@@ -366,6 +431,7 @@ interface CreditPoolCardsProps {
   disabled: boolean;
 }
 export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
+  const { cycleHistoryLimit, onLoadMoreCycleHistory } = useCycleHistoryLimit();
   const {
     awuPoolCurrentCycle,
     isAwuPoolCurrentCycleLoading,
@@ -376,7 +442,12 @@ export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
     excessCycleBreakdown,
     isAwuPoolCycleHistoryLoading,
     isAwuPoolCycleHistoryError,
-  } = useAwuPoolCycleHistory({ workspaceId: owner.sId, disabled });
+    isAwuPoolCycleHistoryValidating,
+  } = useAwuPoolCycleHistory({
+    workspaceId: owner.sId,
+    cycleHistoryLimit,
+    disabled,
+  });
 
   return (
     <CreditPoolCardsFromCycleData
@@ -391,6 +462,11 @@ export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
         isAwuPoolCycleHistoryLoading,
         !!isAwuPoolCycleHistoryError
       )}
+      cycleHistoryLimit={cycleHistoryLimit}
+      onLoadMoreCycleHistory={onLoadMoreCycleHistory}
+      isLoadingMoreCycleHistory={
+        isAwuPoolCycleHistoryValidating && !isAwuPoolCycleHistoryLoading
+      }
     />
   );
 }

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -1,6 +1,5 @@
 import { SummaryCard } from "@app/components/workspace/analytics/SummaryCard";
 import { formatConsumptionDate } from "@app/lib/analytics/consumption_period";
-import { ONE_DAY_MS } from "@app/lib/api/analytics/time_utils";
 import { formatCredits } from "@app/lib/client/credits";
 import { MAX_CYCLE_HISTORY_LIMIT } from "@app/lib/credits/awu_purchase_constants";
 import {
@@ -12,6 +11,7 @@ import type {
   AwuPoolCycleBreakdown,
 } from "@app/types/api/credits/awu_pool_summary";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { ONE_DAY_MS } from "@app/types/shared/utils/date_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   AlertCircle,
@@ -142,7 +142,7 @@ export interface CycleHistoryLoadMore {
 
 interface WorkspaceCreditPoolCycleHistoryTableProps {
   cycleBreakdown: AwuPoolCycleBreakdown[];
-  loadMore: CycleHistoryLoadMore;
+  cycleHistoryLoadMore: CycleHistoryLoadMore;
 }
 
 type CycleHistoryRowData = {
@@ -178,7 +178,7 @@ export const CYCLE_HISTORY_LOAD_MORE_COUNT = 5;
 
 export function WorkspaceCreditPoolCycleHistoryTable({
   cycleBreakdown,
-  loadMore,
+  cycleHistoryLoadMore,
 }: WorkspaceCreditPoolCycleHistoryTableProps) {
   if (cycleBreakdown.length === 0) {
     return null;
@@ -200,9 +200,11 @@ export function WorkspaceCreditPoolCycleHistoryTable({
         columns={CYCLE_HISTORY_COLUMNS}
         // The true total is unknown while more cycles remain; once everything
         // is loaded, the total lets the footer hide its control.
-        totalRowCount={loadMore.hasMore ? undefined : cycleBreakdown.length}
-        onLoadMore={loadMore.onLoadMore}
-        isLoadingMore={loadMore.isLoading}
+        totalRowCount={
+          cycleHistoryLoadMore.hasMore ? undefined : cycleBreakdown.length
+        }
+        onLoadMore={cycleHistoryLoadMore.onLoadMore}
+        isLoadingMore={cycleHistoryLoadMore.isLoading}
       />
     </>
   );
@@ -211,7 +213,7 @@ export function WorkspaceCreditPoolCycleHistoryTable({
 interface WorkspaceCreditPoolHistoryProps {
   tableStatus: CreditPoolFetchStatus;
   cycleBreakdown: AwuPoolCycleBreakdown[];
-  loadMore: CycleHistoryLoadMore;
+  cycleHistoryLoadMore: CycleHistoryLoadMore;
 }
 
 // Table area rendered under the value cards. Kept separate so a slow cycle
@@ -219,7 +221,7 @@ interface WorkspaceCreditPoolHistoryProps {
 function WorkspaceCreditPoolHistory({
   tableStatus,
   cycleBreakdown,
-  loadMore,
+  cycleHistoryLoadMore,
 }: WorkspaceCreditPoolHistoryProps) {
   switch (tableStatus) {
     case "error":
@@ -242,7 +244,7 @@ function WorkspaceCreditPoolHistory({
       return (
         <WorkspaceCreditPoolCycleHistoryTable
           cycleBreakdown={cycleBreakdown}
-          loadMore={loadMore}
+          cycleHistoryLoadMore={cycleHistoryLoadMore}
         />
       );
     default:
@@ -312,7 +314,7 @@ export function WorkspaceCreditPoolSection({
           <WorkspaceCreditPoolHistory
             tableStatus={tableStatus}
             cycleBreakdown={cycleBreakdown}
-            loadMore={cycleHistoryLoadMore}
+            cycleHistoryLoadMore={cycleHistoryLoadMore}
           />
         </>
       )}

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -133,11 +133,16 @@ export function WorkspaceCreditUsageValueCards({
   );
 }
 
+// Travels untouched from the data hooks down to the table.
+export interface CycleHistoryLoadMore {
+  hasMore: boolean;
+  isLoading: boolean;
+  onLoadMore: () => void;
+}
+
 interface WorkspaceCreditPoolCycleHistoryTableProps {
   cycleBreakdown: AwuPoolCycleBreakdown[];
-  onLoadMore: () => void;
-  hasMoreCycleHistory: boolean;
-  isLoadingMoreCycleHistory: boolean;
+  loadMore: CycleHistoryLoadMore;
 }
 
 type CycleHistoryRowData = {
@@ -173,9 +178,7 @@ export const CYCLE_HISTORY_LOAD_MORE_COUNT = 5;
 
 export function WorkspaceCreditPoolCycleHistoryTable({
   cycleBreakdown,
-  onLoadMore,
-  hasMoreCycleHistory,
-  isLoadingMoreCycleHistory,
+  loadMore,
 }: WorkspaceCreditPoolCycleHistoryTableProps) {
   if (cycleBreakdown.length === 0) {
     return null;
@@ -197,9 +200,9 @@ export function WorkspaceCreditPoolCycleHistoryTable({
         columns={CYCLE_HISTORY_COLUMNS}
         // The true total is unknown while more cycles remain; once everything
         // is loaded, the total lets the footer hide its control.
-        totalRowCount={hasMoreCycleHistory ? undefined : cycleBreakdown.length}
-        onLoadMore={onLoadMore}
-        isLoadingMore={isLoadingMoreCycleHistory}
+        totalRowCount={loadMore.hasMore ? undefined : cycleBreakdown.length}
+        onLoadMore={loadMore.onLoadMore}
+        isLoadingMore={loadMore.isLoading}
       />
     </>
   );
@@ -208,9 +211,7 @@ export function WorkspaceCreditPoolCycleHistoryTable({
 interface WorkspaceCreditPoolHistoryProps {
   tableStatus: CreditPoolFetchStatus;
   cycleBreakdown: AwuPoolCycleBreakdown[];
-  onLoadMore: () => void;
-  hasMoreCycleHistory: boolean;
-  isLoadingMoreCycleHistory: boolean;
+  loadMore: CycleHistoryLoadMore;
 }
 
 // Table area rendered under the value cards. Kept separate so a slow cycle
@@ -218,9 +219,7 @@ interface WorkspaceCreditPoolHistoryProps {
 function WorkspaceCreditPoolHistory({
   tableStatus,
   cycleBreakdown,
-  onLoadMore,
-  hasMoreCycleHistory,
-  isLoadingMoreCycleHistory,
+  loadMore,
 }: WorkspaceCreditPoolHistoryProps) {
   switch (tableStatus) {
     case "error":
@@ -243,9 +242,7 @@ function WorkspaceCreditPoolHistory({
       return (
         <WorkspaceCreditPoolCycleHistoryTable
           cycleBreakdown={cycleBreakdown}
-          onLoadMore={onLoadMore}
-          hasMoreCycleHistory={hasMoreCycleHistory}
-          isLoadingMoreCycleHistory={isLoadingMoreCycleHistory}
+          loadMore={loadMore}
         />
       );
     default:
@@ -265,9 +262,7 @@ interface WorkspaceCreditPoolSectionProps {
   currentCycleEndMs: number | null;
   cycleBreakdown: AwuPoolCycleBreakdown[];
   programmaticConsumedCredits: number | null;
-  onLoadMoreCycleHistory: () => void;
-  hasMoreCycleHistory: boolean;
-  isLoadingMoreCycleHistory: boolean;
+  cycleHistoryLoadMore: CycleHistoryLoadMore;
 }
 
 export function WorkspaceCreditPoolSection({
@@ -281,9 +276,7 @@ export function WorkspaceCreditPoolSection({
   currentCycleEndMs,
   cycleBreakdown,
   programmaticConsumedCredits,
-  onLoadMoreCycleHistory,
-  hasMoreCycleHistory,
-  isLoadingMoreCycleHistory,
+  cycleHistoryLoadMore,
 }: WorkspaceCreditPoolSectionProps) {
   if (cardsStatus === "ready" && !isVisible) {
     return null;
@@ -319,9 +312,7 @@ export function WorkspaceCreditPoolSection({
           <WorkspaceCreditPoolHistory
             tableStatus={tableStatus}
             cycleBreakdown={cycleBreakdown}
-            onLoadMore={onLoadMoreCycleHistory}
-            hasMoreCycleHistory={hasMoreCycleHistory}
-            isLoadingMoreCycleHistory={isLoadingMoreCycleHistory}
+            loadMore={cycleHistoryLoadMore}
           />
         </>
       )}
@@ -353,9 +344,7 @@ interface CreditPoolCardsFromCycleDataProps {
   poolCycleBreakdown: AwuPoolCycleBreakdown[];
   excessCycleBreakdown: AwuPoolCycleBreakdown[];
   tableStatus: CreditPoolFetchStatus;
-  hasMoreCycleHistory: boolean;
-  onLoadMoreCycleHistory: () => void;
-  isLoadingMoreCycleHistory: boolean;
+  cycleHistoryLoadMore: CycleHistoryLoadMore;
 }
 export function CreditPoolCardsFromCycleData({
   awuPoolCurrentCycle,
@@ -363,9 +352,7 @@ export function CreditPoolCardsFromCycleData({
   poolCycleBreakdown,
   excessCycleBreakdown,
   tableStatus,
-  hasMoreCycleHistory,
-  onLoadMoreCycleHistory,
-  isLoadingMoreCycleHistory,
+  cycleHistoryLoadMore,
 }: CreditPoolCardsFromCycleDataProps) {
   const {
     totalRemainingCredits,
@@ -403,9 +390,7 @@ export function CreditPoolCardsFromCycleData({
       currentCycleEndMs={currentCycleEndMs}
       cycleBreakdown={hasPool ? poolCycleBreakdown : excessCycleBreakdown}
       programmaticConsumedCredits={programmaticConsumedCredits}
-      onLoadMoreCycleHistory={onLoadMoreCycleHistory}
-      hasMoreCycleHistory={hasMoreCycleHistory}
-      isLoadingMoreCycleHistory={isLoadingMoreCycleHistory}
+      cycleHistoryLoadMore={cycleHistoryLoadMore}
     />
   );
 }
@@ -447,11 +432,12 @@ export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
         isAwuPoolCycleHistoryLoading,
         !!isAwuPoolCycleHistoryError
       )}
-      hasMoreCycleHistory={hasMoreCycleHistory}
-      onLoadMoreCycleHistory={onLoadMoreCycleHistory}
-      isLoadingMoreCycleHistory={
-        isAwuPoolCycleHistoryValidating && !isAwuPoolCycleHistoryLoading
-      }
+      cycleHistoryLoadMore={{
+        hasMore: hasMoreCycleHistory,
+        isLoading:
+          isAwuPoolCycleHistoryValidating && !isAwuPoolCycleHistoryLoading,
+        onLoadMore: onLoadMoreCycleHistory,
+      }}
     />
   );
 }

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -21,6 +21,7 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
+import { useState } from "react";
 
 export type CreditPoolFetchStatus = "loading" | "error" | "ready";
 
@@ -163,23 +164,41 @@ const CYCLE_HISTORY_COLUMNS: ColumnDef<CycleHistoryRowData, string>[] = [
   },
 ];
 
+const INITIAL_CYCLE_HISTORY_ROW_COUNT = 2;
+const CYCLE_HISTORY_LOAD_MORE_COUNT = 5;
+
 export function WorkspaceCreditPoolCycleHistoryTable({
   cycleBreakdown,
 }: WorkspaceCreditPoolCycleHistoryTableProps) {
+  const [visibleRowCount, setVisibleRowCount] = useState(
+    INITIAL_CYCLE_HISTORY_ROW_COUNT
+  );
+
   if (cycleBreakdown.length === 0) {
     return null;
   }
-  const rows: CycleHistoryRowData[] = cycleBreakdown.map((cycle) => ({
-    cycle:
-      cycle.cycleStartMs && cycle.cycleEndMs
-        ? `${formatConsumptionDate(cycle.cycleStartMs)} – ${formatConsumptionDate(cycle.cycleEndMs)}`
-        : "Unknown cycle",
-    consumedCredits: formatCredits(Math.round(cycle.consumedCredits)),
-  }));
+
+  const rows: CycleHistoryRowData[] = cycleBreakdown
+    .slice(0, visibleRowCount)
+    .map((cycle) => ({
+      cycle:
+        cycle.cycleStartMs && cycle.cycleEndMs
+          ? `${formatConsumptionDate(cycle.cycleStartMs)} – ${formatConsumptionDate(cycle.cycleEndMs)}`
+          : "Unknown cycle",
+      consumedCredits: formatCredits(Math.round(cycle.consumedCredits)),
+    }));
+
   return (
     <>
       <Page.H variant="h5">Previous cycles</Page.H>
-      <DataTable data={rows} columns={CYCLE_HISTORY_COLUMNS} />
+      <DataTable
+        data={rows}
+        columns={CYCLE_HISTORY_COLUMNS}
+        totalRowCount={cycleBreakdown.length}
+        onLoadMore={() =>
+          setVisibleRowCount((count) => count + CYCLE_HISTORY_LOAD_MORE_COUNT)
+        }
+      />
     </>
   );
 }

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -195,8 +195,9 @@ export function WorkspaceCreditPoolCycleHistoryTable({
       <DataTable
         data={rows}
         columns={CYCLE_HISTORY_COLUMNS}
-        totalRowCount={cycleBreakdown.length}
-        rowCountIsCapped={hasMoreCycleHistory}
+        // The true total is unknown while more cycles remain; once everything
+        // is loaded, the total lets the footer hide its control.
+        totalRowCount={hasMoreCycleHistory ? undefined : cycleBreakdown.length}
         onLoadMore={onLoadMore}
         isLoadingMore={isLoadingMoreCycleHistory}
       />
@@ -346,26 +347,13 @@ export function useCycleHistoryLimit() {
   return { cycleHistoryLimit, onLoadMoreCycleHistory };
 }
 
-// A fetched count matching the requested limit means the backend may be
-// truncating rather than reporting the true total, so there could be more
-// left to reveal — unless the limit is already at the backend's own cap.
-export function computeHasMoreCycleHistory(
-  fetchedCount: number,
-  cycleHistoryLimit: number
-): boolean {
-  return (
-    fetchedCount === cycleHistoryLimit &&
-    cycleHistoryLimit < MAX_CYCLE_HISTORY_LIMIT
-  );
-}
-
 interface CreditPoolCardsFromCycleDataProps {
   awuPoolCurrentCycle: AwuPoolCurrentCycleResponseBody | null;
   cardsStatus: CreditPoolFetchStatus;
   poolCycleBreakdown: AwuPoolCycleBreakdown[];
   excessCycleBreakdown: AwuPoolCycleBreakdown[];
   tableStatus: CreditPoolFetchStatus;
-  cycleHistoryLimit: number;
+  hasMoreCycleHistory: boolean;
   onLoadMoreCycleHistory: () => void;
   isLoadingMoreCycleHistory: boolean;
 }
@@ -375,7 +363,7 @@ export function CreditPoolCardsFromCycleData({
   poolCycleBreakdown,
   excessCycleBreakdown,
   tableStatus,
-  cycleHistoryLimit,
+  hasMoreCycleHistory,
   onLoadMoreCycleHistory,
   isLoadingMoreCycleHistory,
 }: CreditPoolCardsFromCycleDataProps) {
@@ -400,7 +388,6 @@ export function CreditPoolCardsFromCycleData({
   const hasPool = totalActiveCredits > 0;
   const hasExcessData =
     excessConsumedCredits !== null || excessCycleBreakdown.length > 0;
-  const cycleBreakdown = hasPool ? poolCycleBreakdown : excessCycleBreakdown;
 
   return (
     <WorkspaceCreditPoolSection
@@ -414,13 +401,10 @@ export function CreditPoolCardsFromCycleData({
       }
       currentCycleStartMs={currentCycleStartMs}
       currentCycleEndMs={currentCycleEndMs}
-      cycleBreakdown={cycleBreakdown}
+      cycleBreakdown={hasPool ? poolCycleBreakdown : excessCycleBreakdown}
       programmaticConsumedCredits={programmaticConsumedCredits}
       onLoadMoreCycleHistory={onLoadMoreCycleHistory}
-      hasMoreCycleHistory={computeHasMoreCycleHistory(
-        cycleBreakdown.length,
-        cycleHistoryLimit
-      )}
+      hasMoreCycleHistory={hasMoreCycleHistory}
       isLoadingMoreCycleHistory={isLoadingMoreCycleHistory}
     />
   );
@@ -440,6 +424,7 @@ export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
   const {
     cycleBreakdown: poolCycleBreakdown,
     excessCycleBreakdown,
+    hasMoreCycleHistory,
     isAwuPoolCycleHistoryLoading,
     isAwuPoolCycleHistoryError,
     isAwuPoolCycleHistoryValidating,
@@ -462,7 +447,7 @@ export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
         isAwuPoolCycleHistoryLoading,
         !!isAwuPoolCycleHistoryError
       )}
-      cycleHistoryLimit={cycleHistoryLimit}
+      hasMoreCycleHistory={hasMoreCycleHistory}
       onLoadMoreCycleHistory={onLoadMoreCycleHistory}
       isLoadingMoreCycleHistory={
         isAwuPoolCycleHistoryValidating && !isAwuPoolCycleHistoryLoading

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -3,6 +3,7 @@ import {
   resolveMetronomeCycle,
 } from "@app/lib/api/credits/members_usage";
 import type { Authenticator } from "@app/lib/auth";
+import { MAX_CYCLE_HISTORY_LIMIT } from "@app/lib/credits/awu_purchase_constants";
 import { amountCents } from "@app/lib/metronome/amounts";
 import {
   listMetronomeBalances,
@@ -41,7 +42,6 @@ import type { Invoice } from "@metronome/sdk/resources/v1/customers";
 import { z } from "zod";
 
 export const DEFAULT_CYCLE_HISTORY_LIMIT = 5;
-export const MAX_CYCLE_HISTORY_LIMIT = 24;
 
 /**
  * @cc [owner:arthurvervaet,label:api] cycle-history-limit-bounds

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -40,9 +40,15 @@ import type { LightWorkspaceType } from "@app/types/user";
 import type { Invoice } from "@metronome/sdk/resources/v1/customers";
 import { z } from "zod";
 
-const DEFAULT_CYCLE_HISTORY_LIMIT = 5;
-const MAX_CYCLE_HISTORY_LIMIT = 24;
+export const DEFAULT_CYCLE_HISTORY_LIMIT = 5;
+export const MAX_CYCLE_HISTORY_LIMIT = 24;
 
+/**
+ * @cc [owner:arthurvervaet,label:api] cycle-history-limit-clamp
+ * `cycleHistoryLimit` MUST be clamped to at most `MAX_CYCLE_HISTORY_LIMIT`: callers cannot
+ * request more cycles than that, and an out-of-range value falls back to
+ * `DEFAULT_CYCLE_HISTORY_LIMIT` rather than erroring.
+ */
 export const AwuPoolSummaryQuerySchema = z.object({
   cycleHistoryLimit: z.coerce
     .number()

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -44,10 +44,10 @@ export const DEFAULT_CYCLE_HISTORY_LIMIT = 5;
 export const MAX_CYCLE_HISTORY_LIMIT = 24;
 
 /**
- * @cc [owner:arthurvervaet,label:api] cycle-history-limit-clamp
- * `cycleHistoryLimit` MUST be clamped to at most `MAX_CYCLE_HISTORY_LIMIT`: callers cannot
- * request more cycles than that, and an out-of-range value falls back to
- * `DEFAULT_CYCLE_HISTORY_LIMIT` rather than erroring.
+ * @cc [owner:arthurvervaet,label:api] cycle-history-limit-bounds
+ * A missing, non-integer, or out-of-range `cycleHistoryLimit` (below 1 or above
+ * `MAX_CYCLE_HISTORY_LIMIT`) MUST resolve to `DEFAULT_CYCLE_HISTORY_LIMIT` rather than being
+ * clamped or rejected, so no caller can ever obtain more than `MAX_CYCLE_HISTORY_LIMIT` cycles.
  */
 export const AwuPoolSummaryQuerySchema = z.object({
   cycleHistoryLimit: z.coerce
@@ -366,7 +366,7 @@ function cacheResolverKeyWithHistoryLimit(
   return `${workspaceId}-${cycleHistoryLimit}`;
 }
 
-const AWU_POOL_CYCLE_HISTORY_CACHE_ID = "awuPoolCycleHistory";
+const AWU_POOL_CYCLE_HISTORY_CACHE_ID = "awuPoolCycleHistoryV2";
 const AWU_POOL_CYCLE_HISTORY_CACHE_TTL_MS = 60 * 1000;
 
 const getCachedAwuPoolCycleHistoryOutcome = cacheWithRedis(
@@ -413,7 +413,7 @@ async function getAwuPoolCycleHistoryUncached(
   const [poolLedgerDataResult, finalizedInvoicesResult] = await Promise.all([
     getPoolLedgerData({ metronomeCustomerId, cycleHistoryLimit }),
     listMetronomeFinalizedInvoices(metronomeCustomerId, {
-      limit: cycleHistoryLimit,
+      limit: cycleHistoryLimit + 1,
     }),
   ]);
 
@@ -431,20 +431,35 @@ async function getAwuPoolCycleHistoryUncached(
       },
       "[AwuPoolSummary] Failed to compute cycle breakdown"
     );
-    return new Ok({ cycleBreakdown: [], excessCycleBreakdown: [] });
+    return new Ok({
+      cycleBreakdown: [],
+      excessCycleBreakdown: [],
+      hasMoreCycleHistory: false,
+    });
   }
 
+  // One invoice past the limit is fetched only to learn whether older cycles
+  // exist; it is never surfaced. Row counts cannot answer this because cycles
+  // without consumption are filtered out of the breakdowns.
+  const finalizedInvoices = finalizedInvoicesResult.value.slice(
+    0,
+    cycleHistoryLimit
+  );
+  const hasMoreCycleHistory =
+    finalizedInvoicesResult.value.length > cycleHistoryLimit &&
+    cycleHistoryLimit < MAX_CYCLE_HISTORY_LIMIT;
+
   const cycleBreakdown = computeCycleBreakdown({
-    finalizedInvoices: finalizedInvoicesResult.value,
+    finalizedInvoices,
     ledgerEntries: poolLedgerDataResult.value.ledgerEntries,
     cycleHistoryLimit,
   });
   const excessCycleBreakdown = computeExcessCycleBreakdown(
-    finalizedInvoicesResult.value,
+    finalizedInvoices,
     cycleHistoryLimit
   );
 
-  return new Ok({ cycleBreakdown, excessCycleBreakdown });
+  return new Ok({ cycleBreakdown, excessCycleBreakdown, hasMoreCycleHistory });
 }
 
 export async function getAwuPoolSummary(

--- a/front/lib/credits/awu_purchase_constants.ts
+++ b/front/lib/credits/awu_purchase_constants.ts
@@ -6,3 +6,5 @@ export const MIN_AWU_PURCHASE_CREDITS = 100;
 // own economics (sold at a fixed per-credit rate), so the programmatic
 // `MAX_DISCOUNT_PERCENT` (derived from token-pricing markup) does not apply.
 export const MAX_AWU_DISCOUNT_PERCENT = 15;
+
+export const MAX_CYCLE_HISTORY_LIMIT = 24;

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -7,6 +7,7 @@ import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
   AwuPoolCurrentCycleResponseBody,
+  AwuPoolCycleBreakdown,
   AwuPoolCycleHistoryResponseBody,
   AwuPoolSummaryResponseBody,
 } from "@app/types/api/credits/awu_pool_summary";
@@ -312,10 +313,18 @@ export function useAwuPoolCycleHistory({
     { disabled, keepPreviousData: true }
   );
 
+  const isUsable = !error && !disabled;
+
   return {
-    cycleBreakdown: data?.cycleBreakdown ?? emptyArray(),
-    excessCycleBreakdown: data?.excessCycleBreakdown ?? emptyArray(),
-    hasMoreCycleHistory: data?.hasMoreCycleHistory ?? false,
+    cycleBreakdown: isUsable
+      ? (data?.cycleBreakdown ?? emptyArray<AwuPoolCycleBreakdown>())
+      : emptyArray<AwuPoolCycleBreakdown>(),
+    excessCycleBreakdown: isUsable
+      ? (data?.excessCycleBreakdown ?? emptyArray<AwuPoolCycleBreakdown>())
+      : emptyArray<AwuPoolCycleBreakdown>(),
+    hasMoreCycleHistory: isUsable
+      ? (data?.hasMoreCycleHistory ?? false)
+      : false,
     isAwuPoolCycleHistoryLoading: !error && !data && !disabled,
     isAwuPoolCycleHistoryError: error,
     isAwuPoolCycleHistoryValidating: isValidating,

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -307,12 +307,15 @@ export function useAwuPoolCycleHistory({
       cycleHistoryLimit ? `?cycleHistoryLimit=${cycleHistoryLimit}` : ""
     }`,
     awuFetcher,
-    { disabled }
+    // Keep rows on screen while a larger limit is fetched so "Load more"
+    // appends instead of swapping the table for a spinner.
+    { disabled, keepPreviousData: true }
   );
 
   return {
     cycleBreakdown: data?.cycleBreakdown ?? emptyArray(),
     excessCycleBreakdown: data?.excessCycleBreakdown ?? emptyArray(),
+    hasMoreCycleHistory: data?.hasMoreCycleHistory ?? false,
     isAwuPoolCycleHistoryLoading: !error && !data && !disabled,
     isAwuPoolCycleHistoryError: error,
     isAwuPoolCycleHistoryValidating: isValidating,

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -292,16 +292,20 @@ export function useAwuPoolCurrentCycle({
 
 export function useAwuPoolCycleHistory({
   workspaceId,
+  cycleHistoryLimit,
   disabled,
 }: {
   workspaceId: string;
+  cycleHistoryLimit?: number;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
   const awuFetcher: Fetcher<AwuPoolCycleHistoryResponseBody> = fetcher;
 
   const { data, error, isValidating, mutate } = useSWRWithDefaults(
-    `/api/w/${workspaceId}/credits/awu-pool-cycle-history`,
+    `/api/w/${workspaceId}/credits/awu-pool-cycle-history${
+      cycleHistoryLimit ? `?cycleHistoryLimit=${cycleHistoryLimit}` : ""
+    }`,
     awuFetcher,
     { disabled }
   );

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -196,13 +196,16 @@ export function usePokeAwuPoolCurrentCycle({
 
 export function usePokeAwuPoolCycleHistory({
   owner,
+  cycleHistoryLimit,
   disabled,
-}: PokeConditionalFetchProps) {
+}: PokeConditionalFetchProps & { cycleHistoryLimit?: number }) {
   const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<AwuPoolCycleHistoryResponseBody> = fetcher;
 
   const { data, error, isValidating, mutate } = useSWRWithDefaults(
-    `/api/poke/workspaces/${owner.sId}/credits/awu-pool-cycle-history`,
+    `/api/poke/workspaces/${owner.sId}/credits/awu-pool-cycle-history${
+      cycleHistoryLimit ? `?cycleHistoryLimit=${cycleHistoryLimit}` : ""
+    }`,
     fetcherFn,
     { disabled }
   );

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -13,6 +13,7 @@ import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type {
   AwuPoolCurrentCycleResponseBody,
+  AwuPoolCycleBreakdown,
   AwuPoolCycleHistoryResponseBody,
   AwuPoolSummaryResponseBody,
 } from "@app/types/api/credits/awu_pool_summary";
@@ -212,10 +213,18 @@ export function usePokeAwuPoolCycleHistory({
     { disabled, keepPreviousData: true }
   );
 
+  const isUsable = !error && !disabled;
+
   return {
-    cycleBreakdown: data?.cycleBreakdown ?? emptyArray(),
-    excessCycleBreakdown: data?.excessCycleBreakdown ?? emptyArray(),
-    hasMoreCycleHistory: data?.hasMoreCycleHistory ?? false,
+    cycleBreakdown: isUsable
+      ? (data?.cycleBreakdown ?? emptyArray<AwuPoolCycleBreakdown>())
+      : emptyArray<AwuPoolCycleBreakdown>(),
+    excessCycleBreakdown: isUsable
+      ? (data?.excessCycleBreakdown ?? emptyArray<AwuPoolCycleBreakdown>())
+      : emptyArray<AwuPoolCycleBreakdown>(),
+    hasMoreCycleHistory: isUsable
+      ? (data?.hasMoreCycleHistory ?? false)
+      : false,
     isAwuPoolCycleHistoryLoading: !error && !data && !disabled,
     isAwuPoolCycleHistoryError: error,
     isAwuPoolCycleHistoryValidating: isValidating,

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -207,12 +207,15 @@ export function usePokeAwuPoolCycleHistory({
       cycleHistoryLimit ? `?cycleHistoryLimit=${cycleHistoryLimit}` : ""
     }`,
     fetcherFn,
-    { disabled }
+    // Keep rows on screen while a larger limit is fetched so "Load more"
+    // appends instead of swapping the table for a spinner.
+    { disabled, keepPreviousData: true }
   );
 
   return {
     cycleBreakdown: data?.cycleBreakdown ?? emptyArray(),
     excessCycleBreakdown: data?.excessCycleBreakdown ?? emptyArray(),
+    hasMoreCycleHistory: data?.hasMoreCycleHistory ?? false,
     isAwuPoolCycleHistoryLoading: !error && !data && !disabled,
     isAwuPoolCycleHistoryError: error,
     isAwuPoolCycleHistoryValidating: isValidating,

--- a/front/types/api/credits/awu_pool_summary.ts
+++ b/front/types/api/credits/awu_pool_summary.ts
@@ -33,6 +33,8 @@ export type AwuPoolCycleHistoryResponseBody = {
   // Per-cycle pool consumption, most recent first
   cycleBreakdown: AwuPoolCycleBreakdown[];
   excessCycleBreakdown: AwuPoolCycleBreakdown[];
+  // Whether older cycles exist beyond the requested limit
+  hasMoreCycleHistory: boolean;
 };
 
 export type AwuPoolSummaryResponseBody = AwuPoolCurrentCycleResponseBody &

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -148,14 +148,6 @@ interface DataTableProps<TData extends TBaseData> {
   disableRowClickSelection?: boolean;
 }
 
-/**
- * A tabular data display built on TanStack Table, with text filtering, client-
- * or server-side sorting, pagination, and row selection, rendered with the
- * DataTable.* cell helpers. Use it to list structured records (data sources,
- * members, files); for very long or infinite server-side datasets, prefer
- * ScrollableDataTable, which virtualizes rows and supports onLoadMore.
- * @summary Sortable, filterable, paginated data table.
- */
 const ROW_REVEAL_DURATION_MS = 300;
 
 /**
@@ -241,6 +233,15 @@ function useRowRevealAnimation(rowCount: number, enabled: boolean) {
   return ref;
 }
 
+/**
+ * A tabular data display built on TanStack Table, with text filtering, client-
+ * or server-side sorting, pagination or a "Load more" footer, and row
+ * selection, rendered with the DataTable.* cell helpers. Use it to list
+ * structured records (data sources, members, files); for very long or infinite
+ * server-side datasets, prefer ScrollableDataTable, which virtualizes rows and
+ * loads more on scroll.
+ * @summary Sortable, filterable, paginated data table.
+ */
 export function DataTable<TData extends TBaseData>({
   data,
   totalRowCount,


### PR DESCRIPTION
## Description

Brings in DataTable's onLoadMore/LoadMore footer from sparkle PR #32166 and uses it on the previous-cycles table (shared by the poke pool-usage page and the workspace usage page): show 2 cycles initially, reveal 5 more per click.
<img width="1101" height="213" alt="Capture d’écran 2026-09-10 à 09 30 46" src="https://github.com/user-attachments/assets/33f59e32-e403-4cc2-8092-9c4b4555bb43" />
<img width="1084" height="346" alt="Capture d’écran 2026-09-10 à 09 30 54" src="https://github.com/user-attachments/assets/8b97ef91-f4ae-42ff-bab0-200e6e670ba1" />

## Tests

tested on front-edge

## Risk

Low

## Deploy Plan

Deploy front
