### PR TITLE
Fix: use finalizeUriForProvider() everywhere, prepare the cutoff date for the legacy uri.

### DIFF
--- a/dust.code-workspace
+++ b/dust.code-workspace
@@ -33,7 +33,7 @@
       "preview-proxy": true,
       "prodbox": true,
       "sandbox": true,
-      "scripts": true,
+      "scripts": false,
       "temporal": true,
       "tools": true,
       "x": true

--- a/front/components/actions/mcp/create/RemoteMCPServerConfigurationSection.tsx
+++ b/front/components/actions/mcp/create/RemoteMCPServerConfigurationSection.tsx
@@ -216,7 +216,12 @@ export function RemoteMCPServerConfigurationSection({
           {!defaultServerConfig && authMethod === "oauth-static" && (
             <div className="text-xs text-muted-foreground">
               The redirect URI to allow is{" "}
-              <strong>{finalizeUriForProvider("mcp_static")}</strong>
+              <strong>
+                {finalizeUriForProvider({
+                  provider: "mcp_static",
+                  connection: null,
+                })}
+              </strong>
             </div>
           )}
         </div>

--- a/front/components/actions/mcp/provider_setup_instructions/SnowflakeSetupInstructions.tsx
+++ b/front/components/actions/mcp/provider_setup_instructions/SnowflakeSetupInstructions.tsx
@@ -1,4 +1,4 @@
-import config from "@app/lib/api/config";
+import { finalizeUriForProvider } from "@app/lib/api/oauth/utils";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import {
   Collapsible,
@@ -17,7 +17,10 @@ export function SnowflakeSetupInstructions({
 }: SnowflakeSetupInstructionsProps) {
   const [isOpen, setIsOpen] = useState(false);
 
-  const redirectUri = `${config.getApiBaseUrl()}/oauth/snowflake/finalize`;
+  const redirectUri = finalizeUriForProvider({
+    provider: "snowflake",
+    connection: null,
+  });
 
   return (
     <div className="w-full pt-4">

--- a/front/lib/actions/mcp_oauth_provider.ts
+++ b/front/lib/actions/mcp_oauth_provider.ts
@@ -30,7 +30,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
     // required" on any OAuth-gated server. Returning the URI keeps the
     // interactive authorization-code path, where `saveCodeVerifier()` throws to
     // cleanly signal that OAuth is required.
-    return finalizeUriForProvider("mcp");
+    return finalizeUriForProvider({ provider: "mcp", connection: null });
   }
 
   get clientMetadata(): OAuthClientMetadata {
@@ -55,7 +55,9 @@ export class MCPOAuthProvider implements OAuthClientProvider {
         };
 
     return {
-      redirect_uris: [finalizeUriForProvider("mcp")],
+      redirect_uris: [
+        finalizeUriForProvider({ provider: "mcp", connection: null }),
+      ],
       client_name: "Dust",
       ...informationalUris,
       contacts: ["support@dust.com"],

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -37,7 +37,6 @@ import { SnowflakeOAuthProvider } from "@app/lib/api/oauth/providers/snowflake";
 import { UkgReadyOAuthProvider } from "@app/lib/api/oauth/providers/ukg_ready";
 import { VantaOAuthProvider } from "@app/lib/api/oauth/providers/vanta";
 import { ZendeskOAuthProvider } from "@app/lib/api/oauth/providers/zendesk";
-import { finalizeUriForProvider } from "@app/lib/api/oauth/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { hasFeatureFlag } from "@app/lib/auth";
 import logger from "@app/logger/logger";
@@ -339,11 +338,28 @@ export async function finalizeConnection(
 
   const api = new OAuthAPI(config.getOAuthAPIConfig(), logger);
 
+  // Fetching the connection metadata is necessary to build the redirect URI.
+  const connectionRes = await api.getConnectionMetadata({
+    connectionId,
+  });
+
+  if (connectionRes.isErr()) {
+    logger.error(
+      { connectionId, step: "connection_metadata_retrieval" },
+      "OAuth: Failed to retrieve connection metadata"
+    );
+    return new Err({
+      code: "connection_finalization_failed",
+      message: `Failed to finalize ${provider} connection: failed to retrieve connection metadata`,
+    });
+  }
+
+  const connection = connectionRes.value.connection;
+
   const cRes = await api.finalizeConnection({
     provider,
-    connectionId,
+    connection,
     code,
-    redirectUri: finalizeUriForProvider(provider),
   });
 
   if (cRes.isErr()) {

--- a/front/lib/api/oauth/providers/confluence.ts
+++ b/front/lib/api/oauth/providers/confluence.ts
@@ -1,3 +1,4 @@
+import type { ParsedUrlQuery } from "node:querystring";
 import config from "@app/lib/api/config";
 import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
 import {
@@ -9,7 +10,6 @@ import type {
   OAuthConnectionType,
   OAuthUseCase,
 } from "@app/types/oauth/lib";
-import type { ParsedUrlQuery } from "querystring";
 
 export class ConfluenceOAuthProvider implements BaseOAuthStrategyProvider {
   setupUri({
@@ -37,7 +37,7 @@ export class ConfluenceOAuthProvider implements BaseOAuthStrategyProvider {
       `https://auth.atlassian.com/authorize?audience=api.atlassian.com` +
       `&client_id=${config.getOAuthConfluenceClientId()}` +
       `&scope=${encodeURIComponent(scopes.join(" "))}` +
-      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("confluence"))}` +
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider({ provider: "confluence", connection }))}` +
       `&state=${connection.connection_id}` +
       `&response_type=code&prompt=consent`
     );

--- a/front/lib/api/oauth/providers/confluence_tools.ts
+++ b/front/lib/api/oauth/providers/confluence_tools.ts
@@ -38,7 +38,7 @@ export class ConfluenceToolsOAuthProvider implements BaseOAuthStrategyProvider {
       `https://auth.atlassian.com/authorize?audience=api.atlassian.com` +
       `&client_id=${config.getOAuthConfluenceToolsClientId()}` +
       `&scope=${encodeURIComponent(scopes.join(" "))}` +
-      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("confluence_tools"))}` +
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider({ provider: "confluence_tools", connection }))}` +
       `&state=${connection.connection_id}` +
       `&response_type=code&prompt=consent`
     );

--- a/front/lib/api/oauth/providers/discord.ts
+++ b/front/lib/api/oauth/providers/discord.ts
@@ -36,7 +36,7 @@ export class DiscordOAuthProvider implements BaseOAuthStrategyProvider {
       `client_id=${clientId}` +
       `&scope=${encodeURIComponent(bot_scopes.join("+"))}` +
       `&permissions=83968` + // Allows the bot to read message history, embed links, and send messages
-      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("discord"))}` +
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider({ provider: "discord", connection }))}` +
       `&response_type=code` +
       `&state=${connection.connection_id}`
     );

--- a/front/lib/api/oauth/providers/fathom.ts
+++ b/front/lib/api/oauth/providers/fathom.ts
@@ -23,7 +23,7 @@ export class FathomOAuthProvider implements BaseOAuthStrategyProvider {
     return (
       `https://fathom.video/external/v1/oauth2/authorize` +
       `?client_id=${config.getOAuthFathomClientId()}` +
-      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("fathom"))}` +
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider({ provider: "fathom", connection }))}` +
       `&scope=${encodeURIComponent(scopes.join(" "))}` +
       `&state=${connection.connection_id}` +
       `&response_type=code`

--- a/front/lib/api/oauth/providers/freshservice.ts
+++ b/front/lib/api/oauth/providers/freshservice.ts
@@ -85,7 +85,7 @@ export class FreshserviceOAuthProvider implements BaseOAuthStrategyProvider {
       `&client_id=${config.getOAuthFreshserviceClientId()}` +
       `&state=${connection.connection_id}` +
       `&scope=${encodeURIComponent(scopes.join(" "))}` +
-      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("freshservice"))}`
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider({ provider: "freshservice", connection }))}`
     );
   }
 

--- a/front/lib/api/oauth/providers/github.ts
+++ b/front/lib/api/oauth/providers/github.ts
@@ -22,7 +22,10 @@ export class GithubOAuthProvider implements BaseOAuthStrategyProvider {
     if (useCase === "personal_actions") {
       // OAuth flow for personal connections (user access tokens)
       const clientId = config.getOAuthGithubAppPersonalActions();
-      const redirectUri = finalizeUriForProvider("github");
+      const redirectUri = finalizeUriForProvider({
+        provider: "github",
+        connection,
+      });
       const url =
         `https://github.com/login/oauth/authorize?` +
         `client_id=${clientId}` +
@@ -36,7 +39,10 @@ export class GithubOAuthProvider implements BaseOAuthStrategyProvider {
     if (useCase === "webhooks") {
       // OAuth flow for webhook management
       const clientId = config.getOAuthGithubAppWebhooks();
-      const redirectUri = finalizeUriForProvider("github");
+      const redirectUri = finalizeUriForProvider({
+        provider: "github",
+        connection,
+      });
       const url =
         `https://github.com/login/oauth/authorize?` +
         `client_id=${clientId}` +

--- a/front/lib/api/oauth/providers/gmail.ts
+++ b/front/lib/api/oauth/providers/gmail.ts
@@ -43,7 +43,7 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
       response_type: "code",
       client_id: clientId,
       state: connection.connection_id,
-      redirect_uri: finalizeUriForProvider("gmail"),
+      redirect_uri: finalizeUriForProvider({ provider: "gmail", connection }),
       scope: extraConfig.scope,
       access_type: "offline",
       prompt: "consent",

--- a/front/lib/api/oauth/providers/gong.ts
+++ b/front/lib/api/oauth/providers/gong.ts
@@ -32,7 +32,7 @@ export class GongOAuthProvider implements BaseOAuthStrategyProvider {
       `&scope=${encodeURIComponent(scopes.join(" "))}` +
       `&response_type=code` +
       `&state=${connection.connection_id}` +
-      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("gong"))}`
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider({ provider: "gong", connection }))}`
     );
   }
 

--- a/front/lib/api/oauth/providers/google_drive.ts
+++ b/front/lib/api/oauth/providers/google_drive.ts
@@ -38,7 +38,10 @@ export class GoogleDriveOAuthProvider implements BaseOAuthStrategyProvider {
       response_type: "code",
       client_id: config.getOAuthGoogleDriveClientId(),
       state: connection.connection_id,
-      redirect_uri: finalizeUriForProvider("google_drive"),
+      redirect_uri: finalizeUriForProvider({
+        provider: "google_drive",
+        connection,
+      }),
       scope: extraConfig?.scope ?? scopes.join(" "),
       access_type: "offline",
       prompt: "consent",

--- a/front/lib/api/oauth/providers/hubspot.ts
+++ b/front/lib/api/oauth/providers/hubspot.ts
@@ -70,7 +70,7 @@ export class HubspotOAuthProvider implements BaseOAuthStrategyProvider {
     return (
       `https://app.hubspot.com/oauth/authorize` +
       `?client_id=${config.getOAuthHubspotClientId()}` +
-      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("hubspot"))}` +
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider({ provider: "hubspot", connection }))}` +
       `&scope=${encodeURIComponent(requiredScopes.join(" "))}` +
       `&optional_scope=${encodeURIComponent(filteredOptionalScopes.join(" "))}` +
       `&state=${connection.connection_id}`

--- a/front/lib/api/oauth/providers/intercom.ts
+++ b/front/lib/api/oauth/providers/intercom.ts
@@ -22,7 +22,7 @@ export class IntercomOAuthProvider implements BaseOAuthStrategyProvider {
       `https://app.intercom.com/oauth` +
       `?client_id=${config.getOAuthIntercomClientId()}` +
       `&state=${connection.connection_id}` +
-      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("intercom"))}`
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider({ provider: "intercom", connection }))}`
     );
   }
 

--- a/front/lib/api/oauth/providers/jira.ts
+++ b/front/lib/api/oauth/providers/jira.ts
@@ -50,7 +50,7 @@ export class JiraOAuthProvider implements BaseOAuthStrategyProvider {
       `https://auth.atlassian.com/authorize?audience=api.atlassian.com` +
       `&client_id=${config.getOAuthJiraClientId()}` +
       `&scope=${encodeURIComponent(scopes.join(" "))}` +
-      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("jira"))}` +
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider({ provider: "jira", connection }))}` +
       `&state=${connection.connection_id}` +
       `&response_type=code&prompt=consent`
     );

