### PR TITLE
front-sse can be reverted, the card knows it is a revert

### DIFF
--- a/.github/actions/deploy-card/action.yml
+++ b/.github/actions/deploy-card/action.yml
@@ -199,4 +199,4 @@ runs:
           }
 
           core.setOutput('thread_ts', posted.ts);
-          core.setOutput('card', JSON.stringify({ component, target, authors_line: authorsLine, footer, cells }));
+          core.setOutput('card', JSON.stringify({ component, target, authors_line: authorsLine, footer, cells, revert }));

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -26,6 +26,7 @@ on:
           - core
           - front
           - front-edge
+          - front-sse
           - oauth
           - prodbox
           - viz
@@ -106,7 +107,7 @@ jobs:
         run: |
           # The front releases run the front-api images.
           case "${{ inputs.component }}" in
-            front) IMAGE="front-api" ;;
+            front|front-sse) IMAGE="front-api" ;;
             front-edge) IMAGE="front-api-edge" ;;
             *) IMAGE="${{ inputs.component }}" ;;
           esac


### PR DESCRIPTION
## Description

A Revert of front-sse fails before it starts: the image check looks for an image named front-sse, and the front releases all run front-api. front-sse was also missing from the Revert component list, so nobody could have hit that yet. Both fixed, front-sse can be reverted like front.

The deployment card is the other half. dust opens it with a rewind header, then dust-infra redraws it from the card facts and, knowing nothing about reverts, turns it into "front is going live". The facts now carry a `revert` flag and dust-infra (dust-tt/dust-infra#1087) keeps the card speaking of a revert until the end.

## Tests

The workflow parses, the card script passes a node syntax check, and the only change to it is one field in the JSON it already emits. The image check is the same `case` with one more branch. A real Revert of front-sse after both PRs merge is the proof, and an old dust-infra ignores the extra field.

## Risk

Two workflow files, no application code. The worst case is a card that still says going live during a revert, which is today.

## Deploy Plan

Merge, no deploy. dust-tt/dust-infra#1087 can land before or after.
