### PR TITLE
[BYOK] Exclude agent-platform endpoints from BYOK workspaces

### DIFF
--- a/front/CONTRACTS
+++ b/front/CONTRACTS
@@ -448,6 +448,16 @@ schema file, re-register with WorkOS after merge and before deploy:
 `npx tsx front/admin/register_audit_log_schemas.ts --execute --changed`. The CI test enforces
 that the `AuditAction` union and schema files stay consistent.
 
+@cc [label:security;product] byok-never-routes-to-dust-hosted-inference
+A workspace on a BYOK plan (`plan.isByok`) must only reach endpoints served by the model lab's own
+API, using the credentials the workspace provided. Endpoints hosted on Dust's infrastructure —
+`agent-platform` (Vertex, keyed by `AGENT_PLATFORM_PROJECT_ID`) today — must be filtered out in
+`getWorkspaceFilter`, not merely made unreachable by an endpoint's `endpointFilter`: plan and
+feature-flag conditions can change, the BYOK guarantee cannot.
+
+Any new Dust-hosted `Host` value must be added to that exclusion, and every model reachable by a
+BYOK workspace must keep at least one lab-hosted endpoint.
+
 @cc [label:mcp] internal-mcp-server-structure
 Internal MCP servers must live in `lib/api/actions/servers/<server_name>/` and separate metadata,
 tool implementation, and server wiring:

--- a/front/CONTRACTS
+++ b/front/CONTRACTS
@@ -448,16 +448,6 @@ schema file, re-register with WorkOS after merge and before deploy:
 `npx tsx front/admin/register_audit_log_schemas.ts --execute --changed`. The CI test enforces
 that the `AuditAction` union and schema files stay consistent.
 
-@cc [label:security;product] byok-never-routes-to-dust-hosted-inference
-A workspace on a BYOK plan (`plan.isByok`) must only reach endpoints served by the model lab's own
-API, using the credentials the workspace provided. Endpoints hosted on Dust's infrastructure —
-`agent-platform` (Vertex, keyed by `AGENT_PLATFORM_PROJECT_ID`) today — must be filtered out in
-`getWorkspaceFilter`, not merely made unreachable by an endpoint's `endpointFilter`: plan and
-feature-flag conditions can change, the BYOK guarantee cannot.
-
-Any new Dust-hosted `Host` value must be added to that exclusion, and every model reachable by a
-BYOK workspace must keep at least one lab-hosted endpoint.
-
 @cc [label:mcp] internal-mcp-server-structure
 Internal MCP servers must live in `lib/api/actions/servers/<server_name>/` and separate metadata,
 tool implementation, and server wiring:

--- a/front/lib/api/llm/index.test.ts
+++ b/front/lib/api/llm/index.test.ts
@@ -7,6 +7,7 @@ import {
   GOOGLE_AI_STUDIO_HOST,
 } from "@app/lib/model_constructors/types/hosts";
 import {
+  CLAUDE_OPUS_5,
   GEMINI_3_1_PRO,
   GEMINI_3_8_FLASH,
   GLM_5P2,
@@ -81,6 +82,32 @@ describe("getWorkspaceFilter", () => {
     expect(flashEndpoints.some((e) => e.host === GOOGLE_AI_STUDIO_HOST)).toBe(
       true
     );
+  });
+
+  it("excludes agent-platform endpoints for byok workspaces", async () => {
+    const workspace = await WorkspaceFactory.byok();
+    await ProviderCredentialFactory.basic(workspace, "google_ai_studio");
+    await ProviderCredentialFactory.basic(workspace, "anthropic");
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    // Agent-platform endpoints run on Dust's Vertex project, so they must stay
+    // out even for a workspace whose plan and flags would otherwise unlock
+    // them: the filter, not the endpoint availability rules, is the guarantee.
+    const workspaceConfig: WorkspaceConfig = {
+      featureFlags: ["use_vertex_for_supported_models"],
+      isEnterprise: true,
+      isCreditPriced: true,
+    };
+    const filter = getWorkspaceFilter(auth);
+
+    for (const model of [GEMINI_3_8_FLASH, CLAUDE_OPUS_5]) {
+      const endpoints = getStreamEndpoints(workspaceConfig, {
+        ...filter,
+        model: { eq: model },
+      });
+      expect(endpoints.length).toBeGreaterThan(0);
+      expect(endpoints.every((e) => e.host !== AGENT_PLATFORM_HOST)).toBe(true);
+    }
   });
 });
 

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -130,6 +130,17 @@ function getLabAndHostFilter(
 }
 
 // Temporary helper while we have both systems
