### PR TITLE
Allow conversation sandboxes to query Frame databases

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.57"
+version = "0.1.58"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.57"
+version = "0.1.58"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/functions-runner/db/query.test.ts
+++ b/cli/dust-sandbox/functions-runner/db/query.test.ts
@@ -136,6 +136,50 @@ describe("db query", () => {
     });
   });
 
+  test("can return only a preview without creating an inaccessible spill file", async () => {
+    await withDir(async (dir) => {
+      const dbPath = join(dir, "notes.db");
+      unwrap(await reconcile(dbPath, fx("notes.db.ts")));
+      const db = new Database(dbPath);
+      const insert = db.prepare("INSERT INTO notes (label) VALUES (?)");
+      db.exec("BEGIN");
+      for (let i = 0; i < QUERY_INLINE_ROW_CAP + 1; i++) {
+        insert.run(`row-${i}`);
+      }
+      db.exec("COMMIT");
+      db.close();
+
+      const result = unwrap(
+        runQuery(dbPath, "SELECT label FROM notes ORDER BY id", undefined, null)
+      );
+      expect(result.rows.length).toBe(QUERY_INLINE_ROW_CAP);
+      expect(result.row_count).toBe(QUERY_INLINE_ROW_CAP + 1);
+      expect(result.results_file).toBeNull();
+      expect(result.note).toContain("Refine the query with LIMIT and OFFSET");
+    });
+  });
+
+  test("remote previews never skip an oversized row and include later rows", async () => {
+    await withDir(async (dir) => {
+      const dbPath = join(dir, "notes.db");
+      unwrap(await reconcile(dbPath, fx("notes.db.ts")));
+      const db = new Database(dbPath);
+      const insert = db.prepare("INSERT INTO notes (label) VALUES (?)");
+      insert.run("first");
+      insert.run("x".repeat(QUERY_INLINE_PAYLOAD_CAP_BYTES));
+      insert.run("third");
+      db.close();
+
+      const result = unwrap(
+        runQuery(dbPath, "SELECT label FROM notes ORDER BY id", undefined, null)
+      );
+      expect(result.rows).toEqual([{ label: "first" }]);
+      expect(result.row_count).toBe(3);
+      expect(result.results_file).toBeNull();
+      expect(result.note).toContain("the first 1 are shown here");
+    });
+  });
+
   test("runs DML and reports the affected rows", async () => {
     await withDir(async (dir) => {
       const dbPath = await seeded(dir);
@@ -420,6 +464,33 @@ describe("runner db-query envelope", () => {
       const envelope = JSON.parse(stdout.trim());
       expect(envelope.ok).toBe(true);
       expect(envelope.rows).toEqual([{ n: 0 }]);
+    });
+  });
+
+  test("db-query keeps large remote results inline as a preview", async () => {
+    await withDir(async (dir) => {
+      const dbPath = join(dir, "notes.db");
+      await run(["db-reconcile", dbPath, fx("notes.db.ts")]);
+      const db = new Database(dbPath);
+      const insert = db.prepare("INSERT INTO notes (label) VALUES (?)");
+      db.exec("BEGIN");
+      for (let i = 0; i < QUERY_INLINE_ROW_CAP + 1; i++) {
+        insert.run(`row-${i}`);
+      }
+      db.exec("COMMIT");
+      db.close();
+
+      const { stdout, code } = await run(
+        ["db-query", dbPath],
+        "SELECT label FROM notes ORDER BY id",
+        { DUST_DB_QUERY_INLINE_ONLY: "1" }
+      );
+
+      expect(code).toBe(0);
+      const envelope = JSON.parse(stdout.trim());
+      expect(envelope.row_count).toBe(QUERY_INLINE_ROW_CAP + 1);
+      expect(envelope.rows.length).toBe(QUERY_INLINE_ROW_CAP);
+      expect(envelope.results_file).toBeNull();
     });
   });
 

--- a/cli/dust-sandbox/functions-runner/db/query.test.ts
+++ b/cli/dust-sandbox/functions-runner/db/query.test.ts
@@ -115,7 +115,7 @@ describe("db query", () => {
       db.close();
 
       const result = unwrap(
-        runQuery(dbPath, "SELECT label FROM notes ORDER BY id")
+        runQuery(dbPath, "SELECT label FROM notes ORDER BY id", undefined, dir)
       );
       expect(result.rows.length).toBe(QUERY_INLINE_ROW_CAP);
       expect(result.row_count).toBe(QUERY_INLINE_ROW_CAP + 1);
@@ -136,7 +136,7 @@ describe("db query", () => {
     });
   });
 
-  test("can return only a preview without creating an inaccessible spill file", async () => {
+  test("keeps only a preview when no spill directory is given", async () => {
     await withDir(async (dir) => {
       const dbPath = join(dir, "notes.db");
       unwrap(await reconcile(dbPath, fx("notes.db.ts")));
@@ -150,7 +150,7 @@ describe("db query", () => {
       db.close();
 
       const result = unwrap(
-        runQuery(dbPath, "SELECT label FROM notes ORDER BY id", undefined, null)
+        runQuery(dbPath, "SELECT label FROM notes ORDER BY id")
       );
       expect(result.rows.length).toBe(QUERY_INLINE_ROW_CAP);
       expect(result.row_count).toBe(QUERY_INLINE_ROW_CAP + 1);
@@ -159,7 +159,7 @@ describe("db query", () => {
     });
   });
 
-  test("remote previews never skip an oversized row and include later rows", async () => {
+  test("a preview never skips an oversized row to include later rows", async () => {
     await withDir(async (dir) => {
       const dbPath = join(dir, "notes.db");
       unwrap(await reconcile(dbPath, fx("notes.db.ts")));
@@ -171,7 +171,7 @@ describe("db query", () => {
       db.close();
 
       const result = unwrap(
-        runQuery(dbPath, "SELECT label FROM notes ORDER BY id", undefined, null)
+        runQuery(dbPath, "SELECT label FROM notes ORDER BY id")
       );
       expect(result.rows).toEqual([{ label: "first" }]);
       expect(result.row_count).toBe(3);
@@ -354,7 +354,7 @@ describe("db query", () => {
       db.close();
 
       const result = unwrap(
-        runQuery(dbPath, "SELECT label FROM notes ORDER BY id")
+        runQuery(dbPath, "SELECT label FROM notes ORDER BY id", undefined, dir)
       );
       expect(result.rows.length).toBe(1);
       expect(result.row_count).toBe(3);
@@ -467,7 +467,7 @@ describe("runner db-query envelope", () => {
     });
   });
 
-  test("db-query keeps large remote results inline as a preview", async () => {
+  test("db-query keeps large results inline as a preview without a spill dir", async () => {
     await withDir(async (dir) => {
       const dbPath = join(dir, "notes.db");
       await run(["db-reconcile", dbPath, fx("notes.db.ts")]);
@@ -482,8 +482,7 @@ describe("runner db-query envelope", () => {
 
       const { stdout, code } = await run(
         ["db-query", dbPath],
-        "SELECT label FROM notes ORDER BY id",
-        { DUST_DB_QUERY_INLINE_ONLY: "1" }
+        "SELECT label FROM notes ORDER BY id"
       );
 
       expect(code).toBe(0);

--- a/cli/dust-sandbox/functions-runner/db/query.ts
+++ b/cli/dust-sandbox/functions-runner/db/query.ts
@@ -22,9 +22,10 @@ export function runQuery(
   sql: string,
   // Omitted only by tests that don't exercise the quota; runner.ts always passes it.
   maxSizeBytes?: number,
-  // Directory the spill file is written to — a pod file, so the caller can read the full result
-  // set. runner.ts passes the pod-files dir from Rust; tests omit it and fall back to a temp dir.
-  spillDir?: string
+  // Directory for a spill file the local caller can read. `null` keeps only the inline preview
+  // when the caller cannot access this sandbox's files;
+  // tests omit it and fall back to a temp dir.
+  spillDir?: string | null
 ): Result<QueryOutcome, DbCommandError> {
   const trimmed = sql.trim();
   if (trimmed.length === 0) {
@@ -198,7 +199,7 @@ function executionError(e: unknown): DbCommandError {
 // so `INSERT … RETURNING` correctly returns its rows.
 function execute(
   statement: Statement,
-  spillDir: string | undefined
+  spillDir: string | null | undefined
 ): Result<QueryOutcome, DbCommandError> {
   if (statement.columnNames.length > 0) {
     return collectRows(statement, spillDir);
@@ -222,7 +223,7 @@ function execute(
 // Execute a result-returning statement, spilling beyond the inline bounds.
 function collectRows(
   statement: Statement,
-  spillDir: string | undefined
+  spillDir: string | null | undefined
 ): Result<QueryOutcome, DbCommandError> {
   const preview: Record<string, unknown>[] = [];
   let previewBytes = 0;
@@ -230,9 +231,13 @@ function collectRows(
   let rowCount = 0;
   let spillFd: number | null = null;
   let spillPath: string | null = null;
+  let previewTruncated = false;
   try {
     for (const row of statement.iterate()) {
       rowCount++;
+      if (spillDir === null && previewTruncated) {
+        continue;
+      }
       const rowJson = JSON.stringify(row, jsonReplacer);
       if (spillFd === null) {
         if (
@@ -243,6 +248,10 @@ function collectRows(
           preview.push(JSON.parse(rowJson));
           previewBytes += Buffer.byteLength(rowJson, "utf8");
           previewJson.push(rowJson);
+          continue;
+        }
+        if (spillDir === null) {
+          previewTruncated = true;
           continue;
         }
         const dir = spillDir ?? tmpdir();
@@ -271,10 +280,13 @@ function collectRows(
     changes: null,
     results_file: spillPath,
     note:
-      spillPath === null
-        ? null
-        : `${rowCount} rows total; the first ${preview.length} are shown here as a preview. ` +
-          `The complete result set is in ${spillPath}, one JSON object per line.`,
+      spillPath !== null
+        ? `${rowCount} rows total; the first ${preview.length} are shown here as a preview. ` +
+          `The complete result set is in ${spillPath}, one JSON object per line.`
+        : previewTruncated
+          ? `${rowCount} rows total; the first ${preview.length} are shown here as a preview. ` +
+            "Refine the query with LIMIT and OFFSET to inspect the remaining rows."
+          : null,
   });
 }
 

--- a/cli/dust-sandbox/functions-runner/db/query.ts
+++ b/cli/dust-sandbox/functions-runner/db/query.ts
@@ -1,6 +1,5 @@
 import { Database, type Statement } from "bun:sqlite";
 import { closeSync, existsSync, mkdirSync, openSync, writeSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Err, Ok, type Result } from "#result.ts";
 import { applyWritePragmas, DbCommandError } from "./common.ts";
@@ -22,10 +21,9 @@ export function runQuery(
   sql: string,
   // Omitted only by tests that don't exercise the quota; runner.ts always passes it.
   maxSizeBytes?: number,
-  // Directory for a spill file the local caller can read. `null` keeps only the inline preview
-  // when the caller cannot access this sandbox's files;
-  // tests omit it and fall back to a temp dir.
-  spillDir?: string | null
+  // Directory a caller that can read this sandbox's files gets the full result spilled into.
+  // Absent, an oversized result is truncated to the bounded inline preview.
+  spillDir?: string
 ): Result<QueryOutcome, DbCommandError> {
   const trimmed = sql.trim();
   if (trimmed.length === 0) {
@@ -199,7 +197,7 @@ function executionError(e: unknown): DbCommandError {
 // so `INSERT … RETURNING` correctly returns its rows.
 function execute(
   statement: Statement,
-  spillDir: string | null | undefined
+  spillDir: string | undefined
 ): Result<QueryOutcome, DbCommandError> {
   if (statement.columnNames.length > 0) {
     return collectRows(statement, spillDir);
@@ -220,10 +218,11 @@ function execute(
   });
 }
 
-// Execute a result-returning statement, spilling beyond the inline bounds.
+// Execute a result-returning statement. Beyond the inline bounds the full result set is spilled
+// to `spillDir` when given, otherwise only the preview is kept and remaining rows are counted.
 function collectRows(
   statement: Statement,
-  spillDir: string | null | undefined
+  spillDir: string | undefined
 ): Result<QueryOutcome, DbCommandError> {
   const preview: Record<string, unknown>[] = [];
   let previewBytes = 0;
@@ -235,7 +234,7 @@ function collectRows(
   try {
     for (const row of statement.iterate()) {
       rowCount++;
-      if (spillDir === null && previewTruncated) {
+      if (previewTruncated) {
         continue;
       }
       const rowJson = JSON.stringify(row, jsonReplacer);
@@ -250,14 +249,13 @@ function collectRows(
           previewJson.push(rowJson);
           continue;
         }
-        if (spillDir === null) {
+        if (spillDir === undefined) {
           previewTruncated = true;
           continue;
         }
-        const dir = spillDir ?? tmpdir();
-        // The pod-files spill dir (e.g. /files/pod-<id>/.tool_outputs/db) is not pre-created.
-        mkdirSync(dir, { recursive: true });
-        spillPath = join(dir, `dsbx-query-${crypto.randomUUID()}.jsonl`);
+        // The spill dir is not pre-created.
+        mkdirSync(spillDir, { recursive: true });
+        spillPath = join(spillDir, `dsbx-query-${crypto.randomUUID()}.jsonl`);
         spillFd = openSync(spillPath, "w");
         for (const line of previewJson) {
           writeSync(spillFd, `${line}\n`);
@@ -273,20 +271,22 @@ function collectRows(
     }
   }
 
+  let note: string | null = null;
+  if (rowCount > preview.length) {
+    const previewNote = `${rowCount} rows total; the first ${preview.length} are shown here as a preview. `;
+    note =
+      spillPath !== null
+        ? `${previewNote}The complete result set is in ${spillPath}, one JSON object per line.`
+        : `${previewNote}Refine the query with LIMIT and OFFSET to inspect the remaining rows.`;
+  }
+
   return new Ok({
     columns: statement.columnNames,
     rows: preview,
     row_count: rowCount,
     changes: null,
     results_file: spillPath,
-    note:
-      spillPath !== null
-        ? `${rowCount} rows total; the first ${preview.length} are shown here as a preview. ` +
-          `The complete result set is in ${spillPath}, one JSON object per line.`
-        : previewTruncated
-          ? `${rowCount} rows total; the first ${preview.length} are shown here as a preview. ` +
-            "Refine the query with LIMIT and OFFSET to inspect the remaining rows."
-          : null,
+    note,
   });
 }
 

--- a/cli/dust-sandbox/functions-runner/runner.ts
+++ b/cli/dust-sandbox/functions-runner/runner.ts
@@ -22,8 +22,6 @@ import { BadInputError, parseInput, type RequestInput } from "./protocol.ts";
 import { getFunctionSchema } from "./schema.ts";
 import { serve } from "./serve.ts";
 
-const DB_QUERY_INLINE_ONLY_ENV = "DUST_DB_QUERY_INLINE_ONLY";
-
 // Everything this process creates — including files the function body creates
 // itself — must stay group-writable. The shared sandbox directories are setgid
 // with a `g::rwx` default ACL (`/sandbox-state/databases`, `/files`), but a default
@@ -125,8 +123,8 @@ async function dbSchemaHandler(args: string[]): Promise<number> {
 }
 
 async function dbQueryHandler(args: string[]): Promise<number> {
-  // spillDir is where an oversized local result is written; Rust passes a mounted files
-  // directory when the caller can read it. Absent, runQuery falls back to a temp directory.
+  // spillDir is where an oversized result is written in full; Rust passes it only when the caller
+  // can read this sandbox's files. Absent, runQuery keeps just the inline preview.
   const [dbPath, spillDir] = args;
   if (!dbPath) {
     return emitDbBadArgs(
@@ -139,12 +137,7 @@ async function dbQueryHandler(args: string[]): Promise<number> {
     return 1;
   }
   const sql = await Bun.stdin.text();
-  const result = runQuery(
-    dbPath,
-    sql,
-    maxSizeBytes.value,
-    process.env[DB_QUERY_INLINE_ONLY_ENV] === "1" ? null : spillDir
-  );
+  const result = runQuery(dbPath, sql, maxSizeBytes.value, spillDir);
   if (result.isErr()) {
     emitEnvelopeLine(errorEnvelope(result.error));
     return 1;

--- a/cli/dust-sandbox/functions-runner/runner.ts
+++ b/cli/dust-sandbox/functions-runner/runner.ts
@@ -22,6 +22,8 @@ import { BadInputError, parseInput, type RequestInput } from "./protocol.ts";
 import { getFunctionSchema } from "./schema.ts";
 import { serve } from "./serve.ts";
 
+const DB_QUERY_INLINE_ONLY_ENV = "DUST_DB_QUERY_INLINE_ONLY";
+
 // Everything this process creates — including files the function body creates
 // itself — must stay group-writable. The shared sandbox directories are setgid
 // with a `g::rwx` default ACL (`/sandbox-state/databases`, `/files`), but a default
@@ -123,8 +125,8 @@ async function dbSchemaHandler(args: string[]): Promise<number> {
 }
 
 async function dbQueryHandler(args: string[]): Promise<number> {
-  // spillDir is where an oversized result is written as a pod file; Rust passes the pod-files
-  // dir. Absent (a bare dbPath), runQuery falls back to a temp dir.
+  // spillDir is where an oversized local result is written; Rust passes a mounted files
+  // directory when the caller can read it. Absent, runQuery falls back to a temp directory.
   const [dbPath, spillDir] = args;
   if (!dbPath) {
     return emitDbBadArgs(
@@ -137,7 +139,12 @@ async function dbQueryHandler(args: string[]): Promise<number> {
     return 1;
   }
   const sql = await Bun.stdin.text();
-  const result = runQuery(dbPath, sql, maxSizeBytes.value, spillDir);
+  const result = runQuery(
+    dbPath,
+    sql,
+    maxSizeBytes.value,
+    process.env[DB_QUERY_INLINE_ONLY_ENV] === "1" ? null : spillDir
+  );
   if (result.isErr()) {
     emitEnvelopeLine(errorEnvelope(result.error));
     return 1;

--- a/cli/dust-sandbox/src/api/client.rs
+++ b/cli/dust-sandbox/src/api/client.rs
@@ -10,7 +10,8 @@ use super::error::DustApiError;
 use super::types::{
     parse_action_poll_response, ActionPollResponse, CallToolPostResponse, CallToolRequest,
     CallToolResponse, CallToolResult, FrameCallByIdRequest, FrameCallFromSourceRequest,
-    FrameCallResponse, FramePublishRequest, FramePublishResponse, FrameRegisterRequest,
+    FrameCallResponse, FrameDatabaseListResponse, FrameDatabaseQueryRequest,
+    FrameDatabaseQueryResponse, FramePublishRequest, FramePublishResponse, FrameRegisterRequest,
     FrameRegisterResponse, FrameShareLinkResponse, FrameValidateRequest, FrameValidateResponse,
     MCPServerView, SandboxServerViewsResponse,
 };
@@ -71,10 +72,21 @@ impl DustApiClient {
         path: &str,
         query: &[(&str, &str)],
     ) -> anyhow::Result<T> {
+        self.get_with_timeout(path, query, HTTP_REQUEST_TIMEOUT)
+            .await
+    }
+
+    async fn get_with_timeout<T: DeserializeOwned>(
+        &self,
+        path: &str,
+        query: &[(&str, &str)],
+        timeout: Duration,
+    ) -> anyhow::Result<T> {
         let url = self.url(path);
         let resp = self
             .client
             .get(&url)
+            .timeout(timeout)
             .query(query)
             .send()
             .await
@@ -211,6 +223,32 @@ impl DustApiClient {
         self.get(
             "sandbox/frames/share",
             &[("sourceDirectoryPath", source_directory_path)],
+        )
+        .await
+    }
+
+    pub async fn list_frame_databases(
+        &self,
+        frame_id: &str,
+    ) -> anyhow::Result<FrameDatabaseListResponse> {
+        self.get_with_timeout(
+            &format!("sandbox/frames/{frame_id}/databases"),
+            &[],
+            POLL_MAX_DURATION,
+        )
+        .await
+    }
+
+    pub async fn query_frame_database(
+        &self,
+        frame_id: &str,
+        database: &str,
+        sql: &str,
+    ) -> anyhow::Result<FrameDatabaseQueryResponse> {
+        self.post_with_timeout(
+            &format!("sandbox/frames/{frame_id}/databases"),
+            &FrameDatabaseQueryRequest { database, sql },
+            POLL_MAX_DURATION,
         )
         .await
     }
@@ -354,5 +392,50 @@ impl DustApiClient {
             self.post("sandbox/actions/call", &body).await?;
 
         self.poll_action_result(&action_id).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    use super::DustApiClient;
+
+    #[tokio::test]
+    async fn frame_database_list_survives_a_cold_start_beyond_the_default_timeout() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let address = listener.local_addr().expect("read test server address");
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept request");
+            let mut request = [0_u8; 1024];
+            stream.read(&mut request).await.expect("read request");
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let _ = stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 12\r\nConnection: close\r\n\r\n{\"items\":[]}",
+                )
+                .await;
+        });
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(20))
+            .build()
+            .expect("build test client");
+        let api = DustApiClient {
+            client,
+            base_url: format!("http://{address}"),
+        };
+
+        let response = api
+            .list_frame_databases("fil_abc123")
+            .await
+            .expect("Frame database listing should override the default request timeout");
+
+        assert!(response.items.is_empty());
+        server.await.expect("test server completes");
     }
 }

--- a/cli/dust-sandbox/src/api/client.rs
+++ b/cli/dust-sandbox/src/api/client.rs
@@ -413,7 +413,8 @@ mod tests {
         let server = tokio::spawn(async move {
             let (mut stream, _) = listener.accept().await.expect("accept request");
             let mut request = [0_u8; 1024];
-            stream.read(&mut request).await.expect("read request");
+            let bytes_read = stream.read(&mut request).await.expect("read request");
+            assert!(bytes_read > 0, "request must contain bytes");
             tokio::time::sleep(Duration::from_millis(100)).await;
             let _ = stream
                 .write_all(

--- a/cli/dust-sandbox/src/api/mod.rs
+++ b/cli/dust-sandbox/src/api/mod.rs
@@ -4,4 +4,6 @@ mod types;
 
 pub use client::DustApiClient;
 pub use error::DustApiError;
-pub use types::{parse_content_block, CallToolResult, ContentBlock};
+pub use types::{
+    parse_content_block, CallToolResult, ContentBlock, DatabaseEntry, FrameDatabaseQueryResponse,
+};

--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -3,6 +3,37 @@ use std::io::IsTerminal;
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameDatabaseEntry {
+    pub name: String,
+    pub size_bytes: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameDatabaseListResponse {
+    pub items: Vec<FrameDatabaseEntry>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameDatabaseQueryRequest<'a> {
+    pub database: &'a str,
+    pub sql: &'a str,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameDatabaseQueryResponse {
+    pub columns: Vec<String>,
+    pub rows: Vec<serde_json::Map<String, serde_json::Value>>,
+    pub row_count: u64,
+    pub changes: Option<u64>,
+    pub results_file: Option<String>,
+    pub note: Option<String>,
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FrameCallByIdRequest<'a> {

--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -3,17 +3,18 @@ use std::io::IsTerminal;
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
+/// A database listing entry. Deserialized from Front's camelCase JSON; serialized as the
+/// snake_case `dsbx db list` envelope, so local and remote listings print identically.
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct FrameDatabaseEntry {
+#[serde(rename_all(deserialize = "camelCase"))]
+pub struct DatabaseEntry {
     pub name: String,
     pub size_bytes: u64,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Deserialize)]
 pub struct FrameDatabaseListResponse {
-    pub items: Vec<FrameDatabaseEntry>,
+    pub items: Vec<DatabaseEntry>,
 }
 
 #[derive(Debug, Serialize)]
@@ -23,8 +24,10 @@ pub struct FrameDatabaseQueryRequest<'a> {
     pub sql: &'a str,
 }
 
+/// Same convention as `DatabaseEntry`: camelCase in from Front, snake_case out as the
+/// `dsbx db query` envelope the Bun runner prints for local queries.
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all(deserialize = "camelCase"))]
 pub struct FrameDatabaseQueryResponse {
     pub columns: Vec<String>,
     pub rows: Vec<serde_json::Map<String, serde_json::Value>>,

--- a/cli/dust-sandbox/src/commands/db/list.rs
+++ b/cli/dust-sandbox/src/commands/db/list.rs
@@ -3,22 +3,43 @@ use std::path::Path;
 use anyhow::{anyhow, Result};
 use serde::Serialize;
 
-use super::{databases_dir, emit_error};
+use crate::api::DustApiClient;
+
+use super::{databases_dir, emit_error, execution_target, DbExecutionTarget};
 
 #[derive(Serialize, Debug, PartialEq)]
-struct DatabaseEntry {
+pub(crate) struct DatabaseEntry {
     name: String,
     size_bytes: u64,
 }
 
-/// List the live pod databases (`*.db` files in the databases directory) with
+/// List the live sandbox databases (`*.db` files in the databases directory) with
 /// their sizes as a one-line JSON envelope. A missing directory is an empty
 /// list: it is created by the first reconcile that claims a database.
-pub fn cmd_db_list() -> Result<()> {
-    let dir = databases_dir();
-    let databases = enumerate_databases(&dir)
-        .map_err(|e| emit_error(anyhow!("cannot read {}: {e}", dir.display())))?;
+pub async fn cmd_db_list(frame_id: Option<&str>) -> Result<()> {
+    let databases = match execution_target(frame_id)? {
+        DbExecutionTarget::Local => list_local_databases()?,
+        DbExecutionTarget::RemoteFrame(frame_id) => DustApiClient::from_env()?
+            .list_frame_databases(frame_id)
+            .await?
+            .items
+            .into_iter()
+            .map(|database| DatabaseEntry {
+                name: database.name,
+                size_bytes: database.size_bytes,
+            })
+            .collect(),
+    };
 
+    print_databases(&databases)
+}
+
+fn list_local_databases() -> Result<Vec<DatabaseEntry>> {
+    let dir = databases_dir();
+    enumerate_databases(&dir).map_err(|e| emit_error(anyhow!("cannot read {}: {e}", dir.display())))
+}
+
+fn print_databases(databases: &[DatabaseEntry]) -> Result<()> {
     println!(
         "{}",
         serde_json::json!({ "ok": true, "databases": databases })

--- a/cli/dust-sandbox/src/commands/db/list.rs
+++ b/cli/dust-sandbox/src/commands/db/list.rs
@@ -1,17 +1,10 @@
 use std::path::Path;
 
 use anyhow::{anyhow, Result};
-use serde::Serialize;
 
-use crate::api::DustApiClient;
+use crate::api::{DatabaseEntry, DustApiClient};
 
 use super::{databases_dir, emit_error, execution_target, DbExecutionTarget};
-
-#[derive(Serialize, Debug, PartialEq)]
-pub(crate) struct DatabaseEntry {
-    name: String,
-    size_bytes: u64,
-}
 
 /// List the live sandbox databases (`*.db` files in the databases directory) with
 /// their sizes as a one-line JSON envelope. A missing directory is an empty
@@ -19,19 +12,19 @@ pub(crate) struct DatabaseEntry {
 pub async fn cmd_db_list(frame_id: Option<&str>) -> Result<()> {
     let databases = match execution_target(frame_id)? {
         DbExecutionTarget::Local => list_local_databases()?,
-        DbExecutionTarget::RemoteFrame(frame_id) => DustApiClient::from_env()?
-            .list_frame_databases(frame_id)
-            .await?
-            .items
-            .into_iter()
-            .map(|database| DatabaseEntry {
-                name: database.name,
-                size_bytes: database.size_bytes,
-            })
-            .collect(),
+        DbExecutionTarget::RemoteFrame(frame_id) => {
+            list_remote_databases(frame_id).await.map_err(emit_error)?
+        }
     };
 
     print_databases(&databases)
+}
+
+async fn list_remote_databases(frame_id: &str) -> Result<Vec<DatabaseEntry>> {
+    Ok(DustApiClient::from_env()?
+        .list_frame_databases(frame_id)
+        .await?
+        .items)
 }
 
 fn list_local_databases() -> Result<Vec<DatabaseEntry>> {

--- a/cli/dust-sandbox/src/commands/db/mod.rs
+++ b/cli/dust-sandbox/src/commands/db/mod.rs
@@ -1,6 +1,6 @@
-//! `dsbx db` — pod database subcommands (reconcile/schema/list/query).
+//! `dsbx db` database subcommands (reconcile/schema/list/query).
 //!
-//! Databases are per-pod SQLite files `{name}.db` under `$DUST_POD_DATABASES_DIR`
+//! Databases are sandbox-owned SQLite files `{name}.db` under `$DUST_POD_DATABASES_DIR`
 //! (falling back to the image's `/sandbox-state/databases`). This Rust layer owns name
 //! validation and path resolution; the DDL/SQL
 //! work runs in the embedded Bun runner (same privilege-drop machinery as
@@ -8,11 +8,13 @@
 //! root, NODE_PATH pointed at the image's global npm modules so `drizzle-kit`
 //! resolves at run time).
 
+use std::ffi::OsStr;
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
 use clap::Subcommand;
 
+use super::frame::validate_frame_id;
 use super::function::spawn_runner;
 
 mod list;
@@ -34,30 +36,111 @@ pub(crate) use super::function::emit_error;
 /// definition (these here are the superset: PathBuf-typed helper + empty-value fallback).
 pub(crate) const POD_DATABASES_DIR_ENV: &str = "DUST_POD_DATABASES_DIR";
 pub(crate) const DEFAULT_POD_DATABASES_DIR: &str = "/sandbox-state/databases";
+const CONVERSATION_ID_ENV: &str = "CONVERSATION_ID";
+const FRAME_ID_ENV: &str = "FRAME_ID";
 
 #[derive(Subcommand)]
 pub enum DbCommand {
-    /// Reconcile a pod database with a drizzle schema file (additive DDL only)
+    /// Reconcile a sandbox database with a drizzle schema file (additive DDL only)
     Reconcile {
         /// Database name (resolved to <name>.db in ${DUST_POD_DATABASES_DIR})
         name: String,
         /// Path to the drizzle schema file (databases/{db}.db.ts)
         schema_file: String,
     },
-    /// Regenerate a drizzle schema file from a live pod database
+    /// Regenerate a drizzle schema file from a live sandbox database
     Schema {
         /// Database name (resolved to <name>.db in ${DUST_POD_DATABASES_DIR})
         name: String,
         /// Output path for the regenerated schema file
         out_schema: String,
     },
-    /// List pod databases with sizes
-    List,
-    /// Execute one SQL statement (from stdin) against a pod database (SELECT/DML; DDL is refused)
+    /// List databases with sizes
+    List {
+        /// Target Frame ID. Only valid from a conversation sandbox.
+        #[arg(long)]
+        frame: Option<String>,
+    },
+    /// Execute one SQL statement (from stdin) against a database (SELECT/DML; DDL is refused)
     Query {
         /// Database name (resolved to <name>.db in ${DUST_POD_DATABASES_DIR})
         name: String,
+        /// Target Frame ID. Only valid from a conversation sandbox.
+        #[arg(long)]
+        frame: Option<String>,
     },
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum DbExecutionTarget<'a> {
+    Local,
+    RemoteFrame(&'a str),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) enum SandboxOwner {
+    Conversation,
+    Frame,
+    Unknown,
+    Invalid,
+}
+
+fn is_nonempty_marker(value: Option<&OsStr>) -> bool {
+    value.is_some_and(|value| !value.is_empty())
+}
+
+pub(crate) fn sandbox_owner_from_markers(
+    conversation_id: Option<&OsStr>,
+    frame_id: Option<&OsStr>,
+) -> SandboxOwner {
+    match (
+        is_nonempty_marker(conversation_id),
+        is_nonempty_marker(frame_id),
+    ) {
+        (true, false) => SandboxOwner::Conversation,
+        (false, true) => SandboxOwner::Frame,
+        (false, false) => SandboxOwner::Unknown,
+        (true, true) => SandboxOwner::Invalid,
+    }
+}
+
+fn current_sandbox_owner() -> SandboxOwner {
+    sandbox_owner_from_markers(
+        std::env::var_os(CONVERSATION_ID_ENV).as_deref(),
+        std::env::var_os(FRAME_ID_ENV).as_deref(),
+    )
+}
+
+/**
+ * @cc [owner:davidebbo,label:product] frame-target-only-from-conversation
+ * `--frame` MUST be accepted only when `CONVERSATION_ID` is the sole sandbox owner marker. A
+ * conversation sandbox without `--frame` MUST fail instead of inspecting its empty local database
+ * directory, while a Frame sandbox without `--frame` MUST keep using its local databases.
+ */
+pub(crate) fn resolve_execution_target<'a>(
+    requested_frame_id: Option<&'a str>,
+    sandbox_owner: SandboxOwner,
+) -> Result<DbExecutionTarget<'a>> {
+    match (requested_frame_id, sandbox_owner) {
+        (Some(frame_id), SandboxOwner::Conversation) => {
+            validate_frame_id(frame_id)?;
+            Ok(DbExecutionTarget::RemoteFrame(frame_id))
+        }
+        (Some(_), SandboxOwner::Frame | SandboxOwner::Unknown | SandboxOwner::Invalid) => Err(
+            anyhow!("--frame can only be used from a conversation sandbox"),
+        ),
+        (None, SandboxOwner::Conversation) => Err(anyhow!(
+            "conversation sandboxes have no local Frame databases; pass --frame <frame-id>"
+        )),
+        (None, SandboxOwner::Invalid) => Err(anyhow!(
+            "invalid sandbox environment: CONVERSATION_ID and FRAME_ID are both set"
+        )),
+        (None, SandboxOwner::Frame | SandboxOwner::Unknown) => Ok(DbExecutionTarget::Local),
+    }
+}
+
+pub(crate) fn execution_target(frame_id: Option<&str>) -> Result<DbExecutionTarget<'_>> {
+    resolve_execution_target(frame_id, current_sandbox_owner())
 }
 
 /// The configured pod databases directory, falling back to the image constant.
@@ -159,5 +242,54 @@ mod tests {
     fn db_file_path_rejects_invalid_names() {
         assert!(db_file_path("../escape").is_err());
         assert!(db_file_path("Chat").is_err());
+    }
+
+    #[test]
+    fn routes_frame_targets_only_from_conversation_sandboxes() {
+        assert_eq!(
+            resolve_execution_target(Some("fil_abc123"), SandboxOwner::Conversation)
+                .expect("conversation sandbox may target a Frame"),
+            DbExecutionTarget::RemoteFrame("fil_abc123")
+        );
+        assert!(resolve_execution_target(Some("fil_abc123"), SandboxOwner::Frame).is_err());
+        assert!(resolve_execution_target(Some("fil_abc123"), SandboxOwner::Unknown).is_err());
+        assert!(resolve_execution_target(Some("fil_abc123"), SandboxOwner::Invalid).is_err());
+    }
+
+    #[test]
+    fn requires_frame_target_in_conversation_sandboxes() {
+        assert!(resolve_execution_target(None, SandboxOwner::Conversation).is_err());
+        assert_eq!(
+            resolve_execution_target(None, SandboxOwner::Frame)
+                .expect("Frame sandbox uses its local databases"),
+            DbExecutionTarget::Local
+        );
+        assert_eq!(
+            resolve_execution_target(None, SandboxOwner::Unknown)
+                .expect("host invocation keeps local behavior"),
+            DbExecutionTarget::Local
+        );
+    }
+
+    #[test]
+    fn detects_reserved_sandbox_owner_markers() {
+        use std::ffi::OsStr;
+
+        assert_eq!(
+            sandbox_owner_from_markers(Some(OsStr::new("conv_123")), None),
+            SandboxOwner::Conversation
+        );
+        assert_eq!(
+            sandbox_owner_from_markers(None, Some(OsStr::new("fil_123"))),
+            SandboxOwner::Frame
+        );
+        assert_eq!(
+            sandbox_owner_from_markers(Some(OsStr::new("")), None),
+            SandboxOwner::Unknown
+        );
+        assert_eq!(
+            sandbox_owner_from_markers(Some(OsStr::new("conv_123")), Some(OsStr::new("fil_123"))),
+            SandboxOwner::Invalid
+        );
     }
 }

--- a/cli/dust-sandbox/src/commands/db/mod.rs
+++ b/cli/dust-sandbox/src/commands/db/mod.rs
@@ -8,7 +8,6 @@
 //! root, NODE_PATH pointed at the image's global npm modules so `drizzle-kit`
 //! resolves at run time).
 
-use std::ffi::OsStr;
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
@@ -37,7 +36,7 @@ pub(crate) use super::function::emit_error;
 pub(crate) const POD_DATABASES_DIR_ENV: &str = "DUST_POD_DATABASES_DIR";
 pub(crate) const DEFAULT_POD_DATABASES_DIR: &str = "/sandbox-state/databases";
 const CONVERSATION_ID_ENV: &str = "CONVERSATION_ID";
-const FRAME_ID_ENV: &str = "FRAME_ID";
+const NO_LOCAL_DATABASES_MESSAGE: &str = "conversation sandboxes have no local databases";
 
 #[derive(Subcommand)]
 pub enum DbCommand {
@@ -77,70 +76,49 @@ pub(crate) enum DbExecutionTarget<'a> {
     RemoteFrame(&'a str),
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub(crate) enum SandboxOwner {
-    Conversation,
-    Frame,
-    Unknown,
-    Invalid,
-}
-
-fn is_nonempty_marker(value: Option<&OsStr>) -> bool {
-    value.is_some_and(|value| !value.is_empty())
-}
-
-pub(crate) fn sandbox_owner_from_markers(
-    conversation_id: Option<&OsStr>,
-    frame_id: Option<&OsStr>,
-) -> SandboxOwner {
-    match (
-        is_nonempty_marker(conversation_id),
-        is_nonempty_marker(frame_id),
-    ) {
-        (true, false) => SandboxOwner::Conversation,
-        (false, true) => SandboxOwner::Frame,
-        (false, false) => SandboxOwner::Unknown,
-        (true, true) => SandboxOwner::Invalid,
-    }
-}
-
-fn current_sandbox_owner() -> SandboxOwner {
-    sandbox_owner_from_markers(
-        std::env::var_os(CONVERSATION_ID_ENV).as_deref(),
-        std::env::var_os(FRAME_ID_ENV).as_deref(),
-    )
+/// Front sets `CONVERSATION_ID` on conversation-owned sandboxes only (see
+/// `getSandboxOwnerEnvVars` in front/lib/api/sandbox/owner.ts).
+fn in_conversation_sandbox() -> bool {
+    std::env::var_os(CONVERSATION_ID_ENV).is_some_and(|value| !value.is_empty())
 }
 
 /**
  * @cc [owner:davidebbo,label:product] frame-target-only-from-conversation
- * `--frame` MUST be accepted only when `CONVERSATION_ID` is the sole sandbox owner marker. A
- * conversation sandbox without `--frame` MUST fail instead of inspecting its empty local database
- * directory, while a Frame sandbox without `--frame` MUST keep using its local databases.
+ * `--frame` MUST be accepted only in a conversation sandbox (`CONVERSATION_ID` set). A conversation
+ * sandbox without `--frame` MUST fail instead of inspecting its empty local database directory;
+ * any other sandbox MUST keep using its local databases.
  */
-pub(crate) fn resolve_execution_target<'a>(
-    requested_frame_id: Option<&'a str>,
-    sandbox_owner: SandboxOwner,
-) -> Result<DbExecutionTarget<'a>> {
-    match (requested_frame_id, sandbox_owner) {
-        (Some(frame_id), SandboxOwner::Conversation) => {
+pub(crate) fn resolve_execution_target(
+    requested_frame_id: Option<&str>,
+    in_conversation: bool,
+) -> Result<DbExecutionTarget<'_>> {
+    match (requested_frame_id, in_conversation) {
+        (Some(frame_id), true) => {
             validate_frame_id(frame_id)?;
             Ok(DbExecutionTarget::RemoteFrame(frame_id))
         }
-        (Some(_), SandboxOwner::Frame | SandboxOwner::Unknown | SandboxOwner::Invalid) => Err(
-            anyhow!("--frame can only be used from a conversation sandbox"),
-        ),
-        (None, SandboxOwner::Conversation) => Err(anyhow!(
-            "conversation sandboxes have no local Frame databases; pass --frame <frame-id>"
+        (Some(_), false) => Err(anyhow!(
+            "--frame can only be used from a conversation sandbox"
         )),
-        (None, SandboxOwner::Invalid) => Err(anyhow!(
-            "invalid sandbox environment: CONVERSATION_ID and FRAME_ID are both set"
+        (None, true) => Err(anyhow!(
+            "{NO_LOCAL_DATABASES_MESSAGE}; pass --frame <frame-id>"
         )),
-        (None, SandboxOwner::Frame | SandboxOwner::Unknown) => Ok(DbExecutionTarget::Local),
+        (None, false) => Ok(DbExecutionTarget::Local),
     }
 }
 
+/// Resolve where `db list` / `db query` run, emitting the stdout error envelope on failure.
 pub(crate) fn execution_target(frame_id: Option<&str>) -> Result<DbExecutionTarget<'_>> {
-    resolve_execution_target(frame_id, current_sandbox_owner())
+    resolve_execution_target(frame_id, in_conversation_sandbox()).map_err(emit_error)
+}
+
+/// Guard for the local-only subcommands (`reconcile`, `schema`): a conversation sandbox has no
+/// databases of its own, so creating one there would leave it invisible to `db list`.
+pub(crate) fn require_local_databases() -> Result<()> {
+    if in_conversation_sandbox() {
+        return Err(emit_error(anyhow!(NO_LOCAL_DATABASES_MESSAGE)));
+    }
+    Ok(())
 }
 
 /// The configured pod databases directory, falling back to the image constant.
@@ -247,49 +225,20 @@ mod tests {
     #[test]
     fn routes_frame_targets_only_from_conversation_sandboxes() {
         assert_eq!(
-            resolve_execution_target(Some("fil_abc123"), SandboxOwner::Conversation)
+            resolve_execution_target(Some("fil_abc123"), true)
                 .expect("conversation sandbox may target a Frame"),
             DbExecutionTarget::RemoteFrame("fil_abc123")
         );
-        assert!(resolve_execution_target(Some("fil_abc123"), SandboxOwner::Frame).is_err());
-        assert!(resolve_execution_target(Some("fil_abc123"), SandboxOwner::Unknown).is_err());
-        assert!(resolve_execution_target(Some("fil_abc123"), SandboxOwner::Invalid).is_err());
+        assert!(resolve_execution_target(Some("fil_abc123"), false).is_err());
+        assert!(resolve_execution_target(Some("not-a-frame"), true).is_err());
     }
 
     #[test]
     fn requires_frame_target_in_conversation_sandboxes() {
-        assert!(resolve_execution_target(None, SandboxOwner::Conversation).is_err());
+        assert!(resolve_execution_target(None, true).is_err());
         assert_eq!(
-            resolve_execution_target(None, SandboxOwner::Frame)
-                .expect("Frame sandbox uses its local databases"),
+            resolve_execution_target(None, false).expect("other sandboxes use local databases"),
             DbExecutionTarget::Local
-        );
-        assert_eq!(
-            resolve_execution_target(None, SandboxOwner::Unknown)
-                .expect("host invocation keeps local behavior"),
-            DbExecutionTarget::Local
-        );
-    }
-
-    #[test]
-    fn detects_reserved_sandbox_owner_markers() {
-        use std::ffi::OsStr;
-
-        assert_eq!(
-            sandbox_owner_from_markers(Some(OsStr::new("conv_123")), None),
-            SandboxOwner::Conversation
-        );
-        assert_eq!(
-            sandbox_owner_from_markers(None, Some(OsStr::new("fil_123"))),
-            SandboxOwner::Frame
-        );
-        assert_eq!(
-            sandbox_owner_from_markers(Some(OsStr::new("")), None),
-            SandboxOwner::Unknown
-        );
-        assert_eq!(
-            sandbox_owner_from_markers(Some(OsStr::new("conv_123")), Some(OsStr::new("fil_123"))),
-            SandboxOwner::Invalid
         );
     }
 }

--- a/cli/dust-sandbox/src/commands/db/query.rs
+++ b/cli/dust-sandbox/src/commands/db/query.rs
@@ -1,21 +1,31 @@
 use std::ffi::OsStr;
+use std::io::Read;
 
 use anyhow::Result;
 
-use super::{db_file_path, spawn_runner};
+use crate::api::DustApiClient;
 
-/// Env carrying the in-sandbox pod-files dir an oversized query result spills into (a pod file the
-/// caller can read); set by front per exec. Absent, the runner falls back to a temp dir. The name
-/// must match the env var set in front/lib/api/sandbox_functions/dsbx_db.ts.
+use super::{db_file_path, execution_target, spawn_runner, DbExecutionTarget};
+
+/// Env carrying the in-sandbox files dir an oversized local query result spills into; set by Front
+/// per exec. Absent, the runner falls back to a temp dir. The name must match the env var set in
+/// front/lib/api/sandbox_functions/dsbx_db.ts.
 const POD_QUERY_SPILL_DIR_ENV: &str = "DUST_POD_QUERY_SPILL_DIR";
 
-/// Execute one SQL statement (from stdin) against the pod database `name`.
+/// Execute one SQL statement (from stdin) against the sandbox database `name`.
 /// The runner allows SELECT and DML and refuses DDL (a statement that changes
 /// the schema is rolled back), so the schema only evolves through reconcile.
 /// Rows come back in the stdout JSON envelope; a result crossing the inline
 /// bounds is written in full to a spill file — under the pod-files spill dir —
 /// the envelope names. Runs as `agent-proxied` like `function run`.
-pub async fn cmd_db_query(name: &str) -> Result<()> {
+pub async fn cmd_db_query(name: &str, frame_id: Option<&str>) -> Result<()> {
+    match execution_target(frame_id)? {
+        DbExecutionTarget::Local => run_local_query(name).await,
+        DbExecutionTarget::RemoteFrame(frame_id) => run_remote_query(name, frame_id).await,
+    }
+}
+
+async fn run_local_query(name: &str) -> Result<()> {
     let db_path = db_file_path(name)?;
     let spill_dir = std::env::var_os(POD_QUERY_SPILL_DIR_ENV).filter(|d| !d.is_empty());
 
@@ -26,4 +36,25 @@ pub async fn cmd_db_query(name: &str) -> Result<()> {
 
     let code = spawn_runner("db-query", &args, true).await?;
     std::process::exit(code);
+}
+
+async fn run_remote_query(name: &str, frame_id: &str) -> Result<()> {
+    let mut sql = String::new();
+    std::io::stdin().read_to_string(&mut sql)?;
+    let response = DustApiClient::from_env()?
+        .query_frame_database(frame_id, name, &sql)
+        .await?;
+    println!(
+        "{}",
+        serde_json::json!({
+            "ok": true,
+            "columns": response.columns,
+            "rows": response.rows,
+            "row_count": response.row_count,
+            "changes": response.changes,
+            "results_file": response.results_file,
+            "note": response.note,
+        })
+    );
+    Ok(())
 }

--- a/cli/dust-sandbox/src/commands/db/query.rs
+++ b/cli/dust-sandbox/src/commands/db/query.rs
@@ -2,22 +2,25 @@ use std::ffi::OsStr;
 use std::io::Read;
 
 use anyhow::Result;
+use serde::Serialize;
 
-use crate::api::DustApiClient;
+use crate::api::{DustApiClient, FrameDatabaseQueryResponse};
 
-use super::{db_file_path, execution_target, spawn_runner, DbExecutionTarget};
+use super::super::frame::print_response;
+use super::{db_file_path, emit_error, execution_target, spawn_runner, DbExecutionTarget};
 
-/// Env carrying the in-sandbox files dir an oversized local query result spills into; set by Front
-/// per exec. Absent, the runner falls back to a temp dir. The name must match the env var set in
-/// front/lib/api/sandbox_functions/dsbx_db.ts.
+/// Env carrying a directory the caller can read, into which an oversized local query result is
+/// spilled in full. Absent, the runner keeps only the bounded inline preview (Front's Frame
+/// database endpoint leaves it unset, since a remote caller cannot open this sandbox's files).
 const POD_QUERY_SPILL_DIR_ENV: &str = "DUST_POD_QUERY_SPILL_DIR";
 
 /// Execute one SQL statement (from stdin) against the sandbox database `name`.
 /// The runner allows SELECT and DML and refuses DDL (a statement that changes
 /// the schema is rolled back), so the schema only evolves through reconcile.
 /// Rows come back in the stdout JSON envelope; a result crossing the inline
-/// bounds is written in full to a spill file — under the pod-files spill dir —
-/// the envelope names. Runs as `agent-proxied` like `function run`.
+/// bounds is written in full to a spill file the envelope names when a spill
+/// dir is configured, and is otherwise truncated to a preview. Runs as
+/// `agent-proxied` like `function run`.
 pub async fn cmd_db_query(name: &str, frame_id: Option<&str>) -> Result<()> {
     match execution_target(frame_id)? {
         DbExecutionTarget::Local => run_local_query(name).await,
@@ -38,23 +41,26 @@ async fn run_local_query(name: &str) -> Result<()> {
     std::process::exit(code);
 }
 
+/// The stdout envelope for a remote query: `ok` plus the runner's snake_case fields, identical to
+/// what a local `db query` prints.
+#[derive(Serialize)]
+struct QueryEnvelope {
+    ok: bool,
+    #[serde(flatten)]
+    response: FrameDatabaseQueryResponse,
+}
+
 async fn run_remote_query(name: &str, frame_id: &str) -> Result<()> {
+    let response = query_remote_database(name, frame_id)
+        .await
+        .map_err(emit_error)?;
+    print_response(&QueryEnvelope { ok: true, response })
+}
+
+async fn query_remote_database(name: &str, frame_id: &str) -> Result<FrameDatabaseQueryResponse> {
     let mut sql = String::new();
     std::io::stdin().read_to_string(&mut sql)?;
-    let response = DustApiClient::from_env()?
+    DustApiClient::from_env()?
         .query_frame_database(frame_id, name, &sql)
-        .await?;
-    println!(
-        "{}",
-        serde_json::json!({
-            "ok": true,
-            "columns": response.columns,
-            "rows": response.rows,
-            "row_count": response.row_count,
-            "changes": response.changes,
-            "results_file": response.results_file,
-            "note": response.note,
-        })
-    );
-    Ok(())
+        .await
 }

--- a/cli/dust-sandbox/src/commands/db/reconcile.rs
+++ b/cli/dust-sandbox/src/commands/db/reconcile.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use anyhow::{anyhow, Result};
 
-use super::{db_file_path, emit_error, spawn_runner};
+use super::{db_file_path, emit_error, require_local_databases, spawn_runner};
 
 /// Reconcile the pod database `name` with the drizzle schema file at
 /// `schema_file`: the runner plans via drizzle-kit, applies ADDITIVE statements
@@ -11,6 +11,7 @@ use super::{db_file_path, emit_error, spawn_runner};
 /// database file is created on first claim. stdout carries the runner's
 /// one-line JSON envelope; exit code passes through.
 pub async fn cmd_db_reconcile(name: &str, schema_file: &str) -> Result<()> {
+    require_local_databases()?;
     let db_path = db_file_path(name)?;
     let schema_path = Path::new(schema_file);
     if !schema_path.is_file() {

--- a/cli/dust-sandbox/src/commands/db/schema.rs
+++ b/cli/dust-sandbox/src/commands/db/schema.rs
@@ -2,13 +2,14 @@ use std::path::Path;
 
 use anyhow::Result;
 
-use super::{db_file_path, spawn_runner};
+use super::{db_file_path, require_local_databases, spawn_runner};
 
 /// Regenerate a drizzle `{db}.db.ts` schema file from the live pod database
 /// `name`, writing it to `out_schema` (file-output pattern: the file is the
 /// payload, stdout only carries the `{ok}` envelope). Column modes are not
 /// recoverable from SQLite — the regenerated file carries storage types only.
 pub async fn cmd_db_schema(name: &str, out_schema: &str) -> Result<()> {
+    require_local_databases()?;
     let db_path = db_file_path(name)?;
 
     let code = spawn_runner(

--- a/cli/dust-sandbox/src/commands/frame/call.rs
+++ b/cli/dust-sandbox/src/commands/frame/call.rs
@@ -1,10 +1,10 @@
 use std::path::Path;
 
-use anyhow::{bail, Context};
+use anyhow::Context;
 
 use crate::api::DustApiClient;
 
-use super::{print_response, scoped_path};
+use super::{print_response, scoped_path, validate_frame_id};
 
 pub async fn run(target: &str, function_name: &str, input: Option<&str>) -> anyhow::Result<()> {
     let input = parse_input(input)?;
@@ -21,20 +21,6 @@ pub async fn run(target: &str, function_name: &str, input: Option<&str>) -> anyh
             .await?
     };
     print_response(&response)
-}
-
-fn validate_frame_id(frame_id: &str) -> anyhow::Result<()> {
-    let Some(encoded) = frame_id.strip_prefix("fil_") else {
-        bail!("invalid Frame ID: {frame_id}");
-    };
-    if encoded.is_empty()
-        || !encoded
-            .chars()
-            .all(|character| character.is_ascii_alphanumeric())
-    {
-        bail!("invalid Frame ID: {frame_id}");
-    }
-    Ok(())
 }
 
 fn parse_input(input: Option<&str>) -> anyhow::Result<Option<serde_json::Value>> {

--- a/cli/dust-sandbox/src/commands/frame/mod.rs
+++ b/cli/dust-sandbox/src/commands/frame/mod.rs
@@ -126,7 +126,7 @@ pub(crate) fn validate_frame_id(frame_id: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn print_response(response: &impl serde::Serialize) -> anyhow::Result<()> {
+pub(crate) fn print_response(response: &impl serde::Serialize) -> anyhow::Result<()> {
     println!("{}", serde_json::to_string(response)?);
     Ok(())
 }

--- a/cli/dust-sandbox/src/commands/frame/mod.rs
+++ b/cli/dust-sandbox/src/commands/frame/mod.rs
@@ -112,6 +112,20 @@ fn scoped_manifest_path(path: &Path) -> anyhow::Result<String> {
     scoped_path(path)
 }
 
+pub(crate) fn validate_frame_id(frame_id: &str) -> anyhow::Result<()> {
+    let Some(encoded) = frame_id.strip_prefix("fil_") else {
+        bail!("invalid Frame ID: {frame_id}");
+    };
+    if encoded.is_empty()
+        || !encoded
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric())
+    {
+        bail!("invalid Frame ID: {frame_id}");
+    }
+    Ok(())
+}
+
 fn print_response(response: &impl serde::Serialize) -> anyhow::Result<()> {
     println!("{}", serde_json::to_string(response)?);
     Ok(())

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -29,7 +29,7 @@ enum Commands {
         #[command(subcommand)]
         command: commands::function::FunctionCommand,
     },
-    /// Manage pod databases
+    /// Manage sandbox databases
     Db {
         #[command(subcommand)]
         command: commands::db::DbCommand,
@@ -127,8 +127,12 @@ async fn run() -> anyhow::Result<()> {
             commands::db::DbCommand::Schema { name, out_schema } => {
                 commands::cmd_db_schema(&name, &out_schema).await?
             }
-            commands::db::DbCommand::List => commands::cmd_db_list()?,
-            commands::db::DbCommand::Query { name } => commands::cmd_db_query(&name).await?,
+            commands::db::DbCommand::List { frame } => {
+                commands::cmd_db_list(frame.as_deref()).await?
+            }
+            commands::db::DbCommand::Query { name, frame } => {
+                commands::cmd_db_query(&name, frame.as_deref()).await?
+            }
         },
         Commands::Frame { command } => match command {
             commands::frame::FrameCommand::Call {
@@ -465,7 +469,22 @@ mod tests {
         let cli = Cli::try_parse_from(["dsbx", "db", "list"]).expect("parse");
         match cli.command {
             Commands::Db { command } => match command {
-                commands::db::DbCommand::List => {}
+                commands::db::DbCommand::List { frame } => assert_eq!(frame, None),
+                _ => panic!("expected list"),
+            },
+            _ => panic!("expected db"),
+        }
+    }
+
+    #[test]
+    fn db_list_with_frame_parses() {
+        let cli =
+            Cli::try_parse_from(["dsbx", "db", "list", "--frame", "fil_abc123"]).expect("parse");
+        match cli.command {
+            Commands::Db { command } => match command {
+                commands::db::DbCommand::List { frame } => {
+                    assert_eq!(frame.as_deref(), Some("fil_abc123"));
+                }
                 _ => panic!("expected list"),
             },
             _ => panic!("expected db"),
@@ -477,7 +496,26 @@ mod tests {
         let cli = Cli::try_parse_from(["dsbx", "db", "query", "chat"]).expect("parse");
         match cli.command {
             Commands::Db { command } => match command {
-                commands::db::DbCommand::Query { name } => assert_eq!(name, "chat"),
+                commands::db::DbCommand::Query { name, frame } => {
+                    assert_eq!(name, "chat");
+                    assert_eq!(frame, None);
+                }
+                _ => panic!("expected query"),
+            },
+            _ => panic!("expected db"),
+        }
+    }
+
+    #[test]
+    fn db_query_with_frame_parses() {
+        let cli = Cli::try_parse_from(["dsbx", "db", "query", "chat", "--frame", "fil_abc123"])
+            .expect("parse");
+        match cli.command {
+            Commands::Db { command } => match command {
+                commands::db::DbCommand::Query { name, frame } => {
+                    assert_eq!(name, "chat");
+                    assert_eq!(frame.as_deref(), Some("fil_abc123"));
+                }
                 _ => panic!("expected query"),
             },
             _ => panic!("expected db"),

--- a/front-api/middlewares/ctx.ts
+++ b/front-api/middlewares/ctx.ts
@@ -64,6 +64,12 @@ export type SandboxCtx = {
   };
 };
 
+export type SandboxFrameCtx = SandboxCtx & {
+  Variables: {
+    frame: FileResource;
+  };
+};
+
 export type SpaceCtx = WorkspaceAwareCtx & {
   Variables: {
     space: SpaceResource;
@@ -97,4 +103,5 @@ export const pokeFrameFunctionApp = () => createHono<PokeFrameFunctionCtx>();
 export const pokeFrameApp = () => createHono<PokeFrameCtx>();
 export const publicApiApp = () => createHono<PublicApiCtx>();
 export const sandboxApp = () => createHono<SandboxCtx>();
+export const sandboxFrameApp = () => createHono<SandboxFrameCtx>();
 export const skillApp = () => createHono<SkillCtx>();

--- a/front-api/middlewares/with_frames.ts
+++ b/front-api/middlewares/with_frames.ts
@@ -3,6 +3,7 @@ import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_res
 import type {
   PokeFrameCtx,
   PokeFrameFunctionCtx,
+  SandboxFrameCtx,
 } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { createMiddleware } from "hono/factory";
@@ -12,10 +13,10 @@ import { createMiddleware } from "hono/factory";
  * any other kind of file, and stashes it on the context under `frame`. Apply at the `[frameId]`
  * level so sub-routes read `ctx.get("frame")` instead of each re-fetching and re-validating it.
  *
- * Apply after the poke auth middleware so `ctx.get("auth")` is available.
+ * Apply after the auth middleware (poke or sandbox) so `ctx.get("auth")` is available.
  */
 export function withFrame() {
-  return createMiddleware<PokeFrameCtx>(async (ctx, next) => {
+  return createMiddleware<PokeFrameCtx | SandboxFrameCtx>(async (ctx, next) => {
     const auth = ctx.get("auth");
     const frameId = ctx.req.param("frameId");
 

--- a/front-api/routes/poke/workspaces/[wId]/frames/[frameId]/databases.ts
+++ b/front-api/routes/poke/workspaces/[wId]/frames/[frameId]/databases.ts
@@ -1,5 +1,5 @@
+import { listFrameDatabases } from "@app/lib/api/frames/databases";
 import type { PokeListFrameDatabases } from "@app/lib/api/poke/frames";
-import { listFrameDatabases } from "@app/lib/api/poke/frames";
 import { pokeFrameApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/[frameId]/databases.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/[frameId]/databases.test.ts
@@ -189,9 +189,37 @@ describe("conversation sandbox Frame database access", () => {
         sandbox: context.sandbox,
         database: "tasks",
         sql: "UPDATE tasks SET done = 1 WHERE owner = 'me'",
-        resultMode: "inline_preview",
       }
     );
+  });
+
+  it("lets a userless conversation token reach its own conversation's Frame", async () => {
+    const context = await createSandboxTokenTestContext({
+      userlessToken: true,
+    });
+    await FeatureFlagFactory.basic(context.auth, "frames_v2");
+    const frame = await makeConversationFrame({
+      auth: context.auth,
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    });
+    vi.mocked(ensureFrameSandboxReady).mockResolvedValue(
+      new Ok({
+        sandbox: context.sandbox,
+        freshlyCreated: false,
+        scope: { spaceId: null },
+      })
+    );
+    vi.mocked(listDatabasesOnReadySandbox).mockResolvedValue(new Ok([]));
+
+    const response = await requestFrameDatabases({
+      workspaceId: context.workspace.sId,
+      frameId: frame.sId,
+      token: context.token,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ items: [] });
   });
 
   it("denies a same-workspace Frame whose source the caller cannot write", async () => {

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/[frameId]/databases.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/[frameId]/databases.test.ts
@@ -1,0 +1,283 @@
+import { ensureFrameSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import {
+  listDatabasesOnReadySandbox,
+  queryDatabaseOnReadySandbox,
+} from "@app/lib/api/sandbox_functions/dsbx_db";
+import { Authenticator } from "@app/lib/auth";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import {
+  createPersistedFrameFunctionInvocationTokenTestContext,
+  createSandboxTokenTestContext,
+} from "@app/tests/utils/SandboxTokenFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
+import { frameV2ContentType } from "@app/types/files";
+import { getConversationFilesBasePath } from "@app/types/mount_path";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(import("@app/lib/api/sandbox/lifecycle"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, ensureFrameSandboxReady: vi.fn() };
+});
+
+vi.mock(
+  import("@app/lib/api/sandbox_functions/dsbx_db"),
+  async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+      ...actual,
+      listDatabasesOnReadySandbox: vi.fn(),
+      queryDatabaseOnReadySandbox: vi.fn(),
+    };
+  }
+);
+
+async function makeConversationFrame({
+  auth,
+  workspaceId,
+  conversationId,
+  directory = "Status",
+}: {
+  auth: Authenticator;
+  workspaceId: string;
+  conversationId: string;
+  directory?: string;
+}): Promise<FileResource> {
+  return FileFactory.create(auth, null, {
+    contentType: frameV2ContentType,
+    fileName: FRAME_MANIFEST_FILE,
+    fileSize: 100,
+    status: "ready",
+    useCase: "conversation",
+    useCaseMetadata: { conversationId },
+    mountFilePath: `${getConversationFilesBasePath({
+      workspaceId,
+      conversationId,
+    })}${directory}/${FRAME_MANIFEST_FILE}`,
+  });
+}
+
+function frameDatabasesUrl(workspaceId: string, frameId: string): string {
+  return `/api/v1/w/${workspaceId}/sandbox/frames/${frameId}/databases`;
+}
+
+function requestFrameDatabases({
+  workspaceId,
+  frameId,
+  token,
+  query,
+}: {
+  workspaceId: string;
+  frameId: string;
+  token: string;
+  query?: { database: string; sql: string };
+}) {
+  return honoApp.request(frameDatabasesUrl(workspaceId, frameId), {
+    method: query ? "POST" : "GET",
+    headers: {
+      authorization: `Bearer ${token}`,
+      ...(query ? { "content-type": "application/json" } : {}),
+    },
+    body: query ? JSON.stringify(query) : undefined,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("conversation sandbox Frame database access", () => {
+  it("lists databases for a Frame whose source the caller can write", async () => {
+    const context = await createSandboxTokenTestContext();
+    await FeatureFlagFactory.basic(context.auth, "frames_v2");
+    const frame = await makeConversationFrame({
+      auth: context.auth,
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    });
+    vi.mocked(ensureFrameSandboxReady).mockResolvedValue(
+      new Ok({
+        sandbox: context.sandbox,
+        freshlyCreated: false,
+        scope: { spaceId: null },
+      })
+    );
+    vi.mocked(listDatabasesOnReadySandbox).mockResolvedValue(
+      new Ok([{ name: "tasks", sizeBytes: 8192 }])
+    );
+
+    const response = await requestFrameDatabases({
+      workspaceId: context.workspace.sId,
+      frameId: frame.sId,
+      token: context.token,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      items: [{ name: "tasks", sizeBytes: 8192 }],
+    });
+    expect(ensureFrameSandboxReady).toHaveBeenCalledWith(
+      expect.any(Authenticator),
+      frame
+    );
+    expect(listDatabasesOnReadySandbox).toHaveBeenCalledWith(
+      expect.any(Authenticator),
+      context.sandbox
+    );
+  });
+
+  it("runs data-changing SQL for an authorized Frame", async () => {
+    const context = await createSandboxTokenTestContext();
+    await FeatureFlagFactory.basic(context.auth, "frames_v2");
+    const frame = await makeConversationFrame({
+      auth: context.auth,
+      workspaceId: context.workspace.sId,
+      conversationId: context.conversation.sId,
+    });
+    vi.mocked(ensureFrameSandboxReady).mockResolvedValue(
+      new Ok({
+        sandbox: context.sandbox,
+        freshlyCreated: false,
+        scope: { spaceId: null },
+      })
+    );
+    vi.mocked(queryDatabaseOnReadySandbox).mockResolvedValue(
+      new Ok({
+        columns: [],
+        rows: [],
+        rowCount: 0,
+        changes: 3,
+        resultsFile: null,
+        note: null,
+      })
+    );
+
+    const response = await requestFrameDatabases({
+      workspaceId: context.workspace.sId,
+      frameId: frame.sId,
+      token: context.token,
+      query: {
+        database: "tasks",
+        sql: "UPDATE tasks SET done = 1 WHERE owner = 'me'",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      columns: [],
+      rows: [],
+      rowCount: 0,
+      changes: 3,
+      resultsFile: null,
+      note: null,
+    });
+    expect(ensureFrameSandboxReady).toHaveBeenCalledWith(
+      expect.any(Authenticator),
+      frame
+    );
+    expect(queryDatabaseOnReadySandbox).toHaveBeenCalledWith(
+      expect.any(Authenticator),
+      {
+        sandbox: context.sandbox,
+        database: "tasks",
+        sql: "UPDATE tasks SET done = 1 WHERE owner = 'me'",
+        resultMode: "inline_preview",
+      }
+    );
+  });
+
+  it("denies a same-workspace Frame whose source the caller cannot write", async () => {
+    const context = await createSandboxTokenTestContext();
+    await FeatureFlagFactory.basic(context.auth, "frames_v2");
+    const metadataResult = await WorkspaceResource.updateMetadata(
+      context.workspace.id,
+      { privateConversationUrlsByDefault: true }
+    );
+    expect(metadataResult.isOk()).toBe(true);
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(context.workspace, otherUser, {
+      role: "user",
+    });
+    const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      context.workspace.sId
+    );
+    const otherConversation = await ConversationFactory.create(otherAuth, {
+      agentConfigurationId: context.agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    const frame = await makeConversationFrame({
+      auth: otherAuth,
+      workspaceId: context.workspace.sId,
+      conversationId: otherConversation.sId,
+      directory: "Private",
+    });
+
+    const response = await requestFrameDatabases({
+      workspaceId: context.workspace.sId,
+      frameId: frame.sId,
+      token: context.token,
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { message: "You do not have access to this Frame's databases." },
+    });
+    expect(ensureFrameSandboxReady).not.toHaveBeenCalled();
+  });
+
+  it("does not resolve a Frame from another workspace", async () => {
+    const context = await createSandboxTokenTestContext();
+    await FeatureFlagFactory.basic(context.auth, "frames_v2");
+    const { authenticator: otherAuth, workspace: otherWorkspace } =
+      await createResourceTest({ role: "admin" });
+    const otherConversation = await ConversationFactory.create(otherAuth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+    });
+    const otherFrame = await makeConversationFrame({
+      auth: otherAuth,
+      workspaceId: otherWorkspace.sId,
+      conversationId: otherConversation.sId,
+    });
+
+    const response = await requestFrameDatabases({
+      workspaceId: context.workspace.sId,
+      frameId: otherFrame.sId,
+      token: context.token,
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { message: "Frame not found." },
+    });
+    expect(ensureFrameSandboxReady).not.toHaveBeenCalled();
+  });
+
+  it("rejects Frame function invocation tokens", async () => {
+    const context =
+      await createPersistedFrameFunctionInvocationTokenTestContext();
+
+    const response = await requestFrameDatabases({
+      workspaceId: context.workspace.sId,
+      frameId: context.frame.sId,
+      token: context.token,
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        message: "This sandbox token cannot access this endpoint.",
+      },
+    });
+    expect(ensureFrameSandboxReady).not.toHaveBeenCalled();
+  });
+});

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/[frameId]/databases.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/[frameId]/databases.ts
@@ -1,0 +1,120 @@
+import { isValidPodDatabaseName } from "@app/lib/api/sandbox/db";
+import { ensureFrameSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import {
+  type LiveDatabaseEntry,
+  listDatabasesOnReadySandbox,
+  type QueryDatabaseResult,
+  queryDatabaseOnReadySandbox,
+} from "@app/lib/api/sandbox_functions/dsbx_db";
+import { sandboxFrameApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const FrameDatabaseQueryRequestSchema = z.object({
+  database: z.string().refine(isValidPodDatabaseName),
+  sql: z.string().min(1),
+});
+
+type FrameDatabaseListResponse = {
+  items: LiveDatabaseEntry[];
+};
+
+const app = sandboxFrameApp();
+
+/**
+ * @ignoreswagger
+ * internal endpoint
+ */
+app.get("/", async (ctx): HandlerResult<FrameDatabaseListResponse> => {
+  const auth = ctx.get("auth");
+  const frame = ctx.get("frame");
+  const ensureResult = await ensureFrameSandboxReady(auth, frame);
+  if (ensureResult.isErr()) {
+    return apiError(
+      ctx,
+      {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to start the Frame sandbox.",
+        },
+      },
+      ensureResult.error
+    );
+  }
+
+  const result = await listDatabasesOnReadySandbox(
+    auth,
+    ensureResult.value.sandbox
+  );
+  if (result.isErr()) {
+    return apiError(
+      ctx,
+      {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to list Frame databases.",
+        },
+      },
+      result.error
+    );
+  }
+
+  return ctx.json({ items: result.value }, 200);
+});
+
+/**
+ * @ignoreswagger
+ * internal endpoint
+ */
+app.post(
+  "/",
+  validate("json", FrameDatabaseQueryRequestSchema),
+  async (ctx): HandlerResult<QueryDatabaseResult> => {
+    const auth = ctx.get("auth");
+    const frame = ctx.get("frame");
+    const ensureResult = await ensureFrameSandboxReady(auth, frame);
+    if (ensureResult.isErr()) {
+      return apiError(
+        ctx,
+        {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to start the Frame sandbox.",
+          },
+        },
+        ensureResult.error
+      );
+    }
+
+    const result = await queryDatabaseOnReadySandbox(auth, {
+      sandbox: ensureResult.value.sandbox,
+      ...ctx.req.valid("json"),
+      resultMode: "inline_preview",
+    });
+    if (result.isErr()) {
+      const isBadQuery = result.error.code === "reconcile_blocked";
+      return apiError(
+        ctx,
+        {
+          status_code: isBadQuery ? 400 : 500,
+          api_error: {
+            type: isBadQuery
+              ? "invalid_request_error"
+              : "internal_server_error",
+            message: result.error.message,
+          },
+        },
+        result.error
+      );
+    }
+
+    return ctx.json(result.value, 200);
+  }
+);
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/[frameId]/databases.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/[frameId]/databases.ts
@@ -1,16 +1,27 @@
-import { isValidPodDatabaseName } from "@app/lib/api/sandbox/db";
-import { ensureFrameSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import {
-  type LiveDatabaseEntry,
-  listDatabasesOnReadySandbox,
-  type QueryDatabaseResult,
-  queryDatabaseOnReadySandbox,
+  listFrameDatabases,
+  queryFrameDatabase,
+} from "@app/lib/api/frames/databases";
+import { canWriteFrameV2Source } from "@app/lib/api/frames/permissions";
+import { isValidPodDatabaseName } from "@app/lib/api/sandbox/db";
+import type {
+  LiveDatabaseEntry,
+  QueryDatabaseResult,
 } from "@app/lib/api/sandbox_functions/dsbx_db";
+import { isResourceSId } from "@app/lib/resources/string_ids";
+import type { SandboxFrameCtx } from "@front-api/middlewares/ctx";
 import { sandboxFrameApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
+import { withFrame } from "@front-api/middlewares/with_frames";
+import { createMiddleware } from "hono/factory";
 import { z } from "zod";
+
+const FrameParamsSchema = z.object({
+  frameId: z.string().refine((value) => isResourceSId("file", value)),
+});
 
 const FrameDatabaseQueryRequestSchema = z.object({
   database: z.string().refine(isValidPodDatabaseName),
@@ -21,34 +32,61 @@ type FrameDatabaseListResponse = {
   items: LiveDatabaseEntry[];
 };
 
+/**
+ * @cc [owner:davidebbo,label:security;product] frame-database-authorization
+ * A Frame database request MUST be granted only when the Frame belongs to the conversation named
+ * by the caller's action token (`cId`), or the caller can write the Frame's source
+ * (`canWriteFrameV2Source`). The Frame MUST be resolved inside the token's workspace, and the
+ * check MUST run before the Frame sandbox is started or queried. The action-token requirement
+ * itself is enforced by the parent `sandboxAuth({ allowedTokenKinds: ["action"] })` mount.
+ */
+function requireFrameDatabaseAccess() {
+  return createMiddleware<SandboxFrameCtx>(async (ctx, next) => {
+    const auth = ctx.get("auth");
+    const frame = ctx.get("frame");
+    const { cId } = ctx.get("sandboxClaims");
+
+    // A conversation's own Frames are reachable from that conversation's sandbox even when the
+    // run has no user (Slack bot user, triggers), which `canWriteFrameV2Source` cannot grant.
+    const conversationMatch =
+      cId === undefined ? null : frame.belongsToConversation(cId);
+    const ownConversationFrame =
+      conversationMatch !== null &&
+      conversationMatch.isOk() &&
+      conversationMatch.value;
+    if (!ownConversationFrame && !(await canWriteFrameV2Source(auth, frame))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "You do not have access to this Frame's databases.",
+        },
+      });
+    }
+
+    await next();
+  });
+}
+
+// Mounted at /api/v1/w/:wId/sandbox/frames/:frameId/databases.
 const app = sandboxFrameApp();
+
+app.use("*", validate("param", FrameParamsSchema));
+app.use(
+  "*",
+  withFeatureFlag("frames_v2", {
+    message: "Frames v2 is not enabled for this workspace.",
+  })
+);
+app.use("*", withFrame());
+app.use("*", requireFrameDatabaseAccess());
 
 /**
  * @ignoreswagger
  * internal endpoint
  */
 app.get("/", async (ctx): HandlerResult<FrameDatabaseListResponse> => {
-  const auth = ctx.get("auth");
-  const frame = ctx.get("frame");
-  const ensureResult = await ensureFrameSandboxReady(auth, frame);
-  if (ensureResult.isErr()) {
-    return apiError(
-      ctx,
-      {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: "Failed to start the Frame sandbox.",
-        },
-      },
-      ensureResult.error
-    );
-  }
-
-  const result = await listDatabasesOnReadySandbox(
-    auth,
-    ensureResult.value.sandbox
-  );
+  const result = await listFrameDatabases(ctx.get("auth"), ctx.get("frame"));
   if (result.isErr()) {
     return apiError(
       ctx,
@@ -56,7 +94,7 @@ app.get("/", async (ctx): HandlerResult<FrameDatabaseListResponse> => {
         status_code: 500,
         api_error: {
           type: "internal_server_error",
-          message: "Failed to list Frame databases.",
+          message: `Failed to list Frame databases: ${result.error.message}`,
         },
       },
       result.error
@@ -74,28 +112,11 @@ app.post(
   "/",
   validate("json", FrameDatabaseQueryRequestSchema),
   async (ctx): HandlerResult<QueryDatabaseResult> => {
-    const auth = ctx.get("auth");
-    const frame = ctx.get("frame");
-    const ensureResult = await ensureFrameSandboxReady(auth, frame);
-    if (ensureResult.isErr()) {
-      return apiError(
-        ctx,
-        {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Failed to start the Frame sandbox.",
-          },
-        },
-        ensureResult.error
-      );
-    }
-
-    const result = await queryDatabaseOnReadySandbox(auth, {
-      sandbox: ensureResult.value.sandbox,
-      ...ctx.req.valid("json"),
-      resultMode: "inline_preview",
-    });
+    const result = await queryFrameDatabase(
+      ctx.get("auth"),
+      ctx.get("frame"),
+      ctx.req.valid("json")
+    );
     if (result.isErr()) {
       const isBadQuery = result.error.code === "reconcile_blocked";
       return apiError(

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/[frameId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/[frameId]/index.ts
@@ -1,0 +1,82 @@
+import { canWriteFrameV2Source } from "@app/lib/api/frames/permissions";
+import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { isResourceSId } from "@app/lib/resources/string_ids";
+import type { SandboxFrameCtx } from "@front-api/middlewares/ctx";
+import { sandboxFrameApp } from "@front-api/middlewares/ctx";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { createMiddleware } from "hono/factory";
+import { z } from "zod";
+
+import databases from "./databases";
+
+const FrameParamsSchema = z.object({
+  frameId: z.string().refine((value) => isResourceSId("file", value)),
+});
+
+/**
+ * @cc [owner:davidebbo,label:security;product] frame-database-authorization
+ * Frame database requests MUST use a conversation action token, resolve the target Frame inside
+ * that token's authenticated workspace, and require write access to the Frame's source before
+ * starting or querying its sandbox.
+ */
+function authorizeFrameDatabaseAccess() {
+  return createMiddleware<SandboxFrameCtx>(async (ctx, next) => {
+    const auth = ctx.get("auth");
+    const claims = ctx.get("sandboxClaims");
+    if (!isSandboxExecTokenPayload(claims)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "This sandbox token cannot access Frame databases.",
+        },
+      });
+    }
+    if (!(await hasFeatureFlag(auth, "frames_v2"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Frames v2 is not enabled for this workspace.",
+        },
+      });
+    }
+
+    const frameId = ctx.req.param("frameId");
+    const frame = frameId ? await FileResource.fetchById(auth, frameId) : null;
+    if (!frame?.isFrameV2) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "file_not_found",
+          message: "Frame not found.",
+        },
+      });
+    }
+    if (!(await canWriteFrameV2Source(auth, frame))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "You do not have access to this Frame's databases.",
+        },
+      });
+    }
+
+    ctx.set("frame", frame);
+    await next();
+  });
+}
+
+// Mounted at /api/v1/w/:wId/sandbox/frames/:frameId.
+const app = sandboxFrameApp();
+
+app.use("*", validate("param", FrameParamsSchema));
+app.use("*", authorizeFrameDatabaseAccess());
+
+app.route("/databases", databases);
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/[frameId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/[frameId]/index.ts
@@ -1,81 +1,9 @@
-import { canWriteFrameV2Source } from "@app/lib/api/frames/permissions";
-import { isSandboxExecTokenPayload } from "@app/lib/api/sandbox/access_tokens";
-import { hasFeatureFlag } from "@app/lib/auth";
-import { FileResource } from "@app/lib/resources/file_resource";
-import { isResourceSId } from "@app/lib/resources/string_ids";
-import type { SandboxFrameCtx } from "@front-api/middlewares/ctx";
-import { sandboxFrameApp } from "@front-api/middlewares/ctx";
-import { apiError } from "@front-api/middlewares/utils";
-import { validate } from "@front-api/middlewares/validator";
-import { createMiddleware } from "hono/factory";
-import { z } from "zod";
+import { sandboxApp } from "@front-api/middlewares/ctx";
 
 import databases from "./databases";
 
-const FrameParamsSchema = z.object({
-  frameId: z.string().refine((value) => isResourceSId("file", value)),
-});
-
-/**
- * @cc [owner:davidebbo,label:security;product] frame-database-authorization
- * Frame database requests MUST use a conversation action token, resolve the target Frame inside
- * that token's authenticated workspace, and require write access to the Frame's source before
- * starting or querying its sandbox.
- */
-function authorizeFrameDatabaseAccess() {
-  return createMiddleware<SandboxFrameCtx>(async (ctx, next) => {
-    const auth = ctx.get("auth");
-    const claims = ctx.get("sandboxClaims");
-    if (!isSandboxExecTokenPayload(claims)) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "invalid_request_error",
-          message: "This sandbox token cannot access Frame databases.",
-        },
-      });
-    }
-    if (!(await hasFeatureFlag(auth, "frames_v2"))) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Frames v2 is not enabled for this workspace.",
-        },
-      });
-    }
-
-    const frameId = ctx.req.param("frameId");
-    const frame = frameId ? await FileResource.fetchById(auth, frameId) : null;
-    if (!frame?.isFrameV2) {
-      return apiError(ctx, {
-        status_code: 404,
-        api_error: {
-          type: "file_not_found",
-          message: "Frame not found.",
-        },
-      });
-    }
-    if (!(await canWriteFrameV2Source(auth, frame))) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "invalid_request_error",
-          message: "You do not have access to this Frame's databases.",
-        },
-      });
-    }
-
-    ctx.set("frame", frame);
-    await next();
-  });
-}
-
 // Mounted at /api/v1/w/:wId/sandbox/frames/:frameId.
-const app = sandboxFrameApp();
-
-app.use("*", validate("param", FrameParamsSchema));
-app.use("*", authorizeFrameDatabaseAccess());
+const app = sandboxApp();
 
 app.route("/databases", databases);
 

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
@@ -123,6 +123,9 @@ app.post(
   }
 );
 
-app.route("/:frameId{fil_[A-Za-z0-9]+}", frameById);
+// A plain param, not a regex-constrained one: Hono's RegExpRouter cannot merge `/:frameId{...}`
+// with the `/:frameId/call` sibling above and would silently downgrade the whole app to the trie
+// router. The id shape is validated in the sub-app instead.
+app.route("/:frameId", frameById);
 
 export default app;

--- a/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/frames/index.ts
@@ -11,7 +11,7 @@ import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
+import frameById from "./[frameId]";
 import call from "./call";
 import callById from "./call_by_id";
 import register from "./register";
@@ -122,5 +122,7 @@ app.post(
     }
   }
 );
+
+app.route("/:frameId{fil_[A-Za-z0-9]+}", frameById);
 
 export default app;

--- a/front/lib/api/frames/databases.ts
+++ b/front/lib/api/frames/databases.ts
@@ -1,0 +1,67 @@
+import { ensureFrameSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import type {
+  LiveDatabaseEntry,
+  QueryDatabaseResult,
+} from "@app/lib/api/sandbox_functions/dsbx_db";
+import {
+  listDatabasesOnReadySandbox,
+  queryDatabaseOnReadySandbox,
+} from "@app/lib/api/sandbox_functions/dsbx_db";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import type { Authenticator } from "@app/lib/auth";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+/**
+ * There is no database-backed record of a Frame's databases: the only source of truth is the live
+ * `{db}.db` files in the Frame sandbox, so every operation here wakes (or cold starts) it. Callers
+ * are expected to reach for it on explicit action only.
+ */
+async function readyFrameSandbox(
+  auth: Authenticator,
+  frame: FileResource
+): Promise<Result<SandboxResource, SandboxFunctionError>> {
+  const ensureResult = await ensureFrameSandboxReady(auth, frame);
+  if (ensureResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError(
+        "sandbox_unavailable",
+        ensureResult.error.message
+      )
+    );
+  }
+  return new Ok(ensureResult.value.sandbox);
+}
+
+export async function listFrameDatabases(
+  auth: Authenticator,
+  frame: FileResource
+): Promise<Result<LiveDatabaseEntry[], SandboxFunctionError>> {
+  const sandboxResult = await readyFrameSandbox(auth, frame);
+  if (sandboxResult.isErr()) {
+    return sandboxResult;
+  }
+  return listDatabasesOnReadySandbox(auth, sandboxResult.value);
+}
+
+/**
+ * Run one SQL statement (SELECT or DML) against a Frame database. Oversized results come back as
+ * a bounded inline preview: the caller is not on the Frame sandbox and could not read a spill file.
+ */
+export async function queryFrameDatabase(
+  auth: Authenticator,
+  frame: FileResource,
+  { database, sql }: { database: string; sql: string }
+): Promise<Result<QueryDatabaseResult, SandboxFunctionError>> {
+  const sandboxResult = await readyFrameSandbox(auth, frame);
+  if (sandboxResult.isErr()) {
+    return sandboxResult;
+  }
+  return queryDatabaseOnReadySandbox(auth, {
+    sandbox: sandboxResult.value,
+    database,
+    sql,
+  });
+}

--- a/front/lib/api/poke/frames.ts
+++ b/front/lib/api/poke/frames.ts
@@ -5,9 +5,7 @@ import {
   loadFramePublicationDescriptor,
   readFramePublicationFunctionBundle,
 } from "@app/lib/api/frames/publication_storage";
-import { ensureFrameSandboxReady } from "@app/lib/api/sandbox/lifecycle";
-import { listDatabasesOnReadySandbox } from "@app/lib/api/sandbox_functions/dsbx_db";
-import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import type { LiveDatabaseEntry } from "@app/lib/api/sandbox_functions/dsbx_db";
 import type { Authenticator } from "@app/lib/auth";
 import filestorageConfig from "@app/lib/file_storage/config";
 import { makeGcsConsoleUrl, makeGcsUri } from "@app/lib/poke/gcs";
@@ -29,7 +27,6 @@ import type {
 } from "@app/types/files";
 import type { PokeSandboxType } from "@app/types/poke";
 import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -370,46 +367,8 @@ export async function getFrameFunctionSource(
 // Mirrors `LiveDatabaseEntry` from the sandbox-functions layer, but declared here so client code
 // (the SWR hook, the table component) never imports that server-internal module (see
 // `PokePodDatabase` in `lib/api/poke/projects.ts` for the same pattern on the pod side).
-export type PokeFrameDatabase = {
-  name: string;
-  sizeBytes: number;
-};
+export type PokeFrameDatabase = LiveDatabaseEntry;
 
 export type PokeListFrameDatabases = {
   items: PokeFrameDatabase[];
 };
-
-/**
- * There is no database-backed record of a Frame's databases: the only source of truth is the live
- * `{db}.db` files in the Frame sandbox, so this wakes (or cold starts) it. Poke fetches it on
- * explicit user action only.
- */
-export async function listFrameDatabases(
-  auth: Authenticator,
-  frame: FileResource
-): Promise<Result<PokeFrameDatabase[], SandboxFunctionError>> {
-  const ensureResult = await ensureFrameSandboxReady(auth, frame);
-  if (ensureResult.isErr()) {
-    return new Err(
-      new SandboxFunctionError(
-        "sandbox_unavailable",
-        ensureResult.error.message
-      )
-    );
-  }
-
-  const databasesResult = await listDatabasesOnReadySandbox(
-    auth,
-    ensureResult.value.sandbox
-  );
-  if (databasesResult.isErr()) {
-    return databasesResult;
-  }
-
-  return new Ok(
-    databasesResult.value.map((entry) => ({
-      name: entry.name,
-      sizeBytes: entry.sizeBytes,
-    }))
-  );
-}

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base and sbx bedrock image tags", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.107",
+      tag: "0.8.108",
     });
     expect(getDustBaseImage().baseImage).toEqual({
       type: "docker",
@@ -484,7 +484,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.57/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.58/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,8 +26,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.11.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.107";
-const DSBX_CLI_VERSION = "0.1.57";
+const DUST_BASE_IMAGE_VERSION = "0.8.108";
+const DSBX_CLI_VERSION = "0.1.58";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
 // the stable identity used when creating the workload account.

--- a/front/lib/api/sandbox_functions/dsbx_db.test.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.test.ts
@@ -194,41 +194,6 @@ describe("listDatabasesOnReadySandbox", () => {
 });
 
 describe("queryDatabaseOnReadySandbox", () => {
-  it("uses sandbox scratch space for large results by default", async () => {
-    const { authenticator, sandbox } = await setup();
-    vi.spyOn(sandbox, "exec").mockResolvedValue(
-      new Ok({
-        exitCode: 0,
-        stdout: JSON.stringify({
-          ok: true,
-          columns: ["id"],
-          rows: [{ id: 1 }],
-          row_count: 1,
-          changes: null,
-          results_file: null,
-          note: null,
-        }),
-        stderr: "",
-      })
-    );
-
-    await queryDatabaseOnReadySandbox(authenticator, {
-      sandbox,
-      database: "tasks",
-      sql: "SELECT id FROM tasks",
-    });
-
-    expect(sandbox.exec).toHaveBeenCalledWith(
-      authenticator,
-      expect.stringContaining("db query -- 'tasks'"),
-      expect.objectContaining({
-        envVars: expect.objectContaining({
-          DUST_POD_QUERY_SPILL_DIR: "/tmp/dust-sandbox-db-query-results",
-        }),
-      })
-    );
-  });
-
   it("runs a data-changing statement against the supplied owner sandbox", async () => {
     const { authenticator, sandbox } = await setup();
     vi.spyOn(sandbox, "exec").mockResolvedValue(
@@ -251,7 +216,6 @@ describe("queryDatabaseOnReadySandbox", () => {
       sandbox,
       database: "tasks",
       sql: "UPDATE tasks SET done = 1 WHERE owner = 'me'",
-      resultMode: "inline_preview",
     });
 
     expect(result.isOk() && result.value).toEqual({
@@ -266,7 +230,6 @@ describe("queryDatabaseOnReadySandbox", () => {
       authenticator,
       expect.stringContaining("db query -- 'tasks'"),
       expect.objectContaining({
-        envVars: expect.objectContaining({ DUST_DB_QUERY_INLINE_ONLY: "1" }),
         stdin: "UPDATE tasks SET done = 1 WHERE owner = 'me'",
         user: "agent-proxied",
       })

--- a/front/lib/api/sandbox_functions/dsbx_db.test.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.test.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import {
   getDatabaseSchemaOnReadySandbox,
   listDatabasesOnReadySandbox,
+  queryDatabaseOnReadySandbox,
   reconcileDatabaseOnReadySandbox,
 } from "@app/lib/api/sandbox_functions/dsbx_db";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
@@ -189,6 +190,87 @@ describe("listDatabasesOnReadySandbox", () => {
     const result = await listDatabasesOnReadySandbox(authenticator, sandbox);
 
     expect(result.isErr()).toBe(true);
+  });
+});
+
+describe("queryDatabaseOnReadySandbox", () => {
+  it("uses sandbox scratch space for large results by default", async () => {
+    const { authenticator, sandbox } = await setup();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          ok: true,
+          columns: ["id"],
+          rows: [{ id: 1 }],
+          row_count: 1,
+          changes: null,
+          results_file: null,
+          note: null,
+        }),
+        stderr: "",
+      })
+    );
+
+    await queryDatabaseOnReadySandbox(authenticator, {
+      sandbox,
+      database: "tasks",
+      sql: "SELECT id FROM tasks",
+    });
+
+    expect(sandbox.exec).toHaveBeenCalledWith(
+      authenticator,
+      expect.stringContaining("db query -- 'tasks'"),
+      expect.objectContaining({
+        envVars: expect.objectContaining({
+          DUST_POD_QUERY_SPILL_DIR: "/tmp/dust-sandbox-db-query-results",
+        }),
+      })
+    );
+  });
+
+  it("runs a data-changing statement against the supplied owner sandbox", async () => {
+    const { authenticator, sandbox } = await setup();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          ok: true,
+          columns: [],
+          rows: [],
+          row_count: 0,
+          changes: 2,
+          results_file: null,
+          note: null,
+        }),
+        stderr: "",
+      })
+    );
+
+    const result = await queryDatabaseOnReadySandbox(authenticator, {
+      sandbox,
+      database: "tasks",
+      sql: "UPDATE tasks SET done = 1 WHERE owner = 'me'",
+      resultMode: "inline_preview",
+    });
+
+    expect(result.isOk() && result.value).toEqual({
+      columns: [],
+      rows: [],
+      rowCount: 0,
+      changes: 2,
+      resultsFile: null,
+      note: null,
+    });
+    expect(sandbox.exec).toHaveBeenCalledWith(
+      authenticator,
+      expect.stringContaining("db query -- 'tasks'"),
+      expect.objectContaining({
+        envVars: expect.objectContaining({ DUST_DB_QUERY_INLINE_ONLY: "1" }),
+        stdin: "UPDATE tasks SET done = 1 WHERE owner = 'me'",
+        user: "agent-proxied",
+      })
+    );
   });
 });
 

--- a/front/lib/api/sandbox_functions/dsbx_db.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.ts
@@ -19,6 +19,7 @@ import {
 } from "@app/types/mount_path";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { z } from "zod";
 
@@ -26,6 +27,7 @@ import type { DbErrorKind } from "../../../../cli/dust-sandbox/functions-runner/
 
 const DSBX_BIN_PATH = "/opt/bin/dsbx";
 const DB_EXEC_TIMEOUT_MS = 60 * 1000;
+const DB_QUERY_INLINE_ONLY_ENV = "DUST_DB_QUERY_INLINE_ONLY";
 
 // The two error envelopes a dsbx db command can print: the runner's typed `{ok:false}`
 // (DbCommandError in cli/dust-sandbox/functions-runner/db/common.ts) and dsbx's own bare
@@ -430,6 +432,27 @@ export interface QueryDatabaseResult {
   note: string | null;
 }
 
+type QueryDatabaseResultMode = "sandbox_file" | "inline_preview";
+
+function queryDatabaseResultEnvVars(
+  resultMode: QueryDatabaseResultMode
+): Record<string, string> {
+  switch (resultMode) {
+    case "inline_preview":
+      // Cross-sandbox callers cannot open a result file here. Keep the bounded preview inline and
+      // tell them to paginate instead of returning an unusable path.
+      return { [DB_QUERY_INLINE_ONLY_ENV]: "1" };
+    case "sandbox_file":
+      // Oversized results spill here rather than into a files mount: a Frame-owned sandbox carries
+      // no agent-visible one. The spill is a plain sandbox path, so `resultsFile` is read back off
+      // the same sandbox the caller passed in. The var name must match POD_QUERY_SPILL_DIR_ENV in
+      // cli/dust-sandbox/src/commands/db/query.rs.
+      return { DUST_POD_QUERY_SPILL_DIR: DB_QUERY_SPILL_ROOT };
+    default:
+      return assertNever(resultMode);
+  }
+}
+
 /**
  * `dsbx db query`: execute one SQL statement (stdin) against a live database. The runner allows
  * SELECT and DML but refuses DDL/PRAGMA/ATTACH, so the schema only evolves through reconcile.
@@ -440,18 +463,20 @@ export async function queryDatabaseOnReadySandbox(
     sandbox,
     database,
     sql,
-  }: { sandbox: SandboxResource; database: string; sql: string }
+    resultMode = "sandbox_file",
+  }: {
+    sandbox: SandboxResource;
+    database: string;
+    sql: string;
+    resultMode?: QueryDatabaseResultMode;
+  }
 ): Promise<Result<QueryDatabaseResult, SandboxFunctionError>> {
   const result = await execDbCommandOnReadySandbox(auth, sandbox, {
     // `--` stops the model-influenced database name from being read as a flag.
     command: `set -euo pipefail\n${DSBX_BIN_PATH} db query -- ${shellEscape(database)}`,
     schema: queryEnvelopeSchema,
     what: `dsbx db query ${database}`,
-    // Oversized results spill here rather than into a files mount: a Frame-owned sandbox carries
-    // no agent-visible one. The spill is a plain sandbox path, so `resultsFile` is read back off
-    // the same sandbox the caller passed in. The var name must match POD_QUERY_SPILL_DIR_ENV in
-    // cli/dust-sandbox/src/commands/db/query.rs.
-    envVars: { DUST_POD_QUERY_SPILL_DIR: DB_QUERY_SPILL_ROOT },
+    envVars: queryDatabaseResultEnvVars(resultMode),
     stdin: sql,
   });
   if (result.isErr()) {

--- a/front/lib/api/sandbox_functions/dsbx_db.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.ts
@@ -19,7 +19,6 @@ import {
 } from "@app/types/mount_path";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { z } from "zod";
 
@@ -27,7 +26,6 @@ import type { DbErrorKind } from "../../../../cli/dust-sandbox/functions-runner/
 
 const DSBX_BIN_PATH = "/opt/bin/dsbx";
 const DB_EXEC_TIMEOUT_MS = 60 * 1000;
-const DB_QUERY_INLINE_ONLY_ENV = "DUST_DB_QUERY_INLINE_ONLY";
 
 // The two error envelopes a dsbx db command can print: the runner's typed `{ok:false}`
 // (DbCommandError in cli/dust-sandbox/functions-runner/db/common.ts) and dsbx's own bare
@@ -340,10 +338,8 @@ const schemaEnvelopeSchema = z.union([
   dbErrorEnvelopeSchema,
 ]);
 
-// Non-mounted scratch roots for regenerated schema files and oversized query results
-// (cf. BUILD_STAGING_ROOT).
+// Non-mounted scratch root for regenerated schema files (cf. BUILD_STAGING_ROOT).
 const DB_SCHEMA_STAGING_ROOT = "/tmp/dust-sandbox-db-schemas";
-const DB_QUERY_SPILL_ROOT = "/tmp/dust-sandbox-db-query-results";
 
 /**
  * `dsbx db schema`: regenerate a drizzle schema file from the live database and read its text
@@ -425,37 +421,18 @@ export interface QueryDatabaseResult {
   // Rows affected for statements that return no columns (plain INSERT/UPDATE/DELETE); null for
   // result-returning statements.
   changes: number | null;
-  // Set when the result crossed the runner's inline bounds: `rows` is then a preview and the full
-  // result set is at this sandbox path, one JSON object per line. Read it back off the same
-  // sandbox; it is scratch space, so it does not outlive the sandbox.
+  // Sandbox path of a full spill of an oversized result. Always null here: no spill directory is
+  // passed to dsbx, so the runner keeps `rows` as a bounded preview and `note` says how to page.
+  // Kept for parity with the local `dsbx db query` envelope.
   resultsFile: string | null;
   note: string | null;
-}
-
-type QueryDatabaseResultMode = "sandbox_file" | "inline_preview";
-
-function queryDatabaseResultEnvVars(
-  resultMode: QueryDatabaseResultMode
-): Record<string, string> {
-  switch (resultMode) {
-    case "inline_preview":
-      // Cross-sandbox callers cannot open a result file here. Keep the bounded preview inline and
-      // tell them to paginate instead of returning an unusable path.
-      return { [DB_QUERY_INLINE_ONLY_ENV]: "1" };
-    case "sandbox_file":
-      // Oversized results spill here rather than into a files mount: a Frame-owned sandbox carries
-      // no agent-visible one. The spill is a plain sandbox path, so `resultsFile` is read back off
-      // the same sandbox the caller passed in. The var name must match POD_QUERY_SPILL_DIR_ENV in
-      // cli/dust-sandbox/src/commands/db/query.rs.
-      return { DUST_POD_QUERY_SPILL_DIR: DB_QUERY_SPILL_ROOT };
-    default:
-      return assertNever(resultMode);
-  }
 }
 
 /**
  * `dsbx db query`: execute one SQL statement (stdin) against a live database. The runner allows
  * SELECT and DML but refuses DDL/PRAGMA/ATTACH, so the schema only evolves through reconcile.
+ * No spill directory (`DUST_POD_QUERY_SPILL_DIR`) is passed: the caller is never on this sandbox,
+ * so an oversized result is returned as a bounded inline preview rather than an unreadable path.
  */
 export async function queryDatabaseOnReadySandbox(
   auth: Authenticator,
@@ -463,12 +440,10 @@ export async function queryDatabaseOnReadySandbox(
     sandbox,
     database,
     sql,
-    resultMode = "sandbox_file",
   }: {
     sandbox: SandboxResource;
     database: string;
     sql: string;
-    resultMode?: QueryDatabaseResultMode;
   }
 ): Promise<Result<QueryDatabaseResult, SandboxFunctionError>> {
   const result = await execDbCommandOnReadySandbox(auth, sandbox, {
@@ -476,7 +451,6 @@ export async function queryDatabaseOnReadySandbox(
     command: `set -euo pipefail\n${DSBX_BIN_PATH} db query -- ${shellEscape(database)}`,
     schema: queryEnvelopeSchema,
     what: `dsbx db query ${database}`,
-    envVars: queryDatabaseResultEnvVars(resultMode),
     stdin: sql,
   });
   if (result.isErr()) {

--- a/front/tests/utils/SandboxTokenFactory.ts
+++ b/front/tests/utils/SandboxTokenFactory.ts
@@ -29,9 +29,13 @@ process.env.DUST_SANDBOX_JWT_SECRET ??= "test-sandbox-jwt-secret";
 export async function createSandboxTokenTestContext({
   disableComputerFeature = false,
   usePodSpaceForConversation = false,
+  // Mint the exec token without a user, as for a run driven by a non-human actor (Slack bot
+  // user, trigger). The conversation itself is still created by the member user.
+  userlessToken = false,
 }: {
   disableComputerFeature?: boolean;
   usePodSpaceForConversation?: boolean;
+  userlessToken?: boolean;
 } = {}) {
   const user = await UserFactory.basic();
   const workspace = await WorkspaceFactory.basic();
@@ -127,7 +131,10 @@ export async function createSandboxTokenTestContext({
     displayLabels: null,
   };
 
-  const token = await generateSandboxExecToken(auth, {
+  const tokenAuth = userlessToken
+    ? await Authenticator.internalAdminForWorkspace(workspace.sId)
+    : auth;
+  const token = await generateSandboxExecToken(tokenAuth, {
     agentConfiguration: agentConfig,
     agentMessage,
     conversation,


### PR DESCRIPTION
## Description

- Add `--frame <frame-id>` to `dsbx db list` and `dsbx db query` in conversation sandboxes.
- Forward those commands through Front to the target Frame v2 sandbox. Frame sandboxes keep local database behavior without `--frame`.
- Require a conversation action token and write access to the Frame source before Front starts or queries the target sandbox.
- Support SELECT and data-changing SQL while preserving the existing single-statement and no-DDL checks.
- Return bounded, ordered previews for large remote result sets instead of inaccessible Frame-local spill files.
- Bump dsbx to 0.1.58 and dust-base to 0.8.108.

## Tests

- `cargo test` in `cli/dust-sandbox`: 413 unit tests and 1 e2e test
- `bun test functions-runner/db/query.test.ts`: 22 tests
- Focused `front` tests: 31 tests
- Focused `front-api` Frame route tests: 21 tests
- `npx tsgo --noEmit` in `front` and `front-api`
- Biome, Rust formatting, Swagger annotation, code-contract, and diff checks

## Risk

The endpoint can mutate Frame databases. Front requires write access to the Frame source, rejects function invocation tokens, and resolves the Frame within the token workspace before starting its sandbox. Cross-workspace requests return 404, and same-workspace callers without write access receive 403.

Large results stay within the existing inline limits. Reverting this change removes remote access, but it cannot undo database writes that already ran.

## Deploy Plan

1. Deploy Front and Front API with the internal Frame database endpoint.
2. Run the manual `Release dsbx CLI` workflow to publish `dsbx-v0.1.58`.
3. Build and release `dust-base:0.8.108`.
4. Replace sandboxes running older dust-base versions so both conversation and Frame sandboxes receive the new CLI.
