### PR TITLE
The deployment card

### DIFF
--- a/.github/actions/deploy-card/action.yml
+++ b/.github/actions/deploy-card/action.yml
@@ -22,7 +22,7 @@ inputs:
     description: "Slack bot token"
     required: true
   infra_token:
-    description: "Token that reads dust-infra, for the tags currently deployed"
+    description: "Token that reads dust-infra, for the cells and the tags currently deployed"
     required: true
 
 outputs:
@@ -50,6 +50,12 @@ runs:
       with:
         script: |
           const fs = require('fs');
+          const owner = context.repo.owner;
+          const repo = context.repo.repo;
+          const component = process.env.COMPONENT;
+          const tag = process.env.IMAGE_TAG;
+          const revert = process.env.IS_REVERT === 'true';
+          const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
           const slack = async (method, body) => {
             const res = await fetch(`https://slack.com/api/${method}`, {
               method: 'POST',
@@ -59,97 +65,133 @@ runs:
             if (!res.ok) core.warning(`${method}: ${res.error}`);
             return res;
           };
-          const infra = github.getOctokit(process.env.INFRA_TOKEN);
-          const owner = context.repo.owner;
-          const component = process.env.COMPONENT;
-          const sha = context.sha;
-          const revert = process.env.IS_REVERT === 'true';
+          const infra = getOctokit(process.env.INFRA_TOKEN);
+          const infraFile = async (path) => {
+            const { data } = await infra.rest.repos.getContent({ owner, repo: 'dust-infra', path, ref: 'main' });
+            return Buffer.from(data.content, 'base64').toString();
+          };
+          const infraDir = async (path) => {
+            const { data } = await infra.rest.repos.getContent({ owner, repo: 'dust-infra', path, ref: 'main' });
+            return data.map((f) => f.name);
+          };
 
-          // Which cells, and what each of them runs today. The legacy clusters are
-          // cell-00000 and cell-00001, everything else is a descriptor cell with a versions
-          // file of its own name.
-          const legacy = { 'cell-00000': 'dust-kube-us-central1', 'cell-00001': 'dust-kube-europe-west1' };
+          // The cells, the same way dust-infra resolves them: the legacy clusters are the
+          // Novu cells without a descriptor, a descriptor cell is in only if it lists the
+          // component (egress-proxy goes by its feature flag).
+          const legacyOf = { 'cell-00000': 'dust-kube-us-central1', 'cell-00001': 'dust-kube-europe-west1' };
+          const described = {};
+          try {
+            for (const name of (await infraDir('cells')).filter((n) => n.endsWith('.yaml'))) {
+              const text = await infraFile(`cells/${name}`);
+              const cell = (text.match(/^cell:\s*(\S+)/m) || [])[1];
+              if (!cell) continue;
+              const apps = [...(text.match(/^applications:\n((?:\s+-\s+\S+\n)+)/m) || ['', ''])[1].matchAll(/-\s+(\S+)/g)].map((m) => m[1]);
+              const egress = /^\s+egress_proxy:\s*true/m.test(text);
+              described[cell] = apps.includes(component) || (component === 'egress-proxy' && egress);
+            }
+          } catch (e) { core.warning(`could not read the cell descriptors: ${e.message}`); }
+          let legacyCells = Object.keys(legacyOf);
+          try {
+            const novu = JSON.parse(await infraFile('.github/configs/novu-cells.json'));
+            legacyCells = Object.keys(novu).filter((c) => !(c in described));
+          } catch (e) { core.warning(`could not read the Novu cells: ${e.message}`); }
+
           let cells;
           if (process.env.CELLS === 'all') {
-            const { data } = await infra.rest.repos.getContent({ owner, repo: 'dust-infra', path: 'versions', ref: 'main' });
-            const files = data.map((f) => f.name.replace(/\.yaml$/, '')).filter((n) => !n.includes('private'));
-            cells = [...Object.keys(legacy), ...files.filter((n) => n.startsWith('cell-'))].sort();
+            cells = [...legacyCells, ...Object.keys(described).filter((c) => described[c])].sort();
           } else {
             cells = process.env.CELLS.split(',').map((c) => c.trim()).filter(Boolean);
           }
           const target = process.env.CELLS === 'all' ? 'all cells' : cells.join(', ');
 
+          // What each cell runs today, from the versions files dust-infra keeps on main.
           const currentTags = new Set();
           for (const cell of cells) {
-            const file = `versions/${legacy[cell] || cell}.yaml`;
+            const file = `versions/${legacyOf[cell] || cell}.yaml`;
             try {
-              const { data } = await infra.rest.repos.getContent({ owner, repo: 'dust-infra', path: file, ref: 'main' });
-              const text = Buffer.from(data.content, 'base64').toString();
-              const m = text.match(new RegExp(`^${component}:\\s*"?([0-9a-f]+)"?\\s*$`, 'm'));
+              const m = (await infraFile(file)).match(new RegExp(`^${component}:\\s*"?([0-9a-f]+)"?\\s*$`, 'm'));
               if (m) currentTags.add(m[1]);
             } catch (e) { core.warning(`no versions file for ${cell}: ${e.message}`); }
           }
 
-          // The changelog is the widest range among the cells: whoever has a commit landing
-          // on any of them is mentioned.
-          let commits = [];
-          for (const tag of currentTags) {
+          // The changelog is the widest range among the cells, so whoever has a commit landing
+          // on any of them is on the card. A revert lists what is being rolled back.
+          const compare = async (base, head) => {
+            const commits = [];
+            let total = 0;
+            for (let page = 1; page <= 5; page++) {
+              const { data } = await github.rest.repos.compareCommitsWithBasehead({ owner, repo, basehead: `${base}...${head}`, per_page: 100, page });
+              total = data.total_commits;
+              commits.push(...data.commits);
+              if (commits.length >= total || data.commits.length === 0) break;
+            }
+            return { commits, total };
+          };
+          let shipping = { commits: [], total: 0 };
+          for (const current of currentTags) {
+            if (current === tag) continue;
             try {
-              const { data } = await github.rest.repos.compareCommitsWithBasehead({ owner, repo: context.repo.repo, basehead: `${tag}...${sha}`, per_page: 250 });
-              if (data.commits.length > commits.length) commits = data.commits;
-            } catch (e) { core.warning(`cannot compare ${tag}...${sha}: ${e.message}`); }
+              const range = revert ? await compare(tag, current) : await compare(current, tag);
+              if (range.total > shipping.total) shipping = range;
+            } catch (e) { core.warning(`cannot compare ${current} and ${tag}: ${e.message}`); }
           }
 
-          // GitHub login -> email through .authors, email -> Slack id. Unknown authors keep
+          // GitHub login to email through .authors, email to Slack id. Unknown authors keep
           // their name.
-          const authorsFile = fs.existsSync('.authors') ? fs.readFileSync('.authors', 'utf8') : '';
-          const emailOf = (login) => { const m = authorsFile.match(new RegExp(`^${login}: (\\S+)`, 'm')); return m ? m[1] : null; };
+          const emails = new Map();
+          if (fs.existsSync('.authors')) {
+            for (const line of fs.readFileSync('.authors', 'utf8').split('\n')) {
+              const [login, email] = line.split(': ');
+              if (login && email) emails.set(login.trim().toLowerCase(), email.trim());
+            }
+          }
           const mention = async (login, name) => {
-            const email = login && emailOf(login);
+            const email = login && emails.get(login.toLowerCase());
             if (email) {
               const res = await slack('users.lookupByEmail', { email });
               if (res.ok) return `<@${res.user.id}>`;
             }
-            return name || login || 'someone';
+            return esc(name || login || 'someone');
           };
           const authors = new Map();
-          for (const c of commits) {
+          for (const c of shipping.commits) {
             const login = c.author && c.author.login;
             const key = login || c.commit.author.name;
             if (!authors.has(key)) authors.set(key, await mention(login, c.commit.author.name));
           }
           const starter = await mention(context.actor, context.actor);
           const list = [...authors.values()];
-          const people = list.length === 0 ? starter
-            : list.length === 1 ? list[0]
-            : `${list.slice(0, -1).join(', ')} and ${list[list.length - 1]}`;
-          const authorsLine = commits.length > 0
-            ? `${commits.length} commit${commits.length === 1 ? '' : 's'} by ${people}`
-            : `Redeploying \`${process.env.IMAGE_TAG}\`, no new commit`;
+          const people = list.length === 1 ? list[0] : `${list.slice(0, -1).join(', ')} and ${list[list.length - 1]}`;
+          const count = `${shipping.total} commit${shipping.total === 1 ? '' : 's'}`;
+          const authorsLine = shipping.total > 0
+            ? (revert ? `Rolling back ${count} by ${people}` : `${count} by ${people}`)
+            : currentTags.size === 0 ? `Previous version unknown, started by ${starter}`
+            : `Same version as today, started by ${starter}`;
 
-          const runUrl = `${context.serverUrl}/${owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-          const commitUrl = `${context.serverUrl}/${owner}/${context.repo.repo}/commit/${sha}`;
-          const when = new Date().toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', timeZone: 'Europe/Paris' });
-          const footer = `started by ${starter} at ${when} · <${commitUrl}|${process.env.IMAGE_TAG}> · <${runUrl}|run>`;
+          const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+          const commitUrl = `${context.serverUrl}/${owner}/${repo}/commit/${tag}`;
+          const now = Math.floor(Date.now() / 1000);
+          const footer = `started by ${starter} at <!date^${now}^{time}|${new Date(now * 1000).toISOString().slice(11, 16)} UTC> · <${commitUrl}|${tag}> · <${runUrl}|run>`;
           const title = revert ? `⏮️ ${component} is being reverted on ${target}` : `🚀 ${component} is going live on ${target}`;
+          const short = (text) => (text.length > 150 ? `${text.slice(0, 147)}…` : text);
 
           const posted = await slack('chat.postMessage', {
             channel: process.env.CHANNEL,
-            text: title,
+            text: short(title),
             blocks: [
-              { type: 'header', text: { type: 'plain_text', text: title, emoji: true } },
+              { type: 'header', text: { type: 'plain_text', text: short(title), emoji: true } },
               { type: 'section', text: { type: 'mrkdwn', text: authorsLine } },
               { type: 'section', text: { type: 'mrkdwn', text: cells.map((c) => `⏳ ${c}  waiting`).join('\n') } },
               { type: 'context', elements: [{ type: 'mrkdwn', text: footer }] },
             ],
           });
-          if (!posted.ok) core.setFailed('could not post the deployment card');
+          if (!posted.ok) { core.setFailed('could not post the deployment card'); return; }
 
-          if (commits.length > 0) {
-            const shown = commits.slice(-20).reverse();
-            const lines = shown.map((c) => `• <${c.html_url}|${c.commit.message.split('\n')[0]}> (${c.commit.author.name})`);
-            if (commits.length > shown.length) lines.push(`… and ${commits.length - shown.length} more`);
-            await slack('chat.postMessage', { channel: process.env.CHANNEL, thread_ts: posted.ts, text: `📝 What is shipping\n${lines.join('\n')}` });
+          if (shipping.commits.length > 0) {
+            const newest = shipping.commits.slice(-20).reverse();
+            const lines = newest.map((c) => `• <${c.html_url}|${esc(c.commit.message.split('\n')[0])}> (${esc(c.commit.author.name)})`);
+            if (shipping.total > newest.length) lines.push(`… and ${shipping.total - newest.length} more`);
+            await slack('chat.postMessage', { channel: process.env.CHANNEL, thread_ts: posted.ts, text: `📝 ${revert ? 'What is being rolled back' : 'What is shipping'}\n${lines.join('\n')}` });
           }
 
           core.setOutput('thread_ts', posted.ts);

--- a/.github/actions/deploy-card/action.yml
+++ b/.github/actions/deploy-card/action.yml
@@ -1,0 +1,156 @@
+name: "Deploy card"
+description: "Posts the deployment card: who is shipping what to which cells, with the commit authors mentioned, and the changelog in its thread"
+
+inputs:
+  component:
+    description: "Component being deployed"
+    required: true
+  image_tag:
+    description: "Image tag being deployed, the short sha"
+    required: true
+  cells:
+    description: "Cells chosen in the workflow input, a cell id or all"
+    required: true
+  is_revert:
+    description: "Whether this is a revert"
+    required: false
+    default: "false"
+  channel:
+    description: "Slack channel"
+    required: true
+  slack_token:
+    description: "Slack bot token"
+    required: true
+  infra_token:
+    description: "Token that reads dust-infra, for the tags currently deployed"
+    required: true
+
+outputs:
+  thread_ts:
+    description: "Timestamp of the card, the thread every later message replies to"
+    value: ${{ steps.card.outputs.thread_ts }}
+  card:
+    description: "Card facts as JSON for dust-infra to redraw the card"
+    value: ${{ steps.card.outputs.card }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Post the card
+      id: card
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        SLACK_TOKEN: ${{ inputs.slack_token }}
+        CHANNEL: ${{ inputs.channel }}
+        COMPONENT: ${{ inputs.component }}
+        IMAGE_TAG: ${{ inputs.image_tag }}
+        CELLS: ${{ inputs.cells }}
+        IS_REVERT: ${{ inputs.is_revert }}
+        INFRA_TOKEN: ${{ inputs.infra_token }}
+      with:
+        script: |
+          const fs = require('fs');
+          const slack = async (method, body) => {
+            const res = await fetch(`https://slack.com/api/${method}`, {
+              method: 'POST',
+              headers: { Authorization: `Bearer ${process.env.SLACK_TOKEN}`, 'Content-Type': 'application/json; charset=utf-8' },
+              body: JSON.stringify(body),
+            }).then((r) => r.json()).catch((e) => ({ ok: false, error: String(e) }));
+            if (!res.ok) core.warning(`${method}: ${res.error}`);
+            return res;
+          };
+          const infra = github.getOctokit(process.env.INFRA_TOKEN);
+          const owner = context.repo.owner;
+          const component = process.env.COMPONENT;
+          const sha = context.sha;
+          const revert = process.env.IS_REVERT === 'true';
+
+          // Which cells, and what each of them runs today. The legacy clusters are
+          // cell-00000 and cell-00001, everything else is a descriptor cell with a versions
+          // file of its own name.
+          const legacy = { 'cell-00000': 'dust-kube-us-central1', 'cell-00001': 'dust-kube-europe-west1' };
+          let cells;
+          if (process.env.CELLS === 'all') {
+            const { data } = await infra.rest.repos.getContent({ owner, repo: 'dust-infra', path: 'versions', ref: 'main' });
+            const files = data.map((f) => f.name.replace(/\.yaml$/, '')).filter((n) => !n.includes('private'));
+            cells = [...Object.keys(legacy), ...files.filter((n) => n.startsWith('cell-'))].sort();
+          } else {
+            cells = process.env.CELLS.split(',').map((c) => c.trim()).filter(Boolean);
+          }
+          const target = process.env.CELLS === 'all' ? 'all cells' : cells.join(', ');
+
+          const currentTags = new Set();
+          for (const cell of cells) {
+            const file = `versions/${legacy[cell] || cell}.yaml`;
+            try {
+              const { data } = await infra.rest.repos.getContent({ owner, repo: 'dust-infra', path: file, ref: 'main' });
+              const text = Buffer.from(data.content, 'base64').toString();
+              const m = text.match(new RegExp(`^${component}:\\s*"?([0-9a-f]+)"?\\s*$`, 'm'));
+              if (m) currentTags.add(m[1]);
+            } catch (e) { core.warning(`no versions file for ${cell}: ${e.message}`); }
+          }
+
+          // The changelog is the widest range among the cells: whoever has a commit landing
+          // on any of them is mentioned.
+          let commits = [];
+          for (const tag of currentTags) {
+            try {
+              const { data } = await github.rest.repos.compareCommitsWithBasehead({ owner, repo: context.repo.repo, basehead: `${tag}...${sha}`, per_page: 250 });
+              if (data.commits.length > commits.length) commits = data.commits;
+            } catch (e) { core.warning(`cannot compare ${tag}...${sha}: ${e.message}`); }
+          }
+
+          // GitHub login -> email through .authors, email -> Slack id. Unknown authors keep
+          // their name.
+          const authorsFile = fs.existsSync('.authors') ? fs.readFileSync('.authors', 'utf8') : '';
+          const emailOf = (login) => { const m = authorsFile.match(new RegExp(`^${login}: (\\S+)`, 'm')); return m ? m[1] : null; };
+          const mention = async (login, name) => {
+            const email = login && emailOf(login);
+            if (email) {
+              const res = await slack('users.lookupByEmail', { email });
+              if (res.ok) return `<@${res.user.id}>`;
+            }
+            return name || login || 'someone';
+          };
+          const authors = new Map();
+          for (const c of commits) {
+            const login = c.author && c.author.login;
+            const key = login || c.commit.author.name;
+            if (!authors.has(key)) authors.set(key, await mention(login, c.commit.author.name));
+          }
+          const starter = await mention(context.actor, context.actor);
+          const list = [...authors.values()];
+          const people = list.length === 0 ? starter
+            : list.length === 1 ? list[0]
+            : `${list.slice(0, -1).join(', ')} and ${list[list.length - 1]}`;
+          const authorsLine = commits.length > 0
+            ? `${commits.length} commit${commits.length === 1 ? '' : 's'} by ${people}`
+            : `Redeploying \`${process.env.IMAGE_TAG}\`, no new commit`;
+
+          const runUrl = `${context.serverUrl}/${owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+          const commitUrl = `${context.serverUrl}/${owner}/${context.repo.repo}/commit/${sha}`;
+          const when = new Date().toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', timeZone: 'Europe/Paris' });
+          const footer = `started by ${starter} at ${when} · <${commitUrl}|${process.env.IMAGE_TAG}> · <${runUrl}|run>`;
+          const title = revert ? `⏮️ ${component} is being reverted on ${target}` : `🚀 ${component} is going live on ${target}`;
+
+          const posted = await slack('chat.postMessage', {
+            channel: process.env.CHANNEL,
+            text: title,
+            blocks: [
+              { type: 'header', text: { type: 'plain_text', text: title, emoji: true } },
+              { type: 'section', text: { type: 'mrkdwn', text: authorsLine } },
+              { type: 'section', text: { type: 'mrkdwn', text: cells.map((c) => `⏳ ${c}  waiting`).join('\n') } },
+              { type: 'context', elements: [{ type: 'mrkdwn', text: footer }] },
+            ],
+          });
+          if (!posted.ok) core.setFailed('could not post the deployment card');
+
+          if (commits.length > 0) {
+            const shown = commits.slice(-20).reverse();
+            const lines = shown.map((c) => `• <${c.html_url}|${c.commit.message.split('\n')[0]}> (${c.commit.author.name})`);
+            if (commits.length > shown.length) lines.push(`… and ${commits.length - shown.length} more`);
+            await slack('chat.postMessage', { channel: process.env.CHANNEL, thread_ts: posted.ts, text: `📝 What is shipping\n${lines.join('\n')}` });
+          }
+
+          core.setOutput('thread_ts', posted.ts);
+          core.setOutput('card', JSON.stringify({ component, target, authors_line: authorsLine, footer, cells }));

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,26 +103,37 @@ jobs:
     needs: [prepare]
     runs-on: ubuntu-latest
     outputs:
-      thread_ts: ${{ steps.build_message.outputs.thread_ts }}
+      thread_ts: ${{ steps.card.outputs.thread_ts }}
+      card: ${{ steps.card.outputs.card }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: |
             /.authors
-            /.github/actions/slack-notify/
+            /.github/actions/deploy-card/
             /.github/actions/slack-check-deployment-blocked/
           sparse-checkout-cone-mode: false
 
-      - name: Notify Build And Deploy Start
-        id: build_message
-        uses: ./.github/actions/slack-notify
+      # Reads dust-infra's versions files for what each cell runs today.
+      - name: Generate infra token
+        id: infra-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          step: "start"
-          channel: ${{ secrets.SLACK_CHANNEL_ID }}
+          client-id: ${{ secrets.INFRA_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.INFRA_DISPATCH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: dust-infra
+
+      - name: Post the deployment card
+        id: card
+        uses: ./.github/actions/deploy-card
+        with:
           component: ${{ inputs.component }}
           image_tag: ${{ needs.prepare.outputs.short_sha }}
-          region: ${{ inputs.cells }}
+          cells: ${{ inputs.cells }}
+          channel: ${{ secrets.SLACK_CHANNEL_ID }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          infra_token: ${{ steps.infra-token.outputs.token }}
 
       - name: Slack Check Deployment Blocked
         if: ${{ inputs.check_deployment_blocked == 'check' }}
@@ -185,20 +196,6 @@ jobs:
           contentful_access_token: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
           workload_identity_provider: "projects/357744735673/locations/global/workloadIdentityPools/github-pool-apps/providers/github-provider-apps"
 
-      - name: Notify build success
-        uses: ./.github/actions/slack-notify
-        with:
-          step: "build_success"
-          channel: ${{ secrets.SLACK_CHANNEL_ID }}
-          thread_ts: ${{ needs.notify-start.outputs.thread_ts }}
-          component: ${{ inputs.component }}
-          image_tag: ${{ needs.prepare.outputs.short_sha }}
-          region: ${{ inputs.cells }}
-          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          current_version: ${{ steps.build.outputs.current_version }}
-          commit_diff: ${{ steps.build.outputs.commit_diff }}
-          commit_count: ${{ steps.build.outputs.commit_count }}
-
       - name: Notify Failure
         if: failure()
         uses: ./.github/actions/slack-notify
@@ -258,20 +255,6 @@ jobs:
           contentful_access_token: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
           workload_identity_provider: "projects/357744735673/locations/global/workloadIdentityPools/github-pool-apps/providers/github-provider-apps"
 
-      - name: Notify build success
-        uses: ./.github/actions/slack-notify
-        with:
-          step: "build_success"
-          channel: ${{ secrets.SLACK_CHANNEL_ID }}
-          thread_ts: ${{ needs.notify-start.outputs.thread_ts }}
-          component: ${{ inputs.component }}
-          image_tag: ${{ needs.prepare.outputs.short_sha }}
-          region: ${{ matrix.region }}
-          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          current_version: ${{ steps.build.outputs.current_version }}
-          commit_diff: ${{ steps.build.outputs.commit_diff }}
-          commit_count: ${{ steps.build.outputs.commit_count }}
-
       - name: Notify Failure
         if: failure()
         uses: ./.github/actions/slack-notify
@@ -320,6 +303,7 @@ jobs:
           IMAGE_TAG: ${{ needs.prepare.outputs.short_sha }}
           SLACK_THREAD_TS: ${{ needs.notify-start.outputs.thread_ts }}
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ID }}
+          CARD: ${{ needs.notify-start.outputs.card }}
           DEPLOY_SPA_APP: ${{ inputs.deploy_spa_app }}
           DEPLOY_SPA_POKE: ${{ inputs.deploy_spa_poke }}
           SPA_APP_VERSION_ID: ${{ needs.deploy-app.outputs.version_id }}
@@ -340,6 +324,7 @@ jobs:
               image_tag: process.env.IMAGE_TAG,
               slack_thread_ts: process.env.SLACK_THREAD_TS,
               slack_channel: process.env.SLACK_CHANNEL,
+              card: process.env.CARD,
               playwright_sha: process.env.PLAYWRIGHT_SHA,
             };
 

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -55,21 +55,31 @@ jobs:
   notify-start:
     runs-on: ubuntu-latest
     outputs:
-      thread_ts: ${{ steps.build_message.outputs.thread_ts }}
+      thread_ts: ${{ steps.card.outputs.thread_ts }}
+      card: ${{ steps.card.outputs.card }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Notify Start
-        id: build_message
-        uses: ./.github/actions/slack-notify
+      - name: Generate infra token
+        id: infra-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          step: "start"
-          channel: ${{ secrets.SLACK_CHANNEL_ID }}
+          client-id: ${{ secrets.INFRA_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.INFRA_DISPATCH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: dust-infra
+
+      - name: Post the deployment card
+        id: card
+        uses: ./.github/actions/deploy-card
+        with:
           component: ${{ inputs.component }}
           image_tag: ${{ inputs.image_tag }}
-          region: ${{ inputs.cells }}
+          cells: ${{ inputs.cells }}
+          is_revert: "true"
+          channel: ${{ secrets.SLACK_CHANNEL_ID }}
           slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          is_revert: true
+          infra_token: ${{ steps.infra-token.outputs.token }}
 
   # Images are built once into the global registry, so one check covers every region.
   validate-image:
@@ -158,6 +168,7 @@ jobs:
                 component: '${{ inputs.component }}',
                 image_tag: '${{ inputs.image_tag }}',
                 slack_thread_ts: "${{ needs.notify-start.outputs.thread_ts }}",
+                card: ${{ toJSON(needs.notify-start.outputs.card) }},
                 slack_channel: '${{ secrets.SLACK_CHANNEL_ID }}',
                 run_playwright: false,
               }


### PR DESCRIPTION
## Description

Today a deploy opens the channel with a four bullet header, a build notice, and lines from dust-infra as cells complete. The only person told anything is the one who clicked deploy. The engineers whose commits are going live find out when someone asks.

After this PR a deploy opens with one card, and the authors of the commits shipping are mentioned on it, once, when it starts:

```
🚀 front is going live on all cells
3 commits by @arthur, @jd and @flavien

