### PR TITLE
fix(front): keep agent picker row actions above the dropdown scrollbar

### DIFF
--- a/front/components/assistant/AgentPicker.tsx
+++ b/front/components/assistant/AgentPicker.tsx
@@ -140,7 +140,7 @@ export function AgentPicker({
                   isSelected ? "bg-primary-100" : ""
                 }`}
                 endComponent={
-                  <div className="z-10 flex items-center gap-1">
+                  <div className="flex items-center gap-1">
                     {isSelected && (
                       // Show a tick by default; on hover swap it for an X to
                       // signal that clicking will deselect the agent.

--- a/front/components/assistant/AgentPicker.tsx
+++ b/front/components/assistant/AgentPicker.tsx
@@ -140,7 +140,7 @@ export function AgentPicker({
                   isSelected ? "bg-primary-100" : ""
                 }`}
                 endComponent={
-                  <div className="flex items-center gap-1">
+                  <div className="z-10 flex items-center gap-1">
                     {isSelected && (
                       // Show a tick by default; on hover swap it for an X to
                       // signal that clicking will deselect the agent.

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -35,7 +35,7 @@ type ItemVariantType = (typeof ITEM_VARIANTS)[number];
 export const menuStyleClasses = {
   inset: "pl-8",
   container: cn(
-    "rounded-xl border-hovering p-1",
+    "rounded-xl border-hovering",
     "border border-border",
     "bg-overlay-background",
     "text-foreground",
@@ -294,7 +294,7 @@ const DropdownMenuSubContent = React.forwardRef<
         {...props}
       >
         {dropdownHeaders && (
-          <div className="sticky top-0 bg-overlay-background">
+          <div className="sticky top-0 bg-overlay-background px-1 pt-1">
             {dropdownHeaders}
           </div>
         )}
@@ -303,7 +303,7 @@ const DropdownMenuSubContent = React.forwardRef<
           hideScrollBar={false}
           orientation="vertical"
           viewportClassName={cn(
-            "flex-1",
+            "flex-1 p-1",
             "max-h-[calc(var(--radix-dropdown-menu-content-available-height)-var(--header-height,20px))]"
           )}
         >
@@ -519,13 +519,18 @@ const DropdownMenuContent = React.forwardRef<
         onCloseAutoFocus={handleCloseAutoFocus}
         {...props}
       >
-        <div className="sticky top-0 bg-overlay-background">
+        <div
+          className={cn(
+            "sticky top-0 bg-overlay-background",
+            dropdownHeaders && "px-1 pt-1"
+          )}
+        >
           {dropdownHeaders && dropdownHeaders}
         </div>
         <ScrollArea
           className="w-full flex-1"
           viewportClassName={cn(
-            "flex-1",
+            "flex-1 p-1",
             "max-h-[calc(var(--radix-dropdown-menu-content-available-height)-var(--header-height,20px))]"
           )}
           viewportRef={viewportRef}


### PR DESCRIPTION
## Description

In the agent picker, the scroll area draws is on top of the "agent details" button and prevent click on a big part of the button. 
Adding a bigger z-index fixes this. 


https://github.com/user-attachments/assets/1429da09-6655-4118-9854-9f6f0fab2675

## Tests

Previewed locally.

## Risk

Low. z-index only

## Deploy Plan

Regular front deploy.
