### PR TITLE
[Admin Governance] Repair agent editor history with a targeted backfill

### DIFF
--- a/front/migrations/20260910_repair_agent_editor_memberships.test.ts
+++ b/front/migrations/20260910_repair_agent_editor_memberships.test.ts
@@ -1,0 +1,121 @@
+import { AgentResource } from "@app/lib/resources/agent_resource";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import logger from "@app/logger/logger";
+import { repairEditorMemberships } from "@app/migrations/20260910_repair_agent_editor_memberships";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import assert from "assert";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const REVOKED_AT = new Date("2026-05-02T12:00:00Z");
+
+async function seedRevokedEditor() {
+  vi.setSystemTime(new Date("2026-05-01T12:00:00Z"));
+  const {
+    authenticator: auth,
+    workspace,
+    user,
+  } = await createResourceTest({ role: "admin" });
+  const agent = await AgentConfigurationFactory.createTestAgent(auth);
+  const legacy = await GroupResource.findEditorGroupForAgent(auth, agent);
+  assert(legacy.isOk());
+  const resource = await AgentResource.fetchByAgentConfiguration(auth, agent);
+  assert(resource.id !== null);
+  const grant = {
+    grantType: "editor" as const,
+    resourceType: "agent" as const,
+    resourceId: resource.id,
+  };
+  const target = await GroupPermissionResource.findRegularAutoGroupForGrant(
+    auth,
+    grant
+  );
+  assert(target);
+  const unrelated = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, unrelated, { role: "user" });
+  const added = await legacy.value.dangerouslyAddMember(auth, {
+    user: unrelated.toJSON(),
+  });
+  assert(added.isOk());
+  vi.setSystemTime(REVOKED_AT);
+  for (const group of [legacy.value, target]) {
+    const removed = await group.dangerouslyRemoveMember(auth, {
+      user: user.toJSON(),
+    });
+    assert(removed.isOk());
+  }
+  const revoked = await MembershipResource.revokeMembership({
+    user,
+    workspace,
+    allowLastAdminRevocation: true,
+  });
+  assert(revoked.isOk());
+  vi.setSystemTime(new Date("2026-09-07T12:00:00Z"));
+  return {
+    auth,
+    workspace,
+    user,
+    unrelated,
+    grant,
+    target,
+    legacy: legacy.value,
+  };
+}
+
+describe("repairEditorMemberships", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it.each([
+    false,
+    true,
+  ])("repairs only affected editors (already rejoined: %s)", async (rejoined) => {
+    const { auth, workspace, user, unrelated, grant, target, legacy } =
+      await seedRevokedEditor();
+    if (rejoined) {
+      await MembershipFactory.associate(workspace, user, { role: "user" });
+      const restored = await legacy.dangerouslyAddMember(auth, {
+        user: user.toJSON(),
+      });
+      assert(restored.isOk());
+    } else {
+      assert((await target.delete(auth)).isOk());
+    }
+    const spec = {
+      wId: workspace.sId,
+      logger: logger.child({}, { level: "silent" }),
+    };
+    const expected = rejoined
+      ? { ended: 0, active: 1 }
+      : { ended: 1, active: 0 };
+    for (const execute of [false, false, true]) {
+      await expect(
+        repairEditorMemberships({ ...spec, execute })
+      ).resolves.toEqual(expected);
+    }
+    await expect(
+      repairEditorMemberships({ ...spec, execute: true })
+    ).resolves.toEqual({ ended: 0, active: 0 });
+    const repaired = await GroupPermissionResource.findRegularAutoGroupForGrant(
+      auth,
+      grant
+    );
+    assert(repaired);
+    expect(await repaired.isMember(user)).toBe(rejoined);
+    expect(await repaired.isMember(unrelated)).toBe(false);
+
+    if (!rejoined) {
+      await MembershipFactory.associate(workspace, user, { role: "user" });
+      await GroupResource.dangerouslyRestoreGroupMembershipsRevokedWith({
+        user,
+        workspace,
+        revokedAt: REVOKED_AT,
+      });
+      expect(await repaired.isMember(user)).toBe(true);
+    }
+    expect(await legacy.isMember(unrelated)).toBe(true);
+  });
+});

--- a/front/migrations/20260910_repair_agent_editor_memberships.test.ts
+++ b/front/migrations/20260910_repair_agent_editor_memberships.test.ts
@@ -4,6 +4,7 @@ import { AgentResource } from "@app/lib/resources/agent_resource";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import logger from "@app/logger/logger";
 import { repairEditorMemberships } from "@app/migrations/20260910_repair_agent_editor_memberships";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -11,6 +12,7 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import assert from "assert";