⏳ cell-00000  waiting
⏳ cell-00001  waiting
⏳ cell-00002  waiting

started by @arthur at 09:25 · ccd48c3 · run
```

The commits are the difference between what each target cell runs today, read from the versions files dust-infra keeps on main, and the commit being deployed, the widest range across the cells. Authors resolve to Slack through the `.authors` file, unknown ones keep their name, and messages are escaped so a commit subject cannot break the card. The list itself goes into the thread as "What is shipping", newest first, twenty at most with a count of the rest. The cells are resolved the way dust-infra resolves them, the legacy clusters from the Novu cell list and the descriptor cells that list the component, so the card and the deploy agree on who is in. dust-infra (dust-tt/dust-infra#1084) then moves the cell lines and the header, the card facts travel in the dispatch payload.

Revert opens the same card with a rewind header and lists what is being rolled back. The two build notices are gone, the card and its thread carry what they said, and the build step's commit diff outputs are left in place for a later cleanup.

## Tests

The script passes a syntax check and actionlint is clean on both workflows. The descriptor parsing was run against the real cell-00002 descriptor and returns its twelve applications and the egress proxy flag. Two independent reviews found and fixed: the octokit for dust-infra was built through a method that does not exist in github-script, a revert compared the wrong pair of commits and would have mentioned the wrong people, the compare API caps at a hundred commits per page, and a Slack failure let the changelog land at top level. The Slack and GitHub calls themselves need a real run, the first deploy after both PRs merge is the proof.

## Risk

Slack text, and a read of dust-infra through the App token the deploy already uses. If the card cannot be posted the job fails before building, as it does today when the start notice fails.

## Deploy Plan

Merge this first, then dust-tt/dust-infra#1084. In between, dust-infra ignores the card and keeps posting its own cell lines in the thread.
