### PR TITLE
Only front changelogs credit per-commit authors

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -280,12 +280,13 @@ runs:
 
         echo "📋 Getting commit diff: $CURRENT_TAG → $TARGET_TAG"
 
-        # front-edge changelogs skip per-commit authors, the run initiator is
-        # already named in the start message.
-        if [ "${{ inputs.component }}" = "front-edge" ]; then
-          LOG_FORMAT="%h %s"
-        else
+        # Only front changelogs credit per-commit authors, it is the deploy
+        # where the whole monorepo's work ships. Everywhere else the run
+        # initiator is already named in the start message.
+        if [ "${{ inputs.component }}" = "front" ]; then
           LOG_FORMAT="%h %s (%an)"
+        else
+          LOG_FORMAT="%h %s"
         fi
 
         # Get commits between versions (handle case where CURRENT_TAG might not exist in git)

--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -280,12 +280,20 @@ runs:
 
         echo "📋 Getting commit diff: $CURRENT_TAG → $TARGET_TAG"
 
+        # front-edge changelogs skip per-commit authors, the run initiator is
+        # already named in the start message.
+        if [ "${{ inputs.component }}" = "front-edge" ]; then
+          LOG_FORMAT="%h %s"
+        else
+          LOG_FORMAT="%h %s (%an)"
+        fi
+
         # Get commits between versions (handle case where CURRENT_TAG might not exist in git)
         if git rev-parse --verify "$CURRENT_TAG" >/dev/null 2>&1; then
-          COMMITS_RAW=$(git log --oneline --pretty=format:"%h %s (%an)" $CURRENT_TAG..$TARGET_TAG 2>/dev/null | head -10 || true)
+          COMMITS_RAW=$(git log --oneline --pretty=format:"$LOG_FORMAT" $CURRENT_TAG..$TARGET_TAG 2>/dev/null | head -10 || true)
         else
           echo "Previous tag $CURRENT_TAG not found in git history, showing recent commits"
-          COMMITS_RAW=$(git log --oneline --pretty=format:"%h %s (%an)" -10 $TARGET_TAG 2>/dev/null || true)
+          COMMITS_RAW=$(git log --oneline --pretty=format:"$LOG_FORMAT" -10 $TARGET_TAG 2>/dev/null || true)
         fi
 
         # Store raw commits data


### PR DESCRIPTION
## Description

Every deploy posts a changelog to Slack crediting the author of each commit in the range. That attribution only carries meaning on front deploys: we work in a monorepo and front is where the whole team's work ships, so seeing your name there tells you your commit reached production. On every other component (front-edge, connectors, core, ...) the range is just whatever landed on main since the last run, and the credit reads as if a crowd shipped a deploy none of them started.

The changelog now credits per-commit authors on front only. Everywhere else the commit list stays and the person who triggered the deploy remains named (and mentioned) in the start message. The author names were plain text from git log, not Slack mentions, so nobody was being pinged either way, this is about attribution.

## Tests

None, the change is a format string picked by component in the commit-diff step. The next deploys are the proof.

## Risk

Notification formatting only, nothing in the build or deploy path.

## Deploy Plan

Merge, takes effect on the next deploys.