### PR TITLE
Fix Microsoft Select All skipping SharePoint libraries

### DIFF
--- a/front/components/ContentNodeTree.test.tsx
+++ b/front/components/ContentNodeTree.test.tsx
@@ -1,6 +1,6 @@
 import { ContentNodeTree } from "@app/components/ContentNodeTree";
 import type { ContentNode } from "@app/types/connectors/connectors_api";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 vi.stubGlobal(
@@ -12,27 +12,34 @@ vi.stubGlobal(
   }
 );
 
+function makeNode(
+  overrides: Partial<ContentNode> & Pick<ContentNode, "internalId" | "title">
+): ContentNode {
+  return {
+    childrenCount: 0,
+    expandable: false,
+    lastUpdatedAt: null,
+    mimeType: "application/vnd.dust.folder",
+    parentInternalId: null,
+    permission: "none",
+    providerVisibility: null,
+    sourceUrl: null,
+    type: "folder",
+    ...overrides,
+  };
+}
+
 describe("ContentNodeTree", () => {
-  it("does not select prevented nodes but can unselect them", () => {
-    const selectableNode = {
-      childrenCount: 0,
-      expandable: false,
+  it("does not select prevented nodes but can unselect them", async () => {
+    const selectableNode = makeNode({
       internalId: "selectable",
-      lastUpdatedAt: null,
-      mimeType: "application/vnd.dust.folder",
-      parentInternalId: null,
-      permission: "none",
-      providerVisibility: null,
-      sourceUrl: null,
       title: "Selectable",
-      type: "folder",
-    } satisfies ContentNode;
-    const preventedNode = {
-      ...selectableNode,
+    });
+    const preventedNode = makeNode({
       internalId: "prevented",
       preventSelection: true,
       title: "Prevented",
-    } satisfies ContentNode;
+    });
     const setSelectedNodes = vi.fn();
 
     render(
@@ -50,6 +57,10 @@ describe("ContentNodeTree", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Select All" }));
 
+    await waitFor(() => {
+      expect(setSelectedNodes).toHaveBeenCalled();
+    });
+
     const updateSelection = setSelectedNodes.mock.lastCall?.[0];
     expect(updateSelection?.({})).toEqual({
       selectable: {
@@ -60,6 +71,10 @@ describe("ContentNodeTree", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Unselect All" }));
+
+    await waitFor(() => {
+      expect(setSelectedNodes).toHaveBeenCalledTimes(2);
+    });
 
     const clearSelection = setSelectedNodes.mock.lastCall?.[0];
     expect(
@@ -80,6 +95,52 @@ describe("ContentNodeTree", () => {
         isSelected: false,
         node: preventedNode,
         parents: [],
+      },
+    });
+  });
+
+  it("selects children of prevented containers via fetchChildResources", async () => {
+    const site = makeNode({
+      expandable: true,
+      internalId: "site",
+      preventSelection: true,
+      title: "SharePoint site",
+    });
+    const drive = makeNode({
+      internalId: "drive",
+      parentInternalId: "site",
+      title: "Documents",
+    });
+    const setSelectedNodes = vi.fn();
+    const fetchChildResources = vi.fn(async () => [drive]);
+
+    render(
+      <ContentNodeTree
+        isTitleFilterEnabled
+        selectedNodes={{}}
+        setSelectedNodes={setSelectedNodes}
+        fetchChildResources={fetchChildResources}
+        useResourcesHook={() => ({
+          resources: [site],
+          isResourcesLoading: false,
+          isResourcesError: false,
+        })}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Select All" }));
+
+    await waitFor(() => {
+      expect(fetchChildResources).toHaveBeenCalledWith("site");
+      expect(setSelectedNodes).toHaveBeenCalled();
+    });
+
+    const updateSelection = setSelectedNodes.mock.lastCall?.[0];
+    expect(updateSelection?.({})).toEqual({
+      drive: {
+        isSelected: true,
+        node: drive,
+        parents: ["site"],
       },
     });
   });

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -1,3 +1,7 @@
+import {
+  collectSelectableNodesForSelectAll,
+  unselectVisibleNodesAndDescendants,
+} from "@app/components/ContentNodeTreeSelection";
 import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { getVisualForContentNode } from "@app/lib/content_nodes";
@@ -79,6 +83,7 @@ type ContextType = {
   emptyComponent: ReactNode;
   defaultExpandedIds?: string[];
   getLabel?: (node: ContentNode) => string;
+  fetchChildResources?: (parentId: string) => Promise<ContentNode[]>;
 };
 
 const ContentNodeTreeContext = React.createContext<ContextType | undefined>(
@@ -184,6 +189,7 @@ function ContentNodeTreeChildren({
     emptyComponent,
     defaultExpandedIds,
     getLabel,
+    fetchChildResources,
   } = useContentNodeTreeContext();
 
   const sendNotification = useSendNotification();
@@ -192,6 +198,7 @@ function ContentNodeTreeChildren({
   // If the user pressed "select all", we want to display "unselect all" and vice versa.
   // But if the user types in the search bar, we want to reset the button to "select all".
   const [selectAllClicked, setSelectAllClicked] = useState(false);
+  const [isSelectAllLoading, setIsSelectAllLoading] = useState(false);
 
   const {
     resources,
@@ -353,6 +360,48 @@ function ContentNodeTreeChildren({
     </Tree>
   );
 
+  const handleSelectAllClick = async () => {
+    if (!setSelectedNodes) {
+      return;
+    }
+    if (selectAllClicked) {
+      setSelectAllClicked(false);
+      setSelectedNodes((prev) =>
+        unselectVisibleNodesAndDescendants(prev, filteredNodes)
+      );
+      return;
+    }
+
+    setIsSelectAllLoading(true);
+    try {
+      const nodesToSelect = await collectSelectableNodesForSelectAll({
+        nodes: filteredNodes,
+        parentIds,
+        fetchChildResources,
+      });
+      setSelectAllClicked(true);
+      setSelectedNodes((prev) => {
+        const newState = { ...prev };
+        for (const { node, parents } of nodesToSelect) {
+          newState[node.internalId] = {
+            isSelected: true,
+            node,
+            parents,
+          };
+        }
+        return newState;
+      });
+    } catch {
+      sendNotification({
+        type: "error",
+        title: "Failed to select all",
+        description: "Could not load folders to select. Please try again.",
+      });
+    } finally {
+      setIsSelectAllLoading(false);
+    }
+  };
+
   return (
     <>
       {isTitleFilterEnabled && setSelectedNodes && (
@@ -372,29 +421,18 @@ function ContentNodeTreeChildren({
 
             <Button
               icon={CheckDone01}
-              label={selectAllClicked ? "Unselect All" : "Select All"}
+              label={
+                isSelectAllLoading
+                  ? "Loading..."
+                  : selectAllClicked
+                    ? "Unselect All"
+                    : "Select All"
+              }
               size="sm"
               className="m-1"
               variant="ghost"
-              disabled={filteredNodes.length === 0}
-              onClick={() => {
-                const isSelected = !selectAllClicked;
-                setSelectAllClicked(isSelected);
-                setSelectedNodes((prev) => {
-                  const newState = { ...prev };
-                  const nodesToUpdate = isSelected
-                    ? filteredNodes.filter((n) => n.preventSelection !== true)
-                    : filteredNodes;
-                  nodesToUpdate.forEach((n) => {
-                    newState[n.internalId] = {
-                      isSelected,
-                      node: n,
-                      parents: isSelected ? parentIds : [],
-                    };
-                  });
-                  return newState;
-                });
-              }}
+              disabled={filteredNodes.length === 0 || isSelectAllLoading}
+              onClick={handleSelectAllClick}
             />
           </div>
         </>
@@ -463,6 +501,11 @@ interface ContentNodeTreeProps {
    * Optional function to compute the display label for a node. Defaults to node.title.
    */
   getLabel?: (node: ContentNode) => string;
+  /**
+   * Fetches children of a node. Used by Select All to expand non-selectable
+   * containers (e.g. Microsoft SharePoint sites) and select their libraries.
+   */
+  fetchChildResources?: (parentId: string) => Promise<ContentNode[]>;
 }
 
 export function ContentNodeTree({
@@ -478,6 +521,7 @@ export function ContentNodeTree({
   defaultExpandedIds,
   additionalActionsForContentNode,
   getLabel,
+  fetchChildResources,
 }: ContentNodeTreeProps) {
   return (
     <ContentNodeTreeContextProvider
@@ -490,6 +534,7 @@ export function ContentNodeTree({
         emptyComponent,
         defaultExpandedIds,
         getLabel,
+        fetchChildResources,
       }}
     >
       <ContentNodeTreeChildren

--- a/front/components/ContentNodeTreeSelection.test.ts
+++ b/front/components/ContentNodeTreeSelection.test.ts
@@ -1,0 +1,136 @@
+import {
+  collectSelectableNodesForSelectAll,
+  unselectVisibleNodesAndDescendants,
+} from "@app/components/ContentNodeTreeSelection";
+import type { ContentNode } from "@app/types/connectors/connectors_api";
+import { describe, expect, it, vi } from "vitest";
+
+function makeNode(
+  overrides: Partial<ContentNode> & Pick<ContentNode, "internalId" | "title">
+): ContentNode {
+  return {
+    childrenCount: 0,
+    expandable: false,
+    lastUpdatedAt: null,
+    mimeType: "application/vnd.dust.folder",
+    parentInternalId: null,
+    permission: "none",
+    providerVisibility: null,
+    sourceUrl: null,
+    type: "folder",
+    ...overrides,
+  };
+}
+
+describe("collectSelectableNodesForSelectAll", () => {
+  it("skips prevented nodes when no child fetcher is provided", async () => {
+    const site = makeNode({
+      internalId: "site",
+      title: "Site",
+      preventSelection: true,
+      expandable: true,
+    });
+    const folder = makeNode({
+      internalId: "folder",
+      title: "Folder",
+    });
+
+    const selected = await collectSelectableNodesForSelectAll({
+      nodes: [site, folder],
+      parentIds: [],
+    });
+
+    expect(selected).toEqual([{ node: folder, parents: [] }]);
+  });
+
+  it("selects selectable children of prevented containers", async () => {
+    const site = makeNode({
+      internalId: "site",
+      title: "Site",
+      preventSelection: true,
+      expandable: true,
+    });
+    const drive = makeNode({
+      internalId: "drive",
+      title: "Documents",
+      parentInternalId: "site",
+    });
+    const fetchChildResources = vi.fn(async () => [drive]);
+
+    const selected = await collectSelectableNodesForSelectAll({
+      nodes: [site],
+      parentIds: [],
+      fetchChildResources,
+    });
+
+    expect(fetchChildResources).toHaveBeenCalledWith("site");
+    expect(selected).toEqual([{ node: drive, parents: ["site"] }]);
+  });
+
+  it("recurses through nested prevented containers", async () => {
+    const site = makeNode({
+      internalId: "site",
+      title: "Site",
+      preventSelection: true,
+      expandable: true,
+    });
+    const subSite = makeNode({
+      internalId: "subsite",
+      title: "Subsite",
+      preventSelection: true,
+      expandable: true,
+      parentInternalId: "site",
+    });
+    const drive = makeNode({
+      internalId: "drive",
+      title: "Documents",
+      parentInternalId: "subsite",
+    });
+    const fetchChildResources = vi.fn(async (parentId: string) => {
+      if (parentId === "site") {
+        return [subSite];
+      }
+      if (parentId === "subsite") {
+        return [drive];
+      }
+      return [];
+    });
+
+    const selected = await collectSelectableNodesForSelectAll({
+      nodes: [site],
+      parentIds: [],
+      fetchChildResources,
+    });
+
+    expect(selected).toEqual([{ node: drive, parents: ["subsite", "site"] }]);
+  });
+});
+
+describe("unselectVisibleNodesAndDescendants", () => {
+  it("unselects visible nodes and selected descendants", () => {
+    const site = makeNode({
+      internalId: "site",
+      title: "Site",
+      preventSelection: true,
+      expandable: true,
+    });
+    const drive = makeNode({
+      internalId: "drive",
+      title: "Documents",
+      parentInternalId: "site",
+    });
+
+    const next = unselectVisibleNodesAndDescendants(
+      {
+        site: { isSelected: true, node: site, parents: [] },
+        drive: { isSelected: true, node: drive, parents: ["site"] },
+      },
+      [site]
+    );
+
+    expect(next).toEqual({
+      site: { isSelected: false, node: site, parents: [] },
+      drive: { isSelected: false, node: drive, parents: [] },
+    });
+  });
+});

--- a/front/components/ContentNodeTreeSelection.ts
+++ b/front/components/ContentNodeTreeSelection.ts
@@ -1,0 +1,115 @@
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { ContentNode } from "@app/types/connectors/connectors_api";
+
+export type FetchChildResources = (parentId: string) => Promise<ContentNode[]>;
+
+export type SelectableNodeWithParents = {
+  node: ContentNode;
+  parents: string[];
+};
+
+/**
+ * @cc [owner:frankaloia,label:product] skip-prevented-nodes
+ * Select All MUST NOT mark a node with `preventSelection === true` as selected.
+ */
+/**
+ * @cc [owner:frankaloia,label:product] expand-prevented-containers
+ * When Select All encounters an expandable node with `preventSelection === true` and
+ * `fetchChildResources` is provided, it MUST fetch that node's children and select
+ * the selectable descendants instead of the container. If `fetchChildResources` is
+ * omitted, prevented nodes MUST be skipped and MUST NOT be selected.
+ */
+export async function collectSelectableNodesForSelectAll({
+  nodes,
+  parentIds,
+  fetchChildResources,
+  visitedInternalIds = new Set<string>(),
+}: {
+  nodes: ContentNode[];
+  parentIds: string[];
+  fetchChildResources?: FetchChildResources;
+  visitedInternalIds?: Set<string>;
+}): Promise<SelectableNodeWithParents[]> {
+  const selected: SelectableNodeWithParents[] = [];
+  const containersToExpand: ContentNode[] = [];
+
+  for (const node of nodes) {
+    if (visitedInternalIds.has(node.internalId)) {
+      continue;
+    }
+    if (node.preventSelection !== true) {
+      selected.push({ node, parents: parentIds });
+      continue;
+    }
+    if (node.expandable && fetchChildResources) {
+      containersToExpand.push(node);
+    }
+  }
+
+  const fetchChildren = fetchChildResources;
+  if (containersToExpand.length === 0 || !fetchChildren) {
+    return selected;
+  }
+
+  const nested = await concurrentExecutor(
+    containersToExpand,
+    async (node) => {
+      const nextVisited = new Set(visitedInternalIds);
+      nextVisited.add(node.internalId);
+      const children = await fetchChildren(node.internalId);
+      return collectSelectableNodesForSelectAll({
+        nodes: children,
+        parentIds: [node.internalId, ...parentIds],
+        fetchChildResources: fetchChildren,
+        visitedInternalIds: nextVisited,
+      });
+    },
+    { concurrency: 8 }
+  );
+
+  return [...selected, ...nested.flat()];
+}
+
+/**
+ * @cc [owner:frankaloia,label:product] unselect-descendants
+ * Unselect All at a tree level MUST unselect the currently visible nodes and any
+ * already selected descendants of those nodes, including previously persisted
+ * selections on non-selectable containers.
+ */
+type SelectionStatus = {
+  isSelected: boolean;
+  node: ContentNode;
+  parents: string[];
+};
+
+export function unselectVisibleNodesAndDescendants(
+  prev: Record<string, SelectionStatus>,
+  filteredNodes: ContentNode[]
+): Record<string, SelectionStatus> {
+  const filteredIds = new Set(filteredNodes.map((n) => n.internalId));
+  const newState: Record<string, SelectionStatus> = { ...prev };
+
+  for (const [id, status] of Object.entries(prev)) {
+    const isVisible = filteredIds.has(id);
+    const isDescendant = (status.parents ?? []).some((parentId) =>
+      filteredIds.has(parentId)
+    );
+    if (isVisible || isDescendant) {
+      newState[id] = {
+        ...status,
+        isSelected: false,
+        parents: [],
+      };
+    }
+  }
+
+  for (const node of filteredNodes) {
+    newState[node.internalId] = {
+      isSelected: false,
+      node,
+      parents: [],
+    };
+  }
+
+  return newState;
+}

--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -28,6 +28,7 @@ import { clientFetch } from "@app/lib/egress/client";
 import {
   useConnectorConfig,
   useConnectorPermissions,
+  useFetchConnectorPermissions,
   useOAuthMetadata,
 } from "@app/lib/swr/connectors";
 import { useSlackIsLegacy } from "@app/lib/swr/oauth";
@@ -803,6 +804,12 @@ export function ConnectorPermissionsModal({
     dataSource.connectorProvider === "notion" &&
     featureFlags.includes("advanced_notion_management");
 
+  const fetchChildResources = useFetchConnectorPermissions({
+    owner,
+    dataSource,
+    viewType: "all",
+  });
+
   const getNodeParents = (node: ContentNodeWithParent) => {
     if (node.parentInternalId) {
       return [node.parentInternalId];
@@ -1095,6 +1102,7 @@ export function ConnectorPermissionsModal({
                         }
                         isRoundedBackground={true}
                         useResourcesHook={useResourcesHook}
+                        fetchChildResources={fetchChildResources}
                         selectedNodes={
                           canUpdatePermissions ? selectedNodes : undefined
                         }

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -16,7 +16,7 @@ import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
 import type { DataSourceType } from "@app/types/data_source";
 import type { APIError } from "@app/types/error";
 import type { LightWorkspaceType } from "@app/types/user";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { Fetcher } from "swr";
 
 interface UseConnectorPermissionsReturn<T extends ConnectorPermission | null> {
@@ -26,6 +26,38 @@ interface UseConnectorPermissionsReturn<T extends ConnectorPermission | null> {
   isResourcesLoading: boolean;
   isResourcesError: boolean;
   resourcesError: APIError | null;
+}
+
+function getConnectorPermissionsUrl({
+  owner,
+  dataSource,
+  parentId,
+  filterPermission,
+  viewType,
+}: {
+  owner: LightWorkspaceType;
+  dataSource: DataSourceType;
+  parentId: string | null;
+  filterPermission?: ConnectorPermission | null;
+  viewType?: ContentNodesViewType;
+}): string {
+  let url = `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/permissions?viewType=${viewType}`;
+  if (parentId) {
+    url += `&parentId=${parentId}`;
+  }
+  if (filterPermission) {
+    url += `&filterPermission=${filterPermission}`;
+  }
+  return url;
+}
+
+function isVisibleConnectorResource(
+  resource: ContentNode,
+  includePrivateSlackChannels: boolean
+): boolean {
+  return (
+    resource.providerVisibility !== "private" || includePrivateSlackChannels
+  );
 }
 
 export function useConnectorPermissions<T extends ConnectorPermission | null>({
@@ -51,34 +83,69 @@ export function useConnectorPermissions<T extends ConnectorPermission | null>({
       : GetDataSourcePermissionsResponseBody
   > = fetcher;
 
-  let url = `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/permissions?viewType=${viewType}`;
-  if (parentId) {
-    url += `&parentId=${parentId}`;
-  }
-  if (filterPermission) {
-    url += `&filterPermission=${filterPermission}`;
-  }
+  const url = getConnectorPermissionsUrl({
+    owner,
+    dataSource,
+    parentId,
+    filterPermission,
+    viewType,
+  });
 
   const { data, error } = useSWRWithDefaults(url, permissionsFetcher, {
     disabled,
   });
 
+  const includePrivateSlackChannels = featureFlags.includes(
+    "index_private_slack_channel"
+  );
+
   return {
     resources: useMemo(
       () =>
         data
-          ? data.resources.filter(
-              (resource) =>
-                resource.providerVisibility !== "private" ||
-                featureFlags.includes("index_private_slack_channel")
+          ? data.resources.filter((resource) =>
+              isVisibleConnectorResource(resource, includePrivateSlackChannels)
             )
           : [],
-      [data, featureFlags]
+      [data, includePrivateSlackChannels]
     ),
     isResourcesLoading: !error && !data,
     isResourcesError: error,
     resourcesError: error ? (error.error as APIError) : null,
   } as UseConnectorPermissionsReturn<T>;
+}
+
+export function useFetchConnectorPermissions({
+  owner,
+  dataSource,
+  viewType = "all",
+}: {
+  owner: LightWorkspaceType;
+  dataSource: DataSourceType;
+  viewType?: ContentNodesViewType;
+}): (parentId: string) => Promise<ContentNode[]> {
+  const { fetcher } = useFetcher();
+  const { featureFlags } = useFeatureFlags();
+  const includePrivateSlackChannels = featureFlags.includes(
+    "index_private_slack_channel"
+  );
+
+  return useCallback(
+    async (parentId: string) => {
+      const data: GetDataSourcePermissionsResponseBody = await fetcher(
+        getConnectorPermissionsUrl({
+          owner,
+          dataSource,
+          parentId,
+          viewType,
+        })
+      );
+      return data.resources.filter((resource) =>
+        isVisibleConnectorResource(resource, includePrivateSlackChannels)
+      );
+    },
+    [dataSource, fetcher, includePrivateSlackChannels, owner, viewType]
+  );
 }
 
 export function useConnectorConfig({


### PR DESCRIPTION
## Summary
- Eng runner ticket: https://github.com/dust-tt/tasks/issues/10351
- Select All on Microsoft connections was a no-op because the root list is SharePoint sites marked `preventSelection`, after [#29485](https://github.com/dust-tt/dust/pull/29485).
- Select All now loads children of those non-selectable site containers and selects the libraries/folders underneath, without persisting the site itself.
- Unselect All clears those selected descendants as well.

## Testing
Validated locally

## Risk
This can be slow because we are now traversing the tree of nested subsites. This will only effect connectors with top level nodes taht are not selectable


## Deploy Plan
Deploy front

r? @philipperolet Addressing eng runner ticket