### PR TITLE
doc: put analytics export under Analytics tag

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -237,7 +237,7 @@
         "summary": "Export workspace analytics",
         "description": "Export analytics data for the workspace identified by {wId} in CSV or JSON format.",
         "tags": [
-          "Workspace"
+          "Analytics"
         ],
         "security": [
           {

--- a/front-api/routes/v1/w/[wId]/analytics/export.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/export.ts
@@ -5,7 +5,7 @@
  *     summary: Export workspace analytics
  *     description: Export analytics data for the workspace identified by {wId} in CSV or JSON format.
  *     tags:
- *       - Workspace
+ *       - Analytics
  *     security:
  *       - BearerAuth: []
  *     parameters:


### PR DESCRIPTION
## Description

The export endpoint is the only endpoint under the "Workspace" folder in our docs. Moving to Analytics to better reflect what it does.

<img width="305" height="248" alt="Screenshot 2026-09-10 at 10 13 48" src="https://github.com/user-attachments/assets/87bdcb3c-1073-4ae1-9e87-8c3498083230" />


## Tests


## Risk

Low

## Deploy Plan

Deploy OpenAPI Docs