### PR TITLE
Wake-ups: add a tab in automations to list your wakeups

### DIFF
--- a/front-api/routes/w/[wId]/me/index.ts
+++ b/front-api/routes/w/[wId]/me/index.ts
@@ -6,6 +6,7 @@ import memory from "./memory";
 import pendingInvitations from "./pending-invitations";
 import slackNotifications from "./slack-notifications";
 import triggers from "./triggers";
+import wakeups from "./wakeups";
 
 // Mounted under /api/w/:wId/me.
 const app = workspaceApp();
@@ -16,5 +17,6 @@ app.route("/memory", memory);
 app.route("/pending-invitations", pendingInvitations);
 app.route("/slack-notifications", slackNotifications);
 app.route("/triggers", triggers);
+app.route("/wakeups", wakeups);
 
 export default app;

--- a/front-api/routes/w/[wId]/me/wakeups.test.ts
+++ b/front-api/routes/w/[wId]/me/wakeups.test.ts
@@ -48,7 +48,6 @@ describe("GET /api/w/:wId/me/wakeups", () => {
     expect(response.status).toBe(200);
 
     const data = await response.json();
-    expect(data.totalCount).toBe(1);
     expect(data.wakeUps).toHaveLength(1);
     expect(data.wakeUps[0].wakeUp).toMatchObject({
       sId: wakeUp.sId,
@@ -98,7 +97,6 @@ describe("GET /api/w/:wId/me/wakeups", () => {
     expect(response.status).toBe(200);
 
     const data = await response.json();
-    expect(data.totalCount).toBe(0);
     expect(data.wakeUps).toEqual([]);
   });
 
@@ -126,7 +124,6 @@ describe("GET /api/w/:wId/me/wakeups", () => {
     expect(response.status).toBe(200);
 
     const data = await response.json();
-    expect(data.totalCount).toBe(1);
     expect(data.wakeUps).toHaveLength(1);
     expect(data.wakeUps[0].wakeUp.sId).toBe(cancelledWakeUp.sId);
   });
@@ -169,12 +166,11 @@ describe("GET /api/w/:wId/me/wakeups", () => {
     expect(response.status).toBe(200);
 
     const data = await response.json();
-    expect(data.totalCount).toBe(1);
     expect(data.wakeUps).toHaveLength(1);
     expect(data.wakeUps[0].wakeUp.sId).toBe(scheduledWakeUp.sId);
   });
 
-  it("paginates through the caller's wake-ups", async () => {
+  it("returns the caller's whole list, without pagination", async () => {
     const { workspace, auth } = await createPrivateApiMockRequest({
       role: "user",
     });
@@ -193,20 +189,11 @@ describe("GET /api/w/:wId/me/wakeups", () => {
       reason: "second",
     });
 
-    const firstPage = await getUserWakeUps(workspace.sId, "?limit=1&offset=0");
-    expect(firstPage.status).toBe(200);
-    const firstPageData = await firstPage.json();
-    expect(firstPageData.totalCount).toBe(2);
-    expect(firstPageData.wakeUps).toHaveLength(1);
+    const response = await getUserWakeUps(workspace.sId);
+    expect(response.status).toBe(200);
 
-    const secondPage = await getUserWakeUps(workspace.sId, "?limit=1&offset=1");
-    expect(secondPage.status).toBe(200);
-    const secondPageData = await secondPage.json();
-    expect(secondPageData.totalCount).toBe(2);
-    expect(secondPageData.wakeUps).toHaveLength(1);
-    expect(secondPageData.wakeUps[0].wakeUp.sId).not.toBe(
-      firstPageData.wakeUps[0].wakeUp.sId
-    );
+    const data = await response.json();
+    expect(data.wakeUps).toHaveLength(2);
   });
 
   it("returns an empty list when the caller has no wake-up", async () => {
@@ -216,6 +203,6 @@ describe("GET /api/w/:wId/me/wakeups", () => {
     expect(response.status).toBe(200);
 
     const data = await response.json();
-    expect(data).toEqual({ totalCount: 0, wakeUps: [] });
+    expect(data).toEqual({ wakeUps: [] });
   });
 });

--- a/front-api/routes/w/[wId]/me/wakeups.test.ts
+++ b/front-api/routes/w/[wId]/me/wakeups.test.ts
@@ -60,6 +60,9 @@ describe("GET /api/w/:wId/me/wakeups", () => {
         timezone: "Europe/Paris",
       },
     });
+    // Numeric database identifiers must not reach browser clients, and the owner is the caller.
+    expect(data.wakeUps[0].wakeUp).not.toHaveProperty("id");
+    expect(data.wakeUps[0].wakeUp).not.toHaveProperty("user");
     expect(data.wakeUps[0].conversation).toEqual({
       sId: conversation.sId,
       title: "Test Conversation",

--- a/front-api/routes/w/[wId]/me/wakeups.test.ts
+++ b/front-api/routes/w/[wId]/me/wakeups.test.ts
@@ -1,0 +1,218 @@
+import { Authenticator } from "@app/lib/auth";
+import * as wakeUpClient from "@app/temporal/triggers/wakeup_client";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WakeUpFactory } from "@app/tests/utils/WakeUpFactory";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+function getUserWakeUps(workspaceId: string, query = "") {
+  return honoApp.request(`/api/w/${workspaceId}/me/wakeups${query}`);
+}
+
+describe("GET /api/w/:wId/me/wakeups", () => {
+  beforeEach(() => {
+    vi.spyOn(
+      wakeUpClient,
+      "launchOrScheduleWakeUpTemporalWorkflow"
+    ).mockResolvedValue(new Ok(undefined));
+    vi.spyOn(wakeUpClient, "cancelWakeUpTemporalWorkflow").mockResolvedValue(
+      new Ok(undefined)
+    );
+  });
+
+  it("returns the caller's wake-ups with their conversation", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "user",
+    });
+
+    const agentConfiguration =
+      await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfiguration.sId,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const wakeUp = await WakeUpFactory.cron(
+      auth,
+      conversation,
+      agentConfiguration,
+      { cronExpression: "0 7 * * *", reason: "daily digest" }
+    );
+
+    const response = await getUserWakeUps(workspace.sId);
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.totalCount).toBe(1);
+    expect(data.wakeUps).toHaveLength(1);
+    expect(data.wakeUps[0].wakeUp).toMatchObject({
+      sId: wakeUp.sId,
+      reason: "daily digest",
+      status: "scheduled",
+      scheduleConfig: {
+        type: "cron",
+        cron: "0 7 * * *",
+        timezone: "Europe/Paris",
+      },
+    });
+    expect(data.wakeUps[0].conversation).toEqual({
+      sId: conversation.sId,
+      title: "Test Conversation",
+    });
+  });
+
+  it("does not return the wake-ups of another member", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(
+      workspace,
+      otherUser,
+      { role: "user" },
+      undefined
+    );
+    const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      workspace.sId
+    );
+
+    const agentConfiguration =
+      await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(otherAuth, {
+      agentConfigurationId: agentConfiguration.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    await WakeUpFactory.cron(otherAuth, conversation, agentConfiguration);
+
+    const response = await getUserWakeUps(workspace.sId);
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.totalCount).toBe(0);
+    expect(data.wakeUps).toEqual([]);
+  });
+
+  it("returns wake-ups in the requested status", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "user",
+    });
+
+    const agentConfiguration =
+      await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfiguration.sId,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const cancelledWakeUp = await WakeUpFactory.cron(
+      auth,
+      conversation,
+      agentConfiguration
+    );
+    await cancelledWakeUp.markCancelled(auth);
+    await WakeUpFactory.cron(auth, conversation, agentConfiguration);
+
+    const response = await getUserWakeUps(workspace.sId, "?status=cancelled");
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.totalCount).toBe(1);
+    expect(data.wakeUps).toHaveLength(1);
+    expect(data.wakeUps[0].wakeUp.sId).toBe(cancelledWakeUp.sId);
+  });
+
+  it("rejects an unknown status", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "user" });
+
+    const response = await getUserWakeUps(workspace.sId, "?status=snoozed");
+    expect(response.status).toBe(400);
+  });
+
+  it("defaults to the scheduled wake-ups only", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "user",
+    });
+
+    const agentConfiguration =
+      await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfiguration.sId,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const cancelledWakeUp = await WakeUpFactory.cron(
+      auth,
+      conversation,
+      agentConfiguration,
+      { reason: "cancelled one" }
+    );
+    await cancelledWakeUp.markCancelled(auth);
+
+    const scheduledWakeUp = await WakeUpFactory.cron(
+      auth,
+      conversation,
+      agentConfiguration,
+      { reason: "scheduled one" }
+    );
+
+    const response = await getUserWakeUps(workspace.sId);
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.totalCount).toBe(1);
+    expect(data.wakeUps).toHaveLength(1);
+    expect(data.wakeUps[0].wakeUp.sId).toBe(scheduledWakeUp.sId);
+  });
+
+  it("paginates through the caller's wake-ups", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "user",
+    });
+
+    const agentConfiguration =
+      await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfiguration.sId,
+      messagesCreatedAt: [new Date()],
+    });
+
+    await WakeUpFactory.cron(auth, conversation, agentConfiguration, {
+      reason: "first",
+    });
+    await WakeUpFactory.cron(auth, conversation, agentConfiguration, {
+      reason: "second",
+    });
+
+    const firstPage = await getUserWakeUps(workspace.sId, "?limit=1&offset=0");
+    expect(firstPage.status).toBe(200);
+    const firstPageData = await firstPage.json();
+    expect(firstPageData.totalCount).toBe(2);
+    expect(firstPageData.wakeUps).toHaveLength(1);
+
+    const secondPage = await getUserWakeUps(workspace.sId, "?limit=1&offset=1");
+    expect(secondPage.status).toBe(200);
+    const secondPageData = await secondPage.json();
+    expect(secondPageData.totalCount).toBe(2);
+    expect(secondPageData.wakeUps).toHaveLength(1);
+    expect(secondPageData.wakeUps[0].wakeUp.sId).not.toBe(
+      firstPageData.wakeUps[0].wakeUp.sId
+    );
+  });
+
+  it("returns an empty list when the caller has no wake-up", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "user" });
+
+    const response = await getUserWakeUps(workspace.sId);
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data).toEqual({ totalCount: 0, wakeUps: [] });
+  });
+});

