### PR TITLE
[LLM] Claude Opus 5 EU agent-platform endpoint

### DIFF
--- a/front/CONTRACTS
+++ b/front/CONTRACTS
@@ -448,15 +448,6 @@ schema file, re-register with WorkOS after merge and before deploy:
 `npx tsx front/admin/register_audit_log_schemas.ts --execute --changed`. The CI test enforces
 that the `AuditAction` union and schema files stay consistent.
 
-@cc [label:error-handling] single-terminal-model-response-event
-A streamed `ModelResponseEvent` sequence must end with exactly one terminal event — either
-`success` or `error`, never both — and every `token_usage` event must be emitted before it.
-
-Consumers (`LLM.streamWithTracing`, `completeStream`) stop at the first terminal event: anything
-yielded after it is dropped, and a `success` following an `error` double-counts the call as both a
-failure and a success in telemetry. When a provider stop/finish reason maps to an error, hold the
-error back until the usage has been yielded, then yield the error and end the stream.
-
 @cc [label:mcp] internal-mcp-server-structure
 Internal MCP servers must live in `lib/api/actions/servers/<server_name>/` and separate metadata,
 tool implementation, and server wiring:

--- a/front/CONTRACTS
+++ b/front/CONTRACTS
@@ -448,6 +448,15 @@ schema file, re-register with WorkOS after merge and before deploy:
 `npx tsx front/admin/register_audit_log_schemas.ts --execute --changed`. The CI test enforces
 that the `AuditAction` union and schema files stay consistent.
 
+@cc [label:error-handling] single-terminal-model-response-event
+A streamed `ModelResponseEvent` sequence must end with exactly one terminal event — either
+`success` or `error`, never both — and every `token_usage` event must be emitted before it.
+
+Consumers (`LLM.streamWithTracing`, `completeStream`) stop at the first terminal event: anything
+yielded after it is dropped, and a `success` following an `error` double-counts the call as both a
+failure and a success in telemetry. When a provider stop/finish reason maps to an error, hold the
+error back until the usage has been yielded, then yield the error and end the stream.
+
 @cc [label:mcp] internal-mcp-server-structure
 Internal MCP servers must live in `lib/api/actions/servers/<server_name>/` and separate metadata,
 tool implementation, and server wiring:

