### PR TITLE
[connectors] Salesforce: return authorization error from retrievePermissions on expired token

### DIFF
--- a/connectors/src/api/get_connector_permissions.test.ts
+++ b/connectors/src/api/get_connector_permissions.test.ts
@@ -1,0 +1,76 @@
+import type { Server } from "node:http";
+
+import { ConnectorManagerError } from "@connectors/connectors/interface";
+import { Err } from "@dust-tt/client";
+import express from "express";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { getConnectorPermissionsAPIHandler } from "./get_connector_permissions";
+
+const mocks = vi.hoisted(() => ({
+  fetchById: vi.fn(),
+  retrievePermissions: vi.fn(),
+}));
+
+vi.mock("@connectors/connectors", () => ({
+  getConnectorManager: () => ({
+    retrievePermissions: mocks.retrievePermissions,
+  }),
+}));
+
+vi.mock("@connectors/resources/connector_resource", () => ({
+  ConnectorResource: {
+    fetchById: mocks.fetchById,
+  },
+}));
+
+describe("GET /connectors/:connector_id/permissions", () => {
+  let server: Server;
+  let baseUrl = "";
+
+  beforeAll(async () => {
+    const app = express();
+    app.get(
+      "/connectors/:connector_id/permissions",
+      getConnectorPermissionsAPIHandler
+    );
+    server = app.listen(0);
+    await new Promise<void>((resolve) => server.once("listening", resolve));
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected the test server to listen on a TCP port");
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve()))
+    );
+  });
+
+  it("returns 401 connector_authorization_error on EXTERNAL_OAUTH_TOKEN_ERROR", async () => {
+    mocks.fetchById.mockResolvedValue({ id: 1, type: "salesforce" });
+    mocks.retrievePermissions.mockResolvedValue(
+      new Err(
+        new ConnectorManagerError(
+          "EXTERNAL_OAUTH_TOKEN_ERROR",
+          "Authorization error, please re-authorize."
+        )
+      )
+    );
+
+    const response = await fetch(
+      `${baseUrl}/connectors/1/permissions?viewType=document&filterPermission=read`
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "connector_authorization_error",
+        message: "Authorization error, please re-authorize.",
+      },
+    });
+  });
+});

