### PR TITLE
fix(triggers): stop retrying trigger runs blocked by the programmatic cap

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -70,6 +70,7 @@ import {
   isPoolDepleted,
   isProgrammaticApiBlocked,
   isUserBlocked,
+  PROGRAMMATIC_CAP_REACHED_MESSAGE,
 } from "@app/lib/api/credits/access_control";
 import { maybeAutoUpgradeSeat } from "@app/lib/api/credits/auto_seat_upgrade";
 import { getProgrammaticRateLimiterCreditState } from "@app/lib/api/credits/programmatic_usage_limit";
@@ -2658,8 +2659,7 @@ export async function checkMessagesLimit(
           status_code: 429,
           api_error: {
             type: "rate_limit_error",
-            message:
-              "Your workspace has reached its programmatic monthly spending cap. An admin can raise the cap in the workspace's usage settings.",
+            message: PROGRAMMATIC_CAP_REACHED_MESSAGE,
           },
         });
       }

--- a/front/lib/api/credits/access_control.ts
+++ b/front/lib/api/credits/access_control.ts
@@ -25,7 +25,21 @@ import {
   isUserBlockedByMetronome,
 } from "@app/lib/metronome/user_block";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { isCreditPricedPlan } from "@app/types/plan";
 import type { ModelId } from "@app/types/shared/model_id";
