### PR TITLE
feat(conversation): add "with love from gabriel" under new-conversation greeting

### DIFF
--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -364,6 +364,7 @@ export function ConversationContainerVirtuoso({
                   ))}
                 </h3>
               }
+              description="with love from gabriel"
             />
           </div>
           <div


### PR DESCRIPTION
## Description

I pass `description="with love from gabriel"` to `Page.Header` in `ConversationContainer`, so the empty-state composer shows the subtitle below the new-conversation greeting. Attach a screenshot or GIF of the updated empty state.

## Tests

I tested manually by opening a new conversation with no active conversation and confirming that the subtitle appears below the greeting.

## Risk

Low risk. This is a copy-only front-end change scoped to the empty conversation state. Rollback is a one-line revert.

## Deploy Plan

Deploy front.