### PR TITLE
[Coding Rules] Distinguish runtime and non-runtime database access

### DIFF
--- a/front/CONTRACTS
+++ b/front/CONTRACTS
@@ -511,7 +511,7 @@ Direct use of Sequelize models in tests should be avoided in favor of Resources.
 setup and assertions.
 
 When existing Resource APIs cannot express a required fixture or assertion, direct model access
-is allowed under [models-behind-resources]; do not add test-only Resource APIs.
+is allowed under the `models-behind-resources` contract; do not add test-only Resource APIs.
 
 @cc [label:react] component-props-interfaces
 Components props should always be typed using an `interface`.

--- a/front/CONTRACTS
+++ b/front/CONTRACTS
@@ -18,10 +18,18 @@ function doWorkspace({ workspace }: { workspace: WorkspaceType }) { }
 ```
 
 @cc [owner:flvndvd,label:backend] models-behind-resources
-Sequelize models must not be used directly outside Resources.
+Runtime application code must access Sequelize models through Resources. This includes API
+handlers, application services, and background workers.
 
-Any new model should be abstracted to the rest of the codebase through a pre-existing or new
+Non-runtime code (tests, test factories, one-off scripts and backfills) should reuse existing
+Resource APIs when their semantics fit, but may access Sequelize models directly when they do not.
+
+Any new model used by runtime application code should be exposed through a pre-existing or new
 `Resource`.
+
+@cc [owner:philipperolet,label:architecture] non-runtime-code-stays-local
+Keep code used only by tests, test factories, or one-off scripts and backfills in those contexts.
+Do not add runtime APIs or abstractions solely to support non-runtime code.
 
 @cc [owner:flvndvd,label:backend] resource-interfaces-hide-models
 Resource interfaces must not expose Sequelize model objects; accept Resources or Types instead.
@@ -501,6 +509,9 @@ possible.
 @cc [owner:flvndvd,label:testing] tests-use-resources
 Direct use of Sequelize models in tests should be avoided in favor of Resources. This includes test
 setup and assertions.
+
+When existing Resource APIs cannot express a required fixture or assertion, direct model access
+is allowed under [models-behind-resources]; do not add test-only Resource APIs.
 
 @cc [label:react] component-props-interfaces
 Components props should always be typed using an `interface`.


### PR DESCRIPTION
## Description

Extracted from https://github.com/dust-tt/dust/pull/32180 into an independent, documentation-only PR.

Scope the Resources-only database access rule to runtime application code. Tests, test factories, and one-off scripts/backfills still prefer existing Resource APIs, but may access models directly when those APIs cannot express the needed operation. Keep their dedicated code local instead of adding runtime APIs just for them.

Align the testing rule with this boundary, preserving the preference for Resources and factory-based setup. `CODING_RULES.md` was renamed to `CONTRACTS` in https://github.com/dust-tt/dust/pull/31968; checked the former BACK3, TEST2, and TEST5 rules and their current equivalents for consistency. API and worker access restrictions remain unchanged.

## Risks

Blast radius: Front development and review guidance only.
Risk: none

## Deploy Plan

- Merge normally; no deployment or migration required.