--- a/front/lib/api/oauth/providers/linear.ts
+++ b/front/lib/api/oauth/providers/linear.ts
@@ -27,7 +27,7 @@ export class LinearOAuthProvider implements BaseOAuthStrategyProvider {
     return (
       `https://linear.app/oauth/authorize` +
       `?client_id=${encodeURIComponent(config.getOAuthLinearClientId())}` +
-      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("linear"))}` +
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider({ provider: "linear", connection }))}` +
       `&scope=${encodeURIComponent(scopes.join(","))}` +
       `&state=${encodeURIComponent(connection.connection_id)}` +
       `&response_type=code`

--- a/front/lib/api/oauth/providers/mcp.ts
+++ b/front/lib/api/oauth/providers/mcp.ts
@@ -83,7 +83,7 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
     );
     authUrl.searchParams.set(
       "redirect_uri",
-      finalizeUriForProvider(this.provider)
+      finalizeUriForProvider({ provider: "mcp", connection })
     );
     authUrl.searchParams.set("state", connection.connection_id);
 

--- a/front/lib/api/oauth/providers/microsoft.ts
+++ b/front/lib/api/oauth/providers/microsoft.ts
@@ -35,6 +35,7 @@ export class MicrosoftOAuthProvider implements BaseOAuthStrategyProvider {
     };
   }) {
     if (relatedCredential) {
+      // TODO(single-tenant): ask thomas about changing this to use the finalizeUriForProvider function.
       return `${config.getAppUrl()}/oauth/microsoft/finalize?provider=microsoft&code=client&state=${connection.connection_id}`;
     } else {
       const scopes = [
@@ -49,7 +50,10 @@ export class MicrosoftOAuthProvider implements BaseOAuthStrategyProvider {
         response_type: "code",
         client_id: config.getOAuthMicrosoftClientId(),
         state: connection.connection_id,
-        redirect_uri: finalizeUriForProvider("microsoft"),
+        redirect_uri: finalizeUriForProvider({
+          provider: "microsoft",
+          connection,
+        }),
         scope: scopes.join(" "),
       });
       return `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?${qs}`;

--- a/front/lib/api/oauth/providers/microsoft_tools.ts
+++ b/front/lib/api/oauth/providers/microsoft_tools.ts
@@ -40,7 +40,10 @@ export class MicrosoftToolsOAuthProvider implements BaseOAuthStrategyProvider {
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       client_id: clientId || config.getOAuthMicrosoftToolsClientId(),
       state: connection.connection_id,
-      redirect_uri: finalizeUriForProvider("microsoft_tools"),
+      redirect_uri: finalizeUriForProvider({
+        provider: "microsoft_tools",
+        connection,
+      }),
       scope: extraConfig.scope,
     });
     return `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?${qs}`;

--- a/front/lib/api/oauth/providers/monday.ts
+++ b/front/lib/api/oauth/providers/monday.ts
@@ -22,7 +22,7 @@ export class MondayOAuthProvider implements BaseOAuthStrategyProvider {
       `https://auth.monday.com/oauth2/authorize` +
       `?client_id=${config.getOAuthMondayClientId()}` +
       `&state=${connection.connection_id}` +
-      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("monday"))}`
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider({ provider: "monday", connection }))}`
     );
   }
 