+
+export const PROGRAMMATIC_CAP_REACHED_MESSAGE =
+  "Your workspace has reached its programmatic monthly spending cap. An admin can raise the cap in the workspace's usage settings.";
+
+/**
+ * Whether the workspace is on a credit-priced (Metronome) plan, i.e. whether
+ * the pool and programmatic-cap readers below apply to it.
+ */
+export function isCreditPricedWorkspace(auth: Authenticator): boolean {
+  const plan = auth.subscription()?.plan;
+  const owner = auth.getNonNullableWorkspace();
+  return Boolean(owner.metronomeCustomerId && plan && isCreditPricedPlan(plan));
+}
 
 /**
  * Whether the workspace credit pool is depleted (API calls with no per-user

--- a/front/lib/triggers/rate_limits.ts
+++ b/front/lib/triggers/rate_limits.ts
@@ -1,3 +1,7 @@
+import {
+  isCreditPricedWorkspace,
+  isProgrammaticApiBlocked,
+} from "@app/lib/api/credits/access_control";
 import { countActiveSeatsForWorkspace } from "@app/lib/api/workspace_seats";
 import type { Authenticator } from "@app/lib/auth";
 import { computeEffectiveMessageLimit } from "@app/lib/plans/usage/limits";
@@ -6,7 +10,10 @@ import {
   rateLimiter,
 } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
-import type { WebhookTriggerType } from "@app/types/assistant/triggers";
+import type {
+  TriggerType,
+  WebhookTriggerType,
+} from "@app/types/assistant/triggers";
 import { DEFAULT_SINGLE_TRIGGER_EXECUTION_PER_DAY_LIMIT } from "@app/types/assistant/triggers";
 
 const WORKSPACE_MESSAGE_LIMIT_MULTIPLIER = 0.5; // 50% of workspace message limit
@@ -84,4 +91,21 @@ export async function checkTriggerForExecutionPerDayLimit(
   }
 
   return { rateLimited: false };
+}
+
+// Whether a trigger charged to the workspace pool is blocked by the credit-priced
+// programmatic monthly cap. Reads the same state as `checkMessagesLimit`, so callers
+// can reject early instead of letting the run fail (and be retried) downstream.
+export async function isTriggerProgrammaticCapReached(
+  auth: Authenticator,
+  { trigger }: { trigger: Pick<TriggerType, "executionMode"> }
+): Promise<boolean> {
+  if (
+    trigger.executionMode !== "workspace_pool" ||
+    !isCreditPricedWorkspace(auth)
+  ) {
+    return false;
+  }
+
+  return isProgrammaticApiBlocked(auth);
 }

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -1,6 +1,6 @@
 import {
   isPoolDepleted,
-  isProgrammaticApiBlocked,
+  PROGRAMMATIC_CAP_REACHED_MESSAGE,
 } from "@app/lib/api/credits/access_control";
 import { checkProgrammaticUsageLimits } from "@app/lib/api/programmatic_usage/tracking";
 import { FathomClient } from "@app/lib/api/triggers/built-in-webhooks/fathom/fathom_client";
@@ -17,6 +17,7 @@ import type { RateLimitCheckResult } from "@app/lib/triggers/rate_limits";
 import {
   checkTriggerForExecutionPerDayLimit,
   checkWebhookRequestForRateLimit,
+  isTriggerProgrammaticCapReached,
 } from "@app/lib/triggers/rate_limits";
 import { statsDMetrics } from "@app/lib/utils/statsd";
 import { verifySignature } from "@app/lib/webhook_source_server";
@@ -300,21 +301,15 @@ async function checkWorkspaceRateLimit({
           "Your workspace has run out of credits. Please purchase more credits to continue.",
       };
     }
+  }
 
-    // Programmatic monthly cap gate: if the cap is reached, reject early for
-    // triggers charged to the workspace pool.
-    if (
-      !block &&
-      owner.metronomeCustomerId &&
-      trigger.executionMode === "workspace_pool" &&
-      (await isProgrammaticApiBlocked(auth))
-    ) {
-      block = {
-        status: "credits_exhausted",
-        message:
-          "Your workspace has reached its programmatic monthly spending cap. An admin can raise the cap in the workspace's usage settings.",
-      };
-    }
+  // Programmatic monthly cap gate: if the cap is reached, reject early for
+  // triggers charged to the workspace pool.
+  if (!block && (await isTriggerProgrammaticCapReached(auth, { trigger }))) {
+    block = {
+      status: "credits_exhausted",
+      message: PROGRAMMATIC_CAP_REACHED_MESSAGE,
+    };
   }
 
   /**

--- a/front/temporal/triggers/activities.test.ts
+++ b/front/temporal/triggers/activities.test.ts
@@ -7,13 +7,76 @@ import {
   runTriggeredAgentsActivity,
   runWakeUpActivity,
 } from "@app/temporal/triggers/activities";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import { describe, expect, it } from "vitest";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockIsProgrammaticApiBlocked, mockPostUserMessage } = vi.hoisted(
+  () => ({
+    mockIsProgrammaticApiBlocked: vi.fn(),
+    mockPostUserMessage: vi.fn(),
+  })
+);
+
+vi.mock("@app/lib/api/credits/access_control", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@app/lib/api/credits/access_control")
+  >()),
+  isProgrammaticApiBlocked: mockIsProgrammaticApiBlocked,
+}));
+
+vi.mock("@app/lib/api/assistant/conversation", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@app/lib/api/assistant/conversation")
+  >()),
+  postUserMessage: mockPostUserMessage,
+}));
+
+vi.mock("@app/lib/temporal", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@app/lib/temporal")>()),
+  getTemporalClientForAgentNamespace: vi.fn().mockResolvedValue({
+    schedule: {
+      getHandle: vi.fn().mockReturnValue({
+        describe: vi.fn().mockResolvedValue({ info: { recentActions: [] } }),
+        update: vi.fn(),
+        delete: vi.fn(),
+      }),
+    },
+  }),
+}));
 
 const MISSING_WAKE_UP_MODEL_ID = 9_000_000_000;
 const MISSING_TRIGGER_MODEL_ID = 9_000_000_000;
 
+// An enabled schedule trigger charged to the workspace pool, on a credit-priced
+// workspace, so the programmatic monthly cap gate applies.
+async function createProgrammaticScheduleTrigger() {
+  const { authenticator, user, workspace } = await createResourceTest({
+    role: "admin",
+    plan: "creditPriced",
+  });
+  const agent = await AgentConfigurationFactory.createTestAgent(authenticator, {
+    name: "Schedule Agent",
+  });
+  const trigger = await TriggerFactory.schedule(authenticator, {
+    agentConfigurationId: agent.sId,
+    status: "enabled",
+    configuration: { cron: "0 9 * * *", timezone: "UTC" },
+    executionMode: "workspace_pool",
+  });
+
+  return { user, workspace, trigger };
+}
+
 describe("runTriggeredAgentsActivity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsProgrammaticApiBlocked.mockResolvedValue(false);
+    mockPostUserMessage.mockResolvedValue(new Ok(undefined));
+  });
+
   it("skips missing triggers without failing the activity", async () => {
     const { user, workspace } = await createResourceTest({ role: "user" });
     const triggerId = TriggerResource.modelIdToSId({
@@ -44,6 +107,35 @@ describe("runTriggeredAgentsActivity", () => {
         triggerId,
       })
     ).resolves.toBeUndefined();
+  });
+
+  it("stops workspace_pool runs without retrying when the programmatic monthly cap is reached", async () => {
+    mockIsProgrammaticApiBlocked.mockResolvedValue(true);
+    const { user, workspace, trigger } =
+      await createProgrammaticScheduleTrigger();
+
+    await expect(
+      runTriggeredAgentsActivity({
+        userId: user.sId,
+        workspaceId: workspace.sId,
+        triggerId: trigger.sId,
+      })
+    ).resolves.toBeUndefined();
+    expect(mockPostUserMessage).not.toHaveBeenCalled();
+  });
+
+  it("posts the triggered message when the programmatic monthly cap is not reached", async () => {
+    const { user, workspace, trigger } =
+      await createProgrammaticScheduleTrigger();
+
+    await expect(
+      runTriggeredAgentsActivity({
+        userId: user.sId,
+        workspaceId: workspace.sId,
+        triggerId: trigger.sId,
+      })
+    ).resolves.toBeUndefined();
+    expect(mockPostUserMessage).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -10,6 +10,7 @@ import {
   buildAuditLogTarget,
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
+import { PROGRAMMATIC_CAP_REACHED_MESSAGE } from "@app/lib/api/credits/access_control";
 import { PostHogServerSideTracking } from "@app/lib/api/posthog";
 import { Authenticator } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
@@ -19,6 +20,7 @@ import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
 import { getTemporalClientForAgentNamespace } from "@app/lib/temporal";
+import { isTriggerProgrammaticCapReached } from "@app/lib/triggers/rate_limits";
 import { getWebhookRequestPayloadFromGCS } from "@app/lib/triggers/webhook";
 import logger from "@app/logger/logger";
 import { makeTriggerScheduleId } from "@app/temporal/triggers/schedule_client";
@@ -321,6 +323,36 @@ export async function runTriggeredAgentsActivity({
     default: {
       assertNever(trigger);
     }
+  }
+
+  // Programmatic monthly cap: webhook requests are gated at ingestion, schedule
+  // runs only here.
+  if (await isTriggerProgrammaticCapReached(auth, { trigger })) {
+    logger.info(
+      {
+        triggerId: trigger.sId,
+        agentConfigurationId: trigger.agentConfigurationId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+      },
+      "Trigger run skipped: programmatic monthly cap reached."
+    );
+    PostHogServerSideTracking.trackEvent({
+      distinctId: auth.getNonNullableUser().sId,
+      event: "trigger_blocked",
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      extra: {
+        trigger_id: trigger.sId,
+        error_type: "credits_exhausted",
+      },
+    });
+    if (webhookRequest) {
+      await webhookRequest.markRelatedTrigger({
+        trigger,
+        status: "credits_exhausted",
+        errorMessage: PROGRAMMATIC_CAP_REACHED_MESSAGE,
+      });
+    }
+    return;
   }
 
   // Create a single conversation for the editor.

--- a/front/temporal/triggers/workflows.ts
+++ b/front/temporal/triggers/workflows.ts
@@ -6,6 +6,10 @@ import type * as activities from "./activities";
 const { runTriggeredAgentsActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "2 minutes",
   retry: {
+    initialInterval: "30 seconds",
+    backoffCoefficient: 2,
+    maximumAttempts: 3,
+    maximumInterval: "5 minutes",
     nonRetryableErrorTypes: ["TriggerNonRetryableError"],
   },
 });


### PR DESCRIPTION
## Description

A schedule trigger charged to the workspace pool, on a credit-priced workspace that has reached its programmatic monthly cap, kept its Temporal workflow retrying until the cap reset.

**Root cause:** `checkMessagesLimit` surfaces the programmatic cap as a `rate_limit_error`. The trigger activity did not treat that type as terminal (it is shared with genuinely transient per-minute limits), so it threw, and `runTriggeredAgentsActivity` had a retry policy with no `maximumAttempts`. With the schedule's `SKIP` overlap policy, every later scheduled fire was dropped while the stuck workflow spun.

Webhook triggers were already fine: `checkWorkspaceRateLimit` gates on `isProgrammaticApiBlocked` at ingestion, before any workflow starts. Schedule triggers had no equivalent gate.

**What this PR does:**
1. Extracts the webhook ingest gate into `isTriggerProgrammaticCapReached` (`lib/triggers/rate_limits.ts`) and calls it from the trigger activity before creating the conversation. A capped run logs, emits the existing `trigger_blocked` PostHog event, marks a webhook request `credits_exhausted` if one is attached, and returns. No retry.
2. Moves the cap message and a small `isCreditPricedWorkspace(auth)` predicate into `lib/api/credits/access_control.ts`, so the message gate, the webhook gate and the activity share one definition.
3. Second commit: bounds the trigger activity retry policy to match `runWakeUpActivity` (30s initial, x2 backoff, 3 attempts, 5 min max). This covers the race between the pre-check and the message gate, and the legacy daily cap, which also surfaces as `rate_limit_error`.

> [!NOTE]
> The `trigger_blocked` PostHog event on this path now reports `error_type: "credits_exhausted"` instead of `rate_limit_error`, which is what the programmatic cap actually is. Anyone charting that event by `error_type` will see the series move.

## Tests

- `temporal/triggers/activities.test.ts`: a capped `workspace_pool` schedule run resolves without posting a message; an uncapped one posts exactly once.
- Existing webhook ingest tests still pass with the extracted helper.
- `tsc` clean on touched files.

## Risk

Worst case, a schedule run on a capped workspace is skipped when the previous behaviour would have retried and eventually succeeded after the cap reset. That is the intended change. The bounded retry means a trigger run that hits three consecutive transient failures now fails the workflow instead of retrying indefinitely. Safe to rollback.

## Deploy Plan

- [ ] Deploy front

🤖 Generated with [Claude Code](https://claude.com/claude-code)