--- a/connectors/src/connectors/salesforce/index.test.ts
+++ b/connectors/src/connectors/salesforce/index.test.ts
@@ -1,0 +1,148 @@
+import { ConnectorManagerError } from "@connectors/connectors/interface";
+import { ExternalOAuthTokenError } from "@connectors/lib/error";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
+import { Err, Ok } from "@dust-tt/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  SALESFORCE_AUTHORIZATION_ERROR_MESSAGE,
+  SalesforceConnectorManager,
+} from "./index";
+
+const mocks = vi.hoisted(() => ({
+  fetchByConnector: vi.fn(),
+  getConnectorAndCredentials: vi.fn(),
+  getSalesforceConnection: vi.fn(),
+}));
+
+vi.mock(
+  "@connectors/connectors/salesforce/lib/utils",
+  async (importOriginal) => {
+    const mod =
+      await importOriginal<
+        typeof import("@connectors/connectors/salesforce/lib/utils")
+      >();
+    return {
+      ...mod,
+      getConnectorAndCredentials: mocks.getConnectorAndCredentials,
+    };
+  }
+);
+
+vi.mock("@connectors/connectors/salesforce/lib/salesforce_api", () => ({
+  getSalesforceConnection: mocks.getSalesforceConnection,
+  testSalesforceConnection: vi.fn(),
+}));
+
+vi.mock("@connectors/connectors/salesforce/temporal/client", () => ({
+  launchSalesforceSyncWorkflow: vi.fn(),
+  stopSalesforceSyncQueryWorkflow: vi.fn(),
+  stopSalesforceSyncWorkflow: vi.fn(),
+}));
+
+vi.mock("@connectors/resources/salesforce_resources", () => ({
+  SalesforceSyncedQueryResource: {
+    fetchByConnector: mocks.fetchByConnector,
+  },
+}));
+
+const connector = { id: 42 };
+const credentials = {
+  accessToken: "access-token",
+  instanceUrl: "https://example.my.salesforce.com",
+};
+
+describe("SalesforceConnectorManager.retrievePermissions", () => {
+  const manager = new SalesforceConnectorManager(connector.id);
+
+  beforeEach(() => {
+    mocks.getConnectorAndCredentials.mockResolvedValue(
+      new Ok({ connector, credentials })
+    );
+    mocks.getSalesforceConnection.mockResolvedValue(new Ok({}));
+    mocks.fetchByConnector.mockResolvedValue([]);
+  });
+
+  it("returns EXTERNAL_OAUTH_TOKEN_ERROR with the provider message when credentials retrieval throws ExternalOAuthTokenError", async () => {
+    const providerMessage =
+      "Error retrieving access token from salesforce: code=provider_access_token_refresh_error " +
+      "message=invalid_grant token validity expired";
+    mocks.getConnectorAndCredentials.mockRejectedValue(
+      new ExternalOAuthTokenError(new Error(providerMessage))
+    );
+
+    const res = await manager.retrievePermissions();
+
+    expect(res.isErr()).toBe(true);
+    if (res.isErr()) {
+      expect(res.error).toBeInstanceOf(ConnectorManagerError);
+      expect(res.error.code).toBe("EXTERNAL_OAUTH_TOKEN_ERROR");
+      expect(res.error.message).toBe(
+        `${SALESFORCE_AUTHORIZATION_ERROR_MESSAGE} Error: ${providerMessage}`
+      );
+    }
+    expect(mocks.getSalesforceConnection).not.toHaveBeenCalled();
+  });
+
+  it("rethrows unknown errors unchanged", async () => {
+    const error = new Error("Connector 42 not found");
+    mocks.getConnectorAndCredentials.mockRejectedValue(error);
+
+    await expect(manager.retrievePermissions()).rejects.toBe(error);
+  });
+
+  it("returns the error returned by getConnectorAndCredentials", async () => {
+    const error = new ConnectorManagerError(
+      "EXTERNAL_OAUTH_TOKEN_ERROR",
+      "Invalid credentials"
+    );
+    mocks.getConnectorAndCredentials.mockResolvedValue(new Err(error));
+
+    const res = await manager.retrievePermissions();
+
+    expect(res.isErr()).toBe(true);
+    if (res.isErr()) {
+      expect(res.error).toBe(error);
+    }
+  });
+
+  it("returns EXTERNAL_OAUTH_TOKEN_ERROR when the Salesforce connection fails", async () => {
+    mocks.getSalesforceConnection.mockResolvedValue(
+      new Err(new Error("connection failed"))
+    );
+
+    const res = await manager.retrievePermissions();
+
+    expect(res.isErr()).toBe(true);
+    if (res.isErr()) {
+      expect(res.error.code).toBe("EXTERNAL_OAUTH_TOKEN_ERROR");
+      expect(res.error.message).toBe(SALESFORCE_AUTHORIZATION_ERROR_MESSAGE);
+    }
+  });
+
+  it("returns one folder node per synced query", async () => {
+    mocks.fetchByConnector.mockResolvedValue([
+      { id: 7, rootNodeName: "Opportunities" },
+    ]);
+
+    const res = await manager.retrievePermissions();
+
+    expect(res.isOk()).toBe(true);
+    if (res.isOk()) {
+      expect(res.value).toEqual([
+        {
+          internalId: "salesforce-synced-query-42-7",
+          parentInternalId: null,
+          type: "folder",
+          title: "[Synced Query] Opportunities",
+          sourceUrl: null,
+          expandable: false,
+          preventSelection: true,
+          permission: "read",
+          lastUpdatedAt: null,
+          mimeType: INTERNAL_MIME_TYPES.SALESFORCE.SYNCED_QUERY_FOLDER,
+        },
+      ]);
+    }
+  });
+});

--- a/connectors/src/connectors/salesforce/index.ts
+++ b/connectors/src/connectors/salesforce/index.ts
@@ -19,6 +19,7 @@ import {
   stopSalesforceSyncWorkflow,
 } from "@connectors/connectors/salesforce/temporal/client";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SalesforceSyncedQueryResource } from "@connectors/resources/salesforce_resources";
@@ -30,6 +31,9 @@ import { Err, Ok } from "@dust-tt/client";
 const logger = mainLogger.child({
   connector: "salesforce",
 });