--- a/front/lib/api/oauth/providers/notion.ts
+++ b/front/lib/api/oauth/providers/notion.ts
@@ -51,7 +51,7 @@ export class NotionOAuthProvider implements BaseOAuthStrategyProvider {
       `&response_type=code` +
       `&client_id=${clientId}` +
       `&state=${connection.connection_id}` +
-      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("notion"))}`
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider({ provider: "notion", connection }))}`
     );
   }
 

--- a/front/lib/api/oauth/providers/productboard.ts
+++ b/front/lib/api/oauth/providers/productboard.ts
@@ -31,7 +31,7 @@ export class ProductboardOAuthProvider implements BaseOAuthStrategyProvider {
       `&scope=${encodeURIComponent(scopes.join(" "))}` +
       `&response_type=code` +
       `&state=${connection.connection_id}` +
-      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("productboard"))}`
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider({ provider: "productboard", connection }))}`
     );
   }
 

--- a/front/lib/api/oauth/providers/salesforce.ts
+++ b/front/lib/api/oauth/providers/salesforce.ts
@@ -52,7 +52,7 @@ export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
       `?response_type=code` +
       `&client_id=${clientId}` +
       `&state=${connection.connection_id}` +
-      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("salesforce"))}` +
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider({ provider: "salesforce", connection }))}` +
       `&code_challenge=${connection.metadata.code_challenge}` +
       `&code_challenge_method=S256`
     );

