### PR TITLE
[Coding Rules] Keep non-runtime helpers in tests and scripts

### DIFF
--- a/front/lib/api/poke/cloudflare_access.test.ts
+++ b/front/lib/api/poke/cloudflare_access.test.ts
@@ -27,19 +27,16 @@ vi.mock("@app/logger/logger", () => ({
 }));
 
 import {
+  clearCloudflareAccessJwksCacheForTests,
   getCloudflareAccessConfig,
   resolveCloudflareAccessToken,
+  verifyCloudflareAccessJwt,
 } from "./cloudflare_access";
 
-let verifyCloudflareAccessJwt: typeof import("./cloudflare_access").verifyCloudflareAccessJwt;
-
 describe("cloudflare_access", () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks();
-    // Vitest exception to prefer-static-imports: resetModules cannot re-evaluate static imports.
-    // Re-import to clear the cached JWKS between cases without a test-only runtime reset API.
-    vi.resetModules();
-    ({ verifyCloudflareAccessJwt } = await import("./cloudflare_access"));
+    clearCloudflareAccessJwksCacheForTests();
   });
 
   describe("getCloudflareAccessConfig", () => {

--- a/front/lib/api/poke/cloudflare_access.test.ts
+++ b/front/lib/api/poke/cloudflare_access.test.ts
@@ -36,7 +36,8 @@ let verifyCloudflareAccessJwt: typeof import("./cloudflare_access").verifyCloudf
 describe("cloudflare_access", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
-    // Clear the cached JWKS between cases by loading a fresh module instance.
+    // Vitest exception to prefer-static-imports: resetModules cannot re-evaluate static imports.
+    // Re-import to clear the cached JWKS between cases without a test-only runtime reset API.
     vi.resetModules();
     ({ verifyCloudflareAccessJwt } = await import("./cloudflare_access"));
   });

--- a/front/lib/api/poke/cloudflare_access.test.ts
+++ b/front/lib/api/poke/cloudflare_access.test.ts
@@ -27,16 +27,18 @@ vi.mock("@app/logger/logger", () => ({
 }));
 
 import {
-  clearCloudflareAccessJwksCacheForTests,
   getCloudflareAccessConfig,
   resolveCloudflareAccessToken,
-  verifyCloudflareAccessJwt,
 } from "./cloudflare_access";
 
+let verifyCloudflareAccessJwt: typeof import("./cloudflare_access").verifyCloudflareAccessJwt;
+
 describe("cloudflare_access", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
-    clearCloudflareAccessJwksCacheForTests();
+    // Clear the cached JWKS between cases by loading a fresh module instance.
+    vi.resetModules();
+    ({ verifyCloudflareAccessJwt } = await import("./cloudflare_access"));
   });
 
   describe("getCloudflareAccessConfig", () => {

--- a/front/lib/api/poke/cloudflare_access.ts
+++ b/front/lib/api/poke/cloudflare_access.ts
@@ -159,9 +159,3 @@ export async function getPokeRolesForUserViaCloudflareAccess(
     return [];
   }
 }
-
-/** Test-only helper to clear the cached JWKS between cases. */
-export function clearCloudflareAccessJwksCacheForTests(): void {
-  cachedJwks = null;
-  cachedJwksIssuer = null;
-}

--- a/front/lib/api/poke/cloudflare_access.ts
+++ b/front/lib/api/poke/cloudflare_access.ts
@@ -159,3 +159,15 @@ export async function getPokeRolesForUserViaCloudflareAccess(
     return [];
   }
 }
+
+/**
+ * @cc [owner:philipperolet,label:testing] jwks-cache-test-reset
+ * Test-only helper to clear the cached JWKS between cases.
+ * Exception to `non-runtime-code-stays-local`: resetting this private module state here keeps
+ * tests isolated with static imports, without `vi.resetModules()` and dynamic re-imports.
+ * This helper must only be called from tests.
+ */
+export function clearCloudflareAccessJwksCacheForTests(): void {
+  cachedJwks = null;
+  cachedJwksIssuer = null;
+}