--- a/front/lib/llms/stream/endpoints/anthropic_claude_opus_five_eu_agent_platform.ts
+++ b/front/lib/llms/stream/endpoints/anthropic_claude_opus_five_eu_agent_platform.ts
@@ -1,0 +1,18 @@
+import { WithDustClaudeOpusFiveConfig } from "@app/lib/llms/providers/anthropic/models/claude_opus_five";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { AnthropicClaudeOpusFiveEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_five_eu_agent_platform";
+
+export class DustAnthropicClaudeOpusFiveEuropeAgentPlatformStream extends WithDustClaudeOpusFiveConfig(
+  AnthropicClaudeOpusFiveEuropeAgentPlatformStream
+) {
+  static readonly endpointFilter = {
+    or: [
+      {
+        featureFlags: { contains: "use_vertex_for_supported_models" as const },
+      },
+      { isCreditPriced: { eq: true } },
+    ],
+  };
+}
+
+defineDustStreamEndpoint(DustAnthropicClaudeOpusFiveEuropeAgentPlatformStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -2,6 +2,7 @@ import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_st
 import { DustAnthropicClaudeFableFiveGlobalAnthropicStream } from "@app/lib/llms/stream/endpoints/anthropic_claude_fable_five_global_anthropic";
 import { DustAnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStream } from "@app/lib/llms/stream/endpoints/anthropic_claude_haiku_four_dot_five_eu_agent_platform";
 import { DustAnthropicClaudeHaikuFourDotFiveGlobalAnthropicStream } from "@app/lib/llms/stream/endpoints/anthropic_claude_haiku_four_dot_five_global_anthropic";
+import { DustAnthropicClaudeOpusFiveEuropeAgentPlatformStream } from "@app/lib/llms/stream/endpoints/anthropic_claude_opus_five_eu_agent_platform";
 import { DustAnthropicClaudeOpusFiveGlobalAnthropicStream } from "@app/lib/llms/stream/endpoints/anthropic_claude_opus_five_global_anthropic";
 import { DustAnthropicClaudeOpusFourDotEightEuropeAgentPlatformStream } from "@app/lib/llms/stream/endpoints/anthropic_claude_opus_four_dot_eight_eu_agent_platform";
 import { DustAnthropicClaudeOpusFourDotEightGlobalAnthropicStream } from "@app/lib/llms/stream/endpoints/anthropic_claude_opus_four_dot_eight_global_anthropic";
@@ -84,6 +85,8 @@ import type { StreamEndpointId } from "@app/lib/model_constructors/stream";
 export const DUST_STREAM_ENDPOINTS = {
   [DustAnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStream.id]:
     DustAnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStream,
+  [DustAnthropicClaudeOpusFiveEuropeAgentPlatformStream.id]:
+    DustAnthropicClaudeOpusFiveEuropeAgentPlatformStream,
   [DustAnthropicClaudeOpusFourDotEightEuropeAgentPlatformStream.id]:
     DustAnthropicClaudeOpusFourDotEightEuropeAgentPlatformStream,
   [DustAnthropicClaudeOpusFourDotSevenEuropeAgentPlatformStream.id]:

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.test.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.test.ts
@@ -1239,6 +1239,38 @@ describe("rawOutputToEvents", () => {
     });
   });
 
+  it("ends a refused turn on the error event, after usage and with no success", async () => {
+    // Consumers stop at the first success/error event: the error must be last so
+    // the usage is not dropped, and no success may follow a terminal error.
+    const events = await collect(
+      rawOutputToEvents(
+        streamOf([
+          {
+            type: "message_start",
+            message: { id: "msg_1" },
+          } as BetaRawMessageStartEvent,
+          {
+            type: "message_delta",
+            delta: { stop_reason: "refusal", stop_sequence: null },
+            usage: tokenUsage,
+          } as BetaRawMessageStreamEvent,
+          { type: "message_stop" } as BetaRawMessageStreamEvent,
+        ]),
+        metadata,
+        realConverters
+      )
+    );
+
+    expect(events.map((e) => e.type)).toEqual([
+      "response_id",
+      "token_usage",
+      "error",
+    ]);
+    expect(events.at(-1)).toMatchObject({
+      content: { type: "refusal_error" },
+    });
+  });
+
   it("splits cache creation by TTL using the cache_creation breakdown from message_start", async () => {
     // Anthropic only emits the per-TTL split on message_start; the trailing
     // message_delta usage carries the flat cache_creation_input_tokens. The

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
@@ -805,6 +805,11 @@ export async function* rawOutputToEvents(
   let blockState: BlockState | null = null;
   let tokenUsage: BetaMessageDeltaUsage | null = null;
   let stopReason: string | null = null;
+  // A stop reason that maps to an error terminates the turn. Held back so the
+  // usage event is emitted first and the error is the last (and only) terminal
+  // event: consumers stop at the first success/error, so an error yielded
+  // inline would drop the usage that follows it.
+  let terminalError: ErrorEvent | null = null;
   const toolSearchQueriesByToolUseId = new Map<string, string | undefined>();
   // The per-TTL cache-creation breakdown is only emitted on `message_start`;
   // capture it so the trailing `message_delta` usage can be split by TTL.
@@ -919,7 +924,8 @@ export async function* rawOutputToEvents(
           metadata,
           converters
         );
-        outputEvents = events;
+        outputEvents = events.filter((e) => e.type !== "error");
+        terminalError = events.find((e) => e.type === "error") ?? terminalError;
         tokenUsage = usage;
         stopReason = event.delta.stop_reason ?? stopReason;
         break;
@@ -949,6 +955,11 @@ export async function* rawOutputToEvents(
       tokenUsage,
       cacheCreation
     );
+  }
+
+  if (terminalError !== null) {
+    yield terminalError;
+    return;
   }
 
   yield {

--- a/front/lib/model_constructors/stream/endpoint.ts
+++ b/front/lib/model_constructors/stream/endpoint.ts
@@ -14,6 +14,17 @@ export abstract class StreamEndpoint<
   // simply return `I`.
   abstract buildRequestPayload(payload: Payload, config: C): Promise<I> | I;
   abstract streamRaw(input: I): AsyncGenerator<O>;
+  /**
+   * @cc [label:error-handling] single-terminal-model-response-event
+   * The yielded `ModelResponseEvent` sequence must end with exactly one terminal event — either
+   * `success` or `error`, never both — and every `token_usage` event must be emitted before it.
+   *
+   * Consumers (`LLM.streamWithTracing`, `completeStream`) stop at the first terminal event:
+   * anything yielded after it is dropped, and a `success` following an `error` double-counts the
+   * call as both a failure and a success in telemetry. When a provider stop/finish reason maps to
+   * an error, hold the error back until the usage has been yielded, then yield the error and end
+   * the stream.
+   */
   abstract rawStreamOutputToEvents(
     raw: AsyncGenerator<O>
   ): AsyncGenerator<ModelResponseEvent>;

--- a/front/lib/model_constructors/stream/endpoints/anthropic_claude_opus_five_eu_agent_platform.ts
+++ b/front/lib/model_constructors/stream/endpoints/anthropic_claude_opus_five_eu_agent_platform.ts
@@ -1,0 +1,25 @@
+import { WithAnthropicClaudeOpusFiveConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_five";
+import { AnthropicAgentPlatformStream } from "@app/lib/model_constructors/stream/clients/anthropic_agent_platform";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+
+export class AnthropicClaudeOpusFiveEuropeAgentPlatformStream extends WithAnthropicClaudeOpusFiveConfig(
+  AnthropicAgentPlatformStream
+) {
+  // Vertex regional/multi-region endpoints add a 10% premium over global.
+  // https://platform.claude.com/docs/en/about-claude/pricing
+  static readonly tokenPricing = {
+    cacheCreated: 6.88,
+    // 5m cache write = 1.25x base input; 1h cache write = 2x base input.
+    shortCacheCreated: 6.88,
+    longCacheCreated: 11.0,
+    cacheHit: 0.55,
+    standardInput: 5.5,
+    standardOutput: 27.5,
+  };
+  static readonly region = "eu";
+  static readonly regionalEndpoint = "eu";
+
+  static readonly id = this.buildId();
+}
+
+AnthropicClaudeOpusFiveEuropeAgentPlatformStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -2,6 +2,7 @@ import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stre
 import { AnthropicClaudeFableFiveGlobalAnthropicStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_fable_five_global_anthropic";
 import { AnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_haiku_four_dot_five_eu_agent_platform";
 import { AnthropicClaudeHaikuFourDotFiveGlobalAnthropicStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_haiku_four_dot_five_global_anthropic";
+import { AnthropicClaudeOpusFiveEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_five_eu_agent_platform";
 import { AnthropicClaudeOpusFiveGlobalAnthropicStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_five_global_anthropic";
 import { AnthropicClaudeOpusFourDotEightEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_four_dot_eight_eu_agent_platform";
 import { AnthropicClaudeOpusFourDotEightGlobalAnthropicStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_four_dot_eight_global_anthropic";
@@ -77,6 +78,8 @@ import { ZAiGlmFiveDotTwoGlobalFireworksStream } from "@app/lib/model_constructo
 export const STREAM_ENDPOINTS = {
   [AnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStream.id]:
     AnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStream,
+  [AnthropicClaudeOpusFiveEuropeAgentPlatformStream.id]:
+    AnthropicClaudeOpusFiveEuropeAgentPlatformStream,
   [AnthropicClaudeOpusFourDotEightEuropeAgentPlatformStream.id]:
     AnthropicClaudeOpusFourDotEightEuropeAgentPlatformStream,
   [AnthropicClaudeOpusFourDotSevenEuropeAgentPlatformStream.id]:

--- a/front/lib/model_constructors/test/cases.ts
+++ b/front/lib/model_constructors/test/cases.ts
@@ -213,6 +213,10 @@ export const INPUT_CONFIGURATION_ERROR: ResponseChecker = {
   type: "error",
   contentType: "input_configuration_error",
 };
+export const REFUSAL_ERROR: ResponseChecker = {
+  type: "error",
+  contentType: "refusal_error",
+};
 export const SUCCESS: ResponseChecker = { type: "success" };
 export const TOOL_CALL_CALCULATOR: ResponseChecker = {
   type: "tool_call",

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_five_eu_agent_platform.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_five_eu_agent_platform.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment node
+
+import { AnthropicClaudeOpusFiveEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_five_eu_agent_platform";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const AnthropicClaudeOpusFiveEuropeAgentPlatformStreamSetup: StreamSetup =
+  {
+    createInstance: () =>
+      new AnthropicClaudeOpusFiveEuropeAgentPlatformStream({
+        AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
+      }),
+    // `null` runs the case with its default checkers; a checker array overrides
+    // them. Every case always runs.
+    //
+    // Same `configSchema` as the global/Anthropic Opus 5 endpoint (both mix in
+    // `WithAnthropicClaudeOpusFiveConfig`), so the rejected cases are identical:
+    // any `temperature` other than `1`, and effort "minimal". Forcing a tool is
+    // accepted at any effort.
+    tests: {
+      "simple/no-tools/t-default/r-default": null,
+      "simple/no-tools/t-default/r-none": null,
+      "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-default/r-low": null,
+      "simple/no-tools/t-default/r-medium": null,
+      "simple/no-tools/t-default/r-high": null,
+      "simple/no-tools/t-default/r-xhigh": null,
+      "simple/no-tools/t-default/r-maximal": null,
+      "simple/no-tools/t-0/r-default": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-none": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-low": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-medium": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-high": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-xhigh": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-default": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-none": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-low": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-medium": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-high": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-xhigh": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-1/r-default": null,
+      "simple/no-tools/t-1/r-none": null,
+      "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "simple/no-tools/t-1/r-low": null,
+      "simple/no-tools/t-1/r-medium": null,
+      "simple/no-tools/t-1/r-high": null,
+      "simple/no-tools/t-1/r-xhigh": null,
+      "simple/no-tools/t-1/r-maximal": null,
+
+      "calc/calc/t-default/r-medium": null,
+      "calc/calc/t-0.1/r-default": [INPUT_CONFIGURATION_ERROR],
+      "calc/calc/t-0.1/r-medium": [INPUT_CONFIGURATION_ERROR],
+
+      "calc/calc/t-default/r-default/force-tool-default": null,
+      "calc/calc/t-default/r-default/force-tool": null,
+      "calc/calc/t-default/r-high/force-tool": null,
+      "calc/calc/t-default/r-none/force-tool": null,
+
+      "reasoning/no-tools/t-default/r-none": null,
+      "reasoning/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+      "reasoning/no-tools/t-default/r-low": null,
+
+      "output-format/json-schema/t-default/r-none": null,
+      "output-format/json-schema/t-default/r-high": null,
+
+      "following/no-tools/t-default/r-default": null,
+
+      "cache/no-tools/t-default/r-default": null,
+    },
+  };
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/anthropic_claude_opus_five_eu_agent_platform.test.ts
+runStreamEndpointTests(
+  AnthropicClaudeOpusFiveEuropeAgentPlatformStream,
+  AnthropicClaudeOpusFiveEuropeAgentPlatformStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_five_eu_agent_platform.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_five_eu_agent_platform.test.ts
@@ -1,7 +1,10 @@
 // @vitest-environment node
 
 import { AnthropicClaudeOpusFiveEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_five_eu_agent_platform";
-import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import {
+  INPUT_CONFIGURATION_ERROR,
+  REFUSAL_ERROR,
+} from "@app/lib/model_constructors/test/cases";
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
@@ -70,7 +73,10 @@ export const AnthropicClaudeOpusFiveEuropeAgentPlatformStreamSetup: StreamSetup 
 
       "following/no-tools/t-default/r-default": null,
 
-      "cache/no-tools/t-default/r-default": null,
+      // The cache filler ("Guideline N: Always be helpful, harmless, and
+      // honest…" ×200) reads as a system-prompt extraction attempt to this
+      // endpoint, which ends the turn with stop_reason "refusal".
+      "cache/no-tools/t-default/r-default": [REFUSAL_ERROR],
     },
   };
 

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_eight_eu_agent_platform.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_eight_eu_agent_platform.test.ts
@@ -19,9 +19,6 @@ export const AnthropicClaudeOpusFourDotEightEuropeAgentPlatformStreamSetup: Stre
       "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
       "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
       "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
-      // When forcing tool use, reasoning must be set to none.
-      "calc/calc/t-default/r-default/force-tool": [INPUT_CONFIGURATION_ERROR],
-      "calc/calc/t-default/r-high/force-tool": [INPUT_CONFIGURATION_ERROR],
 
       "simple/no-tools/t-default/r-default": null,
       "simple/no-tools/t-default/r-none": null,
@@ -30,7 +27,7 @@ export const AnthropicClaudeOpusFourDotEightEuropeAgentPlatformStreamSetup: Stre
       "simple/no-tools/t-default/r-high": null,
       "simple/no-tools/t-default/r-xhigh": null,
       "simple/no-tools/t-default/r-maximal": null,
-      // Sampling parameters (temperature) were removed on Opus 4.7+.
+      // Opus 4.7+ rejects any temperature other than `1`.
       "simple/no-tools/t-0/r-default": [INPUT_CONFIGURATION_ERROR],
       "simple/no-tools/t-0/r-none": [INPUT_CONFIGURATION_ERROR],
       "simple/no-tools/t-0/r-low": [INPUT_CONFIGURATION_ERROR],
@@ -45,19 +42,22 @@ export const AnthropicClaudeOpusFourDotEightEuropeAgentPlatformStreamSetup: Stre
       "simple/no-tools/t-0.1/r-high": [INPUT_CONFIGURATION_ERROR],
       "simple/no-tools/t-0.1/r-xhigh": [INPUT_CONFIGURATION_ERROR],
       "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
-      "simple/no-tools/t-1/r-default": [INPUT_CONFIGURATION_ERROR],
-      "simple/no-tools/t-1/r-none": [INPUT_CONFIGURATION_ERROR],
-      "simple/no-tools/t-1/r-low": [INPUT_CONFIGURATION_ERROR],
-      "simple/no-tools/t-1/r-medium": [INPUT_CONFIGURATION_ERROR],
-      "simple/no-tools/t-1/r-high": [INPUT_CONFIGURATION_ERROR],
-      "simple/no-tools/t-1/r-xhigh": [INPUT_CONFIGURATION_ERROR],
-      "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+      // `1` is the default temperature, so it is still accepted.
+      "simple/no-tools/t-1/r-default": null,
+      "simple/no-tools/t-1/r-none": null,
+      "simple/no-tools/t-1/r-low": null,
+      "simple/no-tools/t-1/r-medium": null,
+      "simple/no-tools/t-1/r-high": null,
+      "simple/no-tools/t-1/r-xhigh": null,
+      "simple/no-tools/t-1/r-maximal": null,
 
       "calc/calc/t-default/r-medium": null,
       "calc/calc/t-0.1/r-default": [INPUT_CONFIGURATION_ERROR],
       "calc/calc/t-0.1/r-medium": [INPUT_CONFIGURATION_ERROR],
 
       "calc/calc/t-default/r-default/force-tool-default": null,
+      "calc/calc/t-default/r-default/force-tool": null,
+      "calc/calc/t-default/r-high/force-tool": null,
       "calc/calc/t-default/r-none/force-tool": null,
 
       "reasoning/no-tools/t-default/r-none": null,

--- a/front/lib/model_constructors/test/endpoints/setups.ts
+++ b/front/lib/model_constructors/test/endpoints/setups.ts
@@ -6,6 +6,7 @@ import type { StreamEndpointId } from "@app/lib/model_constructors/stream";
 import { AnthropicClaudeFableFiveGlobalAnthropicStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_fable_five_global_anthropic";
 import { AnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_haiku_four_dot_five_eu_agent_platform";
 import { AnthropicClaudeHaikuFourDotFiveGlobalAnthropicStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_haiku_four_dot_five_global_anthropic";
+import { AnthropicClaudeOpusFiveEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_five_eu_agent_platform";
 import { AnthropicClaudeOpusFiveGlobalAnthropicStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_five_global_anthropic";
 import { AnthropicClaudeOpusFourDotEightEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_four_dot_eight_eu_agent_platform";
 import { AnthropicClaudeOpusFourDotEightGlobalAnthropicStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_four_dot_eight_global_anthropic";
@@ -80,6 +81,7 @@ import { ZAiGlmFiveDotTwoGlobalFireworksStream } from "@app/lib/model_constructo
 import { AnthropicClaudeFableFiveGlobalAnthropicStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_fable_five_global_anthropic.test";
 import { AnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_haiku_four_dot_five_eu_agent_platform.test";
 import { AnthropicClaudeHaikuFourDotFiveGlobalAnthropicStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_haiku_four_dot_five_global_anthropic.test";
+import { AnthropicClaudeOpusFiveEuropeAgentPlatformStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_opus_five_eu_agent_platform.test";
 import { AnthropicClaudeOpusFiveGlobalAnthropicStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_opus_five_global_anthropic.test";
 import { AnthropicClaudeOpusFourDotEightEuropeAgentPlatformStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_eight_eu_agent_platform.test";
 import { AnthropicClaudeOpusFourDotEightGlobalAnthropicStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_eight_global_anthropic.test";
@@ -156,6 +158,8 @@ import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 export const STREAM_ENDPOINT_SETUPS = {
   [AnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStream.id]:
     AnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStreamSetup,
+  [AnthropicClaudeOpusFiveEuropeAgentPlatformStream.id]:
+    AnthropicClaudeOpusFiveEuropeAgentPlatformStreamSetup,
   [AnthropicClaudeOpusFourDotEightEuropeAgentPlatformStream.id]:
     AnthropicClaudeOpusFourDotEightEuropeAgentPlatformStreamSetup,
   [AnthropicClaudeOpusFourDotSevenEuropeAgentPlatformStream.id]:

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -421,11 +421,9 @@ export const CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   },
   customBetas: ["auto-thinking-2026-01-12", "max-effort-2026-01-24"],
   disablePrefill: true,
-  // Global (Anthropic direct) only for now; Vertex EU comes in a follow-up once
-  // quota is provisioned, like Opus 4.8 and Sonnet 5 did.
   regionalAvailability: {
     "us-central1": true,
-    "europe-west1": false,
+    "europe-west1": true,
   },
 };
 // https://platform.claude.com/docs/en/about-claude/models/overview


### PR DESCRIPTION
## Description

Adds the Claude Opus 5 EU agent-platform endpoint (Vertex `eu`), and fixes a bug the endpoint surfaced: the Anthropic stream converter emitted the stop-reason error and then a `success`, so consumers — which stop at the first terminal event — dropped the `token_usage` that followed and double-counted the call as both a failure and a success.

## Tests

Added a converter regression test (a refused turn ends on the error, after usage, with no `success`) and pointed the Opus 5 EU cache case at a refusal error; updated the Opus 4.8 EU expectations for temperature 1 and forced tool use. Live endpoint suite (`RUN_LLM_TEST=true`) not run.

## Risk

Refusal and `max_tokens` turns on Anthropic now record the token usage that was previously dropped, so expect a small uptick in recorded usage and a drop in `llm_success.count` for turns that were being counted twice.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`