--- a/front/lib/api/oauth/providers/servicenow.ts
+++ b/front/lib/api/oauth/providers/servicenow.ts
@@ -60,7 +60,10 @@ export class ServiceNowOAuthProvider implements BaseOAuthStrategyProvider {
       response_type: "code",
       client_id: clientId,
       state: connection.connection_id,
-      redirect_uri: finalizeUriForProvider("servicenow"),
+      redirect_uri: finalizeUriForProvider({
+        provider: "servicenow",
+        connection,
+      }),
     });
 
     const authUrl = `${instanceUrl.trim().replace(/\/$/, "")}/oauth_auth.do?${qs}`;

--- a/front/lib/api/oauth/providers/shopify.ts
+++ b/front/lib/api/oauth/providers/shopify.ts
@@ -65,7 +65,10 @@ export class ShopifyOAuthProvider implements BaseOAuthStrategyProvider {
     const url = new URL(`https://${storeDomain}/admin/oauth/authorize`);
     url.searchParams.set("client_id", config.getOAuthShopifyClientId());
     url.searchParams.set("scope", SHOPIFY_SCOPES.join(","));
-    url.searchParams.set("redirect_uri", finalizeUriForProvider("shopify"));
+    url.searchParams.set(
+      "redirect_uri",
+      finalizeUriForProvider({ provider: "shopify", connection })
+    );
     url.searchParams.set("state", connection.connection_id);
     return url.toString();
   }