+
+export const SALESFORCE_AUTHORIZATION_ERROR_MESSAGE =
+  "Salesforce authorization error, please re-authorize.";
 
 export class SalesforceConnectorManager extends BaseConnectorManager<null> {
   readonly provider: ConnectorProvider = "salesforce";
@@ -217,16 +221,36 @@ export class SalesforceConnectorManager extends BaseConnectorManager<null> {
   }
 
   /**
-   * For Salesforce the tree is:
-   * Project > Standard Objects & Custom Objects > Objects.
+   * Salesforce only exposes one flat level of folders: one per synced query, managed by Dust.
+   */
+  /**
+   * @cc [owner:smb2268,label:error-handling] oauth-error-as-result
+   * When credential retrieval throws `ExternalOAuthTokenError`, this method MUST return
+   * `Err(ConnectorManagerError("EXTERNAL_OAUTH_TOKEN_ERROR"))` instead of propagating the exception.
+   * Any other thrown error MUST be rethrown unchanged.
    */
   async retrievePermissions(): Promise<
     Result<ContentNode[], ConnectorManagerError<RetrievePermissionsErrorCode>>
   > {
     // Get connector and credentials.
-    const getConnectorAndCredentialsRes = await getConnectorAndCredentials(
-      this.connectorId
-    );
+    let getConnectorAndCredentialsRes: Awaited<
+      ReturnType<typeof getConnectorAndCredentials>
+    >;
+    try {
+      getConnectorAndCredentialsRes = await getConnectorAndCredentials(
+        this.connectorId
+      );
+    } catch (e) {
+      if (e instanceof ExternalOAuthTokenError) {
+        return new Err(
+          new ConnectorManagerError(
+            "EXTERNAL_OAUTH_TOKEN_ERROR",
+            `${SALESFORCE_AUTHORIZATION_ERROR_MESSAGE} Error: ${e.message}`
+          )
+        );
+      }
+      throw e;
+    }
     if (getConnectorAndCredentialsRes.isErr()) {
       return new Err(getConnectorAndCredentialsRes.error);
     }
@@ -238,7 +262,7 @@ export class SalesforceConnectorManager extends BaseConnectorManager<null> {
       return new Err(
         new ConnectorManagerError(
           "EXTERNAL_OAUTH_TOKEN_ERROR",
-          "Salesforce authorization error, please re-authorize."
+          SALESFORCE_AUTHORIZATION_ERROR_MESSAGE
         )
       );
     }

--- a/connectors/src/connectors/salesforce/index.ts
+++ b/connectors/src/connectors/salesforce/index.ts
@@ -223,12 +223,6 @@ export class SalesforceConnectorManager extends BaseConnectorManager<null> {
   /**
    * Salesforce only exposes one flat level of folders: one per synced query, managed by Dust.
    */
-  /**
-   * @cc [owner:smb2268,label:error-handling] oauth-error-as-result
-   * When credential retrieval throws `ExternalOAuthTokenError`, this method MUST return
-   * `Err(ConnectorManagerError("EXTERNAL_OAUTH_TOKEN_ERROR"))` instead of propagating the exception.
-   * Any other thrown error MUST be rethrown unchanged.
-   */
   async retrievePermissions(): Promise<
     Result<ContentNode[], ConnectorManagerError<RetrievePermissionsErrorCode>>
   > {
@@ -249,6 +243,7 @@ export class SalesforceConnectorManager extends BaseConnectorManager<null> {
           )
         );
       }
+      // Unhandled error, throwing to get a 500.
       throw e;
     }
     if (getConnectorAndCredentialsRes.isErr()) {

--- a/connectors/src/connectors/salesforce/lib/oauth.ts
+++ b/connectors/src/connectors/salesforce/lib/oauth.ts
@@ -10,6 +10,14 @@ export type SalesforceAPICredentials = {
   instanceUrl: string;
 };
 
+/**
+ * @cc [owner:smb2268,label:error-handling] salesforce-sign-in-error-throws
+ * Under the exception in `no-catching-own-errors`, this function MUST throw `ExternalOAuthTokenError`
+ * when the Salesforce token refresh fails with a sign-in error (`invalid_grant`,
+ * `oauth_flow_disabled`, `app_not_found`) so that Temporal activities stop instead of retrying.
+ * Callers at API boundaries MAY catch it with `instanceof ExternalOAuthTokenError`. Other failures
+ * MUST propagate unchanged.
+ */
 export async function getSalesforceCredentials(
   connectionId: string
 ): Promise<Result<SalesforceAPICredentials, Error>> {
@@ -29,7 +37,6 @@ export async function getSalesforceCredentials(
 
     return new Ok({ accessToken, instanceUrl });
   } catch (e: unknown) {
-    // So that will be catched upstream by ActivityInboundLogInterceptor and stop the workflow.
     if (isSalesforceSignInError(e)) {
       throw new ExternalOAuthTokenError(e);
     }

--- a/connectors/src/connectors/salesforce/lib/oauth.ts
+++ b/connectors/src/connectors/salesforce/lib/oauth.ts
@@ -10,14 +10,6 @@ export type SalesforceAPICredentials = {
   instanceUrl: string;
 };
 
-/**
- * @cc [owner:smb2268,label:error-handling] salesforce-sign-in-error-throws
- * Under the exception in `no-catching-own-errors`, this function MUST throw `ExternalOAuthTokenError`
- * when the Salesforce token refresh fails with a sign-in error (`invalid_grant`,
- * `oauth_flow_disabled`, `app_not_found`) so that Temporal activities stop instead of retrying.
- * Callers at API boundaries MAY catch it with `instanceof ExternalOAuthTokenError`. Other failures
- * MUST propagate unchanged.
- */
 export async function getSalesforceCredentials(
   connectionId: string
 ): Promise<Result<SalesforceAPICredentials, Error>> {
@@ -37,6 +29,7 @@ export async function getSalesforceCredentials(
 
     return new Ok({ accessToken, instanceUrl });
   } catch (e: unknown) {
+    // So that will be catched upstream by ActivityInboundLogInterceptor and stop the workflow.
     if (isSalesforceSignInError(e)) {
       throw new ExternalOAuthTokenError(e);
     }


### PR DESCRIPTION
## Description

Datadog monitor 22026960 fired on repeated `Unhandled API Error` logs in connectors for `GET /connectors/:id/permissions?viewType=document&filterPermission=read` on a Salesforce connector. The OAuth refresh had failed with `provider_access_token_refresh_error` / `invalid_grant` (`token validity expired`), so the user needs to re-authorize — but the route returned a 500 instead of the 401 the frontend knows how to act on.

**Root cause:** `getSalesforceCredentials()` deliberately throws `ExternalOAuthTokenError` (so Temporal activities stop instead of retrying). `SalesforceConnectorManager.retrievePermissions()` let that exception escape rather than returning a `ConnectorManagerError`, bypassing the `EXTERNAL_OAUTH_TOKEN_ERROR` → 401 `connector_authorization_error` mapping that already exists in `get_connector_permissions.ts`.

**What this PR does:**
1. Catches `ExternalOAuthTokenError` around the `getConnectorAndCredentials()` call in `retrievePermissions()` and returns `Err(ConnectorManagerError("EXTERNAL_OAUTH_TOKEN_ERROR", ...))`, keeping the provider message in the error text like Google Drive does. Unknown errors are rethrown unchanged.
2. Hoists the re-authorization message into an exported constant.

Shared OAuth handling in `lib/oauth.ts`, `salesforce/lib/oauth.ts`, and `salesforce/lib/utils.ts` is unchanged: sync workflows still get the thrown error.

> [!NOTE]
> Other Salesforce refresh failures that don't match the known sign-in error codes still throw a plain `Error` and still 500. That is intentional per the shared OAuth contract (treated as transient, retried).

## Tests

- `connectors/src/connectors/salesforce/index.test.ts`: thrown `ExternalOAuthTokenError` → `EXTERNAL_OAUTH_TOKEN_ERROR` with the provider message; unknown errors rethrown; returned `Err` passthrough; connection failure mapping; success node shape. All dependencies mocked, no real OAuth or Salesforce calls.
- `connectors/src/api/get_connector_permissions.test.ts`: mounts the real handler on an express app and asserts `EXTERNAL_OAUTH_TOKEN_ERROR` → HTTP 401, `connector_authorization_error`, message passthrough.
- `tsgo --noEmit` and `biome check` clean.

## Risk

Low. Only the Salesforce permissions route changes behavior, from a 500 to a 401 for expired/revoked tokens. Worst case, a caught error that should have been a 500 becomes a 401 prompting re-authorization. Safe to rollback.

## Deploy Plan

- [ ] Deploy connectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)