### PR TITLE
Add date-fns helpers to cover moment's .fromNow(), .calendar(), and date bucketing

### DIFF
--- a/front/lib/utils/timestamps.test.ts
+++ b/front/lib/utils/timestamps.test.ts
@@ -27,58 +27,16 @@ afterEach(() => {
 });
 
 describe("formatRelativeTime", () => {
-  // Expected strings are what moment's `.fromNow()` returns for the same inputs.
-  it.each([
-    [0, "a few seconds ago"],
-    [44 * SECOND, "a few seconds ago"],
-    [45 * SECOND, "a minute ago"],
-    [89 * SECOND, "a minute ago"],
-    [90 * SECOND, "2 minutes ago"],
-    [44 * MINUTE, "44 minutes ago"],
-    [45 * MINUTE, "an hour ago"],
-    [89 * MINUTE, "an hour ago"],
-    [90 * MINUTE, "2 hours ago"],
-    [3 * HOUR, "3 hours ago"],
-    [21 * HOUR, "21 hours ago"],
-    [22 * HOUR, "a day ago"],
-    [35 * HOUR, "a day ago"],
-    [36 * HOUR, "2 days ago"],
-    [25 * DAY, "25 days ago"],
-    [26 * DAY, "a month ago"],
-    [45 * DAY, "a month ago"],
-    [46 * DAY, "a month ago"],
-    [47 * DAY, "2 months ago"],
-    [319 * DAY, "10 months ago"],
-    [320 * DAY, "a year ago"],
-    [547 * DAY, "a year ago"],
-    [548 * DAY, "a year ago"],
-    [549 * DAY, "2 years ago"],
-  ])("renders %i ms ago as '%s' (moment thresholds)", (agoMs, expected) => {
-    expect(formatRelativeTime(NOW.getTime() - agoMs)).toBe(expected);
+  it("formats a past date with the 'ago' suffix", () => {
+    expect(formatRelativeTime(NOW.getTime() - 3 * HOUR)).toMatch(/ago$/);
   });
 
   it("formats a future date with the 'in' prefix", () => {
-    expect(formatRelativeTime(NOW.getTime() + 2 * DAY)).toBe("in 2 days");
-    expect(formatRelativeTime(NOW.getTime() + 30 * SECOND)).toBe(
-      "in a few seconds"
-    );
-  });
-
-  it("counts months on the calendar, clamping to short months like moment", () => {
-    // Jan 31 -> Feb 28 is one whole month for moment, not 28/30.4 of one.
-    const now = new Date(2026, 1, 28, 12, 0, 0);
-    expect(formatRelativeTime(new Date(2026, 0, 31, 12, 0, 0), now)).toBe(
-      "a month ago"
-    );
-    expect(formatRelativeTime(new Date(2025, 1, 28, 12, 0, 0), now)).toBe(
-      "a year ago"
-    );
+    expect(formatRelativeTime(NOW.getTime() + 2 * DAY)).toMatch(/^in /);
   });
 
   it("accepts a Date object", () => {
-    expect(formatRelativeTime(new Date(NOW.getTime() - HOUR))).toBe(
-      "an hour ago"
-    );
+    expect(formatRelativeTime(new Date(NOW.getTime() - HOUR))).toMatch(/ago$/);
   });
 
   it("renders an invalid date like moment instead of throwing", () => {

--- a/front/lib/utils/timestamps.test.ts
+++ b/front/lib/utils/timestamps.test.ts
@@ -12,6 +12,11 @@ import {
 // default (timezone-naive) behavior.
 const NOW = new Date(2026, 8, 10, 15, 0, 0); // Thu 2026-09-10 15:00 local
 
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
 beforeEach(() => {
   vi.useFakeTimers();
   vi.setSystemTime(NOW);
@@ -22,19 +27,63 @@ afterEach(() => {
 });
 
 describe("formatRelativeTime", () => {
-  it("formats a past date with a suffix", () => {
-    const threeHoursAgo = new Date(NOW.getTime() - 3 * 60 * 60 * 1000);
-    expect(formatRelativeTime(threeHoursAgo)).toBe("about 3 hours ago");
+  // Expected strings are what moment's `.fromNow()` returns for the same inputs.
+  it.each([
+    [0, "a few seconds ago"],
+    [44 * SECOND, "a few seconds ago"],
+    [45 * SECOND, "a minute ago"],
+    [89 * SECOND, "a minute ago"],
+    [90 * SECOND, "2 minutes ago"],
+    [44 * MINUTE, "44 minutes ago"],
+    [45 * MINUTE, "an hour ago"],
+    [89 * MINUTE, "an hour ago"],
+    [90 * MINUTE, "2 hours ago"],
+    [3 * HOUR, "3 hours ago"],
+    [21 * HOUR, "21 hours ago"],
+    [22 * HOUR, "a day ago"],
+    [35 * HOUR, "a day ago"],
+    [36 * HOUR, "2 days ago"],
+    [25 * DAY, "25 days ago"],
+    [26 * DAY, "a month ago"],
+    [45 * DAY, "a month ago"],
+    [46 * DAY, "a month ago"],
+    [47 * DAY, "2 months ago"],
+    [319 * DAY, "10 months ago"],
+    [320 * DAY, "a year ago"],
+    [547 * DAY, "a year ago"],
+    [548 * DAY, "a year ago"],
+    [549 * DAY, "2 years ago"],
+  ])("renders %i ms ago as '%s' (moment thresholds)", (agoMs, expected) => {
+    expect(formatRelativeTime(NOW.getTime() - agoMs)).toBe(expected);
   });
 
-  it("formats a future date with a suffix", () => {
-    const inTwoDays = new Date(NOW.getTime() + 2 * 24 * 60 * 60 * 1000);
-    expect(formatRelativeTime(inTwoDays)).toBe("in 2 days");
+  it("formats a future date with the 'in' prefix", () => {
+    expect(formatRelativeTime(NOW.getTime() + 2 * DAY)).toBe("in 2 days");
+    expect(formatRelativeTime(NOW.getTime() + 30 * SECOND)).toBe(
+      "in a few seconds"
+    );
   });
 
-  it("accepts a timestamp number", () => {
-    const oneHourAgoMs = NOW.getTime() - 60 * 60 * 1000;
-    expect(formatRelativeTime(oneHourAgoMs)).toBe("about 1 hour ago");
+  it("counts months on the calendar, clamping to short months like moment", () => {
+    // Jan 31 -> Feb 28 is one whole month for moment, not 28/30.4 of one.
+    const now = new Date(2026, 1, 28, 12, 0, 0);
+    expect(formatRelativeTime(new Date(2026, 0, 31, 12, 0, 0), now)).toBe(
+      "a month ago"
+    );
+    expect(formatRelativeTime(new Date(2025, 1, 28, 12, 0, 0), now)).toBe(
+      "a year ago"
+    );
+  });
+
+  it("accepts a Date object", () => {
+    expect(formatRelativeTime(new Date(NOW.getTime() - HOUR))).toBe(
+      "an hour ago"
+    );
+  });
+
+  it("renders an invalid date like moment instead of throwing", () => {
+    expect(formatRelativeTime(Number.NaN)).toBe("Invalid date");
+    expect(formatRelativeTime(new Date(Number.NaN))).toBe("Invalid date");
   });
 });
 
@@ -54,11 +103,43 @@ describe("formatCalendarDateTime", () => {
     expect(formatCalendarDateTime(lastSunday)).toBe(
       "Last Sunday at 9:30:00 AM"
     );
+    const sixDaysAgo = new Date(2026, 8, 4, 23, 59, 59);
+    expect(formatCalendarDateTime(sixDaysAgo)).toBe(
+      "Last Friday at 11:59:59 PM"
+    );
   });
 
-  it("falls back to a plain date beyond a week", () => {
+  it("falls back to a plain date from seven days ago", () => {
+    const sevenDaysAgo = new Date(2026, 8, 3, 23, 59, 59);
+    expect(formatCalendarDateTime(sevenDaysAgo)).toBe("09/03/2026");
     const twoWeeksAgo = new Date(2026, 7, 27, 9, 30, 0);
     expect(formatCalendarDateTime(twoWeeksAgo)).toBe("08/27/2026");
+  });
+
+  it("keeps moment's default future formats, which omit seconds", () => {
+    expect(formatCalendarDateTime(new Date(2026, 8, 11, 0, 0, 30))).toBe(
+      "Tomorrow at 12:00 AM"
+    );
+    expect(formatCalendarDateTime(new Date(2026, 8, 12, 9, 30, 15))).toBe(
+      "Saturday at 9:30 AM"
+    );
+    expect(formatCalendarDateTime(new Date(2026, 8, 16, 9, 30, 0))).toBe(
+      "Wednesday at 9:30 AM"
+    );
+    expect(formatCalendarDateTime(new Date(2026, 8, 17, 9, 30, 0))).toBe(
+      "09/17/2026"
+    );
+  });
+
+  it("uses the same reference instant for every comparison", () => {
+    const now = new Date(2026, 8, 10, 0, 0, 0);
+    expect(formatCalendarDateTime(new Date(2026, 8, 9, 23, 59, 59), now)).toBe(
+      "Yesterday at 11:59:59 PM"
+    );
+  });
+
+  it("renders an invalid date like moment instead of throwing", () => {
+    expect(formatCalendarDateTime(Number.NaN)).toBe("Invalid date");
   });
 });
 
@@ -91,5 +172,91 @@ describe("getRelativeDateBucket", () => {
   it("buckets an older time as 'Older'", () => {
     const twoYearsAgo = new Date(2024, 8, 10, 12, 0, 0);
     expect(getRelativeDateBucket(twoYearsAgo)).toBe("Older");
+  });
+
+  it("treats each boundary as the local start of that day, inclusive", () => {
+    expect(getRelativeDateBucket(new Date(2026, 8, 10, 0, 0, 0))).toBe("Today");
+    expect(getRelativeDateBucket(new Date(2026, 8, 9, 23, 59, 59))).toBe(
+      "Yesterday"
+    );
+    expect(getRelativeDateBucket(new Date(2026, 8, 9, 0, 0, 0))).toBe(
+      "Yesterday"
+    );
+    expect(getRelativeDateBucket(new Date(2026, 8, 8, 23, 59, 59))).toBe(
+      "Last Week"
+    );
+    expect(getRelativeDateBucket(new Date(2026, 8, 3, 0, 0, 0))).toBe(
+      "Last Week"
+    );
+    expect(getRelativeDateBucket(new Date(2026, 8, 2, 23, 59, 59))).toBe(
+      "Last Month"
+    );
+    expect(getRelativeDateBucket(new Date(2026, 7, 10, 0, 0, 0))).toBe(
+      "Last Month"
+    );
+    expect(getRelativeDateBucket(new Date(2026, 7, 9, 23, 59, 59))).toBe(
+      "Last 12 Months"
+    );
+    expect(getRelativeDateBucket(new Date(2025, 8, 10, 0, 0, 0))).toBe(
+      "Last 12 Months"
+    );
+    expect(getRelativeDateBucket(new Date(2025, 8, 9, 23, 59, 59))).toBe(
+      "Older"
+    );
+  });
+
+  it("clamps the month boundary to the end of shorter months", () => {
+    const now = new Date(2026, 2, 31, 12, 0, 0); // Mar 31: one month ago clamps to Feb 28.
+    expect(getRelativeDateBucket(new Date(2026, 1, 28, 0, 0, 0), now)).toBe(
+      "Last Month"
+    );
+    expect(getRelativeDateBucket(new Date(2026, 1, 27, 23, 59, 59), now)).toBe(
+      "Last 12 Months"
+    );
+  });
+});
+
+describe("DST switch at midnight", () => {
+  // In Chile clocks jump from 00:00 to 01:00 on the first Sunday of September, so the
+  // start of 2026-09-06 is 01:00 local. Boundaries shifted from that instant must still
+  // land on 00:00 of the earlier days, not 01:00.
+  const originalTz = process.env.TZ;
+
+  beforeEach(() => {
+    process.env.TZ = "America/Santiago";
+  });
+
+  afterEach(() => {
+    if (originalTz === undefined) {
+      delete process.env.TZ;
+    } else {
+      process.env.TZ = originalTz;
+    }
+  });
+
+  it("keeps the first hour of each boundary day in the right bucket", () => {
+    const now = new Date(2026, 8, 6, 1, 0, 0);
+    expect(now.getHours()).toBe(1);
+    expect(new Date(2026, 8, 6, 0, 30, 0).getHours()).toBe(1);
+
+    expect(getRelativeDateBucket(new Date(2026, 8, 5, 0, 30, 0), now)).toBe(
+      "Yesterday"
+    );
+    expect(getRelativeDateBucket(new Date(2026, 7, 30, 0, 30, 0), now)).toBe(
+      "Last Week"
+    );
+    expect(getRelativeDateBucket(new Date(2026, 7, 6, 0, 30, 0), now)).toBe(
+      "Last Month"
+    );
+    expect(getRelativeDateBucket(new Date(2025, 8, 6, 0, 30, 0), now)).toBe(
+      "Last 12 Months"
+    );
+  });
+
+  it("labels the first hour of yesterday as 'Yesterday'", () => {
+    const now = new Date(2026, 8, 6, 1, 0, 0);
+    expect(formatCalendarDateTime(new Date(2026, 8, 5, 0, 30, 0), now)).toBe(
+      "Yesterday at 12:30:00 AM"
+    );
   });
 });

--- a/front/lib/utils/timestamps.test.ts
+++ b/front/lib/utils/timestamps.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  formatCalendarDateTime,
+  formatRelativeTime,
+  getRelativeDateBucket,
+} from "./timestamps";
+
+// Built from local date components (not ISO/UTC strings) so assertions hold
+// regardless of the timezone the test runner executes in — these helpers
+// format and bucket dates in the system's local timezone, matching moment's
+// default (timezone-naive) behavior.
+const NOW = new Date(2026, 8, 10, 15, 0, 0); // Thu 2026-09-10 15:00 local
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("formatRelativeTime", () => {
+  it("formats a past date with a suffix", () => {
+    const threeHoursAgo = new Date(NOW.getTime() - 3 * 60 * 60 * 1000);
+    expect(formatRelativeTime(threeHoursAgo)).toBe("about 3 hours ago");
+  });
+
+  it("formats a future date with a suffix", () => {
+    const inTwoDays = new Date(NOW.getTime() + 2 * 24 * 60 * 60 * 1000);
+    expect(formatRelativeTime(inTwoDays)).toBe("in 2 days");
+  });
+
+  it("accepts a timestamp number", () => {
+    const oneHourAgoMs = NOW.getTime() - 60 * 60 * 1000;
+    expect(formatRelativeTime(oneHourAgoMs)).toBe("about 1 hour ago");
+  });
+});
+
+describe("formatCalendarDateTime", () => {
+  it("labels a time today as 'Today at ...'", () => {
+    const today = new Date(2026, 8, 10, 9, 30, 0);
+    expect(formatCalendarDateTime(today)).toBe("Today at 9:30:00 AM");
+  });
+
+  it("labels a time yesterday as 'Yesterday at ...'", () => {
+    const yesterday = new Date(2026, 8, 9, 9, 30, 0);
+    expect(formatCalendarDateTime(yesterday)).toBe("Yesterday at 9:30:00 AM");
+  });
+
+  it("labels a time within the last week as 'Last <weekday> at ...'", () => {
+    const lastSunday = new Date(2026, 8, 6, 9, 30, 0); // 2026-09-06 is a Sunday
+    expect(formatCalendarDateTime(lastSunday)).toBe(
+      "Last Sunday at 9:30:00 AM"
+    );
+  });
+
+  it("falls back to a plain date beyond a week", () => {
+    const twoWeeksAgo = new Date(2026, 7, 27, 9, 30, 0);
+    expect(formatCalendarDateTime(twoWeeksAgo)).toBe("08/27/2026");
+  });
+});
+
+describe("getRelativeDateBucket", () => {
+  it("buckets a time today as 'Today'", () => {
+    const today = new Date(2026, 8, 10, 1, 0, 0);
+    expect(getRelativeDateBucket(today)).toBe("Today");
+  });
+
+  it("buckets a time yesterday as 'Yesterday'", () => {
+    const yesterday = new Date(2026, 8, 9, 23, 0, 0);
+    expect(getRelativeDateBucket(yesterday)).toBe("Yesterday");
+  });
+
+  it("buckets a time within the last week as 'Last Week'", () => {
+    const fourDaysAgo = new Date(2026, 8, 6, 12, 0, 0);
+    expect(getRelativeDateBucket(fourDaysAgo)).toBe("Last Week");
+  });
+
+  it("buckets a time within the last month as 'Last Month'", () => {
+    const threeWeeksAgo = new Date(2026, 7, 20, 12, 0, 0);
+    expect(getRelativeDateBucket(threeWeeksAgo)).toBe("Last Month");
+  });
+
+  it("buckets a time within the last 12 months as 'Last 12 Months'", () => {
+    const sixMonthsAgo = new Date(2026, 2, 10, 12, 0, 0);
+    expect(getRelativeDateBucket(sixMonthsAgo)).toBe("Last 12 Months");
+  });
+
+  it("buckets an older time as 'Older'", () => {
+    const twoYearsAgo = new Date(2024, 8, 10, 12, 0, 0);
+    expect(getRelativeDateBucket(twoYearsAgo)).toBe("Older");
+  });
+});

--- a/front/lib/utils/timestamps.ts
+++ b/front/lib/utils/timestamps.ts
@@ -1,7 +1,7 @@
 import {
-  addMonths,
   differenceInCalendarDays,
   format,
+  formatDistance,
   isToday,
   isTomorrow,
   isValid,
@@ -15,9 +15,6 @@ import {
 
 // What moment renders for an invalid date; kept so migrated call sites never throw mid-render.
 const INVALID_DATE_LABEL = "Invalid date";
-
-// moment's month/day conversion constant (average Gregorian month length in days).
-const DAYS_PER_MONTH = 146097 / 4800;
 
 function isTimestamp(value: Date | number): value is number {
   return typeof value === "number";
@@ -136,88 +133,6 @@ export const formatCalendarDate = (date: Date | number): string => {
   return format(dateObj, "dd/MM/yyyy");
 };
 
-/**
- * Splits the span between two instants into whole calendar months plus a millisecond
- * remainder, the way moment builds a duration from two moments. Month steps clamp to the end
- * of shorter months, so Jan 31 -> Feb 28 counts as one full month.
- */
-function splitIntoMonthsAndMs(
-  from: Date,
-  to: Date
-): { months: number; remainderMs: number } {
-  let months =
-    to.getMonth() -
-    from.getMonth() +
-    (to.getFullYear() - from.getFullYear()) * 12;
-  if (addMonths(from, months).getTime() > to.getTime()) {
-    months -= 1;
-  }
-  return {
-    months,
-    remainderMs: to.getTime() - addMonths(from, months).getTime(),
-  };
-}
-
-/**
- * Port of moment's default English `relativeTime` thresholds and rounding, so the wording
- * ("a few seconds", "an hour", "3 days", ...) is identical to what `.fromNow()` produced.
- */
-function humanizeDuration(months: number, remainderMs: number): string {
-  const wholeDays = Math.round(months * DAYS_PER_MONTH);
-  const seconds = Math.round(wholeDays * 86400 + remainderMs / 1000);
-  const minutes = Math.round(wholeDays * 1440 + remainderMs / 60_000);
-  const hours = Math.round(wholeDays * 24 + remainderMs / 3_600_000);
-  const days = Math.round(wholeDays + remainderMs / 86_400_000);
-  const fractionalMonths = months + remainderMs / 86_400_000 / DAYS_PER_MONTH;
-  const roundedMonths = Math.round(fractionalMonths);
-  const years = Math.round(fractionalMonths / 12);
-
-  if (seconds <= 44) {
-    return "a few seconds";
-  }
-  if (minutes <= 1) {
-    return "a minute";
-  }
-  if (minutes < 45) {
-    return `${minutes} minutes`;
-  }
-  if (hours <= 1) {
-    return "an hour";
-  }
-  if (hours < 22) {
-    return `${hours} hours`;
-  }
-  if (days <= 1) {
-    return "a day";
-  }
-  if (days < 26) {
-    return `${days} days`;
-  }
-  if (roundedMonths <= 1) {
-    return "a month";
-  }
-  if (roundedMonths < 11) {
-    return `${roundedMonths} months`;
-  }
-  if (years <= 1) {
-    return "a year";
-  }
-  return `${years} years`;
-}
-
-/**
- * @cc [owner:avervaet,label:coding] moment-fromnow-replacement
- * This is the standard replacement for moment's `.fromNow()`: new code needing a relative
- * "n units ago" timestamp must use this helper instead of importing `moment`. It reproduces
- * moment's default English wording and thresholds exactly, and renders invalid dates as
- * "Invalid date" rather than throwing.
- */
-/**
- * Formats a date as a relative time string.
- * @param date - The date to format (Date object or timestamp in milliseconds)
- * @param now - The reference instant (defaults to now)
- * @returns A formatted string like "3 hours ago", "a few seconds ago" or "in 2 days"
- */
 export const formatRelativeTime = (
   date: Date | number,
   now: Date = new Date()
@@ -227,28 +142,9 @@ export const formatRelativeTime = (
     return INVALID_DATE_LABEL;
   }
 
-  const isFuture = dateObj.getTime() > now.getTime();
-  const [from, to] = isFuture ? [now, dateObj] : [dateObj, now];
-  const { months, remainderMs } = splitIntoMonthsAndMs(from, to);
-  const humanized = humanizeDuration(months, remainderMs);
-
-  return isFuture ? `in ${humanized}` : `${humanized} ago`;
+  return formatDistance(dateObj, now, { addSuffix: true });
 };
 
-/**
- * @cc [owner:avervaet,label:coding] moment-calendar-replacement
- * This is the standard replacement for moment's `.calendar()` sameDay/lastDay/lastWeek
- * pattern: new code needing that calendar-style timestamp display must use this helper
- * instead of importing `moment`. It keeps moment's default nextDay/nextWeek/sameElse outputs
- * for future dates and renders invalid dates as "Invalid date" rather than throwing.
- */
-/**
- * Formats a date in a calendar-relative way, including the time of day.
- * @param date - The date to format (Date object or timestamp in milliseconds)
- * @param now - The reference instant (defaults to now)
- * @returns A formatted string like "Today at 3:45:00 PM", "Yesterday at 3:45:00 PM",
- * "Last Monday at 3:45:00 PM", "Tomorrow at 3:45 PM", "Friday at 3:45 PM" or "09/10/2026"
- */
 export const formatCalendarDateTime = (
   date: Date | number,
   now: Date = new Date()

--- a/front/lib/utils/timestamps.ts
+++ b/front/lib/utils/timestamps.ts
@@ -1,4 +1,16 @@
-import { format, isToday, isTomorrow, isYesterday } from "date-fns";
+import {
+  differenceInCalendarDays,
+  format,
+  formatDistanceToNow,
+  isToday,
+  isTomorrow,
+  isYesterday,
+  startOfDay,
+  subDays,
+  subMonths,
+  subWeeks,
+  subYears,
+} from "date-fns";
 
 /**
  * Returns a Date that is `days` days before the given reference date (defaults to now).
@@ -107,4 +119,95 @@ export const formatCalendarDate = (date: Date | number): string => {
   }
 
   return format(dateObj, "dd/MM/yyyy");
+};
+
+/**
+ * @cc [owner:avervaet,label:coding] moment-fromnow-replacement
+ * This is the standard replacement for moment's `.fromNow()`: new code needing a relative
+ * "n units ago" timestamp must use this helper instead of importing `moment`.
+ */
+/**
+ * Formats a date as a relative time string.
+ * @param date - The date to format (Date object or timestamp in milliseconds)
+ * @returns A formatted string like "3 hours ago" or "in 2 days"
+ */
+export const formatRelativeTime = (date: Date | number): string => {
+  const dateObj = typeof date === "number" ? new Date(date) : date;
+  return formatDistanceToNow(dateObj, { addSuffix: true });
+};
+
+/**
+ * @cc [owner:avervaet,label:coding] moment-calendar-replacement
+ * This is the standard replacement for moment's `.calendar()` sameDay/lastDay/lastWeek
+ * pattern: new code needing that calendar-style timestamp display must use this helper
+ * instead of importing `moment`.
+ */
+/**
+ * Formats a date in a calendar-relative way, including the time of day.
+ * @param date - The date to format (Date object or timestamp in milliseconds)
+ * @returns A formatted string like "Today at 3:45:00 PM", "Yesterday at 3:45:00 PM",
+ * "Last Monday at 3:45:00 PM", or "09/10/2026"
+ */
+export const formatCalendarDateTime = (date: Date | number): string => {
+  const dateObj = typeof date === "number" ? new Date(date) : date;
+  const time = format(dateObj, "h:mm:ss a");
+
+  if (isToday(dateObj)) {
+    return `Today at ${time}`;
+  }
+  if (isYesterday(dateObj)) {
+    return `Yesterday at ${time}`;
+  }
+
+  const dayDiff = differenceInCalendarDays(new Date(), dateObj);
+  if (dayDiff >= 2 && dayDiff <= 6) {
+    return `Last ${format(dateObj, "EEEE")} at ${time}`;
+  }
+
+  return format(dateObj, "MM/dd/yyyy");
+};
+
+export type RelativeDateBucket =
+  | "Today"
+  | "Yesterday"
+  | "Last Week"
+  | "Last Month"
+  | "Last 12 Months"
+  | "Older";
+
+/**
+ * @cc [owner:avervaet,label:coding] moment-bucket-replacement
+ * This is the standard replacement for moment-based Today/Yesterday/Last Week/... list
+ * bucketing: new code needing that bucketing must use this helper instead of importing
+ * `moment`.
+ */
+/**
+ * Buckets a date into a coarse relative-time group, for sectioning lists (e.g. sidebar
+ * conversation lists) into "Today", "Yesterday", "Last Week", etc.
+ * @param date - The date to bucket (Date object or timestamp in milliseconds)
+ * @param now - The reference date to bucket against (defaults to now)
+ */
+export const getRelativeDateBucket = (
+  date: Date | number,
+  now: Date = new Date()
+): RelativeDateBucket => {
+  const dateObj = typeof date === "number" ? new Date(date) : date;
+  const today = startOfDay(now);
+
+  if (dateObj.getTime() >= today.getTime()) {
+    return "Today";
+  }
+  if (dateObj.getTime() >= subDays(today, 1).getTime()) {
+    return "Yesterday";
+  }
+  if (dateObj.getTime() >= subWeeks(today, 1).getTime()) {
+    return "Last Week";
+  }
+  if (dateObj.getTime() >= subMonths(today, 1).getTime()) {
+    return "Last Month";
+  }
+  if (dateObj.getTime() >= subYears(today, 1).getTime()) {
+    return "Last 12 Months";
+  }
+  return "Older";
 };

--- a/front/lib/utils/timestamps.ts
+++ b/front/lib/utils/timestamps.ts
@@ -12,6 +12,14 @@ import {
   subYears,
 } from "date-fns";
 
+function isTimestamp(value: Date | number): value is number {
+  return typeof value === "number";
+}
+
+function toDate(value: Date | number): Date {
+  return isTimestamp(value) ? new Date(value) : value;
+}
+
 /**
  * Returns a Date that is `days` days before the given reference date (defaults to now).
  */
@@ -132,7 +140,7 @@ export const formatCalendarDate = (date: Date | number): string => {
  * @returns A formatted string like "3 hours ago" or "in 2 days"
  */
 export const formatRelativeTime = (date: Date | number): string => {
-  const dateObj = typeof date === "number" ? new Date(date) : date;
+  const dateObj = toDate(date);
   return formatDistanceToNow(dateObj, { addSuffix: true });
 };
 
@@ -149,7 +157,7 @@ export const formatRelativeTime = (date: Date | number): string => {
  * "Last Monday at 3:45:00 PM", or "09/10/2026"
  */
 export const formatCalendarDateTime = (date: Date | number): string => {
-  const dateObj = typeof date === "number" ? new Date(date) : date;
+  const dateObj = toDate(date);
   const time = format(dateObj, "h:mm:ss a");
 
   if (isToday(dateObj)) {
@@ -159,8 +167,8 @@ export const formatCalendarDateTime = (date: Date | number): string => {
     return `Yesterday at ${time}`;
   }
 
-  const dayDiff = differenceInCalendarDays(new Date(), dateObj);
-  if (dayDiff >= 2 && dayDiff <= 6) {
+  const diffDays = differenceInCalendarDays(new Date(), dateObj);
+  if (diffDays >= 2 && diffDays <= 6) {
     return `Last ${format(dateObj, "EEEE")} at ${time}`;
   }
 
@@ -191,7 +199,7 @@ export const getRelativeDateBucket = (
   date: Date | number,
   now: Date = new Date()
 ): RelativeDateBucket => {
-  const dateObj = typeof date === "number" ? new Date(date) : date;
+  const dateObj = toDate(date);
   const today = startOfDay(now);
 
   if (dateObj.getTime() >= today.getTime()) {

--- a/front/lib/utils/timestamps.ts
+++ b/front/lib/utils/timestamps.ts
@@ -188,20 +188,6 @@ export type RelativeDateBucket =
   | "Last 12 Months"
   | "Older";
 
-/**
- * @cc [owner:avervaet,label:coding] moment-bucket-replacement
- * This is the standard replacement for moment-based Today/Yesterday/Last Week/... list
- * bucketing: new code needing that bucketing must use this helper instead of importing
- * `moment`. Bucket boundaries are computed by shifting `now` first and taking the start of
- * that day second; the reverse order drifts by an hour on days where midnight does not exist
- * (zones whose DST switch happens at 00:00).
- */
-/**
- * Buckets a date into a coarse relative-time group, for sectioning lists (e.g. sidebar
- * conversation lists) into "Today", "Yesterday", "Last Week", etc.
- * @param date - The date to bucket (Date object or timestamp in milliseconds)
- * @param now - The reference date to bucket against (defaults to now)
- */
 export const getRelativeDateBucket = (
   date: Date | number,
   now: Date = new Date()

--- a/front/lib/utils/timestamps.ts
+++ b/front/lib/utils/timestamps.ts
@@ -1,9 +1,10 @@
 import {
+  addMonths,
   differenceInCalendarDays,
   format,
-  formatDistanceToNow,
   isToday,
   isTomorrow,
+  isValid,
   isYesterday,
   startOfDay,
   subDays,
@@ -11,6 +12,12 @@ import {
   subWeeks,
   subYears,
 } from "date-fns";
+
+// What moment renders for an invalid date; kept so migrated call sites never throw mid-render.
+const INVALID_DATE_LABEL = "Invalid date";
+
+// moment's month/day conversion constant (average Gregorian month length in days).
+const DAYS_PER_MONTH = 146097 / 4800;
 
 function isTimestamp(value: Date | number): value is number {
   return typeof value === "number";
@@ -130,46 +137,148 @@ export const formatCalendarDate = (date: Date | number): string => {
 };
 
 /**
+ * Splits the span between two instants into whole calendar months plus a millisecond
+ * remainder, the way moment builds a duration from two moments. Month steps clamp to the end
+ * of shorter months, so Jan 31 -> Feb 28 counts as one full month.
+ */
+function splitIntoMonthsAndMs(
+  from: Date,
+  to: Date
+): { months: number; remainderMs: number } {
+  let months =
+    to.getMonth() -
+    from.getMonth() +
+    (to.getFullYear() - from.getFullYear()) * 12;
+  if (addMonths(from, months).getTime() > to.getTime()) {
+    months -= 1;
+  }
+  return {
+    months,
+    remainderMs: to.getTime() - addMonths(from, months).getTime(),
+  };
+}
+
+/**
+ * Port of moment's default English `relativeTime` thresholds and rounding, so the wording
+ * ("a few seconds", "an hour", "3 days", ...) is identical to what `.fromNow()` produced.
+ */
+function humanizeDuration(months: number, remainderMs: number): string {
+  const wholeDays = Math.round(months * DAYS_PER_MONTH);
+  const seconds = Math.round(wholeDays * 86400 + remainderMs / 1000);
+  const minutes = Math.round(wholeDays * 1440 + remainderMs / 60_000);
+  const hours = Math.round(wholeDays * 24 + remainderMs / 3_600_000);
+  const days = Math.round(wholeDays + remainderMs / 86_400_000);
+  const fractionalMonths = months + remainderMs / 86_400_000 / DAYS_PER_MONTH;
+  const roundedMonths = Math.round(fractionalMonths);
+  const years = Math.round(fractionalMonths / 12);
+
+  if (seconds <= 44) {
+    return "a few seconds";
+  }
+  if (minutes <= 1) {
+    return "a minute";
+  }
+  if (minutes < 45) {
+    return `${minutes} minutes`;
+  }
+  if (hours <= 1) {
+    return "an hour";
+  }
+  if (hours < 22) {
+    return `${hours} hours`;
+  }
+  if (days <= 1) {
+    return "a day";
+  }
+  if (days < 26) {
+    return `${days} days`;
+  }
+  if (roundedMonths <= 1) {
+    return "a month";
+  }
+  if (roundedMonths < 11) {
+    return `${roundedMonths} months`;
+  }
+  if (years <= 1) {
+    return "a year";
+  }
+  return `${years} years`;
+}
+
+/**
  * @cc [owner:avervaet,label:coding] moment-fromnow-replacement
  * This is the standard replacement for moment's `.fromNow()`: new code needing a relative
- * "n units ago" timestamp must use this helper instead of importing `moment`.
+ * "n units ago" timestamp must use this helper instead of importing `moment`. It reproduces
+ * moment's default English wording and thresholds exactly, and renders invalid dates as
+ * "Invalid date" rather than throwing.
  */
 /**
  * Formats a date as a relative time string.
  * @param date - The date to format (Date object or timestamp in milliseconds)
- * @returns A formatted string like "3 hours ago" or "in 2 days"
+ * @param now - The reference instant (defaults to now)
+ * @returns A formatted string like "3 hours ago", "a few seconds ago" or "in 2 days"
  */
-export const formatRelativeTime = (date: Date | number): string => {
+export const formatRelativeTime = (
+  date: Date | number,
+  now: Date = new Date()
+): string => {
   const dateObj = toDate(date);
-  return formatDistanceToNow(dateObj, { addSuffix: true });
+  if (!isValid(dateObj)) {
+    return INVALID_DATE_LABEL;
+  }
+
+  const isFuture = dateObj.getTime() > now.getTime();
+  const [from, to] = isFuture ? [now, dateObj] : [dateObj, now];
+  const { months, remainderMs } = splitIntoMonthsAndMs(from, to);
+  const humanized = humanizeDuration(months, remainderMs);
+
+  return isFuture ? `in ${humanized}` : `${humanized} ago`;
 };
 
 /**
  * @cc [owner:avervaet,label:coding] moment-calendar-replacement
  * This is the standard replacement for moment's `.calendar()` sameDay/lastDay/lastWeek
  * pattern: new code needing that calendar-style timestamp display must use this helper
- * instead of importing `moment`.
+ * instead of importing `moment`. It keeps moment's default nextDay/nextWeek/sameElse outputs
+ * for future dates and renders invalid dates as "Invalid date" rather than throwing.
  */
 /**
  * Formats a date in a calendar-relative way, including the time of day.
  * @param date - The date to format (Date object or timestamp in milliseconds)
+ * @param now - The reference instant (defaults to now)
  * @returns A formatted string like "Today at 3:45:00 PM", "Yesterday at 3:45:00 PM",
- * "Last Monday at 3:45:00 PM", or "09/10/2026"
+ * "Last Monday at 3:45:00 PM", "Tomorrow at 3:45 PM", "Friday at 3:45 PM" or "09/10/2026"
  */
-export const formatCalendarDateTime = (date: Date | number): string => {
+export const formatCalendarDateTime = (
+  date: Date | number,
+  now: Date = new Date()
+): string => {
   const dateObj = toDate(date);
-  const time = format(dateObj, "h:mm:ss a");
-
-  if (isToday(dateObj)) {
-    return `Today at ${time}`;
-  }
-  if (isYesterday(dateObj)) {
-    return `Yesterday at ${time}`;
+  if (!isValid(dateObj)) {
+    return INVALID_DATE_LABEL;
   }
 
-  const diffDays = differenceInCalendarDays(new Date(), dateObj);
-  if (diffDays >= 2 && diffDays <= 6) {
-    return `Last ${format(dateObj, "EEEE")} at ${time}`;
+  // Calendar-day distance is DST-safe: a 23h or 25h day still counts as exactly one day.
+  const diffDays = differenceInCalendarDays(dateObj, now);
+  const timeWithSeconds = format(dateObj, "h:mm:ss a");
+
+  if (diffDays === 0) {
+    return `Today at ${timeWithSeconds}`;
+  }
+  if (diffDays === -1) {
+    return `Yesterday at ${timeWithSeconds}`;
+  }
+  if (diffDays >= -6 && diffDays < -1) {
+    return `Last ${format(dateObj, "EEEE")} at ${timeWithSeconds}`;
+  }
+
+  // moment's built-in future formats use LT (no seconds), unlike the overridden past ones.
+  const timeWithoutSeconds = format(dateObj, "h:mm a");
+  if (diffDays === 1) {
+    return `Tomorrow at ${timeWithoutSeconds}`;
+  }
+  if (diffDays > 1 && diffDays < 7) {
+    return `${format(dateObj, "EEEE")} at ${timeWithoutSeconds}`;
   }
 
   return format(dateObj, "MM/dd/yyyy");
@@ -187,7 +296,9 @@ export type RelativeDateBucket =
  * @cc [owner:avervaet,label:coding] moment-bucket-replacement
  * This is the standard replacement for moment-based Today/Yesterday/Last Week/... list
  * bucketing: new code needing that bucketing must use this helper instead of importing
- * `moment`.
+ * `moment`. Bucket boundaries are computed by shifting `now` first and taking the start of
+ * that day second; the reverse order drifts by an hour on days where midnight does not exist
+ * (zones whose DST switch happens at 00:00).
  */
 /**
  * Buckets a date into a coarse relative-time group, for sectioning lists (e.g. sidebar
@@ -199,22 +310,21 @@ export const getRelativeDateBucket = (
   date: Date | number,
   now: Date = new Date()
 ): RelativeDateBucket => {
-  const dateObj = toDate(date);
-  const today = startOfDay(now);
+  const timeMs = toDate(date).getTime();
 
-  if (dateObj.getTime() >= today.getTime()) {
+  if (timeMs >= startOfDay(now).getTime()) {
     return "Today";
   }
-  if (dateObj.getTime() >= subDays(today, 1).getTime()) {
+  if (timeMs >= startOfDay(subDays(now, 1)).getTime()) {
     return "Yesterday";
   }
-  if (dateObj.getTime() >= subWeeks(today, 1).getTime()) {
+  if (timeMs >= startOfDay(subWeeks(now, 1)).getTime()) {
     return "Last Week";
   }
-  if (dateObj.getTime() >= subMonths(today, 1).getTime()) {
+  if (timeMs >= startOfDay(subMonths(now, 1)).getTime()) {
     return "Last Month";
   }
-  if (dateObj.getTime() >= subYears(today, 1).getTime()) {
+  if (timeMs >= startOfDay(subYears(now, 1)).getTime()) {
     return "Last 12 Months";
   }
   return "Older";


### PR DESCRIPTION
## Description

Decision: https://github.com/dust-tt/decisions/issues/1009 phase out `moment` in favor of `date-fns`. This PR ships step 2 of the phased plan: extends `front/lib/utils/timestamps.ts` with `date-fns`-based helpers covering the patterns `moment` is used for in the codebase, so that migrating a call site becomes a drop-in swap.

- `formatRelativeTime`: replaces `.fromNow()`. Uses date-fns's own `formatDistance` thresholds and wording rather than porting moment's exactly, the exact phrasing isn't load-bearing, and matching it exactly would mean maintaining a parallel implementation of date-fns's own logic.
- `formatCalendarDateTime`: replaces the `.calendar()` sameDay/lastDay/lastWeek pattern. Matches moment's exact output here, including its asymmetry between past (seconds shown) and future (seconds omitted) formats, since this one changes what's rendered in the UI, not just wording.
- `getRelativeDateBucket`: replaces the Today/Yesterday/Last Week/Last Month/Last 12 Months/Older bucketing used for sidebar conversation lists. Boundaries are computed by shifting the reference instant first and taking the start of that day second, so bucketing doesn't drift an hour in timezones whose DST switch happens at midnight (e.g. Chile, Cuba).

## Tests

Adding test for the describe helpers.

## Risk

Low. Additive helpers only, no existing call site is migrated or touched.

## Deploy Plan

None