--- a/front/lib/api/oauth/providers/slack.ts
+++ b/front/lib/api/oauth/providers/slack.ts
@@ -121,7 +121,7 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
       `https://slack.com/oauth/v2/authorize?` +
       `client_id=${clientId}` +
       `&scope=${encodeURIComponent(bot_scopes.join(" "))}` +
-      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("slack"))}` +
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider({ provider: "slack", connection }))}` +
       // Force the team id to be the same as the admin-setup.
       // Edge-case: if the user is not in the team of not logged, it might still connect to the wrong team.
       // We catch it in the `checkConnectionValidPostFinalize` method.

--- a/front/lib/api/oauth/providers/slack_tools.ts
+++ b/front/lib/api/oauth/providers/slack_tools.ts
@@ -95,7 +95,7 @@ export class SlackToolsOAuthProvider implements BaseOAuthStrategyProvider {
       `https://slack.com/oauth/v2/authorize?` +
       `client_id=${clientId}` +
       `&user_scope=${encodeURIComponent(user_scopes.join(" "))}` +
-      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("slack_tools"))}` +
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider({ provider: "slack_tools", connection }))}` +
       // Force the team id to be the same as the admin-setup.
       // Edge-case: if the user is not in the team or not logged in, they might still connect to the wrong team.
       // We catch it in the `checkConnectionValidPostFinalize` method.

