### PR TITLE
[front] Rename spend-limit "Highest" chip to "Active", add remove-personal-limit action

### DIFF
--- a/front/components/workspace/CreditLimitInput.tsx
+++ b/front/components/workspace/CreditLimitInput.tsx
@@ -1,4 +1,4 @@
-import { Chip, Input, Page, Tooltip } from "@dust-tt/sparkle";
+import { Button, Chip, Input, Page, Tooltip } from "@dust-tt/sparkle";
 
 interface CreditLimitNumberInputProps {
   value: string;
@@ -42,9 +42,12 @@ interface CreditLimitInputProps {
   readOnly: boolean;
   // Shown on hover when the field is read-only, to say why it is locked.
   readOnlyTooltip?: string;
-  isHighest: boolean;
+  isActive: boolean;
   validationMessage: string | null;
   onChange: (cleaned: string) => void;
+  // Small text action rendered on the opposite end of the label row (e.g. to
+  // clear the field). Omit when the field has nothing to clear back to.
+  action?: { label: string; onClick: () => void };
 }
 
 export function CreditLimitInput({
@@ -52,9 +55,10 @@ export function CreditLimitInput({
   value,
   readOnly,
   readOnlyTooltip,
-  isHighest,
+  isActive,
   validationMessage,
   onChange,
+  action,
 }: CreditLimitInputProps) {
   const input = (
     <CreditLimitNumberInput
@@ -68,7 +72,16 @@ export function CreditLimitInput({
     <Page.Vertical gap="xs" align="stretch">
       <div className="flex items-center gap-2">
         <span className="text-sm font-medium text-foreground">{label}</span>
-        {isHighest && <Chip size="mini" color="highlight" label="Highest" />}
+        {isActive && <Chip size="mini" color="highlight" label="Active" />}
+        {!readOnly && action && (
+          <Button
+            variant="ghost"
+            size="xs"
+            label={action.label}
+            onClick={action.onClick}
+            className="ml-auto"
+          />
+        )}
       </div>
       {readOnly && readOnlyTooltip ? (
         <Tooltip

--- a/front/components/workspace/EditMemberSpendLimitModal.tsx
+++ b/front/components/workspace/EditMemberSpendLimitModal.tsx
@@ -92,12 +92,12 @@ function MemberSpendLimitForm({
   // server may have introduced a seat type the client hasn't refreshed to
   // know about yet, so unrecognized values are treated as non-pool rather
   // than passed to the exhaustive normalizer.
-  const isDefaultHighest =
+  const isDefaultActive =
     member?.spendLimitSource === "default" &&
     isMembershipSeatType(member.seatType) &&
     normalizeToPoolLimitSeatType(member.seatType) !== null;
   const showDefaultLimit =
-    isDefaultHighest && defaultUserSpendLimit.status !== "unavailable";
+    isDefaultActive && defaultUserSpendLimit.status !== "unavailable";
   const canChangeDefaultLimit =
     showDefaultLimit && canEditDefaultLimit && !readOnly;
   const isDefaultLimitLoaded = defaultUserSpendLimit.status === "ready";
@@ -320,7 +320,7 @@ function MemberSpendLimitForm({
                   ? "Only workspace admins can edit the workspace default limit."
                   : undefined
               }
-              isHighest={false}
+              isActive={false}
               validationMessage={
                 defaultUserSpendLimit.status === "error"
                   ? "The workspace default limit could not be loaded."
@@ -337,12 +337,23 @@ function MemberSpendLimitForm({
             label="Personal limit"
             value={personalLimitInput}
             readOnly={readOnly}
-            isHighest={hasPersonalOverride}
+            isActive={hasPersonalOverride}
             validationMessage={validationMessage}
             onChange={(cleaned) => {
               setPersonalLimitInput(cleaned);
               setValidationMessage(null);
             }}
+            action={
+              personalLimitInput !== ""
+                ? {
+                    label: "Remove personal limit",
+                    onClick: () => {
+                      setPersonalLimitInput("");
+                      setValidationMessage(null);
+                    },
+                  }
+                : undefined
+            }
           />
 
           {memberGroupRows.length > 0 && (

--- a/front/components/workspace/MemberGroupLimitTable.tsx
+++ b/front/components/workspace/MemberGroupLimitTable.tsx
@@ -29,9 +29,7 @@ const groupColumns: ColumnDef<GroupLimitRow, string>[] = [
     cell: ({ row }) => (
       <DataTable.CellContent
         className={
-          row.original.isHighest
-            ? "font-semibold text-highlight-500"
-            : undefined
+          row.original.isActive ? "font-semibold text-highlight-500" : undefined
         }
       >
         {row.original.name}

--- a/front/components/workspace/MemberGroupLimitTable.tsx
+++ b/front/components/workspace/MemberGroupLimitTable.tsx
@@ -1,6 +1,6 @@
 import { CreditLimitNumberInput } from "@app/components/workspace/CreditLimitInput";
 import type { GroupRow } from "@app/components/workspace/member_spend_limit_helpers";
-import { DataTable } from "@dust-tt/sparkle";
+import { Chip, DataTable } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
 interface MemberGroupLimitTableProps {
@@ -32,7 +32,12 @@ const groupColumns: ColumnDef<GroupLimitRow, string>[] = [
           row.original.isActive ? "font-semibold text-highlight-500" : undefined
         }
       >
-        {row.original.name}
+        <div className="flex items-center gap-2">
+          {row.original.name}
+          {row.original.isActive && (
+            <Chip size="mini" color="highlight" label="Active" />
+          )}
+        </div>
       </DataTable.CellContent>
     ),
   },

--- a/front/components/workspace/member_spend_limit_helpers.ts
+++ b/front/components/workspace/member_spend_limit_helpers.ts
@@ -15,7 +15,7 @@ export type GroupRow = {
   name: string;
   poolCapAwuCredits: number | null;
   memberCount: number;
-  isHighest: boolean;
+  isActive: boolean;
   onClick?: () => void;
 };
 
@@ -114,6 +114,6 @@ export function groupRowsForMember(
     name: g.name,
     poolCapAwuCredits: g.poolCapAwuCredits,
     memberCount: g.memberCount,
-    isHighest: !hasPersonalOverride && g.sId === highest?.sId,
+    isActive: !hasPersonalOverride && g.sId === highest?.sId,
   }));
 }


### PR DESCRIPTION
## Description

Renamed the chip that displays the type of limit set from "Highest" to "Active" for user usage.
Added a small "Remove personal limit" text button above the personal-limit field, shown whenever the field has a value.
Added the active chip on top of the group section if the limit is inherited from a group.

<img width="455" height="566" alt="Capture d’écran 2026-09-10 à 11 01 31" src="https://github.com/user-attachments/assets/64d6fbb1-d793-41dc-88d8-6e3c103000a5" />

## Tests

- front-edge

## Risk

Low, UI wording/affordance only, no behavior change to limit resolution.