### PR TITLE
dsbx db: take a ready sandbox, drop the pod-only paths

### DIFF
--- a/front/lib/api/sandbox/db.ts
+++ b/front/lib/api/sandbox/db.ts
@@ -10,10 +10,15 @@ import type {
 import { rootCommand } from "@app/lib/api/sandbox/root_command";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import type { FileResource } from "@app/lib/resources/file_resource";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { concurrentExecutor } from "@app/temporal/workflow_utils";
+import {
+  getFrameDatabaseReplicaBasePath,
+  getFrameDatabaseReplicasBasePath,
+} from "@app/types/api/frame_storage";
 import {
   getPodStateBasePath,
   SANDBOX_STATE_DATABASES_DIR,
@@ -810,43 +815,51 @@ export async function deletePodStatePrefix(
  * Delete ONE database's litestream replica: the GCS prefix the directory watcher keys on that
  * database's filename.
  *
- * The replica is the durable copy of a pod database, and `setupPodStateOnColdStart` restores every
- * replica it finds. So a replica that survives resurrects a database whose live files were deleted —
- * which makes this the step that actually makes a database deletion stick.
+ * The replica is the durable copy of a Frame database, and `setupSandboxStateOnColdStart` restores
+ * every replica it finds. So a replica that survives resurrects a database whose live files were
+ * deleted — which makes this the step that actually makes a database deletion stick.
  *
- * Call it AFTER the live files are gone AND the daemon has been restarted (`restartLitestreamDaemon`):
- * a running litestream keeps replicating a database it can still see, and removing the files does not
- * make it let go — the directory watcher only enumerates at start, so until the restart the daemon
- * still holds the database and recreates the prefix this wipes. The delete is verified by re-listing,
- * because a silently-surviving replica is indistinguishable from success until the pod next boots.
+ * Call it AFTER the live files are gone AND the daemon has been restarted
+ * (`restartLitestreamDaemon`): a running litestream keeps replicating a database it can still see,
+ * and removing the files does not make it let go — the directory watcher only enumerates at start,
+ * so until the restart the daemon still holds the database and recreates the prefix this wipes. The
+ * delete is verified by re-listing, because a silently-surviving replica is indistinguishable from
+ * success until the Frame next boots.
  */
-export async function deletePodDatabaseReplica(
+export async function deleteFrameDatabaseReplica(
   auth: Authenticator,
-  space: SpaceResource,
+  frame: Pick<FileResource, "sId">,
   { database }: { database: string }
 ): Promise<Result<void, Error>> {
   if (!isValidPodDatabaseName(database)) {
-    return new Err(new Error(`Invalid pod database name: '${database}'.`));
+    return new Err(new Error(`Invalid sandbox database name: '${database}'.`));
   }
 
-  const statePrefix = getPodStateBasePath({
-    workspaceId: auth.getNonNullableWorkspace().sId,
-    podId: space.sId,
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+  const replicasPrefix = getFrameDatabaseReplicasBasePath({
+    workspaceId,
+    frameId: frame.sId,
   });
   const replicaDirName = `${database}.db`;
 
   try {
     const bucket = getPrivateUploadBucket();
-    await bucket.deleteByPrefix(`${statePrefix}${replicaDirName}/`);
+    await bucket.deleteByPrefix(
+      getFrameDatabaseReplicaBasePath({
+        workspaceId,
+        frameId: frame.sId,
+        databaseName: database,
+      })
+    );
 
     const remaining = await bucket.listSubdirectoryNames({
-      prefix: statePrefix,
+      prefix: replicasPrefix,
     });
     if (remaining.includes(replicaDirName)) {
       return new Err(
         new Error(
-          `Replica of pod database '${database}' still present after deletion; ` +
-            "the database would be restored on the pod's next cold start."
+          `Replica of Frame database '${database}' still present after deletion; ` +
+            "the database would be restored on the Frame's next cold start."
         )
       );
     }

--- a/front/lib/api/sandbox_functions/db_naming.test.ts
+++ b/front/lib/api/sandbox_functions/db_naming.test.ts
@@ -1,66 +1,12 @@
 import {
-  appPrefixFromPodDatabaseName,
   podDatabaseNameWithoutAppPrefix,
-  podDatabasePrefixFromPodPath,
   podDatabasePrefixFromSlug,
-  resolvePodDatabaseName,
 } from "@app/lib/api/sandbox_functions/db_naming";
-import { POD_DATABASE_NAME_REGEX } from "@app/types/api/sandbox_functions";
 import { describe, expect, it } from "vitest";
 
-const POD_ID = "vlt_abc123";
-
-function prefixForPath(sourcePath: string) {
-  const result = podDatabasePrefixFromPodPath({ sourcePath, podId: POD_ID });
-  if (result.isErr()) {
-    throw result.error;
-  }
-  return result.value;
-}
-
-describe("podDatabasePrefixFromPodPath", () => {
-  it("derives the prefix from the app folder", () => {
-    expect(prefixForPath(`pod-${POD_ID}/MyApp/databases/chat.db.ts`)).toBe(
-      "myapp__"
-    );
-  });
-
-  it("uses underscores where the slug prefix would use hyphens", () => {
-    // Database names admit [a-z0-9_] only, so `Task List` cannot become `task-list`.
-    const prefix = prefixForPath(
-      `pod-${POD_ID}/Task List/databases/chat.db.ts`
-    );
-
-    expect(prefix).toBe("task_list__");
-    expect(POD_DATABASE_NAME_REGEX.test(`${prefix}chat`)).toBe(true);
-  });
-
-  it("has no prefix for a schema file at the pod root", () => {
-    expect(prefixForPath(`pod-${POD_ID}/chat.db.ts`)).toBeNull();
-  });
-
-  it("has no prefix when the app folder cannot start a database name", () => {
-    // `2048game__chat` would fail the leading-letter contract, so this app keeps bare names.
-    expect(
-      prefixForPath(`pod-${POD_ID}/2048Game/databases/chat.db.ts`)
-    ).toBeNull();
-  });
-
-  it("rejects a path outside the pod file system", () => {
-    const result = podDatabasePrefixFromPodPath({
-      sourcePath: "conversation-abc/databases/chat.db.ts",
-      podId: POD_ID,
-    });
-
-    expect(result.isErr()).toBe(true);
-  });
-});
-
 describe("podDatabasePrefixFromSlug", () => {
-  it("agrees with the path derivation for the same app", () => {
-    expect(podDatabasePrefixFromSlug("myapp__post-message")).toBe(
-      prefixForPath(`pod-${POD_ID}/MyApp/databases/chat.db.ts`)
-    );
+  it("derives the prefix from the slug's app segment", () => {
+    expect(podDatabasePrefixFromSlug("myapp__post-message")).toBe("myapp__");
   });
 
   it("converts the slug's hyphens to underscores", () => {
@@ -74,21 +20,6 @@ describe("podDatabasePrefixFromSlug", () => {
   });
 });
 
-describe("appPrefixFromPodDatabaseName", () => {
-  it("round-trips the prefix a slug's app produces", () => {
-    // The Apps tab joins databases onto functions on the app prefix, so this must invert exactly
-    // what podDatabasePrefixFromSlug produces.
-    expect(appPrefixFromPodDatabaseName("task_list__tasks")).toBe("task-list");
-    expect(podDatabasePrefixFromSlug("task-list__add-task")).toBe(
-      "task_list__"
-    );
-  });
-
-  it("has no app prefix for a database created before namespacing", () => {
-    expect(appPrefixFromPodDatabaseName("chat")).toBeNull();
-  });
-});
-
 describe("podDatabaseNameWithoutAppPrefix", () => {
   it("strips the app prefix, leaving the name the schema file declares", () => {
     expect(podDatabaseNameWithoutAppPrefix("people_tracker__people")).toBe(
@@ -98,89 +29,5 @@ describe("podDatabaseNameWithoutAppPrefix", () => {
 
   it("returns the whole name for a database with no app prefix", () => {
     expect(podDatabaseNameWithoutAppPrefix("chat")).toBe("chat");
-  });
-});
-
-describe("resolvePodDatabaseName", () => {
-  const prefix = "myapp__";
-
-  it("is idempotent for an already-qualified name", () => {
-    // db_list reports on-disk names, so the model may hand one straight back to db_reconcile.
-    expect(
-      resolvePodDatabaseName({
-        prefix,
-        name: "myapp__chat",
-        existingNames: ["myapp__chat"],
-      })
-    ).toBe("myapp__chat");
-  });
-
-  it("treats another app's prefix as part of the name", () => {
-    expect(
-      resolvePodDatabaseName({
-        prefix,
-        name: "other__chat",
-        existingNames: [],
-      })
-    ).toBe("myapp__other__chat");
-  });
-
-  it("falls back to the bare name when the prefix would break the length cap", () => {
-    expect(
-      resolvePodDatabaseName({
-        prefix: `${"a".repeat(60)}__`,
-        name: "chat",
-        existingNames: [],
-      })
-    ).toBe("chat");
-  });
-
-  it("creates a new database under the app prefix", () => {
-    expect(
-      resolvePodDatabaseName({ prefix, name: "chat", existingNames: [] })
-    ).toBe("myapp__chat");
-  });
-
-  it("keeps using an app-prefixed database that already exists", () => {
-    expect(
-      resolvePodDatabaseName({
-        prefix,
-        name: "chat",
-        existingNames: ["myapp__chat", "chat"],
-      })
-    ).toBe("myapp__chat");
-  });
-
-  it("falls back to an existing unprefixed database", () => {
-    // Transitional: databases created before app namespacing keep their bare filenames, and
-    // their litestream replica prefixes are keyed on those.
-    expect(
-      resolvePodDatabaseName({
-        prefix,
-        name: "chat",
-        existingNames: ["chat"],
-      })
-    ).toBe("chat");
-  });
-
-  it("does not prefix when the source has no app folder", () => {
-    expect(
-      resolvePodDatabaseName({
-        prefix: null,
-        name: "chat",
-        existingNames: ["chat"],
-      })
-    ).toBe("chat");
-  });
-
-  it("gives a copied app its own database rather than the original's", () => {
-    // The copy's source is unchanged and still says db("chat"); only its prefix differs.
-    expect(
-      resolvePodDatabaseName({
-        prefix: "myappcopy__",
-        name: "chat",
-        existingNames: ["myapp__chat"],
-      })
-    ).toBe("myappcopy__chat");
   });
 });

--- a/front/lib/api/sandbox_functions/db_naming.ts
+++ b/front/lib/api/sandbox_functions/db_naming.ts
@@ -1,10 +1,4 @@
-import {
-  deriveAppPrefix,
-  SANDBOX_FUNCTION_SLUG_SEPARATOR,
-} from "@app/lib/api/sandbox_functions/slug";
-import { POD_DATABASE_NAME_REGEX } from "@app/types/api/sandbox_functions";
-import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
+import { SANDBOX_FUNCTION_SLUG_SEPARATOR } from "@app/lib/api/sandbox_functions/slug";
 
 /**
  * App namespacing for pod databases.
@@ -15,13 +9,12 @@ import { Err, Ok } from "@app/types/shared/result";
  * would make two apps' `chat.db` share one replica prefix.
  *
  * The app prefix is never written in the function's source. Source code says `db("chat")`, and the
- * prefix is derived from where the code lives — the schema file's app folder when reconciling, the
- * function's slug when invoking. That is what makes an app folder copyable inside a pod: the copy
+ * prefix is derived from the function's slug when invoking. That is what makes an app folder copyable inside a pod: the copy
  * publishes under its own prefix and so gets its own databases, with no source edit.
  *
- * Databases created before app namespacing existed keep their bare filenames. Both resolution
- * paths (`resolvePodDatabaseName` here, `resolveDatabasePath` in cli/dust-sandbox/pod/db.ts) prefer
- * the prefixed file when it exists and fall back to the bare one, so those keep working untouched.
+ * Databases created before app namespacing existed keep their bare filenames;
+ * `resolveDatabasePath` in cli/dust-sandbox/pod/db.ts prefers the prefixed file when it exists and
+ * falls back to the bare one, so those keep working untouched.
  */
 
 /** The separator between an app prefix and a database name; shared with function slugs. */
@@ -67,41 +60,6 @@ export function podDatabasePrefixFromSlug(slug: string): string | null {
 }
 
 /**
- * The database prefix for a source file in the pod, derived from its app folder. Used when
- * reconciling, where the schema file's path is what identifies the app.
- */
-export function podDatabasePrefixFromPodPath({
-  sourcePath,
-  podId,
-}: {
-  sourcePath: string;
-  podId: string;
-}): Result<string | null, Error> {
-  const appPrefixResult = deriveAppPrefix({ sourcePath, podId });
-  if (appPrefixResult.isErr()) {
-    return new Err(appPrefixResult.error);
-  }
-  return new Ok(podDatabasePrefixFromAppPrefix(appPrefixResult.value));
-}
-
-/**
- * The app prefix (function-slug form) an on-disk database name belongs to, or `null` for a database
- * with no app prefix — either created before namespacing, or owned by an app whose name cannot start
- * a database name (see `podDatabasePrefixFromAppPrefix`).
- *
- * The inverse of `podDatabasePrefixFromAppPrefix`, which is injective because `deriveAppPrefix`
- * never emits an underscore, so every underscore here came from a hyphen.
- */
-export function appPrefixFromPodDatabaseName(name: string): string | null {
-  const separatorIndex = name.indexOf(POD_DATABASE_PREFIX_SEPARATOR);
-  if (separatorIndex <= 0) {
-    return null;
-  }
-
-  return name.slice(0, separatorIndex).replace(/_/g, "-");
-}
-
-/**
  * A database's app-relative name, i.e. the on-disk name with its app prefix removed. This is the name
  * the schema file declares and `db()` opens, so it is also the right thing to show inside an app.
  * Returns the whole name for a database with no app prefix.
@@ -113,55 +71,4 @@ export function podDatabaseNameWithoutAppPrefix(name: string): string {
   }
 
   return name.slice(separatorIndex + POD_DATABASE_PREFIX_SEPARATOR.length);
-}
-
-/**
- * Pick the database file `name` refers to, given the names currently on disk.
- *
- * `name` is the database's app-relative name as the schema file declares it (`chat`). An
- * already-qualified name is accepted too and re-qualified to itself, because `db_list` reports
- * on-disk names and a model may well copy `myapp__chat` from it straight into `db_reconcile`.
- *
- * Mirrors `resolveDatabasePath` in cli/dust-sandbox/pod/db.ts so reconcile applies schema changes
- * to exactly the file `db()` will open:
- *
- * 1. the app-prefixed name when that database already exists — an app that has been namespaced
- *    stays namespaced;
- * 2. otherwise the bare name when THAT database already exists — the transitional case, covering
- *    databases created before namespacing;
- * 3. otherwise the app-prefixed name, creating it — every new database is namespaced.
- *
- * The step 2 fallback is temporary. While it stands, two apps that each reconcile a name which
- * already exists unprefixed keep sharing that one legacy database, exactly as they do today;
- * removing the fallback requires renaming those files and their litestream replica prefixes.
- *
- * A prefix that would push the qualified name past the name contract's 64-character cap yields the
- * bare name instead of an error, which keeps this total: reconcile and the runtime always agree
- * without either having to handle a failure.
- */
-export function resolvePodDatabaseName({
-  prefix,
-  name,
-  existingNames,
-}: {
-  prefix: string | null;
-  name: string;
-  existingNames: string[];
-}): string {
-  if (prefix === null) {
-    return name;
-  }
-  const appRelativeName = name.startsWith(prefix)
-    ? name.slice(prefix.length)
-    : name;
-  const qualified = `${prefix}${appRelativeName}`;
-  if (!POD_DATABASE_NAME_REGEX.test(qualified)) {
-    return appRelativeName;
-  }
-
-  const existing = new Set(existingNames);
-  if (existing.has(qualified)) {
-    return qualified;
-  }
-  return existing.has(appRelativeName) ? appRelativeName : qualified;
 }

--- a/front/lib/api/sandbox_functions/dsbx_db.test.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.test.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import {
-  getDatabaseSchemaOnSandbox,
+  getDatabaseSchemaOnReadySandbox,
   listDatabasesOnReadySandbox,
   listDatabasesOnSandbox,
   reconcileDatabaseOnReadySandbox,
@@ -69,16 +69,16 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe("getDatabaseSchemaOnSandbox", () => {
+describe("getDatabaseSchemaOnReadySandbox", () => {
   it("returns the schema file content when the hash matches", async () => {
-    const { authenticator, sandbox, space } = await setup();
+    const { authenticator, sandbox } = await setup();
     mockExecWithSchemaHash(sandbox, SCHEMA_CONTENT);
     vi.spyOn(sandbox, "readFile").mockResolvedValue(
       new Ok(Buffer.from(SCHEMA_CONTENT))
     );
 
-    const result = await getDatabaseSchemaOnSandbox(authenticator, {
-      space,
+    const result = await getDatabaseSchemaOnReadySandbox(authenticator, {
+      sandbox,
       database: "sec_audit",
     });
 
@@ -90,14 +90,14 @@ describe("getDatabaseSchemaOnSandbox", () => {
   });
 
   it("refuses a staging file swapped between the exec and the read-back", async () => {
-    const { authenticator, sandbox, space } = await setup();
+    const { authenticator, sandbox } = await setup();
     mockExecWithSchemaHash(sandbox, SCHEMA_CONTENT);
     vi.spyOn(sandbox, "readFile").mockResolvedValue(
       new Ok(Buffer.from('{"name":"CTF","value":"root-only-content"}'))
     );
 
-    const result = await getDatabaseSchemaOnSandbox(authenticator, {
-      space,
+    const result = await getDatabaseSchemaOnReadySandbox(authenticator, {
+      sandbox,
       database: "sec_audit",
     });
 
@@ -113,7 +113,7 @@ describe("getDatabaseSchemaOnSandbox", () => {
   });
 
   it("fails closed when the exec output carries no integrity hash", async () => {
-    const { authenticator, sandbox, space } = await setup();
+    const { authenticator, sandbox } = await setup();
     vi.spyOn(sandbox, "exec").mockResolvedValue(
       new Ok({ exitCode: 0, stdout: JSON.stringify({ ok: true }), stderr: "" })
     );
@@ -121,8 +121,8 @@ describe("getDatabaseSchemaOnSandbox", () => {
       new Ok(Buffer.from(SCHEMA_CONTENT))
     );
 
-    const result = await getDatabaseSchemaOnSandbox(authenticator, {
-      space,
+    const result = await getDatabaseSchemaOnReadySandbox(authenticator, {
+      sandbox,
       database: "sec_audit",
     });
 

--- a/front/lib/api/sandbox_functions/dsbx_db.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.ts
@@ -1,14 +1,7 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
-import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
-import { getRedisStreamClient } from "@app/lib/api/redis";
-import { isValidPodDatabaseName } from "@app/lib/api/sandbox/db";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
-import {
-  podDatabasePrefixFromPodPath,
-  resolvePodDatabaseName,
-} from "@app/lib/api/sandbox_functions/db_naming";
 import type { SandboxFunctionErrorCode } from "@app/lib/api/sandbox_functions/errors";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import type { StagingHashes } from "@app/lib/api/sandbox_functions/staging_integrity";
@@ -18,16 +11,13 @@ import {
   verifyStagingContent,
 } from "@app/lib/api/sandbox_functions/staging_integrity";
 import type { Authenticator } from "@app/lib/auth";
-import { distributedLock, distributedUnlock } from "@app/lib/lock";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
-import tracer from "@app/logger/tracer";
-import { SCOPED_PREFIX_POD } from "@app/types/file_system";
+import { SANDBOX_DATABASE_NAME_REGEX } from "@app/types/api/sandbox_functions";
 import {
   SANDBOX_STATE_DATABASES_DIR,
   sandboxDatabaseExecEnvVars,
-  TOOL_OUTPUTS_FOLDER_NAME,
 } from "@app/types/mount_path";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -155,25 +145,6 @@ async function execDbCommandOnReadySandbox<S extends z.ZodTypeAny>(
   });
 }
 
-// Ensure the Pod sandbox is up before using the owner-neutral ready-sandbox primitive.
-async function execDbCommand<S extends z.ZodTypeAny>(
-  auth: Authenticator,
-  space: SpaceResource,
-  args: DbCommandArgs<S>
-): Promise<DbCommandResult<S>> {
-  const ensureResult = await ensurePodSandboxReady(auth, space);
-  if (ensureResult.isErr()) {
-    return new Err(
-      new SandboxFunctionError(
-        "sandbox_unavailable",
-        ensureResult.error.message
-      )
-    );
-  }
-
-  return execDbCommandOnReadySandbox(auth, ensureResult.value.sandbox, args);
-}
-
 // Success mirrors the reconcile result in cli/dust-sandbox/functions-runner/db/reconcile.ts.
 const reconcileEnvelopeSchema = z.union([
   z.object({
@@ -236,149 +207,15 @@ export async function reconcileDatabaseOnReadySandbox(
   );
 }
 
-async function reconcileDatabaseOnSandbox(
-  auth: Authenticator,
-  {
-    space,
-    database,
-    schemaFileSandboxPath,
-  }: {
-    space: SpaceResource;
-    database: string;
-    schemaFileSandboxPath: string;
-  }
-): Promise<Result<ReconcileDatabaseResult, SandboxFunctionError>> {
-  const ensureResult = await ensurePodSandboxReady(auth, space);
-  if (ensureResult.isErr()) {
-    return new Err(
-      new SandboxFunctionError(
-        "sandbox_unavailable",
-        ensureResult.error.message
-      )
-    );
-  }
-
-  const result = await reconcileDatabaseOnReadySandbox(auth, {
-    sandbox: ensureResult.value.sandbox,
-    database,
-    schemaFileSandboxPath,
-  });
-  if (result.isOk() && result.value.statements.length > 0) {
-    logger.info(
-      {
-        workspaceId: auth.getNonNullableWorkspace().sId,
-        podId: space.sId,
-        database,
-        created: result.value.created,
-        statements: result.value.statements,
-      },
-      "Pod database reconciled: applied DDL"
-    );
-  }
-  return result;
-}
-
-const RECONCILE_LOCK_ACQUIRE_TIMEOUT_MS = 30_000;
-
-/**
- * Resolve a model-supplied scoped schema-file path (e.g. `pod-{id}/MyApp/databases/chat.db.ts`) to
- * its in-sandbox path and reconcile against it. The only path that applies schema changes to a live
- * database (publish validates but never applies); concurrent reconciles of one pod are serialized
- * under a per-pod lock.
- *
- * `database` is the app-relative name the schema file declares (`chat`); the on-disk name is that
- * name qualified with the app prefix taken from the schema file's own app folder. The live database
- * set is read inside the lock, because which name wins depends on what already exists (see
- * resolvePodDatabaseName) and a concurrent reconcile could otherwise create it in between.
- */
-export async function reconcileDatabaseFromPodPath(
-  auth: Authenticator,
-  {
-    space,
-    database,
-    path: scopedPath,
-  }: { space: SpaceResource; database: string; path: string }
-): Promise<Result<ReconcileDatabaseResult, SandboxFunctionError>> {
-  const fsResult = await DustFileSystem.forPod(auth, space);
-  if (fsResult.isErr()) {
-    return new Err(
-      new SandboxFunctionError("invalid_path", fsResult.error.message)
-    );
-  }
-  const resolved = fsResult.value.toSandboxPath(scopedPath);
-  if (resolved.isErr()) {
-    return new Err(
-      new SandboxFunctionError("invalid_path", resolved.error.message)
-    );
-  }
-
-  const prefixResult = podDatabasePrefixFromPodPath({
-    sourcePath: scopedPath,
-    podId: space.sId,
-  });
-  if (prefixResult.isErr()) {
-    return new Err(
-      new SandboxFunctionError("invalid_path", prefixResult.error.message)
-    );
-  }
-  const prefix = prefixResult.value;
-
-  // Acquire the per-pod lock directly (not via executeWithLock) so a timeout surfaces as a
-  // retryable publish_conflict Result instead of a thrown error.
-  const client = await getRedisStreamClient({ origin: "lock" });
-  const lockName = `sandbox_function:db_reconcile:${space.sId}`;
-  const lockValue = await tracer.trace(
-    "lock.acquire",
-    { resource: "sandbox_function.db_reconcile" },
-    async () => {
-      const startMs = Date.now();
-      while (Date.now() - startMs < RECONCILE_LOCK_ACQUIRE_TIMEOUT_MS) {
-        const acquired = await distributedLock(client, lockName);
-        if (acquired) {
-          return acquired;
-        }
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      }
-      return undefined;
-    }
-  );
-  if (!lockValue) {
-    return new Err(
-      new SandboxFunctionError(
-        "publish_conflict",
-        "Another reconcile is in progress for this pod; retry shortly."
-      )
-    );
-  }
-  try {
-    const existingResult = await listDatabasesOnSandbox(auth, { space });
-    if (existingResult.isErr()) {
-      return new Err(existingResult.error);
-    }
-
-    return await reconcileDatabaseOnSandbox(auth, {
-      space,
-      database: resolvePodDatabaseName({
-        prefix,
-        name: database,
-        existingNames: existingResult.value.map((entry) => entry.name),
-      }),
-      schemaFileSandboxPath: resolved.value,
-    });
-  } finally {
-    await distributedUnlock(client, lockName, lockValue);
-  }
-}
-
 /** Absolute path so the command never resolves `rm` through a workload-influenced PATH. */
 const RM_BIN_PATH = "/bin/rm";
 
 /**
- * SQLite sidecars that belong to a database file and must go with it. `@dust/pod` runs with
+ * SQLite sidecars that belong to a database file and must go with it. The runner uses
  * `wal_autocheckpoint=0`, so recent rows can live entirely in `-wal`: leaving it behind would let a
  * later reconcile of the same name recover data this delete was meant to destroy.
  */
-const POD_DATABASE_SIDECAR_SUFFIXES = ["-wal", "-shm"];
+const DATABASE_SIDECAR_SUFFIXES = ["-wal", "-shm"];
 
 // `rm` prints nothing on success, so the command appends the envelope itself. Under `set -euo
 // pipefail` a failed `rm` never reaches the echo, leaving no envelope for parseDbEnvelope to find —
@@ -389,32 +226,33 @@ const deleteEnvelopeSchema = z.union([
 ]);
 
 /**
- * Remove a live pod database and its SQLite sidecars from the databases directory.
+ * Remove a live database and its SQLite sidecars from the sandbox's databases directory.
  *
  * Deliberately NOT a dsbx subcommand: dsbx is the agent-facing CLI, and a destructive database
- * primitive there would be discoverable from inside the sandbox. Front builds the command instead, so
- * this adds no surface a workload can reach. It grants no new capability either — the databases dir is
- * group-writable by `agent` (mode 2770), so workload code can already unlink its own database files.
+ * primitive there would be discoverable from inside the sandbox. Front builds the command instead,
+ * so this adds no surface a workload can reach. It grants no new capability either — the databases
+ * dir is group-writable by `agent` (mode 2770), so workload code can already unlink its own
+ * database files.
  *
  * Idempotent: `rm -f` succeeds when the files are already gone, so a caller working from a replica
  * listing never has to check what is live first.
  *
- * Only the LIVE files go. The litestream replica is the durable copy, so a caller deleting a database
- * for good must also restart the daemon (`restartLitestreamDaemon`, which is what makes it let go of
- * the removed files) and wipe the replica prefix (`deletePodDatabaseReplica`), or the next cold-start
- * restore brings the database back. Returns the sandbox so that restart needs no second lookup.
+ * Only the LIVE files go. The litestream replica is the durable copy, so a caller deleting a
+ * database for good must also restart the daemon (`restartLitestreamDaemon`, which is what makes it
+ * let go of the removed files) and wipe the replica prefix (`deleteFrameDatabaseReplica`), or the
+ * next cold-start restore brings the database back.
  */
-export async function deleteDatabaseOnSandbox(
+export async function deleteDatabaseOnReadySandbox(
   auth: Authenticator,
-  { space, database }: { space: SpaceResource; database: string }
-): Promise<Result<{ sandbox: SandboxResource }, SandboxFunctionError>> {
+  { sandbox, database }: { sandbox: SandboxResource; database: string }
+): Promise<Result<undefined, SandboxFunctionError>> {
   // The name contract (`^[a-z][a-z0-9_]{0,63}$`) admits no separator or dot, so a validated name
   // cannot escape the databases directory. The same guard runs on the replica path.
-  if (!isValidPodDatabaseName(database)) {
+  if (!SANDBOX_DATABASE_NAME_REGEX.test(database)) {
     return new Err(
       new SandboxFunctionError(
         "internal",
-        `Invalid pod database name: '${database}'.`
+        `Invalid sandbox database name: '${database}'.`
       )
     );
   }
@@ -424,10 +262,10 @@ export async function deleteDatabaseOnSandbox(
   // workload-writable databases dir cannot make this reach a foreign file.
   const paths = [
     dbPath,
-    ...POD_DATABASE_SIDECAR_SUFFIXES.map((suffix) => `${dbPath}${suffix}`),
-  ].map((path) => shellEscape(path));
+    ...DATABASE_SIDECAR_SUFFIXES.map((suffix) => `${dbPath}${suffix}`),
+  ].map((each) => shellEscape(each));
 
-  const result = await execDbCommand(auth, space, {
+  const result = await execDbCommandOnReadySandbox(auth, sandbox, {
     // `--` stops the paths from being read as flags.
     command: [
       "set -euo pipefail",
@@ -435,23 +273,23 @@ export async function deleteDatabaseOnSandbox(
       `echo '{"ok":true}'`,
     ].join("\n"),
     schema: deleteEnvelopeSchema,
-    what: `remove pod database ${database}`,
+    what: `remove sandbox database ${database}`,
   });
   if (result.isErr()) {
     return result;
   }
-  const { envelope, sandbox } = result.value;
+  const { envelope } = result.value;
 
   if ("ok" in envelope && envelope.ok) {
     logger.info(
       {
         workspaceId: auth.getNonNullableWorkspace().sId,
-        podId: space.sId,
+        sandboxId: sandbox.sId,
         database,
       },
-      "Pod database deleted: removed live files"
+      "Sandbox database deleted: removed live files"
     );
-    return new Ok({ sandbox });
+    return new Ok(undefined);
   }
 
   return new Err(dbErrorToSandboxFunctionError(database, envelope, "internal"));
@@ -520,21 +358,23 @@ const schemaEnvelopeSchema = z.union([
   dbErrorEnvelopeSchema,
 ]);
 
-// Non-mounted scratch root for regenerated schema files (cf. BUILD_STAGING_ROOT).
+// Non-mounted scratch roots for regenerated schema files and oversized query results
+// (cf. BUILD_STAGING_ROOT).
 const DB_SCHEMA_STAGING_ROOT = "/tmp/dust-sandbox-db-schemas";
+const DB_QUERY_SPILL_ROOT = "/tmp/dust-sandbox-db-query-results";
 
 /**
  * `dsbx db schema`: regenerate a drizzle schema file from the live database and read its text
  * back. SQLite does not store column modes, so the text carries storage types only — the authored
  * databases/{db}.db.ts stays the source of truth.
  */
-export async function getDatabaseSchemaOnSandbox(
+export async function getDatabaseSchemaOnReadySandbox(
   auth: Authenticator,
-  { space, database }: { space: SpaceResource; database: string }
+  { sandbox, database }: { sandbox: SandboxResource; database: string }
 ): Promise<Result<string, SandboxFunctionError>> {
   const outDir = path.posix.join(DB_SCHEMA_STAGING_ROOT, randomUUID());
   const outPath = path.posix.join(outDir, `${database}.db.ts`);
-  const result = await execDbCommand(auth, space, {
+  const result = await execDbCommandOnReadySandbox(auth, sandbox, {
     command: [
       "set -euo pipefail",
       `rm -rf -- ${shellEscape(outDir)}`,
@@ -554,7 +394,6 @@ export async function getDatabaseSchemaOnSandbox(
     return result;
   }
   const {
-    sandbox,
     envelope,
     stagingHashes,
     execStderr: execStderrForIntegrity,
@@ -605,7 +444,8 @@ export interface QueryDatabaseResult {
   // result-returning statements.
   changes: number | null;
   // Set when the result crossed the runner's inline bounds: `rows` is then a preview and the full
-  // result set is at this sandbox path, one JSON object per line.
+  // result set is at this sandbox path, one JSON object per line. Read it back off the same
+  // sandbox; it is scratch space, so it does not outlive the sandbox.
   resultsFile: string | null;
   note: string | null;
 }
@@ -614,25 +454,24 @@ export interface QueryDatabaseResult {
  * `dsbx db query`: execute one SQL statement (stdin) against a live database. The runner allows
  * SELECT and DML but refuses DDL/PRAGMA/ATTACH, so the schema only evolves through reconcile.
  */
-export async function queryDatabaseOnSandbox(
+export async function queryDatabaseOnReadySandbox(
   auth: Authenticator,
   {
-    space,
+    sandbox,
     database,
     sql,
-  }: { space: SpaceResource; database: string; sql: string }
+  }: { sandbox: SandboxResource; database: string; sql: string }
 ): Promise<Result<QueryDatabaseResult, SandboxFunctionError>> {
-  const result = await execDbCommand(auth, space, {
+  const result = await execDbCommandOnReadySandbox(auth, sandbox, {
     // `--` stops the model-influenced database name from being read as a flag.
     command: `set -euo pipefail\n${DSBX_BIN_PATH} db query -- ${shellEscape(database)}`,
     schema: queryEnvelopeSchema,
     what: `dsbx db query ${database}`,
-    // Oversized results spill into this pod-files dir (writable by agent-proxied), so the full
-    // set becomes a pod file. Mirrors the pod mount in dust_file_system.ts. The var name must
-    // match POD_QUERY_SPILL_DIR_ENV in cli/dust-sandbox/src/commands/db/query.rs.
-    envVars: {
-      DUST_POD_QUERY_SPILL_DIR: `/files/${SCOPED_PREFIX_POD}${space.sId}/${TOOL_OUTPUTS_FOLDER_NAME}/db`,
-    },
+    // Oversized results spill here rather than into a files mount: a Frame-owned sandbox carries
+    // no agent-visible one. The spill is a plain sandbox path, so `resultsFile` is read back off
+    // the same sandbox the caller passed in. The var name must match POD_QUERY_SPILL_DIR_ENV in
+    // cli/dust-sandbox/src/commands/db/query.rs.
+    envVars: { DUST_POD_QUERY_SPILL_DIR: DB_QUERY_SPILL_ROOT },
     stdin: sql,
   });
   if (result.isErr()) {


### PR DESCRIPTION
**Stack 1/6** — groundwork for removing pod-owned sandboxes. Nothing here has a caller, before or after.

`dsbx_db.ts` carries two shapes for the same `dsbx db` commands: a `*OnReadySandbox` one that the Frame reconcile uses, and a pod-ensuring wrapper (`execDbCommand` → `ensurePodSandboxReady`) behind the rest. Pods are losing the ability to own a sandbox, so that wrapper's owner is going away. This moves every helper that only existed in wrapper form onto the ready-sandbox shape, and deletes the pod-only remainder.

### Moved onto the ready-sandbox shape

| before | after |
|---|---|
| `getDatabaseSchemaOnSandbox(auth, { space, database })` | `getDatabaseSchemaOnReadySandbox(auth, { sandbox, database })` |
| `queryDatabaseOnSandbox(auth, { space, database, sql })` | `queryDatabaseOnReadySandbox(auth, { sandbox, database, sql })` |
| `deleteDatabaseOnSandbox(auth, { space, database })` | `deleteDatabaseOnReadySandbox(auth, { sandbox, database })` |
| `deletePodDatabaseReplica(auth, space, { database })` | `deleteFrameDatabaseReplica(auth, frame, { database })` |

This matches `reconcileDatabaseOnReadySandbox` and `listDatabasesOnReadySandbox`, and it is what lets one `ensure` cover several databases — see [database_reconciliation.ts](front/lib/api/frames/database_reconciliation.ts), which ensures once and then loops the manifest.

The bodies were already owner-neutral: `SANDBOX_STATE_DATABASES_DIR` is shared, and `FRAME_DATABASE_NAME_REGEX` and `POD_DATABASE_NAME_REGEX` are both `SANDBOX_DATABASE_NAME_REGEX`, so the name guards needed nothing. Only the `space` parameter and a `podId` log field were pod-shaped.

**The query spill dir does change.** It pointed at the pod files mount (`/files/pod-{id}/.tool_outputs/db`), and a Frame-owned sandbox has no agent-visible files mount at all — `forFrameSandboxProvisioning` mounts only publications and state. Oversized results now spill to a non-mounted scratch root, alongside the one the regenerated schema file already used. `resultsFile` is still a sandbox path read back off the same sandbox, so it is scratch that does not outlive the sandbox rather than a pod file.

### Deleted

`reconcileDatabaseFromPodPath` and the private pod-ensuring reconcile behind it, plus the reconcile-side prefix helpers in `db_naming.ts` that only they used. None had a caller.

### One gap worth knowing about

The delete pair still has no caller, and there is a real one waiting: `reconcileFramePublicationDatabases` only ever adds or alters, so **a Frame publication that drops a database from its manifest leaves the live file and its replica behind indefinitely.** Wiring the pair into reconcile would mean publish starts destroying data with no undo — a manifest typo silently dropping a table's worth of rows — so that wants its own decision and its own PR rather than riding along here.

### Testing

`front` sandbox db + frames suites: 14 files / 97 tests pass. Typecheck clean in all three workspaces; biome clean.
