### PR TITLE
feat(input-bar): shorten knowledge attach/search labels to Attach and Search

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -577,7 +577,7 @@ export const InputBarAttachmentsPicker = ({
         <DropdownAnchorTrigger anchorRef={anchorRef} />
       ) : (
         <DropdownMenuSubTrigger
-          label="Attach knowledge"
+          label="Attach"
           icon={
             <Icon
               size="xs"
@@ -795,7 +795,7 @@ export const InputBarAttachmentsPicker = ({
           <div className="flex h-full w-full items-center justify-center">
             <div className="flex flex-col items-center justify-center gap-0 text-center text-base font-semibold text-primary-400">
               <Icon visual={SearchMd} size="sm" />
-              Search knowledge
+              Search
             </div>
           </div>
         )}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1839,7 +1839,7 @@ const InputBarContainer = ({
                             {actions.includes("attachment") && (
                               <DropdownMenuItem
                                 icon={Attachment01}
-                                label="Attach knowledge"
+                                label="Attach"
                                 onClick={() => {
                                   setIsCaptureDropdownOpen(false);
                                   setShowKnowledgePicker(true);

--- a/front/components/assistant/conversation/input_bar/InputBarPlusMenu.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarPlusMenu.tsx
@@ -241,7 +241,7 @@ export function InputBarPlusMenu({
               )}
               {!hideAttachments && (
                 <DropdownMenuItem
-                  label="Attach knowledge"
+                  label="Attach"
                   icon={Attachment01}
                   disabled={disabled}
                   onClick={() => openPicker("attachments")}

--- a/front/components/editor/extensions/shared/slash_suggestion/slashStaticCommands.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/slashStaticCommands.tsx
@@ -11,7 +11,7 @@ export function createAttachKnowledgeSlashCommand(): SlashCommand {
     description: "Search knowledge and reference conversation or pod files",
     icon: getSlashCommandAvatarIcon(Attachment01),
     id: "attach-knowledge",
-    label: "Attach knowledge",
+    label: "Attach",
     tooltip: {
       description: "Use company knowledge or reference files for context.",
       media: (

--- a/sparkle/src/stories/Composer.stories.tsx
+++ b/sparkle/src/stories/Composer.stories.tsx
@@ -637,7 +637,7 @@ function ComposerDemo({
         }}
       >
         <DropdownMenuSubTrigger
-          label="Attach knowledge"
+          label="Attach"
           icon={
             <Icon
               size="xs"
@@ -690,7 +690,7 @@ function ComposerDemo({
             <div className="flex h-full w-full items-center justify-center">
               <div className="flex flex-col items-center justify-center gap-0 text-center text-base font-semibold text-primary-400">
                 <Icon visual={SearchMd} size="sm" />
-                Search knowledge
+                Search
               </div>
             </div>
           )}


### PR DESCRIPTION
## Description
<img width="775" height="563" alt="Screenshot 2026-09-10 at 10 07 17" src="https://github.com/user-attachments/assets/6668fcbe-6b1e-47d6-92ac-77109e4d600f" />

Shortens the knowledge labels in the composer: the attachment entry point now reads **Attach** instead of "Attach knowledge", and the attachments picker empty state reads **Search** instead of "Search knowledge".

Touched all three composer entry points (`InputBarAttachmentsPicker`, `InputBarPlusMenu`, `InputBarContainer`), the `/attach-knowledge` slash command in the editor, and the Sparkle `Composer` story so the mockup stays in sync with the product.

The slash command's own description line ("Search knowledge and reference conversation or pod files") and its tooltip are unchanged — they are prose, not labels.

## Tests

Copy-only change, verified by inspection. In the composer: the `+` menu / attachment sub-trigger shows "Attach", the attachments picker with an empty search shows "Search", and typing `/` lists "Attach".

## Risk

None — no behavior change.

## Deploy Plan

Standard deploy.
