### PR TITLE
Report peak concurrent database queries for Hono requests

### DIFF
--- a/front-api/middlewares/request_instrumentation.test.ts
+++ b/front-api/middlewares/request_instrumentation.test.ts
@@ -1,4 +1,5 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import logger from "@app/logger/logger";
 import {
   getRequestContext,
   RequestCachedQuery,
@@ -11,11 +12,15 @@ import {
 } from "@front-api/lib/request_context";
 import { contextStorage } from "hono/context-storage";
 import { QueryTypes } from "sequelize";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { requestInstrumentation } from "./request_instrumentation";
 
 describe("requestInstrumentation", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("owns the query cache on the Hono context for one request", async () => {
     const app = createHono<RequestStorageEnv>();
     const query = new RequestCachedQuery<"key", number>();
@@ -84,5 +89,34 @@ describe("requestInstrumentation", () => {
         "SELECT current_query() AS \"query\" /*route='%2Fworkspaces%2F%3AworkspaceId'*/",
       route: "/workspaces/:workspaceId",
     });
+  });
+
+  it("logs the peak number of concurrent queries for the request", async () => {
+    const app = createHono<RequestStorageEnv>();
+    const infoSpy = vi
+      .spyOn(logger, "info")
+      .mockImplementation(() => undefined);
+
+    configureHonoRequestStorage();
+    app.use(contextStorage());
+    app.use("*", requestInstrumentation);
+    app.get("/", async (c) => {
+      await Promise.all([
+        // biome-ignore lint/plugin/noRawSql: exercises query concurrency instrumentation
+        frontSequelize.query("SELECT 1"),
+        // biome-ignore lint/plugin/noRawSql: exercises query concurrency instrumentation
+        frontSequelize.query("SELECT 1"),
+      ]);
+
+      return c.body(null);
+    });
+
+    const response = await app.request("/");
+
+    expect(response.status).toBe(200);
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ peakConcurrentQueries: 2 }),
+      "Processed request"
+    );
   });
 });

--- a/front-api/middlewares/request_instrumentation.ts
+++ b/front-api/middlewares/request_instrumentation.ts
@@ -1,3 +1,4 @@
+import { queryTracker } from "@app/lib/api/query_tracker";
 import type { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { statsDMetrics } from "@app/lib/utils/statsd";
@@ -56,6 +57,16 @@ type RouteConcurrencyState = {
 // lifetime. Each route bucket is process-local.
 const routeConcurrencyStates = new Map<string, RouteConcurrencyState>();
 
+/**
+ * @cc [owner:flvndvd,label:api;logging] request-query-tracker-scope
+ * Each Hono request MUST run downstream middleware and handlers within a fresh `queryTracker`
+ * store.
+ */
+/**
+ * @cc [owner:flvndvd,label:api;logging] request-query-tracker-log
+ * Every `Processed request` log MUST report the request store's peak as
+ * `peakConcurrentQueries`.
+ */
 export const requestInstrumentation =
   createMiddleware<RequestInstrumentationEnv>(async (c, next) => {
     // `-1` points at the leaf handler selected by Hono, which is known before
@@ -69,11 +80,12 @@ export const requestInstrumentation =
     };
     c.set("requestContext", reqCtx);
     c.set("queryCache", new RequestQueryCache());
+    const queryTrackerStore = { concurrent: 0, peak: 0 };
 
     if (SKIP_LOGGER_PATHS.has(c.req.path) || c.req.method === "OPTIONS") {
       // Also drop the APM trace so these requests don't show up in Datadog.
       tracer.scope().active()?.setTag("manual.drop", true);
-      return next();
+      return queryTracker.run(queryTrackerStore, next);
     }
 
     const concurrencyKey = `${c.req.method} ${matchedRoute}`;
@@ -100,7 +112,7 @@ export const requestInstrumentation =
 
     const startMs = performance.now();
     try {
-      await next();
+      await queryTracker.run(queryTrackerStore, next);
     } finally {
       routeConcurrencyState.inFlightPeaks.delete(peakRef);
       routeConcurrencyState.activeRequests -= 1;
@@ -158,6 +170,7 @@ export const requestInstrumentation =
           durationMs,
           method: c.req.method,
           peakConcurrency: peakRef.peak,
+          peakConcurrentQueries: queryTrackerStore.peak,
           route,
           sessionId: session?.sessionId ?? "unknown",
           statusCode,

--- a/front/lib/api/query_tracker.ts
+++ b/front/lib/api/query_tracker.ts
@@ -9,7 +9,8 @@ interface QueryTrackerStore {
  * Tracks the peak number of concurrent Sequelize queries within a single request.
  *
  * Usage:
- * - `withLogging` wraps each request handler in `queryTracker.run(store, ...)`.
+ * - Hono's `requestInstrumentation` middleware wraps each request in
+ *   `queryTracker.run(store, ...)`.
  * - `ActivityInboundLogInterceptor` wraps each Temporal activity execution the same way.
  * - `SequelizeWithComments.query()` increments/decrements `store.concurrent` around
  *   every query and updates `store.peak`.


### PR DESCRIPTION
## Description

Peak concurrent database query tracking was lost when API traffic moved from Next.js to Hono. Hono requests now create their own query tracker context and include peakConcurrentQueries in the standard processed-request log, restoring the signal used to spot handlers that put pressure on the connection pool.

## Tests

The request instrumentation test runs two database queries concurrently and checks that the processed-request log reports a peak of 2. The focused suite passes with all three tests. The full workspace type check was not clean because the current worktree contains unrelated type errors in existing and untracked files.

## Risk

Low. The extra AsyncLocalStorage context is request-local and only affects query counting and one log field. Rolling back the PR removes the field and returns to the current behavior.

## Deploy Plan

Deploy front-api normally. No migration or ordering requirement.