### PR TITLE
[front] fix: Select All stuck on "Loading..." forever for empty data source views

### DIFF
--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -140,12 +140,15 @@ function useLazyLoadAllNodes({
     if (!triggered) {
       return;
     }
-    if (nodesError) {
-      // Don't spin forever if the fetch failed.
-      setTriggered(false);
+    if (isLoadingMore) {
+      // A request is in flight: ignore a stale `nodesError` left over from a
+      // previous failed attempt (SWR keeps it cached until this one settles),
+      // otherwise a retry gets aborted before it can complete.
       return;
     }
-    if (isLoadingMore) {
+    if (nodesError) {
+      // The active request (not a stale one) failed: don't spin forever.
+      setTriggered(false);
       return;
     }
     if (hasNextPage) {

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -122,7 +122,14 @@ function useLazyLoadAllNodes({
 }: UseLazyLoadAllNodesOptions) {
   const [triggered, setTriggered] = useState(false);
 
-  const { nodes, hasNextPage, isLoadingMore, loadMore } = useContentNodes({
+  const {
+    nodes,
+    hasNextPage,
+    isLoadingMore,
+    isNodesFetched,
+    nodesError,
+    loadMore,
+  } = useContentNodes({
     owner,
     dataSourceView: triggered ? dataSourceView : undefined,
     viewType,
@@ -133,15 +140,35 @@ function useLazyLoadAllNodes({
     if (!triggered) {
       return;
     }
-    if (hasNextPage && !isLoadingMore) {
+    if (nodesError) {
+      // Don't spin forever if the fetch failed.
+      setTriggered(false);
+      return;
+    }
+    if (isLoadingMore) {
+      return;
+    }
+    if (hasNextPage) {
       void loadMore();
       return;
     }
-    if (!hasNextPage && !isLoadingMore && nodes.length > 0) {
+    // Complete once at least one page has been fetched, even when the view has
+    // no nodes at all. Requiring nodes.length > 0 here used to leave the
+    // "Select All" button stuck on "Loading..." forever for empty views.
+    if (isNodesFetched) {
       onComplete(nodes);
       setTriggered(false);
     }
-  }, [triggered, hasNextPage, isLoadingMore, loadMore, nodes, onComplete]);
+  }, [
+    triggered,
+    nodesError,
+    hasNextPage,
+    isLoadingMore,
+    isNodesFetched,
+    loadMore,
+    nodes,
+    onComplete,
+  ]);
 
   return {
     trigger: () => setTriggered(true),

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -251,6 +251,8 @@ export type FetchDataSourceViewContentNodesOptions = {
 export interface InfiniteContentNodesResult {
   isNodesLoading: boolean;
   isNodesValidating: boolean;
+  // True once at least one page has been fetched (even if it contains no nodes).
+  isNodesFetched: boolean;
   nodesError: unknown;
   nodes: GetDataSourceViewContentNodes["nodes"];
   nextPageCursor: string | null;
@@ -287,6 +289,7 @@ function processInfiniteContentNodesData({
   return {
     isNodesLoading: isLoading && !data,
     isNodesValidating: isValidating,
+    isNodesFetched: data !== undefined,
     nodesError: error,
     nodes,
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing


### PR DESCRIPTION
## Description

Follow-up on #31964 / #31971 (BigQuery connection setup investigation for an EU enterprise workspace).

In the "Add connected data to space" picker, the "Select All" control (`useLazyLoadAllNodes` in `DataSourceViewSelector.tsx`) only completes when `nodes.length > 0`:

```ts
if (!hasNextPage && !isLoadingMore && nodes.length > 0) {
  onComplete(nodes);
  setTriggered(false);
}
```

When the data source view has **zero content nodes** (e.g. a freshly connected BigQuery/Snowflake connection where no table has been selected yet), this condition can never be satisfied, so `triggered` never resets and the button shows "Loading..." forever. This was observed in production: the affected customer's picker showed "Loading..." for 12+ hours on an empty BigQuery view.

The `nodes.length > 0` guard existed to avoid completing during the render gap right after triggering, before SWR has fetched anything (nodes is `[]`, `hasNextPage`/`isLoadingMore` are false). This PR replaces that guard with an explicit signal:

- `InfiniteContentNodesResult` now exposes `isNodesFetched` (`data !== undefined`), i.e. at least one page has actually been fetched.
- `useLazyLoadAllNodes` completes when `isNodesFetched` is true, even with zero nodes, and no longer relies on `nodes.length`.
- Bonus fix: if the content nodes fetch errors (`nodesError`), we now reset `triggered` instead of spinning forever (previously an error also caused a permanent "Loading..." state).

## Tests

- Reviewed the local diff (`git status` / `git diff`); local type-check and unit tests were not run in the sandbox environment, validation is delegated to PR CI.
- Logic walkthrough of the three states: pre-fetch gap (no false completion since `isNodesFetched` is false), empty result (completes with `[]`), multi-page result (unchanged pagination via `loadMore`).

## Risk

Low. Purely additive field on the SWR result plus a guard rewrite in one hook. Behavior for non-empty views is unchanged (pagination loop identical). Safe to rollback.

## Deploy Plan

Standard front deploy. No migration, no config change.