--- a/front/lib/resources/agent_mcp_action/output_storage.ts
+++ b/front/lib/resources/agent_mcp_action/output_storage.ts
@@ -121,23 +121,6 @@ export async function batchWriteContentsToGcs(
 }
 
 /**
- * Rewrites existing output items at deterministic paths so backfill retries are idempotent.
- */
-export async function batchRewriteContentsToGcs(
-  auth: Authenticator,
-  action: AgentMCPActionResource,
-  items: Array<{ itemId: ModelId; content: OutputContent }>
-): Promise<Result<string[], Error>> {
-  return batchWriteContentsToGcsAtPaths(
-    action,
-    items.map(({ itemId, content }) => ({
-      content,
-      gcsPath: getGcsPath(auth, action, itemId.toString()),
-    }))
-  );
-}
-
-/**
  * Fetches content from GCS. Throws on failure (cacheWithRedis propagates the error).
  */
 // itemId is unused in the fetch logic but passed to populate the cache key.

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -1604,14 +1604,6 @@ export class FileResource extends BaseResource<FileModel> {
     return result;
   }
 
-  /**
-   * Public entry point to trigger mount path resolution. Idempotent — no-ops when a path is
-   * already set or when the file's use case isn't mount-eligible. Used by backfill scripts.
-   */
-  async ensureMountFilePath(auth: Authenticator): Promise<void> {
-    await this.resolveAndSetMountFilePath(auth);
-  }
-
   // Mount file path logic.
   //
   // Files used in conversations or Pods are copied to a gcsfuse-mountable GCS path so

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -484,33 +484,6 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     }>;
   }
 