+import { literal, Op } from "sequelize";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const REVOKED_AT = new Date("2026-05-02T12:00:00Z");
@@ -75,6 +77,43 @@ async function seedRevokedEditor() {
 
 describe("repairEditorMemberships", () => {
   afterEach(() => vi.useRealTimers());
+
+  it("compares exact end timestamps and copies the earliest duplicate only once", async () => {
+    const { workspace, user, legacy, target } = await seedRevokedEditor();
+    const where = {
+      workspaceId: workspace.id,
+      groupId: legacy.id,
+      userId: user.id,
+    };
+    await GroupMembershipModel.create({
+      ...where,
+      status: "active",
+      startAt: REVOKED_AT,
+      endAt: REVOKED_AT,
+    });
+    // Both source rows now end one microsecond after the already-copied target history.
+    await GroupMembershipModel.update(
+      { endAt: literal("\"endAt\" + INTERVAL '1 microsecond'") },
+      { where: { ...where, endAt: REVOKED_AT } }
+    );
+    const spec = {
+      wId: workspace.sId,
+      logger: logger.child({}, { level: "silent" }),
+    };
+    for (const execute of [false, true]) {
+      await expect(
+        repairEditorMemberships({ ...spec, execute })
+      ).resolves.toEqual({ ended: 1, active: 0 });
+    }
+    await expect(
+      repairEditorMemberships({ ...spec, execute: true })
+    ).resolves.toEqual({ ended: 0, active: 0 });
+    const copied = await GroupMembershipModel.findOne({
+      where: { ...where, groupId: target.id, endAt: { [Op.gt]: REVOKED_AT } },
+    });
+    assert(copied);
+    expect(copied.startAt.getTime()).toBeLessThan(REVOKED_AT.getTime());
+  });
 
   it("uses the latest non-draft configuration's editor group", async () => {
     const { auth, workspace, agent, target } = await seedRevokedEditor();

--- a/front/migrations/20260910_repair_agent_editor_memberships.test.ts
+++ b/front/migrations/20260910_repair_agent_editor_memberships.test.ts
@@ -1,3 +1,5 @@
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
 import { AgentResource } from "@app/lib/resources/agent_resource";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -20,7 +22,11 @@ async function seedRevokedEditor() {
     workspace,
     user,
   } = await createResourceTest({ role: "admin" });
-  const agent = await AgentConfigurationFactory.createTestAgent(auth);
+  const original = await AgentConfigurationFactory.createTestAgent(auth);
+  const agent = await AgentConfigurationFactory.updateTestAgent(
+    auth,
+    original.sId
+  );
   const legacy = await GroupResource.findEditorGroupForAgent(auth, agent);
   assert(legacy.isOk());
   const resource = await AgentResource.fetchByAgentConfiguration(auth, agent);
@@ -56,6 +62,7 @@ async function seedRevokedEditor() {
   assert(revoked.isOk());
   vi.setSystemTime(new Date("2026-09-07T12:00:00Z"));
   return {
+    agent,
     auth,
     workspace,
     user,
@@ -68,6 +75,31 @@ async function seedRevokedEditor() {
 
 describe("repairEditorMemberships", () => {
   afterEach(() => vi.useRealTimers());
+
+  it("uses the latest non-draft configuration's editor group", async () => {
+    const { auth, workspace, agent, target } = await seedRevokedEditor();
+    assert((await target.delete(auth)).isOk());
+    await GroupAgentModel.destroy({
+      where: { workspaceId: workspace.id, agentConfigurationId: agent.id },
+    });
+    const spec = {
+      wId: workspace.sId,
+      logger: logger.child({}, { level: "silent" }),
+      execute: false,
+    };
+    await expect(repairEditorMemberships(spec)).resolves.toEqual({
+      ended: 0,
+      active: 0,
+    });
+    await AgentConfigurationModel.update(
+      { status: "draft" },
+      { where: { workspaceId: workspace.id, id: agent.id } }
+    );
+    await expect(repairEditorMemberships(spec)).resolves.toEqual({
+      ended: 1,
+      active: 0,
+    });
+  });
 
   it.each([
     false,

--- a/front/migrations/20260910_repair_agent_editor_memberships.ts
+++ b/front/migrations/20260910_repair_agent_editor_memberships.ts
@@ -2,19 +2,22 @@ import { Authenticator } from "@app/lib/auth";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
-import type { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
+import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
+import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { invalidateCacheAfterCommit } from "@app/lib/utils/cache";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import type { ModelId } from "@app/types/shared/model_id";
+import { isString } from "@app/types/shared/utils/general";
 import assert from "assert";
 import type { Transaction } from "sequelize";
-import { QueryTypes } from "sequelize";
+import { col, fn, Op, QueryTypes } from "sequelize";
 
 const BATCH_SIZE = 100;
 const CONCURRENCY = 4;
+const TIMESTAMP_FORMAT = 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"';
 
 type EditorGroup = {
   groupModelId: ModelId;
@@ -24,6 +27,7 @@ type EditorGroup = {
 type MembershipToCopy = Pick<GroupMembershipModel, "id" | "userId"> & {
   active: boolean;
 };
+type MembershipHistory = MembershipToCopy & { groupId: ModelId; key: string };
 type Counts = { ended: number; active: number };
 
 /**
@@ -62,54 +66,136 @@ async function fetchEditorGroups(afterGroupId: ModelId, wId?: string) {
   );
 }
 
+/**
+ * @cc [owner:philipperolet,label:migration] exact-history-keys
+ * Distinct ended timestamps for a user MUST have distinct keys, even within one millisecond.
+ */
+async function fetchGroupHistory(
+  workspaceId: ModelId,
+  groupIds: ModelId[],
+  now: Date,
+  transaction: Transaction
+): Promise<MembershipHistory[]> {
+  // UTC strings with six fractional digits preserve precision for comparison and deduplication.
+  const endAtText = fn(
+    "to_char",
+    fn("timezone", "UTC", col("endAt")),
+    TIMESTAMP_FORMAT
+  );
+  // Both groups use the (workspaceId, groupId, status, startAt) index.
+  const memberships = await GroupMembershipModel.findAll({
+    attributes: ["id", "groupId", "userId", [endAtText, "endAtText"]],
+    where: {
+      workspaceId,
+      groupId: groupIds,
+      status: "active",
+      startAt: { [Op.lte]: now },
+    },
+    // When source rows share a key, preserve the earliest start time.
+    order: [["startAt", "ASC"]],
+    transaction,
+  });
+  const nowText = now.toISOString().replace("Z", "000Z");
+  return memberships.map((membership) => {
+    const endAt = membership.get("endAtText");
+    assert(endAt === null || isString(endAt));
+    const active = endAt === null || endAt > nowText;
+    return {
+      id: membership.id,
+      userId: membership.userId,
+      groupId: membership.groupId,
+      active,
+      // Current rows share one key per user, even if their future end times differ.
+      key: `${membership.userId}:${active ? "active" : endAt}`,
+    };
+  });
+}
+
+async function fetchActiveWorkspaceUsers(
+  workspaceId: ModelId,
+  userIds: ModelId[],
+  now: Date,
+  transaction: Transaction
+): Promise<Set<ModelId>> {
+  // History-bearing users only; uses (workspaceId, userId, startAt, endAt).
+  const memberships = await MembershipModel.findAll({
+    attributes: ["userId"],
+    where: {
+      workspaceId,
+      userId: userIds,
+      startAt: { [Op.lte]: now },
+      [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
+    },
+    transaction,
+  });
+  return new Set(memberships.map((membership) => membership.userId));
+}
+
+function selectMissingMemberships(
+  source: MembershipHistory[],
+  target: MembershipHistory[],
+  restoredUserIds: Set<ModelId>
+): MembershipToCopy[] {
+  // Match history by user/end time; any current target row covers current access.
+  const existingKeys = new Set(target.map((membership) => membership.key));
+  const missing: MembershipToCopy[] = [];
+  for (const membership of source) {
+    // Preserve ended history even for revoked users. Current access requires workspace membership.
+    if (membership.active && !restoredUserIds.has(membership.userId)) {
+      continue;
+    }
+    if (existingKeys.has(membership.key)) {
+      continue;
+    }
+    existingKeys.add(membership.key);
+    missing.push({
+      id: membership.id,
+      userId: membership.userId,
+      active: membership.active,
+    });
+  }
+  return missing;
+}
+
 async function fetchMissingMemberships(
   auth: Authenticator,
   sourceGroupModelId: ModelId,
   targetGroupModelId: ModelId | null,
   transaction: Transaction
 ): Promise<MembershipToCopy[]> {
-  // Only history-bearing users can contribute active rows; no workspace-wide editor comparison.
-  return frontSequelize.query<MembershipToCopy>(
-    `-- Keep one row per user/end time for history, or one row per user for current access.
-     -- Current rows share a NULL deduplication key, even if their future end times differ.
-     SELECT DISTINCT ON (m."userId", CASE WHEN m."endAt" <= :now THEN m."endAt" END)
-       m.id, m."userId",
-       (m."endAt" IS NULL OR m."endAt" > :now) AS active
-     FROM group_memberships m
-     WHERE m."workspaceId" = :workspaceId AND m."groupId" = :sourceGroupModelId
-       AND m.status = 'active' AND m."startAt" <= :now
-       AND (
-         -- Preserve ended rows for future restoration, even while the user is revoked.
-         m."endAt" <= :now OR (
-           -- Also repair current access for users with history who have already rejoined.
-           EXISTS (SELECT 1 FROM group_memberships history
-             WHERE history."workspaceId" = m."workspaceId" AND history."groupId" = m."groupId"
-               AND history."userId" = m."userId" AND history.status = 'active'
-               AND history."endAt" <= :now)
-           -- Legacy group membership alone is insufficient: workspace membership must be current too.
-           AND EXISTS (SELECT 1 FROM memberships wm
-             WHERE wm."workspaceId" = m."workspaceId" AND wm."userId" = m."userId"
-               AND wm."startAt" <= :now AND (wm."endAt" IS NULL OR wm."endAt" > :now))
-       ))
-       -- A matching end time means history was copied; any current target row covers current access.
-       AND NOT EXISTS (SELECT 1 FROM group_memberships target
-         WHERE target."workspaceId" = m."workspaceId" AND target."groupId" = :targetGroupModelId
-           AND target."userId" = m."userId" AND target.status = 'active'
-           AND CASE WHEN m."endAt" <= :now THEN target."endAt" = m."endAt"
-             ELSE target."startAt" <= :now AND (target."endAt" IS NULL OR target."endAt" > :now) END)
-     -- When source rows have the same deduplication key, preserve the earliest start time.
-     ORDER BY m."userId", CASE WHEN m."endAt" <= :now THEN m."endAt" END, m."startAt"`,
-    {
-      replacements: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        sourceGroupModelId,
-        targetGroupModelId,
-        now: new Date(),
-      },
-      type: QueryTypes.SELECT,
-      transaction,
-    }
+  const workspaceId = auth.getNonNullableWorkspace().id;
+  const now = new Date();
+  const groupIds =
+    targetGroupModelId === null
+      ? [sourceGroupModelId]
+      : [sourceGroupModelId, targetGroupModelId];
+  const memberships = await fetchGroupHistory(
+    workspaceId,
+    groupIds,
+    now,
+    transaction
   );
+  const source = memberships.filter(
+    (membership) => membership.groupId === sourceGroupModelId
+  );
+  const target = memberships.filter(
+    (membership) => membership.groupId === targetGroupModelId
+  );
+  // Only history-bearing users can contribute active rows; no workspace-wide editor comparison.
+  const historicalUserIds = [
+    ...new Set(
+      source
+        .filter((membership) => !membership.active)
+        .map((membership) => membership.userId)
+    ),
+  ];
+  const restoredUserIds = await fetchActiveWorkspaceUsers(
+    workspaceId,
+    historicalUserIds,
+    now,
+    transaction
+  );
+  return selectMissingMemberships(source, target, restoredUserIds);
 }
 
 async function copyMemberships(

--- a/front/migrations/20260910_repair_agent_editor_memberships.ts
+++ b/front/migrations/20260910_repair_agent_editor_memberships.ts
@@ -26,41 +26,39 @@ type MembershipToCopy = Pick<GroupMembershipModel, "id" | "userId"> & {
 };
 type Counts = { ended: number; active: number };
 
-async function fetchHistoryGroups(afterGroupId: ModelId, wId?: string) {
+/**
+ * @cc [owner:philipperolet,label:migration] latest-editor-groups
+ * Only groups linked to an agent's latest non-draft configuration are eligible.
+ */
+async function fetchEditorGroups(afterGroupId: ModelId, wId?: string) {
   // Walk group IDs, not workspaces. Membership probes use (workspaceId, groupId, status, startAt).
-  return frontSequelize.query<{ id: ModelId }>(
-    `SELECT g.id FROM groups g
+  // Each editor group belongs to one agent; (agentId, version) supports the latest-version check.
+  return frontSequelize.query<EditorGroup>(
+    `SELECT DISTINCT g.id AS "groupModelId", c."agentId" AS "agentModelId", w."sId" AS "workspaceId"
+     FROM groups g
      JOIN workspaces w ON w.id = g."workspaceId"
+     JOIN group_agents ga ON ga."groupId" = g.id AND ga."workspaceId" = g."workspaceId"
+     JOIN agent_configurations c ON c.id = ga."agentConfigurationId"
+       AND c."workspaceId" = ga."workspaceId"
      WHERE g.kind = 'agent_editors' AND g.id > :afterGroupId
        AND (:wId IS NULL OR w."sId" = :wId)
+       AND c.status <> 'draft'
        AND EXISTS (
          SELECT 1 FROM group_memberships m
          WHERE m."workspaceId" = g."workspaceId" AND m."groupId" = g.id
            AND m.status = 'active' AND m."endAt" <= NOW()
+       )
+       -- Versions share their editor group; retain only the latest non-draft link.
+       AND NOT EXISTS (
+         SELECT 1 FROM agent_configurations newer
+         WHERE newer."agentId" = c."agentId" AND newer."workspaceId" = c."workspaceId"
+           AND newer.status <> 'draft' AND newer.version > c.version
        )
      ORDER BY g.id LIMIT :limit`,
     {
       replacements: { afterGroupId, wId: wId ?? null, limit: BATCH_SIZE },
       type: QueryTypes.SELECT,
     }
-  );
-}
-
-async function fetchEditorGroups(groupIds: ModelId[]) {
-  // Resolve only this batch's links; (agentId, version) supports the latest-version check.
-  return frontSequelize.query<EditorGroup>(
-    `SELECT DISTINCT ga."groupId" AS "groupModelId", c."agentId" AS "agentModelId", w."sId" AS "workspaceId"
-     FROM group_agents ga
-     JOIN agent_configurations c ON c.id = ga."agentConfigurationId"
-       AND c."workspaceId" = ga."workspaceId"
-     JOIN workspaces w ON w.id = ga."workspaceId"
-     WHERE ga."groupId" IN (:groupIds) AND c.status <> 'draft'
-       AND NOT EXISTS (
-         SELECT 1 FROM agent_configurations newer
-         WHERE newer."agentId" = c."agentId" AND newer."workspaceId" = c."workspaceId"
-           AND newer.status <> 'draft' AND newer.version > c.version
-       )`,
-    { replacements: { groupIds }, type: QueryTypes.SELECT }
   );
 }
 
@@ -72,26 +70,34 @@ async function fetchMissingMemberships(
 ): Promise<MembershipToCopy[]> {
   // Only history-bearing users can contribute active rows; no workspace-wide editor comparison.
   return frontSequelize.query<MembershipToCopy>(
-    `SELECT DISTINCT ON (m."userId", CASE WHEN m."endAt" <= :now THEN m."endAt" END)
+    `-- Keep one row per user/end time for history, or one row per user for current access.
+     -- Current rows share a NULL deduplication key, even if their future end times differ.
+     SELECT DISTINCT ON (m."userId", CASE WHEN m."endAt" <= :now THEN m."endAt" END)
        m.id, m."userId",
        (m."endAt" IS NULL OR m."endAt" > :now) AS active
      FROM group_memberships m
      WHERE m."workspaceId" = :workspaceId AND m."groupId" = :sourceGroupModelId
        AND m.status = 'active' AND m."startAt" <= :now
-       AND (m."endAt" <= :now OR (
-         EXISTS (SELECT 1 FROM group_memberships history
-           WHERE history."workspaceId" = m."workspaceId" AND history."groupId" = m."groupId"
-             AND history."userId" = m."userId" AND history.status = 'active'
-             AND history."endAt" <= :now)
-         AND EXISTS (SELECT 1 FROM memberships wm
-           WHERE wm."workspaceId" = m."workspaceId" AND wm."userId" = m."userId"
-             AND wm."startAt" <= :now AND (wm."endAt" IS NULL OR wm."endAt" > :now))
+       AND (
+         -- Preserve ended rows for future restoration, even while the user is revoked.
+         m."endAt" <= :now OR (
+           -- Also repair current access for users with history who have already rejoined.
+           EXISTS (SELECT 1 FROM group_memberships history
+             WHERE history."workspaceId" = m."workspaceId" AND history."groupId" = m."groupId"
+               AND history."userId" = m."userId" AND history.status = 'active'
+               AND history."endAt" <= :now)
+           -- Legacy group membership alone is insufficient: workspace membership must be current too.
+           AND EXISTS (SELECT 1 FROM memberships wm
+             WHERE wm."workspaceId" = m."workspaceId" AND wm."userId" = m."userId"
+               AND wm."startAt" <= :now AND (wm."endAt" IS NULL OR wm."endAt" > :now))
        ))
+       -- A matching end time means history was copied; any current target row covers current access.
        AND NOT EXISTS (SELECT 1 FROM group_memberships target
          WHERE target."workspaceId" = m."workspaceId" AND target."groupId" = :targetGroupModelId
            AND target."userId" = m."userId" AND target.status = 'active'
            AND CASE WHEN m."endAt" <= :now THEN target."endAt" = m."endAt"
              ELSE target."startAt" <= :now AND (target."endAt" IS NULL OR target."endAt" > :now) END)
+     -- When source rows have the same deduplication key, preserve the earliest start time.
      ORDER BY m."userId", CASE WHEN m."endAt" <= :now THEN m."endAt" END, m."startAt"`,
     {
       replacements: {
@@ -264,17 +270,16 @@ export async function repairEditorMemberships({
   let cursor = afterGroupId;
   const totals = { ended: 0, active: 0 };
   for (;;) {
-    const groups = await fetchHistoryGroups(cursor, wId);
-    if (groups.length === 0) {
+    const editors = await fetchEditorGroups(cursor, wId);
+    if (editors.length === 0) {
       return totals;
     }
-    const editors = await fetchEditorGroups(groups.map(({ id }) => id));
     const counts = await repairBatch(editors, execute, logger);
     for (const count of counts) {
       totals.ended += count.ended;
       totals.active += count.active;
     }
-    cursor = groups[groups.length - 1].id;
+    cursor = editors[editors.length - 1].groupModelId;
     logger.info(
       { execute, afterGroupId: cursor, groups: editors.length, ...totals },
       "Agent editor repair batch completed"

--- a/front/migrations/20260910_repair_agent_editor_memberships.ts
+++ b/front/migrations/20260910_repair_agent_editor_memberships.ts
@@ -220,7 +220,11 @@ async function repairEditorGroup(
   });
 }
 
-async function repairBatch(editors: EditorGroup[], execute: boolean) {
+async function repairBatch(
+  editors: EditorGroup[],
+  execute: boolean,
+  logger: Logger
+) {
   const auths = new Map<string, Authenticator>();
   for (const workspaceId of new Set(
     editors.map((editor) => editor.workspaceId)
@@ -235,7 +239,12 @@ async function repairBatch(editors: EditorGroup[], execute: boolean) {
     async (editor) => {
       const auth = auths.get(editor.workspaceId);
       assert(auth);
-      return repairEditorGroup(auth, editor, execute);
+      const counts = await repairEditorGroup(auth, editor, execute);
+      logger.info(
+        { execute, ...editor, ...counts },
+        "Agent editor memberships checked"
+      );
+      return counts;
     },
     { concurrency: CONCURRENCY }
   );
@@ -260,7 +269,7 @@ export async function repairEditorMemberships({
       return totals;
     }
     const editors = await fetchEditorGroups(groups.map(({ id }) => id));
-    const counts = await repairBatch(editors, execute);
+    const counts = await repairBatch(editors, execute, logger);
     for (const count of counts) {
       totals.ended += count.ended;
       totals.active += count.active;

--- a/front/migrations/20260910_repair_agent_editor_memberships.ts
+++ b/front/migrations/20260910_repair_agent_editor_memberships.ts
@@ -1,0 +1,290 @@
+import { Authenticator } from "@app/lib/auth";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
+import type { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { invalidateCacheAfterCommit } from "@app/lib/utils/cache";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import type { ModelId } from "@app/types/shared/model_id";
+import assert from "assert";
+import type { Transaction } from "sequelize";
+import { QueryTypes } from "sequelize";
+
+const BATCH_SIZE = 100;
+const CONCURRENCY = 4;
+
+type EditorGroup = {
+  groupModelId: ModelId;
+  agentModelId: ModelId;
+  workspaceId: string;
+};
+type MembershipToCopy = Pick<GroupMembershipModel, "id" | "userId"> & {
+  active: boolean;
+};
+type Counts = { ended: number; active: number };
+
+async function fetchHistoryGroups(afterGroupId: ModelId, wId?: string) {
+  // Walk group IDs, not workspaces. Membership probes use (workspaceId, groupId, status, startAt).
+  return frontSequelize.query<{ id: ModelId }>(
+    `SELECT g.id FROM groups g
+     JOIN workspaces w ON w.id = g."workspaceId"
+     WHERE g.kind = 'agent_editors' AND g.id > :afterGroupId
+       AND (:wId IS NULL OR w."sId" = :wId)
+       AND EXISTS (
+         SELECT 1 FROM group_memberships m
+         WHERE m."workspaceId" = g."workspaceId" AND m."groupId" = g.id
+           AND m.status = 'active' AND m."endAt" <= NOW()
+       )
+     ORDER BY g.id LIMIT :limit`,
+    {
+      replacements: { afterGroupId, wId: wId ?? null, limit: BATCH_SIZE },
+      type: QueryTypes.SELECT,
+    }
+  );
+}
+
+async function fetchEditorGroups(groupIds: ModelId[]) {
+  // Resolve only this batch's links; (agentId, version) supports the latest-version check.
+  return frontSequelize.query<EditorGroup>(
+    `SELECT DISTINCT ga."groupId" AS "groupModelId", c."agentId" AS "agentModelId", w."sId" AS "workspaceId"
+     FROM group_agents ga
+     JOIN agent_configurations c ON c.id = ga."agentConfigurationId"
+       AND c."workspaceId" = ga."workspaceId"
+     JOIN workspaces w ON w.id = ga."workspaceId"
+     WHERE ga."groupId" IN (:groupIds) AND c.status <> 'draft'
+       AND NOT EXISTS (
+         SELECT 1 FROM agent_configurations newer
+         WHERE newer."agentId" = c."agentId" AND newer."workspaceId" = c."workspaceId"
+           AND newer.status <> 'draft' AND newer.version > c.version
+       )`,
+    { replacements: { groupIds }, type: QueryTypes.SELECT }
+  );
+}
+
+async function fetchMissingMemberships(
+  auth: Authenticator,
+  sourceGroupModelId: ModelId,
+  targetGroupModelId: ModelId | null,
+  transaction: Transaction
+): Promise<MembershipToCopy[]> {
+  // Only history-bearing users can contribute active rows; no workspace-wide editor comparison.
+  return frontSequelize.query<MembershipToCopy>(
+    `SELECT DISTINCT ON (m."userId", CASE WHEN m."endAt" <= :now THEN m."endAt" END)
+       m.id, m."userId",
+       (m."endAt" IS NULL OR m."endAt" > :now) AS active
+     FROM group_memberships m
+     WHERE m."workspaceId" = :workspaceId AND m."groupId" = :sourceGroupModelId
+       AND m.status = 'active' AND m."startAt" <= :now
+       AND (m."endAt" <= :now OR (
+         EXISTS (SELECT 1 FROM group_memberships history
+           WHERE history."workspaceId" = m."workspaceId" AND history."groupId" = m."groupId"
+             AND history."userId" = m."userId" AND history.status = 'active'
+             AND history."endAt" <= :now)
+         AND EXISTS (SELECT 1 FROM memberships wm
+           WHERE wm."workspaceId" = m."workspaceId" AND wm."userId" = m."userId"
+             AND wm."startAt" <= :now AND (wm."endAt" IS NULL OR wm."endAt" > :now))
+       ))
+       AND NOT EXISTS (SELECT 1 FROM group_memberships target
+         WHERE target."workspaceId" = m."workspaceId" AND target."groupId" = :targetGroupModelId
+           AND target."userId" = m."userId" AND target.status = 'active'
+           AND CASE WHEN m."endAt" <= :now THEN target."endAt" = m."endAt"
+             ELSE target."startAt" <= :now AND (target."endAt" IS NULL OR target."endAt" > :now) END)
+     ORDER BY m."userId", CASE WHEN m."endAt" <= :now THEN m."endAt" END, m."startAt"`,
+    {
+      replacements: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        sourceGroupModelId,
+        targetGroupModelId,
+        now: new Date(),
+      },
+      type: QueryTypes.SELECT,
+      transaction,
+    }
+  );
+}
+
+async function copyMemberships(
+  auth: Authenticator,
+  agentModelId: ModelId,
+  group: GroupResource | null,
+  memberships: MembershipToCopy[],
+  transaction: Transaction
+) {
+  const workspaceId = auth.getNonNullableWorkspace().id;
+  const target =
+    group ??
+    (await GroupResource.makeNew(
+      {
+        workspaceId,
+        kind: "regular_auto",
+        name: `Group for permission editor on agent (${agentModelId})`,
+      },
+      { transaction }
+    ));
+  if (!group) {
+    await GroupPermissionResource.grant(auth, {
+      group: target,
+      resourceType: "agent",
+      resourceId: agentModelId,
+      grantType: "editor",
+      transaction,
+    });
+  }
+  // Copy in SQL to preserve timestamp precision beyond JavaScript's milliseconds.
+  await frontSequelize.query(
+    `INSERT INTO group_memberships ("workspaceId", "groupId", "userId", "startAt", "endAt", status, "createdAt", "updatedAt")
+     SELECT "workspaceId", :groupId, "userId", "startAt", "endAt", status, NOW(), NOW()
+     FROM group_memberships WHERE "workspaceId" = :workspaceId AND id IN (:ids)`,
+    {
+      replacements: {
+        workspaceId,
+        groupId: target.id,
+        ids: memberships.map(({ id }) => id),
+      },
+      transaction,
+    }
+  );
+  const activeUsers = memberships.filter(({ active }) => active);
+  if (activeUsers.length > 0) {
+    invalidateCacheAfterCommit(transaction, async () => {
+      await GroupResource.batchInvalidateGroupIdsCacheForUsers(
+        activeUsers.map(({ userId }) => [
+          {
+            user: { id: userId },
+            workspace: { id: workspaceId },
+          },
+        ])
+      );
+    });
+  }
+}
+
+/**
+ * @cc [owner:philipperolet,label:security] preserve-ended-memberships
+ * Copied ended memberships MUST retain their start and end timestamps.
+ */
+/**
+ * @cc [owner:philipperolet,label:security] repair-current-editors-only
+ * Active grants MUST only be copied for history-bearing users who currently belong to both
+ * the legacy editor group and the workspace.
+ */
+/**
+ * @cc [owner:philipperolet,label:migration] editor-repair-dry-run
+ * Dry runs MUST NOT write data.
+ */
+/**
+ * @cc [owner:philipperolet,label:migration] idempotent-editor-repair
+ * Reruns MUST NOT duplicate existing memberships.
+ */
+async function repairEditorGroup(
+  auth: Authenticator,
+  source: EditorGroup,
+  execute: boolean
+): Promise<Counts> {
+  return withTransaction(async (transaction) => {
+    // Same lock as GroupPermissionResource.getGrantLock, including live grant-group cleanup.
+    const key = `group_permissions:${auth.getNonNullableWorkspace().id}:agent:${source.agentModelId}:editor`;
+    await frontSequelize.query("SELECT pg_advisory_xact_lock(hashtext(:key))", {
+      replacements: { key },
+      transaction,
+    });
+    const group = await GroupPermissionResource.findRegularAutoGroupForGrant(
+      auth,
+      {
+        resourceType: "agent",
+        resourceId: source.agentModelId,
+        grantType: "editor",
+        transaction,
+      }
+    );
+    const missing = await fetchMissingMemberships(
+      auth,
+      source.groupModelId,
+      group?.id ?? null,
+      transaction
+    );
+    const active = missing.filter((membership) => membership.active).length;
+    if (execute && missing.length > 0) {
+      await copyMemberships(
+        auth,
+        source.agentModelId,
+        group,
+        missing,
+        transaction
+      );
+    }
+    return { ended: missing.length - active, active };
+  });
+}
+
+async function repairBatch(editors: EditorGroup[], execute: boolean) {
+  const auths = new Map<string, Authenticator>();
+  for (const workspaceId of new Set(
+    editors.map((editor) => editor.workspaceId)
+  )) {
+    auths.set(
+      workspaceId,
+      await Authenticator.internalAdminForWorkspace(workspaceId)
+    );
+  }
+  return concurrentExecutor(
+    editors,
+    async (editor) => {
+      const auth = auths.get(editor.workspaceId);
+      assert(auth);
+      return repairEditorGroup(auth, editor, execute);
+    },
+    { concurrency: CONCURRENCY }
+  );
+}
+
+export async function repairEditorMemberships({
+  execute,
+  logger,
+  wId,
+  afterGroupId = 0,
+}: {
+  execute: boolean;
+  logger: Logger;
+  wId?: string;
+  afterGroupId?: ModelId;
+}): Promise<Counts> {
+  let cursor = afterGroupId;
+  const totals = { ended: 0, active: 0 };
+  for (;;) {
+    const groups = await fetchHistoryGroups(cursor, wId);
+    if (groups.length === 0) {
+      return totals;
+    }
+    const editors = await fetchEditorGroups(groups.map(({ id }) => id));
+    const counts = await repairBatch(editors, execute);
+    for (const count of counts) {
+      totals.ended += count.ended;
+      totals.active += count.active;
+    }
+    cursor = groups[groups.length - 1].id;
+    logger.info(
+      { execute, afterGroupId: cursor, groups: editors.length, ...totals },
+      "Agent editor repair batch completed"
+    );
+  }
+}
+
+if (process.argv[1]?.endsWith("20260910_repair_agent_editor_memberships.ts")) {
+  makeScript(
+    {
+      wId: { type: "string", description: "Restrict to one workspace" },
+      afterGroupId: {
+        type: "number",
+        default: 0,
+        description: "Resume after a completed batch's group ID",
+      },
+    },
+    async ({ execute, wId, afterGroupId }, logger) => {
+      await repairEditorMemberships({ execute, logger, wId, afterGroupId });
+    }
+  );
+}


### PR DESCRIPTION
## Description

Replaces https://github.com/dust-tt/dust/pull/32180. Follows https://github.com/dust-tt/dust/pull/31825.

The original agent editor backfill skipped users who were revoked when it ran. Their ended memberships are missing from grant-backed groups, so rejoining can restore legacy editor access without restoring the corresponding grants.

This standalone repair selects legacy editor groups with ended memberships and their latest non-draft agent links in one joined query, paginated by group ID in batches of 100. It copies missing history unchanged and repairs missing active memberships only for those same users who have already rejoined and remain legacy editors. It does not iterate over workspaces or reconcile unrelated active editors.


## Risks

Blast radius: Agent editor memberships when manually executing this repair.
Risk: standard

Production query-plan validation is pending renewed gcloud authentication. The existing last-active-editor group cleanup is unchanged.

## Deploy Plan

- Make the updated front migration available.
- Validate the candidate selection plan on the US read replica, then dry-run `migrations/20260910_repair_agent_editor_memberships.ts --wId <workspace>` and inspect the counts.
- After approval, run with `--execute` in each region. Resume with `--afterGroupId` from a completed batch if interrupted.
- Dry-run again to verify no missing ended or active memberships. No production writes were run for this PR.

## Tests

- [x] Revoked user: create a missing grant group without activating access, then restore access on rejoin.
- [x] Already-rejoined user: repair missing active access even when history was already copied.
- [x] Read-only dry runs, idempotent reruns, and unrelated active editors left untouched.
- [x] Version filtering: ignore obsolete-only editor links; newer drafts do not hide eligible history.
- [x] History comparison preserves microsecond precision and copies only the earliest duplicate.
- [x] New repair, original backfill, and group-permission resource suites: 50 tests pass.
