### PR TITLE
[front] perf: reduce agent mention count query cost

### DIFF
--- a/front/lib/analytics/agent_message_consumption/documents.ts
+++ b/front/lib/analytics/agent_message_consumption/documents.ts
@@ -39,13 +39,6 @@ export type ConsumptionDocumentsSkipReason =
  * LLM documents receive the remaining model cost. Together, all credit_micro values reconcile to
  * the authoritative message charge.
  */
-/**
- * @cc [owner:aubin-tchoi,label:product] llm-documents-cover-message-counts
- * Every successful nonempty result MUST include an LLM document. All documents in
- * that result MUST share workspace_id, agent_message_id, agent, conversation_id,
- * user, context_origin, and completed_at so distinct message, conversation, and
- * user counts can exclude tool documents without losing coverage.
- */
 export function buildAgentMessageConsumptionAnalyticsDocuments(
   input: AgentMessageConsumptionAnalyticsInput
 ): Result<

--- a/front/lib/analytics/agent_message_consumption/documents.ts
+++ b/front/lib/analytics/agent_message_consumption/documents.ts
@@ -39,6 +39,13 @@ export type ConsumptionDocumentsSkipReason =
  * LLM documents receive the remaining model cost. Together, all credit_micro values reconcile to
  * the authoritative message charge.
  */
+/**
+ * @cc [owner:aubin-tchoi,label:product] llm-documents-cover-message-counts
+ * Every successful nonempty result MUST include an LLM document. All documents in
+ * that result MUST share workspace_id, agent_message_id, agent, conversation_id,
+ * user, context_origin, and completed_at so distinct message, conversation, and
+ * user counts can exclude tool documents without losing coverage.
+ */
 export function buildAgentMessageConsumptionAnalyticsDocuments(
   input: AgentMessageConsumptionAnalyticsInput
 ): Result<

--- a/front/lib/api/assistant/agent_usage.test.ts
+++ b/front/lib/api/assistant/agent_usage.test.ts
@@ -1,5 +1,6 @@
 import { agentMentionsCount } from "@app/lib/api/assistant/agent_usage";
 import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
+import { USER_USAGE_ORIGINS } from "@app/lib/api/programmatic_usage/common";
 import { Ok } from "@app/types/shared/result";
 import { describe, expect, it, vi } from "vitest";
 
@@ -22,18 +23,18 @@ describe("agentMentionsCount", () => {
           by_agent: {
             buckets: [
               {
+                key: "agent-456",
+                doc_count: 12,
+                message_count: { value: 2 },
+                conversation_count: { value: 1 },
+                user_count: { value: 1 },
+              },
+              {
                 key: "agent-123",
                 doc_count: 8,
                 message_count: { value: 5 },
                 conversation_count: { value: 3 },
                 user_count: { value: 2 },
-              },
-              {
-                key: "agent-456",
-                doc_count: 4,
-                message_count: { value: 2 },
-                conversation_count: { value: 1 },
-                user_count: { value: 1 },
               },
             ],
           },
@@ -62,6 +63,8 @@ describe("agentMentionsCount", () => {
         bool: {
           filter: expect.arrayContaining([
             { term: { workspace_id: "workspace-sId" } },
+            { terms: { context_origin: USER_USAGE_ORIGINS } },
+            { term: { consumption_type: "llm" } },
             { exists: { field: "agent.attributed_id" } },
             {
               range: {
@@ -81,14 +84,26 @@ describe("agentMentionsCount", () => {
               order: { message_count: "desc" },
               size: 1000,
             },
-            aggs: expect.objectContaining({
+            aggs: {
               message_count: {
                 cardinality: {
                   field: "agent_message_id",
-                  precision_threshold: 40000,
+                  precision_threshold: 3000,
                 },
               },
-            }),
+              conversation_count: {
+                cardinality: {
+                  field: "conversation_id",
+                  precision_threshold: 3000,
+                },
+              },
+              user_count: {
+                cardinality: {
+                  field: "user.id",
+                  precision_threshold: 3000,
+                },
+              },
+            },
           },
         },
         size: 0,

--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -1,9 +1,8 @@
 import {
-  CARDINALITY_PRECISION_THRESHOLD,
+  AGENT_MESSAGE_ID_FIELD,
   COMPLETED_AT_FIELD,
   CONSUMPTION_DIMENSION_FIELDS,
   CONVERSATION_ID_FIELD,
-  uniqueMessagesCardinalityAgg,
 } from "@app/lib/api/analytics/consumption/scope";
 import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
 import { USER_USAGE_ORIGINS } from "@app/lib/api/programmatic_usage/common";
@@ -23,6 +22,10 @@ import type { RedisClientType } from "redis";
 // Ranking of agents is done over a 30 days period.
 const RANKING_USAGE_DAYS = 30;
 const RANKING_TIMEFRAME_SEC = 60 * 60 * 24 * RANKING_USAGE_DAYS;
+
+// Popularity ranking can use Elasticsearch's default precision instead of the
+// higher precision used by consumption analytics, reducing per-agent memory.
+const RANKING_CARDINALITY_PRECISION_THRESHOLD = 3_000;
 
 const MENTION_COUNT_TTL = 60 * 60 * 24 * 7; // 7 days
 
@@ -161,6 +164,9 @@ export async function agentMentionsCount(
   const filters: estypes.QueryDslQueryContainer[] = [
     { term: { workspace_id: workspaceId } },
     { terms: { context_origin: USER_USAGE_ORIGINS } },
+    // Every indexed message has LLM documents with the same agent, conversation,
+    // and user as its tool documents. Exclude tools, but still dedupe LLM steps.
+    { term: { consumption_type: "llm" } },
     { exists: { field: CONSUMPTION_DIMENSION_FIELDS.agent } },
     {
       range: {
@@ -192,17 +198,22 @@ export async function agentMentionsCount(
           order: { message_count: "desc" },
         },
         aggs: {
-          message_count: uniqueMessagesCardinalityAgg(),
+          message_count: {
+            cardinality: {
+              field: AGENT_MESSAGE_ID_FIELD,
+              precision_threshold: RANKING_CARDINALITY_PRECISION_THRESHOLD,
+            },
+          },
           conversation_count: {
             cardinality: {
               field: CONVERSATION_ID_FIELD,
-              precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+              precision_threshold: RANKING_CARDINALITY_PRECISION_THRESHOLD,
             },
           },
           user_count: {
             cardinality: {
               field: CONSUMPTION_DIMENSION_FIELDS.user,
-              precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+              precision_threshold: RANKING_CARDINALITY_PRECISION_THRESHOLD,
             },
           },
         },


### PR DESCRIPTION
## Description

Counting agent mentions puts heavy load on Elasticsearch (see [monitor](https://dust4ai.slack.com/archives/C05F84CFP0E/p1788980486912309)). Restrict the ranking query to LLM consumption documents and lower its three cardinality aggregations from a precision threshold of 40,000 to Elasticsearch's default of 3,000 (we don't need a perfect precision, and this matches the actual order of magnitude expected), reducing aggregation work and per-agent counter memory.

## Tests

- Updated existing.

## Risk

- Low.

## Deploy Plan

- Deploy front.
