### PR TITLE
chore(sandbox-reaper): bound authenticator fan-out to the connection pool

### DIFF
--- a/front/temporal/sandbox_reaper/activities.ts
+++ b/front/temporal/sandbox_reaper/activities.ts
@@ -23,6 +23,7 @@ import {
 } from "./config";
 
 const REAPER_CONCURRENCY = 16;
+const REAPER_AUTH_CONCURRENCY = 4;
 
 export type ReaperPhase =
   | "kill_requested"
@@ -77,97 +78,113 @@ type SandboxOwnerMaps = {
   ownersBySandboxModelId: Map<ModelId, ReaperSandboxLifecycleOwner>;
 };
 
-type ReaperAuthMaps = {
-  conversation: Map<ModelId, Authenticator>;
-  frame: Map<ModelId, Authenticator>;
-  pod: Map<ModelId, Authenticator>;
-};
+type ReaperAuthKind = "admin" | "conversation";
+
+const REAPER_AUTH_KINDS = ["admin", "conversation"] satisfies ReaperAuthKind[];
+
+type ReaperAuthMaps = Record<ReaperAuthKind, Map<ModelId, Authenticator>>;
+
+function getAuthKindForOwnerKind(
+  kind: ReaperSandboxLifecycleOwner["kind"]
+): ReaperAuthKind {
+  switch (kind) {
+    case "conversation":
+      return "conversation";
+    case "frame":
+    case "pod":
+      return "admin";
+    default:
+      assertNever(kind);
+  }
+}
+
+function buildAuthenticator(
+  authKind: ReaperAuthKind,
+  workspace: WorkspaceResource
+): Promise<Authenticator> {
+  switch (authKind) {
+    case "admin":
+      return Authenticator.internalAdminForWorkspace(workspace.sId, {
+        dangerouslyRequestAllGroups: true,
+      });
+    case "conversation":
+      return Authenticator.internalUserForWorkspace(workspace.sId);
+    default:
+      assertNever(authKind);
+  }
+}
 
 /**
- * Build workspace-scoped authenticators for each owner kind touched by the
- * batch. Conversation lifecycle calls use a plain user auth (global group
- * only). Pod lifecycle calls need the workspace's project groups so their
- * pre-sleep filesystem flush can access restricted projects.
+ * @cc [owner:adrsimon,label:security] conversation-auth-stays-narrow
+ * Conversation-owned sandboxes MUST be reaped with a plain user authenticator (global group
+ * only). Only frame- and pod-owned sandboxes get an admin authenticator with
+ * `dangerouslyRequestAllGroups`, which the pod pre-sleep filesystem flush needs to reach
+ * restricted projects.
+ */
+/**
+ * @cc [owner:adrsimon,label:performance] bounded-auth-fan-out
+ * Every authenticator build MUST share a single `concurrentExecutor` budget. Each build issues
+ * several queries, so splitting them into one executor per kind under a `Promise.all` multiplies
+ * the real ceiling past `POOL_MAX` and leaves the activity queueing on connection acquisition.
  */
 async function fetchAuthMaps(
   sandboxes: SandboxResource[],
   ownerMaps: SandboxOwnerMaps
 ): Promise<ReaperAuthMaps> {
-  const workspaceModelIdsByOwnerKind = {
+  const workspaceModelIdsByAuthKind: Record<ReaperAuthKind, Set<ModelId>> = {
+    admin: new Set<ModelId>(),
     conversation: new Set<ModelId>(),
-    frame: new Set<ModelId>(),
-    pod: new Set<ModelId>(),
   };
 
   for (const sandbox of sandboxes) {
     const ownerRef = ownerMaps.ownerRefsBySandboxModelId.get(sandbox.id);
     if (ownerRef) {
-      workspaceModelIdsByOwnerKind[ownerRef.kind].add(sandbox.workspaceId);
+      workspaceModelIdsByAuthKind[getAuthKindForOwnerKind(ownerRef.kind)].add(
+        sandbox.workspaceId
+      );
     }
   }
 
   const uniqueWorkspaceModelIds = [
     ...new Set([
-      ...workspaceModelIdsByOwnerKind.conversation,
-      ...workspaceModelIdsByOwnerKind.frame,
-      ...workspaceModelIdsByOwnerKind.pod,
+      ...workspaceModelIdsByAuthKind.admin,
+      ...workspaceModelIdsByAuthKind.conversation,
     ]),
   ];
 
   const workspaces = await WorkspaceResource.fetchByModelIds(
     uniqueWorkspaceModelIds
   );
+  const workspacesByModelId = new Map(
+    workspaces.map((workspace) => [workspace.id, workspace])
+  );
 
-  const [conversationEntries, frameEntries, podEntries] = await Promise.all([
-    concurrentExecutor(
-      workspaces.filter((workspace) =>
-        workspaceModelIdsByOwnerKind.conversation.has(workspace.id)
-      ),
-      async (workspace) => {
-        const authenticator = await Authenticator.internalUserForWorkspace(
-          workspace.sId
-        );
-        return [workspace.id, authenticator] as const;
-      },
-      { concurrency: REAPER_CONCURRENCY }
-    ),
-    concurrentExecutor(
-      workspaces.filter((workspace) =>
-        workspaceModelIdsByOwnerKind.frame.has(workspace.id)
-      ),
-      async (workspace) => {
-        const authenticator = await Authenticator.internalAdminForWorkspace(
-          workspace.sId,
-          {
-            dangerouslyRequestAllGroups: true,
-          }
-        );
-        return [workspace.id, authenticator] as const;
-      },
-      { concurrency: REAPER_CONCURRENCY }
-    ),
-    concurrentExecutor(
-      workspaces.filter((workspace) =>
-        workspaceModelIdsByOwnerKind.pod.has(workspace.id)
-      ),
-      async (workspace) => {
-        const authenticator = await Authenticator.internalAdminForWorkspace(
-          workspace.sId,
-          {
-            dangerouslyRequestAllGroups: true,
-          }
-        );
-        return [workspace.id, authenticator] as const;
-      },
-      { concurrency: REAPER_CONCURRENCY }
-    ),
-  ]);
+  const authRequests = REAPER_AUTH_KINDS.flatMap((authKind) =>
+    [...workspaceModelIdsByAuthKind[authKind]].flatMap((workspaceModelId) => {
+      const workspace = workspacesByModelId.get(workspaceModelId);
+      return workspace ? [{ authKind, workspace }] : [];
+    })
+  );
 
-  return {
-    conversation: new Map(conversationEntries),
-    frame: new Map(frameEntries),
-    pod: new Map(podEntries),
+  const authEntries = await concurrentExecutor(
+    authRequests,
+    async ({ authKind, workspace }) => ({
+      authKind,
+      authenticator: await buildAuthenticator(authKind, workspace),
+      workspaceModelId: workspace.id,
+    }),
+    { concurrency: REAPER_AUTH_CONCURRENCY }
+  );
+
+  const authMaps: ReaperAuthMaps = {
+    admin: new Map(),
+    conversation: new Map(),
   };
+  for (const { authKind, authenticator, workspaceModelId } of authEntries) {
+    authMaps[authKind].set(workspaceModelId, authenticator);
+  }
+
+  return authMaps;
 }
 
 /**
@@ -350,7 +367,7 @@ async function processSandboxes(
     async (sandbox): Promise<ProcessSandboxOutcome> => {
       const owner = ownerMaps.ownersBySandboxModelId.get(sandbox.id);
       const auth = owner
-        ? authMaps[owner.kind].get(sandbox.workspaceId)
+        ? authMaps[getAuthKindForOwnerKind(owner.kind)].get(sandbox.workspaceId)
         : undefined;
 
       if (!auth || !owner) {


### PR DESCRIPTION
## Description

`sandboxReaperWorkflow` peaked at 19 concurrency over the last few days.

A batch holds up to 128 sandboxes spanning as many workspaces. Authenticators were built in three separate executors wrapped in one `Promise.all`, one per owner kind, so the real ceiling was 48 concurrent builds. Each build issues about four queries and has its own nested `Promise.all`. 

Frame and pod requested the same authenticator (`internalAdminForWorkspace` with `dangerouslyRequestAllGroups`), so a workspace with both kinds in one batch built it twice, concurrently.

The three executors are now one over a flat list. `REAPER_CONCURRENCY` stays at 16 for the lifecycle executor so capacity reclamation in the `kill_requested` and `running` phases keeps its current speed.

## Tests

Worth watching `peakConcurrentQueries` for `sandboxReaperWorkflow` after deploy. Expect around 8 for the auth phase, with the lifecycle phase as the new ceiling.

## Risk

Low. 

## Deploy Plan

Deploy front.