--- a/front/lib/api/oauth/providers/snowflake.ts
+++ b/front/lib/api/oauth/providers/snowflake.ts
@@ -120,7 +120,10 @@ export class SnowflakeOAuthProvider implements BaseOAuthStrategyProvider {
       response_type: "code",
       client_id: clientId,
       state: connection.connection_id,
-      redirect_uri: finalizeUriForProvider("snowflake"),
+      redirect_uri: finalizeUriForProvider({
+        provider: "snowflake",
+        connection,
+      }),
       scope: `session:role:${role.toUpperCase()}`,
     });
 

--- a/front/lib/api/oauth/providers/ukg_ready.ts
+++ b/front/lib/api/oauth/providers/ukg_ready.ts
@@ -55,7 +55,7 @@ export class UkgReadyOAuthProvider implements BaseOAuthStrategyProvider {
     authUrl.searchParams.set("client_id", clientId);
     authUrl.searchParams.set(
       "redirect_uri",
-      finalizeUriForProvider("ukg_ready")
+      finalizeUriForProvider({ provider: "ukg_ready", connection })
     );
     authUrl.searchParams.set("state", connection.connection_id);
     authUrl.searchParams.set("code_challenge", codeChallenge);

--- a/front/lib/api/oauth/providers/vanta.ts
+++ b/front/lib/api/oauth/providers/vanta.ts
@@ -18,7 +18,9 @@ import type { ParsedUrlQuery } from "querystring";
 
 export class VantaOAuthProvider implements BaseOAuthStrategyProvider {
   setupUri({ connection }: { connection: OAuthConnectionType }) {
-    const finalizeUrl = new URL(finalizeUriForProvider("vanta"));
+    const finalizeUrl = new URL(
+      finalizeUriForProvider({ provider: "vanta", connection })
+    );
     finalizeUrl.searchParams.set("state", connection.connection_id);
     finalizeUrl.searchParams.set("code", "client_credentials");
     return finalizeUrl.toString();

--- a/front/lib/api/oauth/providers/zendesk.ts
+++ b/front/lib/api/oauth/providers/zendesk.ts
@@ -52,7 +52,7 @@ export class ZendeskOAuthProvider implements BaseOAuthStrategyProvider {
       `&scope=${encodeURIComponent(scopes.join(" "))}` +
       `&response_type=code` +
       `&state=${connection.connection_id}` +
-      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("zendesk"))}`
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider({ provider: "zendesk", connection }))}`
     );
   }
 

--- a/front/lib/api/oauth/utils.test.ts
+++ b/front/lib/api/oauth/utils.test.ts
@@ -20,24 +20,24 @@ describe("finalizeUriForProvider", () => {
   });
 
   it("builds the finalize URI on the OAuth redirect base", () => {
-    expect(finalizeUriForProvider("google_drive")).toBe(
-      "https://app.dust.tt/oauth/google_drive/finalize"
-    );
+    expect(
+      finalizeUriForProvider({ provider: "google_drive", connection: null })
+    ).toBe("https://app.dust.tt/oauth/google_drive/finalize");
   });
 
   it("prefers the development base URL in development", () => {
     vi.stubEnv("NODE_ENV", "development");
     config.getDevOAuthRedirectBaseUrl.mockReturnValue("https://dev.example");
-    expect(finalizeUriForProvider("notion")).toBe(
-      "https://dev.example/oauth/notion/finalize"
-    );
+    expect(
+      finalizeUriForProvider({ provider: "notion", connection: null })
+    ).toBe("https://dev.example/oauth/notion/finalize");
   });
 
   it("does not use the development base URL outside development", () => {
     vi.stubEnv("NODE_ENV", "production");
     config.getDevOAuthRedirectBaseUrl.mockReturnValue("https://dev.example");
-    expect(finalizeUriForProvider("notion")).toBe(
-      "https://app.dust.tt/oauth/notion/finalize"
-    );
+    expect(
+      finalizeUriForProvider({ provider: "notion", connection: null })
+    ).toBe("https://app.dust.tt/oauth/notion/finalize");
   });
 });