--- a/front-api/routes/w/[wId]/me/wakeups.ts
+++ b/front-api/routes/w/[wId]/me/wakeups.ts
@@ -1,0 +1,34 @@
+import type { UserWakeUps } from "@app/lib/api/assistant/wakeups";
+import { listUserWakeUps } from "@app/lib/api/assistant/wakeups";
+import { WakeUpStatusSchema } from "@app/types/assistant/wakeups";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const QuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional().default(25),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+  // Only the still-pending wake-ups are of interest by default; terminal ones are history.
+  status: WakeUpStatusSchema.optional().default("scheduled"),
+});
+
+export type GetUserWakeUpsResponseBody = UserWakeUps;
+
+// Mounted at /api/w/:wId/me/wakeups.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+// Internal endpoint backing the "Wake-Ups" tab of the personal automations view.
+app.get(
+  "/",
+  validate("query", QuerySchema),
+  async (ctx): HandlerResult<GetUserWakeUpsResponseBody> => {
+    const auth = ctx.get("auth");
+    const { limit, offset, status } = ctx.req.valid("query");
+
+    return ctx.json(await listUserWakeUps(auth, { limit, offset, status }));
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/me/wakeups.ts
+++ b/front-api/routes/w/[wId]/me/wakeups.ts
@@ -27,7 +27,9 @@ app.get(
     const auth = ctx.get("auth");
     const { limit, offset, status } = ctx.req.valid("query");
 
-    return ctx.json(await listUserWakeUps(auth, { limit, offset, status }));
+    const wakeUps = await listUserWakeUps(auth, { limit, offset, status });
+
+    return ctx.json(wakeUps);
   }
 );
 

--- a/front-api/routes/w/[wId]/me/wakeups.ts
+++ b/front-api/routes/w/[wId]/me/wakeups.ts
@@ -7,8 +7,6 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 const QuerySchema = z.object({
-  limit: z.coerce.number().int().min(1).max(100).optional().default(25),
-  offset: z.coerce.number().int().min(0).optional().default(0),
   // Only the still-pending wake-ups are of interest by default; terminal ones are history.
   status: WakeUpStatusSchema.optional().default("scheduled"),
 });
@@ -25,9 +23,9 @@ app.get(
   validate("query", QuerySchema),
   async (ctx): HandlerResult<GetUserWakeUpsResponseBody> => {
     const auth = ctx.get("auth");
-    const { limit, offset, status } = ctx.req.valid("query");
+    const { status } = ctx.req.valid("query");
 
-    const wakeUps = await listUserWakeUps(auth, { limit, offset, status });
+    const wakeUps = await listUserWakeUps(auth, { status });
 
     return ctx.json(wakeUps);
   }

--- a/front/components/me/UserAutomationsDialog.tsx
+++ b/front/components/me/UserAutomationsDialog.tsx
@@ -1,4 +1,5 @@
 import { UserAutomationsTable } from "@app/components/me/UserAutomationsTable";
+import { UserWakeUpsTable } from "@app/components/me/UserWakeUpsTable";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Dialog,
@@ -6,7 +7,12 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
 } from "@dust-tt/sparkle";
+import { useCallback } from "react";
 
 interface UserAutomationsDialogProps {
   open: boolean;
@@ -19,16 +25,29 @@ export function UserAutomationsDialog({
   onOpenChange,
   owner,
 }: UserAutomationsDialogProps) {
+  const closeDialog = useCallback(() => onOpenChange(false), [onOpenChange]);
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* The portal has no forceMount, so this subtree unmounts when the dialog
-       * closes. The table's SWR hooks need no `disabled` gating. */}
+       * closes. The tables' SWR hooks need no `disabled` gating. */}
       <DialogContent size="2xl" height="xl">
         <DialogHeader>
           <DialogTitle>Automations</DialogTitle>
         </DialogHeader>
         <DialogContainer>
-          <UserAutomationsTable owner={owner} />
+          <Tabs defaultValue="triggers" className="w-full">
+            <TabsList className="mb-4">
+              <TabsTrigger value="triggers" label="Triggers" />
+              <TabsTrigger value="wake-ups" label="Wake-Ups" />
+            </TabsList>
+            <TabsContent value="triggers">
+              <UserAutomationsTable owner={owner} />
+            </TabsContent>
+            <TabsContent value="wake-ups">
+              <UserWakeUpsTable owner={owner} onNavigate={closeDialog} />
+            </TabsContent>
+          </Tabs>
         </DialogContainer>
       </DialogContent>
     </Dialog>

--- a/front/components/me/UserWakeUpsTable.tsx
+++ b/front/components/me/UserWakeUpsTable.tsx
@@ -122,12 +122,9 @@ export function UserWakeUpsTable({ owner, onNavigate }: UserWakeUpsTableProps) {
     pageSize: WAKE_UPS_PAGE_SIZE,
   });
 
-  const { wakeUps, totalCount, isWakeUpsLoading, isWakeUpsError } =
-    useUserWakeUps({
-      owner,
-      limit: pagination.pageSize,
-      offset: pagination.pageIndex * pagination.pageSize,
-    });
+  const { wakeUps, isWakeUpsLoading, isWakeUpsError } = useUserWakeUps({
+    owner,
+  });
 
   const rows: WakeUpRowData[] = useMemo(
     () =>
@@ -170,10 +167,10 @@ export function UserWakeUpsTable({ owner, onNavigate }: UserWakeUpsTableProps) {
 
   return (
     <div className="overflow-x-auto">
+      {/* The endpoint returns the caller's whole list, so the table paginates client-side. */}
       <DataTable
         data={rows}
         columns={COLUMNS}
-        totalRowCount={totalCount}
         pagination={pagination}
         setPagination={setPagination}
       />

--- a/front/components/me/UserWakeUpsTable.tsx
+++ b/front/components/me/UserWakeUpsTable.tsx
@@ -6,7 +6,7 @@ import {
   describeWakeUpSchedule,
   getNextWakeUpFireAtFromScheduleConfig,
 } from "@app/lib/utils/wakeup_description";
-import type { WakeUpType } from "@app/types/assistant/wakeups";
+import type { UserWakeUpType } from "@app/types/assistant/wakeups";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import { DataTable, Spinner, Tooltip } from "@dust-tt/sparkle";
@@ -15,8 +15,7 @@ import { useMemo, useState } from "react";
 
 const WAKE_UPS_PAGE_SIZE = 10;
 
-
-function formatSchedule(wakeUp: WakeUpType): string {
+function formatSchedule(wakeUp: UserWakeUpType): string {
   switch (wakeUp.scheduleConfig.type) {
     case "one_shot":
       // `describeWakeUpSchedule` renders a one-shot as its time of day alone ("at 11:06"), which cannot
@@ -97,11 +96,11 @@ const COLUMNS: ColumnDef<WakeUpRowData>[] = [
         <DataTable.CellContent className="w-full justify-start text-left">
           <span className="truncate text-sm tabular-nums text-muted-foreground">
             {nextFireAt !== null
-            ? new Date(nextFireAt).toLocaleString(undefined, {
-                dateStyle: "short",
-                timeStyle: "short",
-              })
-            : "—"}
+              ? new Date(nextFireAt).toLocaleString(undefined, {
+                  dateStyle: "short",
+                  timeStyle: "short",
+                })
+              : "—"}
           </span>
         </DataTable.CellContent>
       );

--- a/front/components/me/UserWakeUpsTable.tsx
+++ b/front/components/me/UserWakeUpsTable.tsx
@@ -1,0 +1,183 @@
+import type { UserWakeUpWithConversation } from "@app/lib/api/assistant/wakeups";
+import { useAppRouter } from "@app/lib/platform";
+import { useUserWakeUps } from "@app/lib/swr/wakeups";
+import { getConversationRoute } from "@app/lib/utils/router";
+import {
+  describeWakeUpSchedule,
+  getNextWakeUpFireAtFromScheduleConfig,
+} from "@app/lib/utils/wakeup_description";
+import type { WakeUpType } from "@app/types/assistant/wakeups";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import type { LightWorkspaceType } from "@app/types/user";
+import { DataTable, Spinner, Tooltip } from "@dust-tt/sparkle";
+import type { ColumnDef, PaginationState } from "@tanstack/react-table";
+import { useMemo, useState } from "react";
+
+const WAKE_UPS_PAGE_SIZE = 10;
+
+
+function formatSchedule(wakeUp: WakeUpType): string {
+  switch (wakeUp.scheduleConfig.type) {
+    case "one_shot":
+      // `describeWakeUpSchedule` renders a one-shot as its time of day alone ("at 11:06"), which cannot
+      // be told apart from another day's 11:06 and only repeats what the "Next" column already shows.
+      // Here the column answers "does this repeat?" instead.
+      return "once";
+    case "cron":
+      return describeWakeUpSchedule(wakeUp);
+    default:
+      assertNeverAndIgnore(wakeUp.scheduleConfig);
+      return "";
+  }
+}
+
+type WakeUpRowData = UserWakeUpWithConversation & {
+  onClick: () => void;
+};
+
+const COLUMNS: ColumnDef<WakeUpRowData>[] = [
+  {
+    id: "conversation",
+    header: "Conversation",
+    enableSorting: false,
+    meta: { className: "w-[30%] truncate", headerAlign: "left" },
+    cell: (info) => (
+      <DataTable.CellContent className="w-full justify-start text-left">
+        <span className="truncate text-sm font-semibold">
+          {info.row.original.conversation.title ?? "Untitled conversation"}
+        </span>
+      </DataTable.CellContent>
+    ),
+  },
+  {
+    id: "reason",
+    header: "Reason",
+    enableSorting: false,
+    meta: { className: "w-[30%] truncate", headerAlign: "left" },
+    cell: (info) => (
+      <DataTable.CellContent className="w-full justify-start text-left">
+        <Tooltip
+          label={info.row.original.wakeUp.reason}
+          tooltipTriggerAsChild
+          trigger={
+            <span className="truncate text-sm">
+              {info.row.original.wakeUp.reason}
+            </span>
+          }
+        />
+      </DataTable.CellContent>
+    ),
+  },
+  {
+    id: "schedule",
+    header: "Schedule kind",
+    enableSorting: false,
+    meta: { className: "w-[20%] truncate", headerAlign: "left" },
+    cell: (info) => (
+      <DataTable.CellContent className="w-full justify-start text-left">
+        <span className="truncate text-sm text-muted-foreground">
+          {formatSchedule(info.row.original.wakeUp)}
+        </span>
+      </DataTable.CellContent>
+    ),
+  },
+  {
+    id: "nextFire",
+    header: "Next",
+    enableSorting: false,
+    meta: { className: "w-[20%] truncate", headerAlign: "left" },
+    cell: (info) => {
+      // The endpoint only lists active wake-ups, so every row still has a firing ahead of it —
+      // unless the stored cron no longer parses.
+      const nextFireAt = getNextWakeUpFireAtFromScheduleConfig(
+        info.row.original.wakeUp.scheduleConfig
+      );
+
+      return (
+        <DataTable.CellContent className="w-full justify-start text-left">
+          <span className="truncate text-sm tabular-nums text-muted-foreground">
+            {nextFireAt !== null
+            ? new Date(nextFireAt).toLocaleString(undefined, {
+                dateStyle: "short",
+                timeStyle: "short",
+              })
+            : "—"}
+          </span>
+        </DataTable.CellContent>
+      );
+    },
+  },
+];
+
+interface UserWakeUpsTableProps {
+  owner: LightWorkspaceType;
+  // Called before navigating away, so the host dialog closes instead of
+  // staying open on top of the conversation.
+  onNavigate: () => void;
+}
+
+export function UserWakeUpsTable({ owner, onNavigate }: UserWakeUpsTableProps) {
+  const router = useAppRouter();
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: WAKE_UPS_PAGE_SIZE,
+  });
+
+  const { wakeUps, totalCount, isWakeUpsLoading, isWakeUpsError } =
+    useUserWakeUps({
+      owner,
+      limit: pagination.pageSize,
+      offset: pagination.pageIndex * pagination.pageSize,
+    });
+
+  const rows: WakeUpRowData[] = useMemo(
+    () =>
+      wakeUps.map((wakeUp) => ({
+        ...wakeUp,
+        onClick: () => {
+          onNavigate();
+          void router.push(
+            getConversationRoute(owner.sId, wakeUp.conversation.sId)
+          );
+        },
+      })),
+    [wakeUps, onNavigate, router, owner.sId]
+  );
+
+  if (isWakeUpsError) {
+    return (
+      <div className="py-10 text-center text-sm text-muted-foreground">
+        Failed to load your wake-ups.
+      </div>
+    );
+  }
+
+  if (isWakeUpsLoading) {
+    return (
+      <div className="flex justify-center py-10">
+        <Spinner variant="dark" size="md" />
+      </div>
+    );
+  }
+
+  if (wakeUps.length === 0) {
+    return (
+      <div className="py-10 text-center text-sm text-muted-foreground">
+        None of your conversations has a scheduled wake-up. Agents schedule
+        wake-ups to pick a conversation back up on their own.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <DataTable
+        data={rows}
+        columns={COLUMNS}
+        totalRowCount={totalCount}
+        pagination={pagination}
+        setPagination={setPagination}
+      />
+    </div>
+  );
+}

--- a/front/lib/api/assistant/wakeups.ts
+++ b/front/lib/api/assistant/wakeups.ts
@@ -2,12 +2,15 @@ import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import type { ConversationRefType } from "@app/types/assistant/conversation";
-import type { WakeUpStatus, WakeUpType } from "@app/types/assistant/wakeups";
+import type {
+  UserWakeUpType,
+  WakeUpStatus,
+} from "@app/types/assistant/wakeups";
 import { removeNulls } from "@app/types/shared/utils/general";
 
 export interface UserWakeUpWithConversation {
   conversation: ConversationRefType;
-  wakeUp: WakeUpType;
+  wakeUp: UserWakeUpType;
 }
 
 export interface UserWakeUps {
@@ -72,7 +75,9 @@ export async function listUserWakeUps(
           ? refByConversationId.get(conversationId)
           : undefined;
 
-        return conversation ? { conversation, wakeUp: wakeUp.toJSON() } : null;
+        return conversation
+          ? { conversation, wakeUp: wakeUp.toUserListJSON() }
+          : null;
       })
     ),
   };

--- a/front/lib/api/assistant/wakeups.ts
+++ b/front/lib/api/assistant/wakeups.ts
@@ -14,7 +14,6 @@ export interface UserWakeUpWithConversation {
 }
 
 export interface UserWakeUps {
-  totalCount: number;
   wakeUps: UserWakeUpWithConversation[];
 }
 
@@ -26,25 +25,22 @@ export interface UserWakeUps {
 /**
  * @cc [owner:fabiencelier,label:product] drop-unreachable-conversations
  * A wake-up whose conversation the caller cannot read (deleted conversation, revoked space access)
- * MUST be omitted from `wakeUps` rather than returned without its conversation. `totalCount` still
- * counts it, so it can exceed the number of returned rows.
+ * MUST be omitted from `wakeUps` rather than returned without its conversation.
  */
 export async function listUserWakeUps(
   auth: Authenticator,
-  {
-    limit,
-    offset,
-    status,
-  }: { limit: number; offset: number; status: WakeUpStatus }
+  { status }: { status: WakeUpStatus }
 ): Promise<UserWakeUps> {
-  const { wakeUps, totalCount } = await WakeUpResource.listByUserWithTotalCount(
+  // The whole list is returned in one go: a user has few wake-ups in a given status, and paginating
+  // here would advertise a count the permission filtering below can contradict.
+  const wakeUps = await WakeUpResource.listByUser(
     auth,
     auth.getNonNullableUser(),
-    { limit, offset, status }
+    { status }
   );
 
   if (wakeUps.length === 0) {
-    return { totalCount, wakeUps: [] };
+    return { wakeUps: [] };
   }
 
   // `fetchByModelIds` resolves the conversation string ids without permission filtering, so those
@@ -65,7 +61,6 @@ export async function listUserWakeUps(
   );
 
   return {
-    totalCount,
     wakeUps: removeNulls(
       wakeUps.map((wakeUp) => {
         const conversationId = conversationIdByModelId.get(

--- a/front/lib/api/assistant/wakeups.ts
+++ b/front/lib/api/assistant/wakeups.ts
@@ -1,0 +1,79 @@
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
+import type { ConversationRefType } from "@app/types/assistant/conversation";
+import type { WakeUpStatus, WakeUpType } from "@app/types/assistant/wakeups";
+import { removeNulls } from "@app/types/shared/utils/general";
+
+export interface UserWakeUpWithConversation {
+  conversation: ConversationRefType;
+  wakeUp: WakeUpType;
+}
+
+export interface UserWakeUps {
+  totalCount: number;
+  wakeUps: UserWakeUpWithConversation[];
+}
+
+/**
+ * @cc [owner:fabiencelier,label:product;security] only-caller-wake-ups
+ * The returned wake-ups MUST all be owned by `auth`'s user and in `status`. A wake-up owned by
+ * another member of the workspace MUST never be returned, whatever the caller's role.
+ */
+/**
+ * @cc [owner:fabiencelier,label:product] drop-unreachable-conversations
+ * A wake-up whose conversation the caller cannot read (deleted conversation, revoked space access)
+ * MUST be omitted from `wakeUps` rather than returned without its conversation. `totalCount` still
+ * counts it, so it can exceed the number of returned rows.
+ */
+export async function listUserWakeUps(
+  auth: Authenticator,
+  {
+    limit,
+    offset,
+    status,
+  }: { limit: number; offset: number; status: WakeUpStatus }
+): Promise<UserWakeUps> {
+  const { wakeUps, totalCount } = await WakeUpResource.listByUserWithTotalCount(
+    auth,
+    auth.getNonNullableUser(),
+    { limit, offset, status }
+  );
+
+  if (wakeUps.length === 0) {
+    return { totalCount, wakeUps: [] };
+  }
+
+  // `fetchByModelIds` resolves the conversation string ids without permission filtering, so those
+  // ids then go through `fetchByIds`, which applies the caller's read permissions.
+  const conversations = await ConversationResource.fetchByModelIds(
+    auth,
+    Array.from(new Set(wakeUps.map((w) => w.conversationId)))
+  );
+  const conversationIdByModelId = new Map(
+    conversations.map((c) => [c.id, c.sId])
+  );
+  const readableConversations = await ConversationResource.fetchByIds(
+    auth,
+    conversations.map((c) => c.sId)
+  );
+  const refByConversationId = new Map(
+    readableConversations.map((c) => [c.sId, c.toRefJSON()])
+  );
+
+  return {
+    totalCount,
+    wakeUps: removeNulls(
+      wakeUps.map((wakeUp) => {
+        const conversationId = conversationIdByModelId.get(
+          wakeUp.conversationId
+        );
+        const conversation = conversationId
+          ? refByConversationId.get(conversationId)
+          : undefined;
+
+        return conversation ? { conversation, wakeUp: wakeUp.toJSON() } : null;
+      })
+    ),
+  };
+}

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -42,6 +42,7 @@ import type {
   ConversationListItemType,
   ConversationMCPServerViewType,
   ConversationMetadata,
+  ConversationRefType,
   ConversationUrlAccessMode,
   ConversationVisibility,
   ConversationWithoutContentType,
@@ -5403,6 +5404,21 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     );
 
     return transferredCount;
+  }
+
+  /**
+   * Minimal serialization for listings that only need to name a conversation and link to it, such
+   * as the personal wake-ups list. Uses the same display title as `toListItem`.
+   */
+  toRefJSON(): ConversationRefType {
+    return {
+      sId: this.sId,
+      title: getConversationDisplayTitle({
+        created: this.createdAt.getTime(),
+        forkingData: this.forkingData,
+        title: this.title,
+      }),
+    };
   }
 
   toListItem(): ConversationListItemType {

--- a/front/lib/resources/wakeup_resource.test.ts
+++ b/front/lib/resources/wakeup_resource.test.ts
@@ -1,11 +1,8 @@
-import { Authenticator } from "@app/lib/auth";
 import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import * as wakeUpClient from "@app/temporal/triggers/wakeup_client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
-import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WakeUpFactory } from "@app/tests/utils/WakeUpFactory";
 import { Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -25,7 +22,7 @@ async function setup() {
   return { agentConfiguration, authenticator, conversation, workspace };
 }
 
-describe("WakeUpResource.listByUserWithTotalCount", () => {
+describe("WakeUpResource.listByUser", () => {
   beforeEach(() => {
     vi.spyOn(
       wakeUpClient,
@@ -52,108 +49,11 @@ describe("WakeUpResource.listByUserWithTotalCount", () => {
       { reason: "newer" }
     );
 
-    const { wakeUps, totalCount } =
-      await WakeUpResource.listByUserWithTotalCount(
-        authenticator,
-        authenticator.getNonNullableUser(),
-        { limit: 10, offset: 0 }
-      );
+    const wakeUps = await WakeUpResource.listByUser(
+      authenticator,
+      authenticator.getNonNullableUser()
+    );
 
-    expect(totalCount).toBe(2);
     expect(wakeUps.map((w) => w.sId)).toEqual([newer.sId, older.sId]);
-  });
-
-  it("filters on status and counts only the matching wake-ups", async () => {
-    const { agentConfiguration, authenticator, conversation } = await setup();
-
-    const scheduled = await WakeUpFactory.cron(
-      authenticator,
-      conversation,
-      agentConfiguration
-    );
-    const cancelled = await WakeUpFactory.cron(
-      authenticator,
-      conversation,
-      agentConfiguration
-    );
-    await cancelled.markCancelled(authenticator);
-
-    const { wakeUps, totalCount } =
-      await WakeUpResource.listByUserWithTotalCount(
-        authenticator,
-        authenticator.getNonNullableUser(),
-        { limit: 10, offset: 0, status: "scheduled" }
-      );
-
-    expect(totalCount).toBe(1);
-    expect(wakeUps.map((w) => w.sId)).toEqual([scheduled.sId]);
-  });
-
-  it("pages with limit/offset while totalCount stays the full count", async () => {
-    const { agentConfiguration, authenticator, conversation } = await setup();
-
-    await WakeUpFactory.cron(authenticator, conversation, agentConfiguration);
-    const newer = await WakeUpFactory.cron(
-      authenticator,
-      conversation,
-      agentConfiguration
-    );
-
-    const firstPage = await WakeUpResource.listByUserWithTotalCount(
-      authenticator,
-      authenticator.getNonNullableUser(),
-      { limit: 1, offset: 0 }
-    );
-    const secondPage = await WakeUpResource.listByUserWithTotalCount(
-      authenticator,
-      authenticator.getNonNullableUser(),
-      { limit: 1, offset: 1 }
-    );
-
-    expect(firstPage.totalCount).toBe(2);
-    expect(secondPage.totalCount).toBe(2);
-    expect(firstPage.wakeUps.map((w) => w.sId)).toEqual([newer.sId]);
-    expect(secondPage.wakeUps).toHaveLength(1);
-    expect(secondPage.wakeUps[0].sId).not.toBe(newer.sId);
-  });
-
-  it("does not return the wake-ups of another member of the workspace", async () => {
-    const { agentConfiguration, authenticator, conversation, workspace } =
-      await setup();
-
-    const mine = await WakeUpFactory.cron(
-      authenticator,
-      conversation,
-      agentConfiguration
-    );
-
-    const otherUser = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
-    const otherAuthenticator = await Authenticator.fromUserIdAndWorkspaceId(
-      otherUser.sId,
-      workspace.sId
-    );
-    const otherConversation = await ConversationFactory.create(
-      otherAuthenticator,
-      {
-        agentConfigurationId: agentConfiguration.sId,
-        messagesCreatedAt: [new Date()],
-      }
-    );
-    await WakeUpFactory.cron(
-      otherAuthenticator,
-      otherConversation,
-      agentConfiguration
-    );
-
-    const { wakeUps, totalCount } =
-      await WakeUpResource.listByUserWithTotalCount(
-        authenticator,
-        authenticator.getNonNullableUser(),
-        { limit: 10, offset: 0 }
-      );
-
-    expect(totalCount).toBe(1);
-    expect(wakeUps.map((w) => w.sId)).toEqual([mine.sId]);
   });
 });

--- a/front/lib/resources/wakeup_resource.test.ts
+++ b/front/lib/resources/wakeup_resource.test.ts
@@ -1,0 +1,159 @@
+import { Authenticator } from "@app/lib/auth";
+import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
+import * as wakeUpClient from "@app/temporal/triggers/wakeup_client";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WakeUpFactory } from "@app/tests/utils/WakeUpFactory";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+async function setup() {
+  const { authenticator, workspace } = await createResourceTest({
+    role: "user",
+  });
+
+  const agentConfiguration =
+    await AgentConfigurationFactory.createTestAgent(authenticator);
+  const conversation = await ConversationFactory.create(authenticator, {
+    agentConfigurationId: agentConfiguration.sId,
+    messagesCreatedAt: [new Date()],
+  });
+
+  return { agentConfiguration, authenticator, conversation, workspace };
+}
+
+describe("WakeUpResource.listByUserWithTotalCount", () => {
+  beforeEach(() => {
+    vi.spyOn(
+      wakeUpClient,
+      "launchOrScheduleWakeUpTemporalWorkflow"
+    ).mockResolvedValue(new Ok(undefined));
+    vi.spyOn(wakeUpClient, "cancelWakeUpTemporalWorkflow").mockResolvedValue(
+      new Ok(undefined)
+    );
+  });
+
+  it("returns the user's wake-ups, newest first", async () => {
+    const { agentConfiguration, authenticator, conversation } = await setup();
+
+    const older = await WakeUpFactory.cron(
+      authenticator,
+      conversation,
+      agentConfiguration,
+      { reason: "older" }
+    );
+    const newer = await WakeUpFactory.cron(
+      authenticator,
+      conversation,
+      agentConfiguration,
+      { reason: "newer" }
+    );
+
+    const { wakeUps, totalCount } =
+      await WakeUpResource.listByUserWithTotalCount(
+        authenticator,
+        authenticator.getNonNullableUser(),
+        { limit: 10, offset: 0 }
+      );
+
+    expect(totalCount).toBe(2);
+    expect(wakeUps.map((w) => w.sId)).toEqual([newer.sId, older.sId]);
+  });
+
+  it("filters on status and counts only the matching wake-ups", async () => {
+    const { agentConfiguration, authenticator, conversation } = await setup();
+
+    const scheduled = await WakeUpFactory.cron(
+      authenticator,
+      conversation,
+      agentConfiguration
+    );
+    const cancelled = await WakeUpFactory.cron(
+      authenticator,
+      conversation,
+      agentConfiguration
+    );
+    await cancelled.markCancelled(authenticator);
+
+    const { wakeUps, totalCount } =
+      await WakeUpResource.listByUserWithTotalCount(
+        authenticator,
+        authenticator.getNonNullableUser(),
+        { limit: 10, offset: 0, status: "scheduled" }
+      );
+
+    expect(totalCount).toBe(1);
+    expect(wakeUps.map((w) => w.sId)).toEqual([scheduled.sId]);
+  });
+
+  it("pages with limit/offset while totalCount stays the full count", async () => {
+    const { agentConfiguration, authenticator, conversation } = await setup();
+
+    await WakeUpFactory.cron(authenticator, conversation, agentConfiguration);
+    const newer = await WakeUpFactory.cron(
+      authenticator,
+      conversation,
+      agentConfiguration
+    );
+
+    const firstPage = await WakeUpResource.listByUserWithTotalCount(
+      authenticator,
+      authenticator.getNonNullableUser(),
+      { limit: 1, offset: 0 }
+    );
+    const secondPage = await WakeUpResource.listByUserWithTotalCount(
+      authenticator,
+      authenticator.getNonNullableUser(),
+      { limit: 1, offset: 1 }
+    );
+
+    expect(firstPage.totalCount).toBe(2);
+    expect(secondPage.totalCount).toBe(2);
+    expect(firstPage.wakeUps.map((w) => w.sId)).toEqual([newer.sId]);
+    expect(secondPage.wakeUps).toHaveLength(1);
+    expect(secondPage.wakeUps[0].sId).not.toBe(newer.sId);
+  });
+
+  it("does not return the wake-ups of another member of the workspace", async () => {
+    const { agentConfiguration, authenticator, conversation, workspace } =
+      await setup();
+
+    const mine = await WakeUpFactory.cron(
+      authenticator,
+      conversation,
+      agentConfiguration
+    );
+
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+    const otherAuthenticator = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      workspace.sId
+    );
+    const otherConversation = await ConversationFactory.create(
+      otherAuthenticator,
+      {
+        agentConfigurationId: agentConfiguration.sId,
+        messagesCreatedAt: [new Date()],
+      }
+    );
+    await WakeUpFactory.cron(
+      otherAuthenticator,
+      otherConversation,
+      agentConfiguration
+    );
+
+    const { wakeUps, totalCount } =
+      await WakeUpResource.listByUserWithTotalCount(
+        authenticator,
+        authenticator.getNonNullableUser(),
+        { limit: 10, offset: 0 }
+      );
+
+    expect(totalCount).toBe(1);
+    expect(wakeUps.map((w) => w.sId)).toEqual([mine.sId]);
+  });
+});

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -340,6 +340,47 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
     });
   }
 
+  /**
+   * @cc [owner:fabiencelier,label:backend] user-owned-wake-ups-only
+   * The returned wake-ups and `totalCount` MUST only cover wake-ups owned by `user` in the current
+   * workspace and, when `status` is given, in one of those statuses. `totalCount` MUST count every
+   * matching wake-up, independent of `limit` and `offset`.
+   */
+  static async listByUserWithTotalCount(
+    auth: Authenticator,
+    user: UserResource | UserType,
+    {
+      limit,
+      offset,
+      status,
+    }: { limit: number; offset: number; status?: WakeUpStatus | WakeUpStatus[] }
+  ): Promise<{ wakeUps: WakeUpResource[]; totalCount: number }> {
+    const where = {
+      userId: user.id,
+      ...(status !== undefined ? { status } : {}),
+    };
+
+    const [wakeUps, totalCount] = await Promise.all([
+      this.baseFetch(auth, {
+        where,
+        order: [
+          ["createdAt", "DESC"],
+          ["id", "DESC"],
+        ],
+        limit,
+        offset,
+      }),
+      this.model.count({
+        where: {
+          ...where,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        } as WhereOptions<WakeUpModel>,
+      }),
+    ]);
+
+    return { wakeUps, totalCount };
+  }
+
   static async listByAgentConfigurationId(
     auth: Authenticator,
     agentConfigurationId: string,

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -23,6 +23,7 @@ import {
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type {
+  UserWakeUpType,
   WakeUpScheduleConfig,
   WakeUpStatus,
   WakeUpType,
@@ -834,6 +835,39 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
       fireCount: this.fireCount,
       maxFires: this.maxFires(),
       user: this.user.toJSON(),
+    };
+  }
+
+  /**
+   * @cc [owner:fabiencelier,label:security] no-model-ids-for-owner
+   * The returned object MUST NOT carry any numeric database identifier, neither the wake-up's own
+   * `id` nor one nested in a serialized user: it is served to browser clients, which address
+   * wake-ups by `sId` only.
+   */
+  toUserListJSON(): UserWakeUpType {
+    // Listing a user their own wake-ups: `user` would repeat the caller on every row, and `id` is
+    // a ModelId that must not leave the server. Fields are picked explicitly so adding one to
+    // `WakeUpType` is a deliberate decision here too.
+    const {
+      sId,
+      createdAt,
+      agentConfigurationId,
+      scheduleConfig,
+      reason,
+      status,
+      fireCount,
+      maxFires,
+    } = this.toJSON();
+
+    return {
+      sId,
+      createdAt,
+      agentConfigurationId,
+      scheduleConfig,
+      reason,
+      status,
+      fireCount,
+      maxFires,
     };
   }
 

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -343,43 +343,24 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
 
   /**
    * @cc [owner:fabiencelier,label:backend] user-owned-wake-ups-only
-   * The returned wake-ups and `totalCount` MUST only cover wake-ups owned by `user` in the current
-   * workspace and, when `status` is given, in one of those statuses. `totalCount` MUST count every
-   * matching wake-up, independent of `limit` and `offset`.
+   * The returned wake-ups MUST only be the ones owned by `user` in the current workspace and, when
+   * `status` is given, in one of those statuses.
    */
-  static async listByUserWithTotalCount(
+  static async listByUser(
     auth: Authenticator,
     user: UserResource | UserType,
-    {
-      limit,
-      offset,
-      status,
-    }: { limit: number; offset: number; status?: WakeUpStatus | WakeUpStatus[] }
-  ): Promise<{ wakeUps: WakeUpResource[]; totalCount: number }> {
-    const where = {
-      userId: user.id,
-      ...(status !== undefined ? { status } : {}),
-    };
-
-    const [wakeUps, totalCount] = await Promise.all([
-      this.baseFetch(auth, {
-        where,
-        order: [
-          ["createdAt", "DESC"],
-          ["id", "DESC"],
-        ],
-        limit,
-        offset,
-      }),
-      this.model.count({
-        where: {
-          ...where,
-          workspaceId: auth.getNonNullableWorkspace().id,
-        } as WhereOptions<WakeUpModel>,
-      }),
-    ]);
-
-    return { wakeUps, totalCount };
+    { status }: { status?: WakeUpStatus | WakeUpStatus[] } = {}
+  ): Promise<WakeUpResource[]> {
+    return this.baseFetch(auth, {
+      where: {
+        userId: user.id,
+        ...(status !== undefined ? { status } : {}),
+      },
+      order: [
+        ["createdAt", "DESC"],
+        ["id", "DESC"],
+      ],
+    });
   }
 
   static async listByAgentConfigurationId(

--- a/front/lib/swr/wakeups.ts
+++ b/front/lib/swr/wakeups.ts
@@ -109,27 +109,22 @@ export function useCancelWakeUp({
 
 export function useUserWakeUps({
   owner,
-  limit,
-  offset,
   disabled,
 }: {
   owner: LightWorkspaceType;
-  limit: number;
-  offset: number;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
   const userWakeUpsFetcher: Fetcher<UserWakeUps> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/me/wakeups?limit=${limit}&offset=${offset}`,
+    `/api/w/${owner.sId}/me/wakeups`,
     userWakeUpsFetcher,
     { disabled }
   );
 
   return {
     wakeUps: data?.wakeUps ?? emptyArray<UserWakeUpWithConversation>(),
-    totalCount: data?.totalCount ?? 0,
     isWakeUpsLoading: !error && !data && !disabled,
     isWakeUpsError: !!error,
     mutateWakeUps: mutate,

--- a/front/lib/swr/wakeups.ts
+++ b/front/lib/swr/wakeups.ts
@@ -1,5 +1,9 @@
 import { useConversations } from "@app/hooks/conversations/useConversations";
 import { useSendNotification } from "@app/hooks/useNotification";
+import type {
+  UserWakeUps,
+  UserWakeUpWithConversation,
+} from "@app/lib/api/assistant/wakeups";
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetConversationWakeUpsResponseBody } from "@app/types/api/assistant/conversation/wakeups";
@@ -101,4 +105,33 @@ export function useCancelWakeUp({
   );
 
   return { cancelWakeUp };
+}
+
+export function useUserWakeUps({
+  owner,
+  limit,
+  offset,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  limit: number;
+  offset: number;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const userWakeUpsFetcher: Fetcher<UserWakeUps> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/me/wakeups?limit=${limit}&offset=${offset}`,
+    userWakeUpsFetcher,
+    { disabled }
+  );
+
+  return {
+    wakeUps: data?.wakeUps ?? emptyArray<UserWakeUpWithConversation>(),
+    totalCount: data?.totalCount ?? 0,
+    isWakeUpsLoading: !error && !data && !disabled,
+    isWakeUpsError: !!error,
+    mutateWakeUps: mutate,
+  };
 }

--- a/front/lib/utils/wakeup_description.ts
+++ b/front/lib/utils/wakeup_description.ts
@@ -74,7 +74,9 @@ export function formatWakeUpSidebarLabel(timestamp: number): string {
 //   "*/15 * * * *"   -> "every 15 minutes"
 // Cron times are shown verbatim from the schedule's stored timezone — no
 // shift to the viewer's zone, no zone suffix.
-export function describeWakeUpSchedule(wakeUp: WakeUpType): string {
+export function describeWakeUpSchedule(
+  wakeUp: Pick<WakeUpType, "scheduleConfig">
+): string {
   const config = wakeUp.scheduleConfig;
   switch (config.type) {
     case "one_shot":

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -583,6 +583,15 @@ export type ConversationForkedChildType = {
 };
 
 /**
+ * Minimal reference to a conversation: enough to name it and link to it. Used by listings of other
+ * resources that only need to point at their conversation.
+ */
+export type ConversationRefType = {
+  sId: string;
+  title: string | null;
+};
+
+/**
  * Fields needed to render a conversation row in the sidebar list. Served
  * directly from Elasticsearch. No DB hydration required.
  */

--- a/front/types/assistant/wakeups.ts
+++ b/front/types/assistant/wakeups.ts
@@ -42,6 +42,12 @@ export const WakeUpSchema = z.object({
  */
 export type WakeUpType = z.infer<typeof WakeUpSchema>;
 
+/**
+ * A wake-up as served to its own owner: no numeric database identifiers, and no `user` since the
+ * owner is the caller. Produced by `WakeUpResource.toUserListJSON`.
+ */
+export type UserWakeUpType = Omit<WakeUpType, "id" | "user">;
+
 export function isActiveWakeUp(wakeUp: WakeUpType): boolean {
   return ACTIVE_WAKE_UP_STATUSES.includes(wakeUp.status);
 }


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/9378

Add a new tab in the personal "automations" screen to list wakeups.
This uses a new endpoint to list the wakeups, with pagination.
Wakeups are filtered by "scheduled" as other status means the wakeup already fired or has been canceled.
Not adding the option to cancel the trigger, this can be done by going to the conversation page and click the obvious cancel button (this can be reconsidered later if really needed)

<img width="3128" height="1662" alt="image" src="https://github.com/user-attachments/assets/21bed62e-fde7-4d9e-8e2a-9aa79a0648a8" />

## Tests

- unit tests for endpoint and resource method
- manually tested the feature
- manually tested the pagination 


https://github.com/user-attachments/assets/9e69470f-582a-458d-b5ee-07179408f66c

## Risk

low, people can only see their wakeups

## Deploy Plan

deploy front