+/**
+ * @cc [owner:pmilliotte,label:security;product] byok-never-routes-to-dust-hosted-inference
+ * A workspace on a BYOK plan (`plan.isByok`) must only reach endpoints served by the model lab's
+ * own API, using the credentials the workspace provided. Endpoints hosted on Dust's infrastructure
+ * — `agent-platform` (Vertex, keyed by `AGENT_PLATFORM_PROJECT_ID`) today — must be filtered out
+ * here, not merely made unreachable by an endpoint's `endpointFilter`: plan and feature-flag
+ * conditions can change, the BYOK guarantee cannot.
+ *
+ * Any new Dust-hosted `Host` value must be added to that exclusion, and every model reachable by a
+ * BYOK workspace must keep at least one lab-hosted endpoint.
+ */
 export function getWorkspaceFilter(auth: Authenticator): Where<EndpointConfig> {
   const byok = auth.getNonNullablePlan().isByok;
   const providerIds = getWhitelistedProviderIds(auth);
@@ -137,9 +148,6 @@ export function getWorkspaceFilter(auth: Authenticator): Where<EndpointConfig> {
   return {
     ...getLabAndHostFilter(providerIds),
     region: getRegionFilter(auth),
-    // Agent-platform endpoints run on Dust's own Vertex project and ignore the
-    // workspace credentials, so a byok workspace must never reach one: its
-    // inference has to go through the key it provided, on the lab's own API.
     // Conversely we route all non-byok gemini requests to agent platform.
     ...(byok
       ? { not: { host: { eq: AGENT_PLATFORM_HOST } } }

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -18,7 +18,10 @@ import type {
 } from "@app/lib/llms/types/filter";
 import { FIREWORKS_MODEL_PREFIX } from "@app/lib/model_constructors/providers/fireworks/constants";
 import type { Host } from "@app/lib/model_constructors/types/hosts";
-import { GOOGLE_AI_STUDIO_HOST } from "@app/lib/model_constructors/types/hosts";
+import {
+  AGENT_PLATFORM_HOST,
+  GOOGLE_AI_STUDIO_HOST,
+} from "@app/lib/model_constructors/types/hosts";
 import type { Lab } from "@app/lib/model_constructors/types/labs";
 import type { Model } from "@app/lib/model_constructors/types/models";
 import { isModel, NOOP_MODEL } from "@app/lib/model_constructors/types/models";
@@ -134,8 +137,13 @@ export function getWorkspaceFilter(auth: Authenticator): Where<EndpointConfig> {
   return {
     ...getLabAndHostFilter(providerIds),
     region: getRegionFilter(auth),
-    // We route all non-byok gemini requests to agent platform.
-    ...(byok ? {} : { not: { host: { eq: GOOGLE_AI_STUDIO_HOST } } }),
+    // Agent-platform endpoints run on Dust's own Vertex project and ignore the
+    // workspace credentials, so a byok workspace must never reach one: its
+    // inference has to go through the key it provided, on the lab's own API.
+    // Conversely we route all non-byok gemini requests to agent platform.
+    ...(byok
+      ? { not: { host: { eq: AGENT_PLATFORM_HOST } } }
+      : { not: { host: { eq: GOOGLE_AI_STUDIO_HOST } } }),
   };
 }
 


### PR DESCRIPTION
## Description

Excludes `agent-platform` endpoints from BYOK workspaces in `getWorkspaceFilter`: those endpoints run on Dust's own Vertex project (`AGENT_PLATFORM_PROJECT_ID`) and ignore the credentials the workspace provided, and until now nothing in the router prevented a BYOK workspace from reaching one — it was kept out only by each endpoint's `endpointFilter` (`use_vertex_for_supported_models` flag **or** `isCreditPriced`), neither of which mentions BYOK.

## Tests

Added a test that grants a BYOK workspace both the vertex feature flag and credit pricing and asserts agent-platform stays excluded for Gemini and Claude; verified it fails without the fix.

## Risk

BYOK workspaces now route Anthropic and Gemini to the labs' own APIs rather than Vertex; every affected model keeps a lab-hosted endpoint, so nothing becomes unavailable.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`
