### PR TITLE
Normalize connector errors and guard Snowflake failures

### DIFF
--- a/connectors/src/api/create_connector.ts
+++ b/connectors/src/api/create_connector.ts
@@ -3,7 +3,6 @@ import type {
   ConnectorManagerError,
   CreateConnectorErrorCode,
 } from "@connectors/connectors/interface";
-import { errorFromAny } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -228,7 +227,8 @@ const _createConnectorAPIHandler = async (
 
     return res.status(200).json(connector.toJSON());
   } catch (e) {
-    logger.error(errorFromAny(e), "Error in createConnectorAPIHandler");
+    const error = normalizeError(e);
+    logger.error(error, "Error in createConnectorAPIHandler");
 
     const errorMessage = `An unexpected error occured while creating the ${req.params.connector_provider} connector`;
 
@@ -242,7 +242,7 @@ const _createConnectorAPIHandler = async (
           message: errorMessage,
         },
       },
-      normalizeError(e)
+      error
     );
   }
 };

--- a/connectors/src/api/pause_connector.ts
+++ b/connectors/src/api/pause_connector.ts
@@ -1,9 +1,9 @@
 import { getConnectorManager } from "@connectors/connectors";
-import { errorFromAny } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { WithConnectorsAPIErrorReponse } from "@connectors/types";
+import { normalizeError } from "@connectors/types";
 import type { Request, Response } from "express";
 
 type ConnectorPauseResBody = WithConnectorsAPIErrorReponse<{
@@ -45,7 +45,7 @@ const _pauseConnectorAPIHandler = async (
 
     return res.sendStatus(204);
   } catch (e) {
-    logger.error(errorFromAny(e), "Failed to pause the connector");
+    logger.error(normalizeError(e), "Failed to pause the connector");
     return apiError(req, res, {
       status_code: 500,
       api_error: {

--- a/connectors/src/api/unpause_connector.ts
+++ b/connectors/src/api/unpause_connector.ts
@@ -1,9 +1,9 @@
 import { getConnectorManager } from "@connectors/connectors";
-import { errorFromAny } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { WithConnectorsAPIErrorReponse } from "@connectors/types";
+import { normalizeError } from "@connectors/types";
 import type { Request, Response } from "express";
 
 type ConnectorUnpauseResBody = WithConnectorsAPIErrorReponse<{
@@ -45,7 +45,7 @@ const _unpauseConnectorAPIHandler = async (
     return res.sendStatus(204);
   } catch (e) {
     logger.error(
-      { error: errorFromAny(e), connectorId: connector?.id },
+      { error: normalizeError(e), connectorId: connector?.id },
       "Failed to unpause the connector"
     );
     return apiError(req, res, {

--- a/connectors/src/connectors/snowflake/temporal/cast_known_errors.test.ts
+++ b/connectors/src/connectors/snowflake/temporal/cast_known_errors.test.ts
@@ -1,4 +1,7 @@
-import { ThirdPartyConfigurationError } from "@connectors/lib/error";
+import {
+  ExternalOAuthTokenError,
+  ThirdPartyConfigurationError,
+} from "@connectors/lib/error";
 import type {
   ActivityExecuteInput,
   ActivityInboundCallsInterceptor,
@@ -9,6 +12,83 @@ import { describe, expect, it, vi } from "vitest";
 import { SnowflakeCastKnownErrorsInterceptor } from "./cast_known_errors";
 
 describe("SnowflakeCastKnownErrorsInterceptor", () => {
+  it.each([
+    { code: "390189", message: "Role not found" },
+    { code: "390186", message: "Role not authorized" },
+    { code: 390189, message: "Role not found" },
+    { code: 390186, message: "Role not authorized" },
+    { message: "Account is suspended" },
+    { message: "User access disabled" },
+    { message: "SQL access control error: insufficient privileges" },
+    { message: "JWT token is invalid" },
+  ])("preserves the original Error for $message ($code)", async (details) => {
+    const error = Object.assign(new Error(details.message), details, {
+      name: "OperationFailedError",
+    });
+    const next = vi.fn(async () => {
+      throw error;
+    }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+
+    await expect(
+      new SnowflakeCastKnownErrorsInterceptor().execute(
+        { args: [], headers: {} },
+        next
+      )
+    ).rejects.toSatisfy(
+      (caught: unknown) =>
+        caught instanceof ExternalOAuthTokenError &&
+        caught.cause === error &&
+        caught.innerError === error
+    );
+  });
+
+  it("normalizes a recognized plain provider payload before wrapping it", async () => {
+    const error = {
+      name: "OperationFailedError",
+      code: "390189",
+      message: "Role not found",
+    };
+    const next = vi.fn(async () => {
+      throw error;
+    }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+
+    await expect(
+      new SnowflakeCastKnownErrorsInterceptor().execute(
+        { args: [], headers: {} },
+        next
+      )
+    ).rejects.toEqual(
+      new ExternalOAuthTokenError(new Error(JSON.stringify(error)))
+    );
+  });
+
+  it.each([
+    null,
+    undefined,
+    "Request failed",
+    42,
+    false,
+    new Error("Unexpected failure"),
+    {},
+    { name: "OperationFailedError" },
+    { name: "OperationFailedError", message: null },
+    { name: "OperationFailedError", message: 42 },
+    { name: "OperationFailedError", message: {} },
+    { name: "OperationFailedError", code: {} },
+    { name: "OperationFailedError", code: "999999", message: "Unknown" },
+  ])("rethrows unrecognized values unchanged: %j", async (error) => {
+    const next = vi.fn(async () => {
+      throw error;
+    }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+
+    await expect(
+      new SnowflakeCastKnownErrorsInterceptor().execute(
+        { args: [], headers: {} },
+        next
+      )
+    ).rejects.toBe(error);
+  });
+
   it("classifies an expired listing trial as a terminal configuration error", async () => {
     const error = Object.assign(
       new Error("Listing trial time limit exceeded"),

--- a/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
@@ -2,6 +2,7 @@ import {
   ExternalOAuthTokenError,
   ThirdPartyConfigurationError,
 } from "@connectors/lib/error";
+import { normalizeError } from "@dust-tt/client";
 import type {
   ActivityExecuteInput,
   ActivityInboundCallsInterceptor,
@@ -74,74 +75,43 @@ function isSnowflakeIncorrectCredentialsError(
   );
 }
 
-interface SnowflakeRoleNotFoundError extends Error {
-  name: "OperationFailedError";
-  data: {
-    errorCode: "390189";
-    nextAction: "RETRY_LOGIN";
-  };
-}
-
-function isSnowflakeRoleNotFoundError(
-  err: unknown
-): err is SnowflakeRoleNotFoundError {
-  const maybeRoleError = err as {
-    name: "OperationFailedError";
-    code: "390189" | "390186";
-  };
+function isSnowflakeRoleNotFoundError(err: unknown): boolean {
   return (
-    "name" in maybeRoleError &&
-    maybeRoleError.name === "OperationFailedError" &&
-    "code" in maybeRoleError &&
-    ["390189", "390186"].includes(`${maybeRoleError.code}`)
+    typeof err === "object" &&
+    err !== null &&
+    "name" in err &&
+    err.name === "OperationFailedError" &&
+    "code" in err &&
+    (typeof err.code === "string" || typeof err.code === "number") &&
+    ["390189", "390186"].includes(`${err.code}`)
   );
 }
 
-interface SnowflakeSuspendedError extends Error {
-  name: "OperationFailedError";
-}
-
-function isSnowflakeSuspendedError(
-  err: unknown
-): err is SnowflakeSuspendedError {
-  const maybeSuspendedError = err as {
-    name: "OperationFailedError";
-    message: string;
-  };
+function isSnowflakeSuspendedError(err: unknown): boolean {
   return (
-    "name" in maybeSuspendedError &&
-    maybeSuspendedError.name === "OperationFailedError" &&
-    "message" in maybeSuspendedError &&
-    maybeSuspendedError.message.includes("suspended")
+    typeof err === "object" &&
+    err !== null &&
+    "name" in err &&
+    err.name === "OperationFailedError" &&
+    "message" in err &&
+    typeof err.message === "string" &&
+    err.message.includes("suspended")
   );
 }
 
-interface SnowflakeUserAccessDisabledError extends Error {
-  name: "OperationFailedError";
-}
-
-function isSnowflakeUserAccessDisabledError(
-  err: unknown
-): err is SnowflakeUserAccessDisabledError {
-  const userDisabledError = err as {
-    name: "OperationFailedError";
-    message: string;
-  };
+function isSnowflakeUserAccessDisabledError(err: unknown): boolean {
   return (
-    "name" in userDisabledError &&
-    userDisabledError.name === "OperationFailedError" &&
-    "message" in userDisabledError &&
-    userDisabledError.message.includes("User access disabled")
+    typeof err === "object" &&
+    err !== null &&
+    "name" in err &&
+    err.name === "OperationFailedError" &&
+    "message" in err &&
+    typeof err.message === "string" &&
+    err.message.includes("User access disabled")
   );
 }
 
-interface SnowflakeInsufficientPrivilegesError extends Error {
-  name: "OperationFailedError";
-}
-
-function isSnowflakeInsufficientPrivilegesError(
-  err: unknown
-): err is SnowflakeInsufficientPrivilegesError {
+function isSnowflakeInsufficientPrivilegesError(err: unknown): boolean {
   return (
     typeof err === "object" &&
     err !== null &&
@@ -153,13 +123,7 @@ function isSnowflakeInsufficientPrivilegesError(
   );
 }
 
-interface SnowflakeInvalidJwtError extends Error {
-  name: "OperationFailedError";
-}
-
-function isSnowflakeInvalidJwtError(
-  err: unknown
-): err is SnowflakeInvalidJwtError {
+function isSnowflakeInvalidJwtError(err: unknown): boolean {
   return (
     typeof err === "object" &&
     err !== null &&
@@ -202,7 +166,7 @@ export class SnowflakeCastKnownErrorsInterceptor
         isSnowflakeInsufficientPrivilegesError(err) ||
         isSnowflakeInvalidJwtError(err)
       ) {
-        throw new ExternalOAuthTokenError(err);
+        throw new ExternalOAuthTokenError(normalizeError(err));
       }
       if (isSnowflakeListingTrialExpiredError(err)) {
         throw new ThirdPartyConfigurationError(err);

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -1,15 +1,4 @@
-// JS cannot give you any guarantee about the shape of an error you `catch`
-
 import type { APIError, ConnectorProvider } from "@dust-tt/client";
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function errorFromAny(e: any): Error {
-  return {
-    name: e.name || "Error",
-    message: e.message || "Unknown error",
-    stack: e.stack || "No stack trace",
-  };
-}
 
 // Generate dynamic error types.
 type ProviderErrorType =

--- a/connectors/src/start.ts
+++ b/connectors/src/start.ts
@@ -6,6 +6,7 @@ import { runGongWorker } from "@connectors/connectors/gong/temporal/worker";
 import { runMicrosoftWorker } from "@connectors/connectors/microsoft/temporal/worker";
 import { runSalesforceWorker } from "@connectors/connectors/salesforce/temporal/worker";
 import { runSnowflakeWorker } from "@connectors/connectors/snowflake/temporal/worker";
+import { normalizeError } from "@connectors/types";
 import minimist from "minimist";
 
 import { initializeDiscordCommands } from "./api/webhooks/discord/startup";
@@ -16,7 +17,6 @@ import { runNotionWorker } from "./connectors/notion/temporal/worker";
 import { runSlackWorker } from "./connectors/slack/temporal/worker";
 import { runWebCrawlerWorker } from "./connectors/webcrawler/temporal/worker";
 import { runZendeskWorkers } from "./connectors/zendesk/temporal/worker";
-import { errorFromAny } from "./lib/error";
 import logger from "./logger/logger";
 
 const argv = minimist(process.argv.slice(2));
@@ -28,50 +28,50 @@ const port = argv.p;
 startServer(port);
 
 runConfluenceWorker().catch((err) =>
-  logger.error(errorFromAny(err), "Error running confluence worker")
+  logger.error(normalizeError(err), "Error running confluence worker")
 );
 runSlackWorker().catch((err) =>
-  logger.error(errorFromAny(err), "Error running slack worker")
+  logger.error(normalizeError(err), "Error running slack worker")
 );
 runNotionWorker().catch((err) =>
-  logger.error(errorFromAny(err), "Error running notion worker")
+  logger.error(normalizeError(err), "Error running notion worker")
 );
 // Disabled on purpose to avoid heavy load on Notion API in dev
 // runNotionGarbageCollectWorker().catch((err) =>
-//   logger.error(errorFromAny(err), "Error running notion gc worker")
+//   logger.error(normalizeError(err), "Error running notion gc worker")
 // );
 runGithubWorker().catch((err) =>
-  logger.error(errorFromAny(err), "Error running github worker")
+  logger.error(normalizeError(err), "Error running github worker")
 );
 runGoogleWorkers().catch((err) =>
-  logger.error(errorFromAny(err), "Error running google worker")
+  logger.error(normalizeError(err), "Error running google worker")
 );
 runIntercomWorker().catch((err) =>
-  logger.error(errorFromAny(err), "Error running intercom worker")
+  logger.error(normalizeError(err), "Error running intercom worker")
 );
 runZendeskWorkers().catch((err) =>
-  logger.error(errorFromAny(err), "Error running zendesk worker")
+  logger.error(normalizeError(err), "Error running zendesk worker")
 );
 runWebCrawlerWorker().catch((err) =>
-  logger.error(errorFromAny(err), "Error running webcrawler worker")
+  logger.error(normalizeError(err), "Error running webcrawler worker")
 );
 runMicrosoftWorker().catch((err) =>
-  logger.error(errorFromAny(err), "Error running microsoft worker")
+  logger.error(normalizeError(err), "Error running microsoft worker")
 );
 runSnowflakeWorker().catch((err) =>
-  logger.error(errorFromAny(err), "Error running snowflake worker")
+  logger.error(normalizeError(err), "Error running snowflake worker")
 );
 runBigQueryWorker().catch((err) =>
-  logger.error(errorFromAny(err), "Error running bigquery worker")
+  logger.error(normalizeError(err), "Error running bigquery worker")
 );
 runSalesforceWorker().catch((err) =>
-  logger.error(errorFromAny(err), "Error running salesforce worker")
+  logger.error(normalizeError(err), "Error running salesforce worker")
 );
 runGongWorker().catch((err) =>
-  logger.error(errorFromAny(err), "Error running gong worker")
+  logger.error(normalizeError(err), "Error running gong worker")
 );
 runDustProjectWorker().catch((err) =>
-  logger.error(errorFromAny(err), "Error running dust project worker")
+  logger.error(normalizeError(err), "Error running dust project worker")
 );
 
 initializeDiscordCommands();

--- a/connectors/src/start_worker.ts
+++ b/connectors/src/start_worker.ts
@@ -3,14 +3,17 @@ import {
   ALL_WORKERS,
   workerFunctions,
 } from "@connectors/temporal/worker_registry";
-import { isDevelopment, setupGlobalErrorHandler } from "@connectors/types";
+import {
+  isDevelopment,
+  normalizeError,
+  setupGlobalErrorHandler,
+} from "@connectors/types";
 import { closeRedisClients } from "@connectors/types/shared/redis_client";
 import type { Logger, LogLevel } from "@temporalio/common/lib/logger";
 import { Runtime } from "@temporalio/worker/lib/runtime";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
-import { errorFromAny } from "./lib/error";
 import logger from "./logger/logger";
 
 setupGlobalErrorHandler(logger);
@@ -48,14 +51,14 @@ async function runWorkers(workers: WorkerName[]) {
       Promise.resolve()
         .then(() => workerFunctions[worker]())
         .catch((err) => {
-          logger.error(errorFromAny(err), `Error running ${worker} worker.`);
+          logger.error(normalizeError(err), `Error running ${worker} worker.`);
         })
     );
 
     // Wait for all workers to complete
     await Promise.all(promises);
   } catch (e) {
-    logger.error(errorFromAny(e), "Unexpected error during worker startup.");
+    logger.error(normalizeError(e), "Unexpected error during worker startup.");
   }
 
   // Shutdown Temporal native runtime *once*
@@ -83,6 +86,6 @@ yargs(hideBin(process.argv))
   .parseAsync()
   .then(async (args) => runWorkers(args.workers as WorkerName[]))
   .catch((err) => {
-    logger.error(errorFromAny(err), "Error running workers");
+    logger.error(normalizeError(err), "Error running workers");
     process.exit(1);
   });


### PR DESCRIPTION
## Description

Replace all 20 `errorFromAny` call sites with `normalizeError` and delete the helper, which could fail on null or undefined and returned a plain object instead of an `Error`.

Validate Snowflake error fields before inspecting them. Preserve recognized provider failures, normalize plain payloads before wrapping them, and rethrow unrecognized values unchanged instead of masking them with a `TypeError`. This fixes three more guard candidates from the `normalize-caught-errors` inventory.

## Tests

23 Snowflake interceptor cases pass with an isolated Vitest configuration, without database setup. Nine regression cases failed before the fix. Coverage includes numeric/string role codes, recognized errors, plain provider payloads, and malformed or primitive thrown values.

## Risk

Low. 

## Deploy Plan

- Deploy `connectors`.