--- a/front/lib/api/oauth/utils.ts
+++ b/front/lib/api/oauth/utils.ts
@@ -1,16 +1,36 @@
 import config from "@app/lib/api/config";
-import type { OAuthProvider } from "@app/types/oauth/lib";
+import type { OAuthConnectionType, OAuthProvider } from "@app/types/oauth/lib";
 import { isDevelopment } from "@app/types/shared/env";
 import type { ParsedUrlQuery } from "querystring";
 
-export function finalizeUriForProvider(provider: OAuthProvider): string {
+// This is the cutoff date for the OAuth redirect base URL.
+// Before this date, we use the api URL.
+// After this date, we use the app URL.
+const CUTOFF_DATE_FOR_OAUTH_REDIRECT_BASE_URL = new Date("2030-01-01");
+
+export function finalizeUriForProvider({
+  provider,
+  connection,
+}: {
+  provider: OAuthProvider;
+  connection: OAuthConnectionType | null;
+}): string {
   if (isDevelopment()) {
     const devBaseUrl = config.getDevOAuthRedirectBaseUrl();
     if (devBaseUrl) {
       return devBaseUrl + `/oauth/${provider}/finalize`;
     }
   }
-  return config.getOAuthRedirectBaseUrl() + `/oauth/${provider}/finalize`;
+
+  if (
+    connection &&
+    connection.created < CUTOFF_DATE_FOR_OAUTH_REDIRECT_BASE_URL.getTime()
+  ) {
+    // TODO(single-tenant): we need to use the api URL here.
+    return config.getOAuthRedirectBaseUrl() + `/oauth/${provider}/finalize`;
+  } else {
+    return config.getOAuthRedirectBaseUrl() + `/oauth/${provider}/finalize`;
+  }
 }
 
 export function getStringFromQuery(

--- a/front/types/oauth/oauth_api.ts
+++ b/front/types/oauth/oauth_api.ts
@@ -1,4 +1,5 @@
 import { internalFetch } from "@app/lib/api/internal_fetch";
+import { finalizeUriForProvider } from "@app/lib/api/oauth/utils";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import type { ApiKeyCredentialsType } from "@app/types/provider_credential";
 import type {
@@ -122,17 +123,16 @@ export class OAuthAPI {
 
   async finalizeConnection({
     provider,
-    connectionId,
+    connection,
     code,
-    redirectUri,
   }: {
     provider: OAuthProvider;
-    connectionId: string;
+    connection: OAuthConnectionType;
     code: string;
-    redirectUri: string;
   }): Promise<OAuthAPIResponse<{ connection: OAuthConnectionType }>> {
+    const redirectUri = finalizeUriForProvider({ provider, connection });
     const response = await this._fetchWithError(
-      `${this._url}/connections/${connectionId}/finalize`,
+      `${this._url}/connections/${connection.connection_id}/finalize`,
       {
         method: "POST",
         headers: {


### PR DESCRIPTION
## Description

I route OAuth setup and finalization through `finalizeUriForProvider` with the connection metadata required to select the redirect base. All provider implementations now pass their `connection`, while static MCP/Snowflake flows pass `null`; `finalizeConnection` fetches metadata before calling the OAuth API. The redirect utility now carries the cutoff-date path for legacy URI handling, and its unit tests cover development and production bases.

## Tests

Updated `front/lib/api/oauth/utils.test.ts`. CI `lint` and `tsgo` checks passed; test shards were still running when this description was generated.

## Risk

Medium risk: an incorrect provider-specific redirect URI or failed metadata lookup can block OAuth connection setup. The change is isolated to OAuth routing and rollback is a straightforward revert.

## Deploy Plan

Deploy `front`. No SQL migration or infrastructure change is required.