-  /**
-   * DANGEROUS: Lists triggers across workspaces for maintenance scripts.
-   * Should only be used in scripts, never in API routes or lib/api.
-   */
-  static async listAllForScript(options?: {
-    workspaceId?: ModelId;
-    status?: TriggerStatus;
-  }): Promise<TriggerResource[]> {
-    const where: {
-      workspaceId?: ModelId;
-      status?: TriggerStatus;
-    } = {};
-
-    if (options?.workspaceId) {
-      where.workspaceId = options.workspaceId;
-    }
-    if (options?.status) {
-      where.status = options.status;
-    }
-
-    const res = await this.model.findAll({
-      where,
-    });
-
-    return res.map((c) => new this(this.model, c.get()));
-  }
-
   static async update(
     auth: Authenticator,
     sId: string,

--- a/front/scripts/backfill_frame_mount_paths.ts
+++ b/front/scripts/backfill_frame_mount_paths.ts
@@ -2,6 +2,7 @@ import { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { FileModel } from "@app/lib/resources/storage/models/files";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { ensureMountFilePath } from "@app/scripts/backfill_mount_helpers";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import { frameContentType, frameSlideshowContentType } from "@app/types/files";
@@ -104,7 +105,7 @@ makeScript(
               }
 
               try {
-                await file.ensureMountFilePath(auth);
+                await ensureMountFilePath(auth, file);
                 totalUpdated++;
               } catch (err) {
                 logger.error(

--- a/front/scripts/backfill_mcp_action_output_item_gcs_paths.ts
+++ b/front/scripts/backfill_mcp_action_output_item_gcs_paths.ts
@@ -1,11 +1,16 @@
 import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
-import { batchRewriteContentsToGcs } from "@app/lib/resources/agent_mcp_action/output_storage";
+import {
+  deleteContentsFromGcs,
+  MCP_OUTPUT_ITEMS_PREFIX,
+} from "@app/lib/resources/agent_mcp_action/output_storage";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { concurrentExecutor, withRetry } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { WhereOptions } from "sequelize";
 import { Op } from "sequelize";
@@ -14,6 +19,37 @@ import { makeScript } from "./helpers";
 import { runOnAllWorkspaces } from "./workspace_helpers";
 
 const BATCH_SIZE_DEFAULT = 200;
+
+/**
+ * Rewrites existing output items at deterministic paths so backfill retries are idempotent.
+ */
+async function rewriteContentToGcs(
+  auth: Authenticator,
+  action: AgentMCPActionResource,
+  item: Pick<AgentMCPActionOutputItemModel, "id" | "content">
+): Promise<Result<string, Error>> {
+  const workspace = auth.getNonNullableWorkspace();
+  const gcsPath = `w/${workspace.sId}/${MCP_OUTPUT_ITEMS_PREFIX}/${action.sId}/${item.id}.json`;
+  const result = await withRetry(() =>
+    getPrivateUploadBucket()
+      .file(gcsPath)
+      .save(Buffer.from(JSON.stringify(item.content), "utf-8"), {
+        contentType: "application/json",
+      })
+  );
+  if (result.isErr()) {
+    // A failed save may still have persisted its object before returning an error.
+    const cleanupResult = await deleteContentsFromGcs([gcsPath]);
+    if (cleanupResult.isErr()) {
+      logger.error(
+        { err: cleanupResult.error, actionId: action.sId },
+        "Failed to clean up partially written MCP output items"
+      );
+    }
+    return result;
+  }
+  return new Ok(gcsPath);
+}
 
 // New paths live under `w/<workspaceId>/...`. Anything else (`mcp_output_items/...`
 // or NULL) needs to be migrated.
@@ -144,11 +180,7 @@ makeScript(
               // Re-write content from DB to the new GCS path. The DB column is NOT NULL during the
               // migration period, so it's available even for items that already have a
               // (legacy-prefix) GCS object.
-              const writeResult = await batchRewriteContentsToGcs(
-                auth,
-                action,
-                [{ itemId: item.id, content: item.content }]
-              );
+              const writeResult = await rewriteContentToGcs(auth, action, item);
               if (writeResult.isErr()) {
                 scriptLogger.error(
                   {
@@ -162,18 +194,8 @@ makeScript(
                 return;
               }
 
-              const newPath = writeResult.value[0];
-              if (!newPath) {
-                scriptLogger.error(
-                  { workspaceId: workspaceId, itemId: item.id },
-                  "[Backfill MCP output GCS paths] GCS write returned no path; skipping"
-                );
-                errors += 1;
-                return;
-              }
-
               await AgentMCPActionOutputItemModel.update(
-                { contentGcsPath: newPath },
+                { contentGcsPath: writeResult.value },
                 {
                   where: { id: item.id, workspaceId: workspaceModelId },
                   silent: true,

--- a/front/scripts/backfill_mount_helpers.test.ts
+++ b/front/scripts/backfill_mount_helpers.test.ts
@@ -1,0 +1,106 @@
+import { FileResource } from "@app/lib/resources/file_resource";
+import { FileModel } from "@app/lib/resources/storage/models/files";
+import { ensureMountFilePath } from "@app/scripts/backfill_mount_helpers";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { frameContentType } from "@app/types/files";
+import { disambiguateFileName } from "@app/types/mount_path";
+import { assert, describe, expect, it } from "vitest";
+
+describe("mount path backfills", () => {
+  it.each([
+    {
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: "conv-backfill" },
+      contentType: frameContentType,
+      fileName: "frame.html",
+      relativePath: "conversations/conv-backfill/files/frame.html",
+    },
+    {
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: "pod-backfill" },
+      contentType: "application/pdf",
+      fileName: "report.pdf",
+      relativePath: "pods/pod-backfill/files/report.pdf",
+    },
+  ] as const)("mounts an already-ready $useCase file without changing metadata", async (fixture) => {
+    const { authenticator: auth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const file = await FileFactory.create(auth, null, {
+      ...fixture,
+      fileSize: 100,
+      status: "created",
+    });
+    // Model access creates the historical state: ready, but predating automatic mount resolution.
+    await FileModel.update(
+      { status: "ready" },
+      { where: { id: file.id, workspaceId: workspace.id } }
+    );
+    const legacyFile = await FileResource.fetchById(auth, file.sId);
+    assert(legacyFile);
+    fileStorageMock.setFileContent((path) =>
+      path.endsWith("/processed") ? "processed" : "original"
+    );
+
+    await ensureMountFilePath(auth, legacyFile);
+
+    const mounted = await FileResource.fetchById(auth, file.sId);
+    assert(mounted);
+    expect(mounted.status).toBe("ready");
+    expect(mounted.useCaseMetadata).toEqual(fixture.useCaseMetadata);
+    expect(mounted.mountFilePath).toBe(
+      `w/${workspace.sId}/${fixture.relativePath}`
+    );
+    assert(mounted.mountFilePath);
+    expect(fileStorageMock.getObject(mounted.mountFilePath)).toBe("original");
+    const processedPath = mounted.getProcessedMountFilePath();
+    if (fixture.useCase === "project_context") {
+      assert(processedPath);
+      expect(fileStorageMock.getObject(processedPath)).toBe("processed");
+    } else {
+      expect(processedPath).toBeNull();
+    }
+  });
+
+  it("preserves a colliding file and retries a failed copy at the claimed path", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const desiredPath = `w/${workspace.sId}/conversations/conv-backfill/files/frame.html`;
+    const attributes = {
+      contentType: frameContentType,
+      fileName: "frame.html",
+      fileSize: 100,
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: "conv-backfill" },
+      status: "created",
+    } as const;
+    await FileFactory.create(auth, null, {
+      ...attributes,
+      mountFilePath: desiredPath,
+    });
+    const file = await FileFactory.create(auth, null, attributes);
+    fileStorageMock.setObject(desiredPath, "existing frame");
+    fileStorageMock.setFileContent(() => "backfilled frame");
+    fileStorageMock.setCopyFileFails(() => true);
+
+    await expect(ensureMountFilePath(auth, file)).rejects.toThrow(
+      "Simulated GCS copy failure"
+    );
+    const claimed = await FileResource.fetchById(auth, file.sId);
+    assert(claimed);
+    expect(claimed.mountFilePath).toBe(
+      `w/${workspace.sId}/conversations/conv-backfill/files/${disambiguateFileName(file)}`
+    );
+    fileStorageMock.setCopyFileFails(() => false);
+    await ensureMountFilePath(auth, claimed);
+
+    assert(claimed.mountFilePath);
+    expect(fileStorageMock.getObject(claimed.mountFilePath)).toBe(
+      "backfilled frame"
+    );
+    expect(fileStorageMock.getObject(desiredPath)).toBe("existing frame");
+  });
+});

--- a/front/scripts/backfill_mount_helpers.ts
+++ b/front/scripts/backfill_mount_helpers.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert";
+import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { FileModel } from "@app/lib/resources/storage/models/files";
+import {
+  isConversationFileUseCase,
+  isSandboxFunctionContentType,
+} from "@app/types/files";
+import {
+  disambiguateFileName,
+  getConversationFilesBasePath,
+  getPodFilesBasePath,
+  getPodSandboxFunctionsBasePath,
+} from "@app/types/mount_path";
+import { Op, UniqueConstraintError } from "sequelize";
+
+function getMountBasePath(
+  auth: Authenticator,
+  file: FileResource
+): string | null {
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+  const { useCase, useCaseMetadata } = file;
+  if (isConversationFileUseCase(useCase) && useCaseMetadata?.conversationId) {
+    return getConversationFilesBasePath({
+      workspaceId,
+      conversationId: useCaseMetadata.conversationId,
+    });
+  }
+  if (useCase === "project_context" && useCaseMetadata?.spaceId) {
+    const scope = { workspaceId, podId: useCaseMetadata.spaceId };
+    return isSandboxFunctionContentType(file.contentType)
+      ? getPodSandboxFunctionsBasePath(scope)
+      : getPodFilesBasePath(scope);
+  }
+  return null;
+}
+
+async function claimMountPath(
+  file: FileResource,
+  mountFilePath: string,
+  fallbackPath: string
+): Promise<FileResource> {
+  const options = {
+    where: { id: file.id, workspaceId: file.workspaceId },
+    returning: true as const,
+  };
+  let rows: FileModel[];
+  try {
+    [, rows] = await FileModel.update({ mountFilePath }, options);
+  } catch (err) {
+    if (
+      !(err instanceof UniqueConstraintError) ||
+      mountFilePath === fallbackPath
+    ) {
+      throw err;
+    }
+    [, rows] = await FileModel.update({ mountFilePath: fallbackPath }, options);
+  }
+  assert(rows[0], "File must exist when claiming its mount path");
+  return new FileResource(FileModel, rows[0].get());
+}
+
+/**
+ * @cc [owner:philipperolet,label:backfill] mount-path-claim-before-copy
+ * Backfills must claim a workspace-unique mount path before copying content, using the file's
+ * sId-disambiguated name on collision. They must not change the file's status or metadata.
+ */
+/**
+ * Backfill entry point for mount path resolution. Reuses an existing path or no-ops when the
+ * file's use case isn't mount-eligible. Copies are retried when a path was already claimed.
+ */
+export async function ensureMountFilePath(
+  auth: Authenticator,
+  file: FileResource
+): Promise<void> {
+  assert(
+    auth.getNonNullableWorkspace().id === file.workspaceId,
+    "Workspace mismatch"
+  );
+  let mountedFile = file;
+  if (!file.mountFilePath) {
+    const basePath = getMountBasePath(auth, file);
+    if (!basePath) {
+      return;
+    }
+    const desiredPath = `${basePath}${file.fileName}`;
+    const fallbackPath = `${basePath}${disambiguateFileName(file)}`;
+    // Uses the unique (workspaceId, mountFilePath) index, also enforcing concurrent claims below.
+    const existing = await FileModel.findOne({
+      attributes: ["id"],
+      where: {
+        workspaceId: file.workspaceId,
+        mountFilePath: desiredPath,
+        id: { [Op.ne]: file.id },
+      },
+    });
+    mountedFile = await claimMountPath(
+      file,
+      existing ? fallbackPath : desiredPath,
+      fallbackPath
+    );
+  }
+
+  assert(
+    mountedFile.mountFilePath,
+    "File must own a mount path before copying"
+  );
+  const bucket = getPrivateUploadBucket();
+  await bucket.copyFile(
+    mountedFile.getCloudStoragePath(auth, "original"),
+    mountedFile.mountFilePath
+  );
+  const processedMountPath = mountedFile.getProcessedMountFilePath();
+  if (processedMountPath) {
+    await bucket.copyFile(
+      mountedFile.getCloudStoragePath(auth, "processed"),
+      processedMountPath
+    );
+  }
+}

--- a/front/scripts/backfill_project_context_mount_paths.ts
+++ b/front/scripts/backfill_project_context_mount_paths.ts
@@ -2,6 +2,7 @@ import { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { FileModel } from "@app/lib/resources/storage/models/files";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { ensureMountFilePath } from "@app/scripts/backfill_mount_helpers";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import { Op } from "sequelize";
@@ -98,7 +99,7 @@ makeScript(
               }
 
               try {
-                await file.ensureMountFilePath(auth);
+                await ensureMountFilePath(auth, file);
                 totalUpdated++;
               } catch (err) {
                 logger.error(

--- a/front/scripts/clear_schedules_disabled_triggers.ts
+++ b/front/scripts/clear_schedules_disabled_triggers.ts
@@ -1,7 +1,8 @@
 import { Authenticator } from "@app/lib/auth";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
-import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import type { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { makeScript } from "@app/scripts/helpers";
+import { listTriggersForMaintenance } from "@app/scripts/trigger_helpers";
 
 /**
  * This script removes temporal workflows for all disabled triggers across all workspaces.
@@ -10,7 +11,7 @@ import { makeScript } from "@app/scripts/helpers";
 
 makeScript({}, async ({ execute }, logger) => {
   // List all disabled triggers.
-  const triggerResources = await TriggerResource.listAllForScript({
+  const triggerResources = await listTriggersForMaintenance({
     status: "disabled",
   });
 

--- a/front/scripts/trigger_helpers.ts
+++ b/front/scripts/trigger_helpers.ts
@@ -1,0 +1,34 @@
+import { TriggerModel } from "@app/lib/models/agent/triggers/triggers";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import type { TriggerStatus } from "@app/types/assistant/triggers";
+import type { ModelId } from "@app/types/shared/model_id";
+
+const TriggerModelWithBypass: ModelStaticWorkspaceAware<TriggerModel> =
+  TriggerModel;
+
+/**
+ * DANGEROUS: Lists triggers across workspaces for maintenance scripts.
+ * Should only be used in scripts, never in API routes or lib/api.
+ */
+export async function listTriggersForMaintenance(options: {
+  workspaceId?: ModelId;
+  status?: TriggerStatus;
+}): Promise<TriggerResource[]> {
+  const where: { workspaceId?: ModelId; status?: TriggerStatus } = {};
+  if (options.workspaceId) {
+    where.workspaceId = options.workspaceId;
+  }
+  if (options.status) {
+    where.status = options.status;
+  }
+  // Workspace-scoped reads use the workspaceId index; all-workspace maintenance scans the table.
+  const triggers = await TriggerModelWithBypass.findAll({
+    where,
+    // WORKSPACE_ISOLATION_BYPASS: Maintenance may intentionally select triggers across workspaces.
+    dangerouslyBypassWorkspaceIsolationSecurity: !where.workspaceId,
+  });
+  return triggers.map(
+    (trigger) => new TriggerResource(TriggerModel, trigger.get())
+  );
+}

--- a/front/scripts/trigger_maintenance.ts
+++ b/front/scripts/trigger_maintenance.ts
@@ -1,9 +1,10 @@
 import { Authenticator } from "@app/lib/auth";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
-import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import type { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { makeScript } from "@app/scripts/helpers";
+import { listTriggersForMaintenance } from "@app/scripts/trigger_helpers";
 
 const OPERATIONS = ["stop", "refresh"] as const;
 type Operation = (typeof OPERATIONS)[number];
@@ -56,7 +57,7 @@ makeScript(
     }
 
     // List all triggers, optionally filtered by workspace.
-    const triggerResources = await TriggerResource.listAllForScript({
+    const triggerResources = await listTriggersForMaintenance({
       workspaceId: wid,
     });
     const activeTriggers = triggerResources.filter(


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/32181 and [spolu's request](https://github.com/dust-tt/dust/pull/32181#issuecomment-5607983244) to fix the existing `non-runtime-code-stays-local` violations identified in [the review](https://github.com/dust-tt/dust/pull/32181#pullrequestreview-5159244036).

Moves three script-only entry points out of runtime modules: cross-workspace trigger listing, the file mount-path backfill wrapper, and the deterministic MCP output rewrite wrapper. Maintenance and backfill logic lives under `front/scripts`.

Retains the Cloudflare JWKS cache-reset helper as a documented, test-only exception: it resets private module state while keeping static imports and avoiding module reloads. The Cloudflare test remains unchanged.

Mount backfills preserve path collision handling, content copies, and file status/metadata without exposing a new Resource API or rewriting metadata to trigger resolution. Other pre-existing violations are intentionally out of scope.

## Risks

Blast radius: trigger maintenance scripts and file/MCP output backfills.
Risk: low. Runtime behavior is unchanged; script-local mount resolution must preserve the existing path and copy semantics.

## Deploy Plan

- Deploy front normally. No migration or maintenance script needs to run for this cleanup.

## Tests

- [x] Cloudflare access tests and existing file, trigger, and MCP action Resource tests.
- [x] Mount backfill regression tests: already-ready conversation/project files, processed copies, filename collisions, and retry after a failed copy.
- [x] 125 tests passed across five test files.
