### PR TITLE
feat(microsoft): sync SharePoint lists as tables

### DIFF
--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -10,6 +10,7 @@ import {
 import {
   getDriveAsContentNode,
   getFolderAsContentNode,
+  getListAsContentNode,
   getMicrosoftNodeAsContentNode,
   getSiteAsContentNode,
 } from "@connectors/connectors/microsoft/lib/content_nodes";
@@ -18,6 +19,7 @@ import {
   getAllPaginatedEntities,
   getDrives,
   getFilesAndFolders,
+  getLists,
   getSites,
   getSubSites,
 } from "@connectors/connectors/microsoft/lib/graph_api";
@@ -433,9 +435,17 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
           const drives = await getAllPaginatedEntities((nextLink) =>
             getDrives(logger, client, parentInternalId, nextLink)
           );
+          const lists = await getAllPaginatedEntities((nextLink) =>
+            getLists(logger, client, parentInternalId, nextLink)
+          );
+          const { itemAPIPath: siteItemAPIPath } =
+            typeAndPathFromInternalId(parentInternalId);
           nodes.push(
             ...subSites.map((n) => getSiteAsContentNode(n, parentInternalId)),
-            ...drives.map((n) => getDriveAsContentNode(n, parentInternalId))
+            ...drives.map((n) => getDriveAsContentNode(n, parentInternalId)),
+            ...lists.map((n) =>
+              getListAsContentNode(n, parentInternalId, siteItemAPIPath)
+            )
           );
           break;
         }
@@ -454,6 +464,7 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
         case "page":
         case "message":
         case "worksheet":
+        case "list":
           throw new Error(
             `Unexpected node type ${nodeType} for retrievePermissions`
           );
@@ -845,7 +856,7 @@ export async function retrieveChildrenNodes(
   microsoftNode: MicrosoftNodeResource,
   expandWorksheet: boolean
 ): Promise<Result<ContentNode[], Error>> {
-  const nodeType: MicrosoftNodeType[] = ["file", "folder", "drive"];
+  const nodeType: MicrosoftNodeType[] = ["file", "folder", "drive", "list"];
   if (expandWorksheet) {
     nodeType.push("worksheet");
   }

--- a/connectors/src/connectors/microsoft/lib/content_nodes.ts
+++ b/connectors/src/connectors/microsoft/lib/content_nodes.ts
@@ -1,6 +1,7 @@
 import {
   getDriveInternalId,
   getDriveItemInternalId,
+  getListInternalId,
   getSiteAPIPath,
 } from "@connectors/connectors/microsoft/lib/graph_api";
 import type { DriveItem } from "@connectors/connectors/microsoft/lib/types";
@@ -8,7 +9,8 @@ import { internalIdFromTypeAndPath } from "@connectors/connectors/microsoft/lib/
 import type { MicrosoftNodeResource } from "@connectors/resources/microsoft_resource";
 import type { ContentNode, ContentNodeType } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
-import type { Drive, Site } from "@microsoft/microsoft-graph-types";
+import { assertNever } from "@dust-tt/client";
+import type { Drive, List, Site } from "@microsoft/microsoft-graph-types";
 
 export function getRootNodes(): ContentNode[] {
   return [getSitesRootAsContentNode()];
@@ -94,26 +96,68 @@ export function getFolderAsContentNode(
   };
 }
 
+export function getListAsContentNode(
+  list: List,
+  parentInternalId: string,
+  siteItemAPIPath: string
+): ContentNode {
+  return {
+    internalId: getListInternalId(list, siteItemAPIPath),
+    parentInternalId,
+    // A SharePoint list is a single structured table (unlike an Excel file which
+    // expands to several worksheets), so it is a directly-selectable leaf.
+    type: "table",
+    title: list.displayName || list.name || "unnamed",
+    sourceUrl: list.webUrl ?? null,
+    lastUpdatedAt: null,
+    expandable: false,
+    permission: "none",
+    mimeType: INTERNAL_MIME_TYPES.MICROSOFT.LIST,
+  };
+}
+
 export function getMicrosoftNodeAsContentNode(
   node: MicrosoftNodeResource,
   expandWorksheet: boolean
 ): ContentNode {
-  // When table picking we want spreadsheets to expand to select the different
-  // sheets. While extracting data we want to treat them as regular files.
+  // A SharePoint list is a single leaf table. Spreadsheets expand into their
+  // worksheets, but only while table-picking; otherwise treat them as files.
   const isExpandable =
-    !node.mimeType ||
-    (node.mimeType ===
-      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" &&
-      expandWorksheet);
+    node.nodeType !== "list" &&
+    (!node.mimeType ||
+      (node.mimeType ===
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" &&
+        expandWorksheet));
   let type: ContentNodeType;
-  if (["drive", "folder"].includes(node.nodeType)) {
-    type = "folder";
-  } else if (node.nodeType === "worksheet") {
-    type = expandWorksheet ? "table" : "document";
-  } else if (node.nodeType === "file") {
-    type = "document";
-  } else {
-    throw new Error(`Unsupported nodeType ${node.nodeType}.`);
+  let mimeType: string;
+  switch (node.nodeType) {
+    case "drive":
+    case "folder":
+      type = "folder";
+      mimeType = INTERNAL_MIME_TYPES.MICROSOFT.FOLDER;
+      break;
+    case "worksheet":
+      type = expandWorksheet ? "table" : "document";
+      mimeType =
+        type === "table"
+          ? INTERNAL_MIME_TYPES.MICROSOFT.SPREADSHEET
+          : node.mimeType || INTERNAL_MIME_TYPES.MICROSOFT.FOLDER;
+      break;
+    case "list":
+      type = "table";
+      mimeType = INTERNAL_MIME_TYPES.MICROSOFT.LIST;
+      break;
+    case "file":
+      type = "document";
+      mimeType = node.mimeType || INTERNAL_MIME_TYPES.MICROSOFT.FOLDER;
+      break;
+    case "sites-root":
+    case "site":
+    case "page":
+    case "message":
+      throw new Error(`Unsupported nodeType ${node.nodeType}.`);
+    default:
+      assertNever(node.nodeType);
   }
 
   return {
@@ -125,11 +169,6 @@ export function getMicrosoftNodeAsContentNode(
     lastUpdatedAt: null,
     expandable: isExpandable,
     permission: "none",
-    mimeType:
-      type === "table"
-        ? INTERNAL_MIME_TYPES.MICROSOFT.SPREADSHEET
-        : type === "folder"
-          ? INTERNAL_MIME_TYPES.MICROSOFT.FOLDER
-          : node.mimeType || INTERNAL_MIME_TYPES.MICROSOFT.FOLDER,
+    mimeType,
   };
 }

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -10,6 +10,7 @@ import {
   DRIVE_ITEM_DELTA_SELECTS,
   DRIVE_ITEM_EXPANDS_AND_SELECTS,
   DRIVE_ITEM_EXPANDS_AND_SELECTS_WITH_LABELS,
+  LIST_ITEM_EXPANDS_AND_SELECTS,
 } from "@connectors/connectors/microsoft/lib/types";
 import {
   internalIdFromTypeAndPath,
@@ -28,6 +29,8 @@ import type {
   Drive,
   Entity,
   ItemReference,
+  List,
+  ListItem,
   Organization,
   Site,
   WorkbookRange,
@@ -151,6 +154,92 @@ export async function getDrives(
   const res = nextLink
     ? await clientApiGet(logger, client, nextLink)
     : await clientApiGet(logger, client, `${parentResourcePath}/drives`);
+
+  if ("@odata.nextLink" in res) {
+    return {
+      results: res.value,
+      nextLink: res["@odata.nextLink"],
+    };
+  }
+
+  return { results: res.value };
+}
+
+// Only user-created custom lists ("genericList") are synced. SharePoint
+// provisions many built-in lists under other templates — document/picture/page
+// libraries, workflow tasks, publishing reports, calendars, etc. — which are
+// noise as structured tables. Structured system templates (events, tasks,
+// issueTracking, ...) can be added here later if customers ask for them.
+const SYNCABLE_LIST_TEMPLATES = new Set(["genericList"]);
+
+/**
+ * Returns whether a SharePoint list should be synced as a structured table.
+ * Hidden lists are internal SharePoint plumbing; everything that is not a
+ * user-created custom list (`genericList`) is excluded (see
+ * SYNCABLE_LIST_TEMPLATES). Document libraries in particular are already synced
+ * as drives.
+ */
+export function isSyncableList(list: List): boolean {
+  const info = list.list;
+  if (!info || info.hidden) {
+    return false;
+  }
+  return !!info.template && SYNCABLE_LIST_TEMPLATES.has(info.template);
+}
+
+export async function getLists(
+  logger: LoggerInterface,
+  client: Client,
+  parentInternalId: string,
+  nextLink?: string
+): Promise<{ results: List[]; nextLink?: string }> {
+  const { nodeType, itemAPIPath: parentResourcePath } =
+    typeAndPathFromInternalId(parentInternalId);
+
+  if (nodeType !== "site") {
+    throw new Error(
+      `Invalid node type: ${nodeType} for getLists, expected site`
+    );
+  }
+
+  const endpoint = `${parentResourcePath}/lists?$select=id,name,displayName,webUrl,createdDateTime,lastModifiedDateTime,list`;
+
+  const res = nextLink
+    ? await clientApiGet(logger, client, nextLink)
+    : await clientApiGet(logger, client, endpoint);
+
+  const lists: List[] = res.value;
+  const results = lists.filter(isSyncableList);
+
+  if ("@odata.nextLink" in res) {
+    return {
+      results,
+      nextLink: res["@odata.nextLink"],
+    };
+  }
+
+  return { results };
+}
+
+export async function getListItems(
+  logger: LoggerInterface,
+  client: Client,
+  listInternalId: string,
+  nextLink?: string
+): Promise<{ results: ListItem[]; nextLink?: string }> {
+  const { nodeType, itemAPIPath } = typeAndPathFromInternalId(listInternalId);
+
+  if (nodeType !== "list") {
+    throw new Error(
+      `Invalid node type: ${nodeType} for getListItems, expected list`
+    );
+  }
+
+  const endpoint = `${itemAPIPath}/items?${LIST_ITEM_EXPANDS_AND_SELECTS}`;
+
+  const res = nextLink
+    ? await clientApiGet(logger, client, nextLink)
+    : await clientApiGet(logger, client, endpoint);
 
   if ("@odata.nextLink" in res) {
     return {
@@ -569,6 +658,16 @@ export function getWorksheetInternalId(
   return internalIdFromTypeAndPath({
     itemAPIPath: `${parentItemApiPath}/workbook/worksheets/${item.id}`,
     nodeType: "worksheet",
+  });
+}
+
+export function getListInternalId(list: List, siteItemAPIPath: string) {
+  if (!list.id) {
+    throw new Error("Unexpected: no id for list");
+  }
+  return internalIdFromTypeAndPath({
+    nodeType: "list",
+    itemAPIPath: `${siteItemAPIPath}/lists/${list.id}`,
   });
 }
 

--- a/connectors/src/connectors/microsoft/lib/types.ts
+++ b/connectors/src/connectors/microsoft/lib/types.ts
@@ -46,6 +46,12 @@ export const DRIVE_ITEM_DELTA_SELECTS =
 export const MICROSOFT_SKIP_REASON_SENSITIVITY_LABEL_NOT_ALLOWED =
   "sensitivity_label_not_allowed" as const;
 
+// SharePoint list items are fetched with their `fields` expanded so we get every
+// custom column value in a single call. Unlike driveItems, list items carry no
+// download URL and no heavy binary payload, so this projection stays lean.
+export const LIST_ITEM_EXPANDS_AND_SELECTS =
+  "$expand=fields&$select=id,webUrl,createdDateTime,lastModifiedDateTime,createdBy,lastModifiedBy";
+
 export const MICROSOFT_NODE_TYPES = [
   "sites-root",
   "site",
@@ -55,6 +61,7 @@ export const MICROSOFT_NODE_TYPES = [
   "page",
   "message",
   "worksheet",
+  "list",
 ] as const;
 export type MicrosoftNodeType = (typeof MICROSOFT_NODE_TYPES)[number];
 

--- a/connectors/src/connectors/microsoft/lib/utils.ts
+++ b/connectors/src/connectors/microsoft/lib/utils.ts
@@ -137,7 +137,7 @@ export async function _getListColumns({
  * Graph API returns objects for taxonomy terms, lookups, and person/group
  * fields — interpolating them directly produces "[object Object]".
  */
-function formatFieldValue(v: unknown): string | null {
+export function formatFieldValue(v: unknown): string | null {
   if (v === null || v === undefined) {
     return null;
   }

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -53,6 +53,10 @@ import {
   // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
 } from "@connectors/connectors/microsoft/temporal/file";
 import {
+  syncOneList,
+  // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
+} from "@connectors/connectors/microsoft/temporal/lists";
+import {
   getMimeTypesToSync,
   resolveMicrosoftMimeType,
 } from "@connectors/connectors/microsoft/temporal/mime_types";
@@ -489,6 +493,58 @@ export async function getRootNodesToSyncFromResources(
   );
 
   return nodeResources.map((r) => r.internalId);
+}
+
+/**
+ * @cc [label:backend;architecture] microsoft-lists-synced-separately
+ * SharePoint lists (nodeType "list") live at the site level, parallel to drives,
+ * and have no `driveId`. They MUST NOT flow through the drive/folder delta
+ * pipeline: `getRootNodesToSync`, `groupRootItemsByDriveId` and `populateDeltas`
+ * only accept drive/folder nodes (`groupRootItemsByDriveId` derives a driveId and
+ * throws otherwise). List roots are therefore enumerated only here and synced as
+ * standalone tables via `syncOneListActivity`.
+ *
+ * Returns the internal ids of the SharePoint lists selected for sync.
+ */
+export async function getListNodesToSync(
+  connectorId: ModelId
+): Promise<string[]> {
+  const rootResources =
+    await MicrosoftRootResource.listRootsByConnectorId(connectorId);
+
+  return rootResources
+    .filter((resource) => resource.nodeType === "list")
+    .map((resource) => resource.internalId);
+}
+
+export async function syncOneListActivity({
+  connectorId,
+  listInternalId,
+  skipIfUnchanged,
+}: {
+  connectorId: ModelId;
+  listInternalId: string;
+  skipIfUnchanged: boolean;
+}): Promise<void> {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    throw new Error(`Connector ${connectorId} not found`);
+  }
+  const logger = getActivityLogger(connector);
+
+  const res = await syncOneList({
+    connectorId,
+    listInternalId,
+    skipIfUnchanged,
+    localLogger: logger.child({ connectorId, listInternalId }),
+    heartbeat,
+  });
+
+  // Report the failure at the activity boundary so Temporal can retry, rather
+  // than returning it as data (see `temporal-activity-failure-boundary`).
+  if (res.isErr()) {
+    throw res.error;
+  }
 }
 
 export async function groupRootItemsByDriveId(nodeIds: string[]) {

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -16,6 +16,10 @@ import {
 } from "@connectors/connectors/microsoft/lib/utils";
 import { isSiteNotFoundError } from "@connectors/connectors/microsoft/temporal/cast_known_errors";
 import {
+  deleteList,
+  // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
+} from "@connectors/connectors/microsoft/temporal/lists";
+import {
   getMimeTypesToSync,
   resolveMicrosoftMimeType,
 } from "@connectors/connectors/microsoft/temporal/mime_types";
@@ -65,6 +69,7 @@ import {
   WithRetriesError,
 } from "@connectors/types";
 import type { Result } from "@dust-tt/client";
+import { assertNever } from "@dust-tt/client";
 import { GraphError } from "@microsoft/microsoft-graph-client";
 import axios from "axios";
 
@@ -903,41 +908,61 @@ export async function recursiveNodeDeletion({
 
   const { nodeType } = typeAndPathFromInternalId(nodeId);
 
-  if (nodeType === "file") {
-    try {
-      await deleteFile({
+  switch (nodeType) {
+    case "file":
+      try {
+        await deleteFile({
+          connectorId,
+          dataSourceConfig,
+          internalId: node.internalId,
+          logger,
+        });
+        deletedFiles.push(node.internalId);
+      } catch (error) {
+        logger.error(
+          { connectorId, nodeId, error },
+          `Failed to delete document ${node.internalId} from core data source`
+        );
+      }
+      break;
+    case "list":
+      await deleteList(dataSourceConfig, connectorId, node.internalId);
+      await node.delete();
+      deletedFiles.push(node.internalId);
+      break;
+    case "folder":
+    case "drive": {
+      const children = await node.fetchChildren();
+      for (const child of children) {
+        const result = await recursiveNodeDeletion({
+          nodeId: child.internalId,
+          connectorId,
+          dataSourceConfig,
+          logger,
+          reason: "recursive_cleanup",
+        });
+        deletedFiles.push(...result);
+      }
+      await deleteFolder({
         connectorId,
         dataSourceConfig,
         internalId: node.internalId,
         logger,
+        reason,
       });
       deletedFiles.push(node.internalId);
-    } catch (error) {
-      logger.error(
-        { connectorId, nodeId, error },
-        `Failed to delete document ${node.internalId} from core data source`
-      );
+      break;
     }
-  } else if (nodeType === "folder" || nodeType === "drive") {
-    const children = await node.fetchChildren();
-    for (const child of children) {
-      const result = await recursiveNodeDeletion({
-        nodeId: child.internalId,
-        connectorId,
-        dataSourceConfig,
-        logger,
-        reason: "recursive_cleanup",
-      });
-      deletedFiles.push(...result);
-    }
-    await deleteFolder({
-      connectorId,
-      dataSourceConfig,
-      internalId: node.internalId,
-      logger,
-      reason,
-    });
-    deletedFiles.push(node.internalId);
+    // Worksheets are deleted with their parent spreadsheet; the remaining node
+    // types are never selected for sync and so never reach deletion.
+    case "worksheet":
+    case "sites-root":
+    case "site":
+    case "page":
+    case "message":
+      break;
+    default:
+      assertNever(nodeType);
   }
 
   return deletedFiles;

--- a/connectors/src/connectors/microsoft/temporal/lists.test.ts
+++ b/connectors/src/connectors/microsoft/temporal/lists.test.ts
@@ -1,0 +1,193 @@
+import { isSyncableList } from "@connectors/connectors/microsoft/lib/graph_api";
+import {
+  isLookupLikeColumn,
+  isTableColumn,
+  listItemsToRows,
+} from "@connectors/connectors/microsoft/temporal/lists";
+import type {
+  ColumnDefinition,
+  FieldValueSet,
+  List,
+  ListItem,
+} from "@microsoft/microsoft-graph-types";
+import { describe, expect, it } from "vitest";
+
+// Graph types model list-item `fields` only as `Entity`, so fixtures go through
+// a factory whose open-fields type keeps the item structurally checked (no cast).
+type OpenFields = FieldValueSet & Record<string, unknown>;
+function makeListItem(fields: OpenFields): ListItem {
+  return { fields };
+}
+
+describe("isSyncableList", () => {
+  const asList = (list: List["list"]): List => ({ list }) as List;
+
+  it("syncs visible user-created custom lists", () => {
+    expect(isSyncableList(asList({ template: "genericList" }))).toBe(true);
+  });
+
+  it("excludes hidden custom lists", () => {
+    expect(
+      isSyncableList(asList({ template: "genericList", hidden: true }))
+    ).toBe(false);
+  });
+
+  it("excludes document, picture and page libraries", () => {
+    expect(isSyncableList(asList({ template: "documentLibrary" }))).toBe(false);
+    expect(isSyncableList(asList({ template: "pictureLibrary" }))).toBe(false);
+    expect(isSyncableList(asList({ template: "webPageLibrary" }))).toBe(false);
+  });
+
+  it("excludes non-generic structured templates for now", () => {
+    expect(isSyncableList(asList({ template: "events" }))).toBe(false);
+    expect(isSyncableList(asList({ template: "tasks" }))).toBe(false);
+  });
+
+  it("excludes lists with no template or list facet", () => {
+    expect(isSyncableList(asList({}))).toBe(false);
+    expect(isSyncableList({} as List)).toBe(false);
+  });
+});
+
+describe("isTableColumn", () => {
+  it("keeps the primary Title field even though it is read-only", () => {
+    expect(isTableColumn({ name: "Title", readOnly: true })).toBe(true);
+  });
+
+  it("keeps author-created data columns", () => {
+    expect(isTableColumn({ name: "Status", displayName: "Status" })).toBe(true);
+  });
+
+  it("drops hidden and read-only columns", () => {
+    expect(isTableColumn({ name: "Secret", hidden: true })).toBe(false);
+    expect(isTableColumn({ name: "Computed", readOnly: true })).toBe(false);
+  });
+
+  it("drops SharePoint system/plumbing columns", () => {
+    expect(isTableColumn({ name: "_UIVersionString" })).toBe(false);
+    expect(isTableColumn({ name: "ContentType" })).toBe(false);
+    expect(isTableColumn({ name: "Attachments" })).toBe(false);
+    expect(isTableColumn({ name: "Custom", columnGroup: "_Hidden" })).toBe(
+      false
+    );
+  });
+
+  it("drops columns without a name", () => {
+    expect(isTableColumn({} as ColumnDefinition)).toBe(false);
+  });
+});
+
+describe("listItemsToRows", () => {
+  const columns: ColumnDefinition[] = [
+    { name: "Title", displayName: "Task" },
+    { name: "Status", displayName: "Status" },
+    { name: "Owner", displayName: "Owner" },
+  ];
+
+  it("emits a header row using display names", () => {
+    const rows = listItemsToRows(columns, []);
+    expect(rows).toEqual([["Task", "Status", "Owner"]]);
+  });
+
+  it("maps each item's fields into ordered cells", () => {
+    const items = [
+      makeListItem({ Title: "Ship it", Status: "Done" }),
+      makeListItem({ Title: "Plan", Status: "Todo" }),
+    ];
+
+    expect(listItemsToRows(columns, items)).toEqual([
+      ["Task", "Status", "Owner"],
+      ["Ship it", "Done", ""],
+      ["Plan", "Todo", ""],
+    ]);
+  });
+
+  it("flattens person and lookup field objects to display strings", () => {
+    const items = [
+      makeListItem({
+        Title: "Review",
+        Owner: { displayName: "Ada Lovelace", email: "ada@example.com" },
+      }),
+    ];
+
+    expect(listItemsToRows(columns, items)).toEqual([
+      ["Task", "Status", "Owner"],
+      ["Review", "", "Ada Lovelace"],
+    ]);
+  });
+
+  it("falls back to an empty cell for missing/null values", () => {
+    const items = [makeListItem({ Title: "Only title", Status: null })];
+
+    expect(listItemsToRows(columns, items)).toEqual([
+      ["Task", "Status", "Owner"],
+      ["Only title", "", ""],
+    ]);
+  });
+});
+
+describe("isLookupLikeColumn", () => {
+  it("detects person/group columns", () => {
+    expect(isLookupLikeColumn({ name: "Owner", personOrGroup: {} })).toBe(true);
+  });
+
+  it("detects lookup columns", () => {
+    expect(isLookupLikeColumn({ name: "Ref", lookup: { listId: "abc" } })).toBe(
+      true
+    );
+  });
+
+  it("treats plain columns as non-lookup", () => {
+    expect(isLookupLikeColumn({ name: "Status" })).toBe(false);
+  });
+});
+
+describe("listItemsToRows with lookup/person resolution", () => {
+  const columns: ColumnDefinition[] = [
+    { name: "Title", displayName: "Task" },
+    { name: "Owner", displayName: "Owner", personOrGroup: {} },
+    { name: "ref", displayName: "Ref", lookup: { listId: "l1" } },
+  ];
+
+  it("resolves person and lookup ids from the `<name>LookupId` field", () => {
+    const items = [
+      makeListItem({ Title: "A", OwnerLookupId: "10", refLookupId: "1" }),
+    ];
+
+    const resolvers = {
+      Owner: { "10": "thomas draier" },
+      ref: { "1": "Reference One" },
+    };
+
+    expect(listItemsToRows(columns, items, resolvers)).toEqual([
+      ["Task", "Owner", "Ref"],
+      ["A", "thomas draier", "Reference One"],
+    ]);
+  });
+
+  it("joins multi-value lookups and falls back to the raw id when unresolved", () => {
+    const items = [
+      makeListItem({
+        Title: "B",
+        OwnerLookupId: ["10", "11"],
+        refLookupId: "99",
+      }),
+    ];
+
+    const resolvers = { Owner: { "10": "Ada", "11": "Grace" } };
+
+    expect(listItemsToRows(columns, items, resolvers)).toEqual([
+      ["Task", "Owner", "Ref"],
+      ["B", "Ada, Grace", "99"],
+    ]);
+  });
+
+  it("emits an empty cell when a lookup id is absent", () => {
+    const items = [makeListItem({ Title: "C" })];
+
+    expect(listItemsToRows(columns, items, {})).toEqual([
+      ["Task", "Owner", "Ref"],
+      ["C", "", ""],
+    ]);
+  });
+});

--- a/connectors/src/connectors/microsoft/temporal/lists.ts
+++ b/connectors/src/connectors/microsoft/temporal/lists.ts
@@ -1,0 +1,494 @@
+// biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
+import { getMicrosoftClient } from "@connectors/connectors/microsoft";
+import {
+  clientApiGet,
+  getAllPaginatedEntities,
+  getItem,
+  getListItems,
+} from "@connectors/connectors/microsoft/lib/graph_api";
+import {
+  formatFieldValue,
+  typeAndPathFromInternalId,
+} from "@connectors/connectors/microsoft/lib/utils";
+import { isItemNotFoundError } from "@connectors/connectors/microsoft/temporal/cast_known_errors";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import {
+  deleteDataSourceTable,
+  upsertDataSourceTableFromCsv,
+} from "@connectors/lib/data_sources";
+import { TablesError } from "@connectors/lib/error";
+import type { Logger } from "@connectors/logger/logger";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { MicrosoftNodeResource } from "@connectors/resources/microsoft_resource";
+import type { DataSourceConfig, ModelId } from "@connectors/types";
+import {
+  cacheWithRedis,
+  INTERNAL_MIME_TYPES,
+  slugify,
+} from "@connectors/types";
+import type { Result } from "@dust-tt/client";
+import { Err, Ok } from "@dust-tt/client";
+import type { Client } from "@microsoft/microsoft-graph-client";
+import type {
+  ColumnDefinition,
+  List,
+  ListItem,
+} from "@microsoft/microsoft-graph-types";
+import { stringify } from "csv-stringify/sync";
+
+// A SharePoint list is turned into a single structured table. Very large lists
+// are skipped to protect the worker's memory and the tables backend, mirroring
+// the Excel worksheet row cap.
+const MAXIMUM_NUMBER_OF_LIST_ITEMS = 50000;
+
+// SharePoint list `columns` include a large amount of internal plumbing. We keep
+// the primary `Title` field plus author-created data columns, and drop the rest.
+const LIST_COLUMN_NOISE = new Set([
+  "ContentType",
+  "Attachments",
+  "Edit",
+  "DocIcon",
+  "LinkTitle",
+  "LinkTitleNoMenu",
+  "LinkTitle2",
+  "ItemChildCount",
+  "FolderChildCount",
+  "AppAuthor",
+  "AppEditor",
+  "ComplianceAssetId",
+  "_UIVersionString",
+]);
+
+export function isTableColumn(column: ColumnDefinition): boolean {
+  if (!column.name) {
+    return false;
+  }
+  // `Title` is the list's primary field and is read-only in the definition, but
+  // it carries the main content, so keep it explicitly.
+  if (column.name === "Title") {
+    return true;
+  }
+  if (column.hidden || column.readOnly) {
+    return false;
+  }
+  if (column.name.startsWith("_")) {
+    return false;
+  }
+  if (column.columnGroup?.startsWith("_")) {
+    return false;
+  }
+  return !LIST_COLUMN_NOISE.has(column.name);
+}
+
+async function getListColumnsForTable(
+  logger: Logger,
+  client: Client,
+  listInternalId: string
+): Promise<ColumnDefinition[]> {
+  const { itemAPIPath } = typeAndPathFromInternalId(listInternalId);
+  const res = await clientApiGet(logger, client, `${itemAPIPath}/columns`);
+  const columns: ColumnDefinition[] = res.value;
+  return columns.filter(isTableColumn);
+}
+
+// Person and Lookup columns only return their numeric id in the item `fields`,
+// under a `<internalName>LookupId` key (e.g. `OwnerLookupId`, `refLookupId`).
+// `LookupResolvers` maps a column's internal name to an id -> display-string map
+// so those ids can be resolved back to human-readable values.
+export type LookupResolvers = Record<string, Record<string, string>>;
+
+export function isLookupLikeColumn(column: ColumnDefinition): boolean {
+  return !!(column.lookup || column.personOrGroup);
+}
+
+// The `<name>LookupId` value is a single id or, for multi-value columns, an
+// array of ids. Normalize both shapes to an array of string ids.
+function normalizeLookupIds(raw: unknown): string[] {
+  if (raw === null || raw === undefined) {
+    return [];
+  }
+  const values = Array.isArray(raw) ? raw : [raw];
+  return values
+    .filter((v) => v !== null && v !== undefined)
+    .map((v) => String(v));
+}
+
+export function listItemsToRows(
+  columns: ColumnDefinition[],
+  items: ListItem[],
+  resolvers: LookupResolvers = {}
+): string[][] {
+  const header = columns.map((c) => c.displayName || c.name || "");
+  const rows: string[][] = [header];
+  for (const item of items) {
+    const fields = (item.fields ?? {}) as Record<string, unknown>;
+    rows.push(
+      columns.map((c) => {
+        if (!c.name) {
+          return "";
+        }
+        if (isLookupLikeColumn(c)) {
+          const ids = normalizeLookupIds(fields[`${c.name}LookupId`]);
+          const idToValue = resolvers[c.name] ?? {};
+          // Fall back to the raw id when a value could not be resolved, so the
+          // reference is never silently dropped.
+          const values = ids
+            .map((id) => idToValue[id] ?? id)
+            .filter((v) => v.length > 0);
+          return values.join(", ");
+        }
+        return formatFieldValue(fields[c.name]) ?? "";
+      })
+    );
+  }
+  return rows;
+}
+
+async function fetchItemsAsMap(
+  logger: Logger,
+  client: Client,
+  itemsEndpoint: string,
+  valueGetter: (fields: Record<string, unknown>) => string | null
+): Promise<Record<string, string>> {
+  const items = await getAllPaginatedEntities<ListItem>(async (nextLink) => {
+    const res = nextLink
+      ? await clientApiGet(logger, client, nextLink)
+      : await clientApiGet(logger, client, itemsEndpoint);
+    const results: ListItem[] = res.value;
+    return {
+      results,
+      nextLink: res["@odata.nextLink"],
+    };
+  });
+
+  const map: Record<string, string> = {};
+  for (const item of items) {
+    if (item.id === null || item.id === undefined) {
+      continue;
+    }
+    const value = valueGetter((item.fields ?? {}) as Record<string, unknown>);
+    if (value !== null) {
+      map[String(item.id)] = value;
+    }
+  }
+  return map;
+}
+
+// The site's hidden "User Information List" maps person/group lookup ids to the
+// actual users. Cached per site for the sync's duration.
+const getUserInfoMap = cacheWithRedis(
+  async ({
+    logger,
+    client,
+    siteAPIPath,
+  }: {
+    logger: Logger;
+    client: Client;
+    siteAPIPath: string;
+  }): Promise<Record<string, string>> => {
+    const listsRes = await clientApiGet(
+      logger,
+      client,
+      `${siteAPIPath}/lists?$select=id,name,displayName,list`
+    );
+    const lists: List[] = listsRes.value;
+    const userList = lists.find(
+      (l) =>
+        l.list?.template === "userInformationList" ||
+        l.displayName === "User Information List" ||
+        l.name === "User Information List"
+    );
+    if (!userList?.id) {
+      logger.warn(
+        { siteAPIPath },
+        "[List] User Information List not found; person columns will show ids."
+      );
+      return {};
+    }
+    return fetchItemsAsMap(
+      logger,
+      client,
+      `${siteAPIPath}/lists/${userList.id}/items?$expand=fields($select=Title,EMail)`,
+      (fields) =>
+        formatFieldValue(fields.Title) ?? formatFieldValue(fields.EMail)
+    );
+  },
+  ({ siteAPIPath }) => `microsoft-userinfo-${siteAPIPath}`,
+  { ttlMs: 10 * 60 * 1000 }
+);
+
+// A lookup column references another list; resolve its ids to the value of the
+// referenced column. Cached per (list, column) for the sync's duration.
+const getLookupMap = cacheWithRedis(
+  async ({
+    logger,
+    client,
+    siteAPIPath,
+    listId,
+    columnName,
+  }: {
+    logger: Logger;
+    client: Client;
+    siteAPIPath: string;
+    listId: string;
+    columnName: string;
+  }): Promise<Record<string, string>> =>
+    fetchItemsAsMap(
+      logger,
+      client,
+      `${siteAPIPath}/lists/${listId}/items?$expand=fields($select=${columnName})`,
+      (fields) => formatFieldValue(fields[columnName])
+    ),
+  ({ siteAPIPath, listId, columnName }) =>
+    `microsoft-lookup-${siteAPIPath}-${listId}-${columnName}`,
+  { ttlMs: 10 * 60 * 1000 }
+);
+
+// Site API path for a list, e.g. "/sites/{siteId}" from the list's item path
+// "/sites/{siteId}/lists/{listId}".
+function siteAPIPathForList(listItemAPIPath: string): string {
+  const marker = "/lists/";
+  const idx = listItemAPIPath.indexOf(marker);
+  return idx === -1 ? listItemAPIPath : listItemAPIPath.slice(0, idx);
+}
+
+async function buildLookupResolvers(
+  logger: Logger,
+  client: Client,
+  listItemAPIPath: string,
+  columns: ColumnDefinition[]
+): Promise<LookupResolvers> {
+  const siteAPIPath = siteAPIPathForList(listItemAPIPath);
+  const resolvers: LookupResolvers = {};
+
+  for (const column of columns) {
+    if (!column.name) {
+      continue;
+    }
+    try {
+      if (column.personOrGroup) {
+        resolvers[column.name] = await getUserInfoMap({
+          logger,
+          client,
+          siteAPIPath,
+        });
+      } else if (column.lookup?.listId && column.lookup.columnName) {
+        resolvers[column.name] = await getLookupMap({
+          logger,
+          client,
+          siteAPIPath,
+          listId: column.lookup.listId,
+          columnName: column.lookup.columnName,
+        });
+      }
+    } catch (err) {
+      // Expected: the referenced list (or user information list) was deleted.
+      // Fall back to raw ids for this column. Any other error (throttling,
+      // transient upstream) must propagate so Temporal can retry.
+      if (!isItemNotFoundError(err)) {
+        throw err;
+      }
+      logger.warn(
+        { column: column.name, error: err },
+        "[List] Referenced list not found; using raw ids for column."
+      );
+    }
+  }
+
+  return resolvers;
+}
+
+async function upsertListTable(
+  connector: ConnectorResource,
+  listInternalId: string,
+  list: List,
+  rows: string[][]
+): Promise<void> {
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const listName = list.displayName || list.name || "Untitled list";
+  const tableName = slugify(listName.substring(0, 32));
+  const tableDescription = `Structured data from the SharePoint list "${listName}".`;
+  const csv = stringify(rows);
+
+  await upsertDataSourceTableFromCsv({
+    dataSourceConfig,
+    tableId: listInternalId,
+    tableName,
+    tableDescription,
+    tableCsv: csv,
+    loggerArgs: {
+      connectorId: connector.id,
+      listId: listInternalId,
+    },
+    truncate: true,
+    // A list is a top-level selectable table: it is its own parent and has no
+    // enclosing folder in the data source.
+    parents: [listInternalId],
+    parentId: null,
+    title: listName,
+    mimeType: INTERNAL_MIME_TYPES.MICROSOFT.LIST,
+    sourceUrl: list.webUrl ?? undefined,
+  });
+}
+
+async function upsertListInDb(
+  connector: ConnectorResource,
+  listInternalId: string,
+  list: List
+): Promise<void> {
+  await MicrosoftNodeResource.upsert({
+    internalId: listInternalId,
+    connectorId: connector.id,
+    lastSeenTs: new Date(),
+    nodeType: "list" as const,
+    name: list.displayName || list.name || "",
+    mimeType: INTERNAL_MIME_TYPES.MICROSOFT.LIST,
+    lastUpsertedTs: new Date(),
+    // Lists are selected as roots; they have no synced parent node.
+    parentInternalId: null,
+    webUrl: list.webUrl ?? null,
+  });
+}
+
+/**
+ * Syncs a single SharePoint list into a Dust table.
+ *
+ * When `skipIfUnchanged` is set (incremental sync), the list is only re-synced
+ * if its `lastModifiedDateTime` is newer than the last time we upserted it.
+ * SharePoint bumps a list's `lastModifiedDateTime` when its items change, which
+ * lets us avoid re-uploading unchanged lists on every incremental pass.
+ */
+export async function syncOneList({
+  connectorId,
+  listInternalId,
+  skipIfUnchanged,
+  localLogger,
+  heartbeat,
+}: {
+  connectorId: ModelId;
+  listInternalId: string;
+  skipIfUnchanged: boolean;
+  localLogger: Logger;
+  heartbeat: () => Promise<void>;
+}): Promise<Result<null, Error>> {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    throw new Error(`Connector with id ${connectorId} not found`);
+  }
+
+  const { nodeType, itemAPIPath } = typeAndPathFromInternalId(listInternalId);
+  if (nodeType !== "list") {
+    return new Err(
+      new Error(`Unexpected node type ${nodeType} for syncOneList`)
+    );
+  }
+
+  const client = await getMicrosoftClient(connector.connectionId);
+
+  const list = await getItem<List>(localLogger, client, itemAPIPath);
+
+  if (skipIfUnchanged) {
+    const existing = await MicrosoftNodeResource.fetchByInternalId(
+      connectorId,
+      listInternalId
+    );
+    // Skip the (full) re-upload when the list has not changed since we last
+    // synced it. SharePoint bumps a list's `lastModifiedDateTime` when its items
+    // change; comparing it against our last upsert time avoids re-uploading
+    // unchanged lists on every incremental pass.
+    const lastModified = list.lastModifiedDateTime
+      ? new Date(list.lastModifiedDateTime).getTime()
+      : null;
+    const lastUpserted = existing?.lastUpsertedTs?.getTime() ?? null;
+    if (
+      lastModified !== null &&
+      lastUpserted !== null &&
+      lastModified <= lastUpserted
+    ) {
+      localLogger.info(
+        { listInternalId },
+        "[List] Skipping unchanged list on incremental sync."
+      );
+      return new Ok(null);
+    }
+  }
+
+  localLogger.info({ listInternalId }, "[List] Syncing SharePoint list.");
+
+  const columns = await getListColumnsForTable(
+    localLogger,
+    client,
+    listInternalId
+  );
+
+  if (columns.length === 0) {
+    localLogger.warn(
+      { listInternalId },
+      "[List] No usable columns found, skipping list."
+    );
+    return new Ok(null);
+  }
+
+  const items = await getAllPaginatedEntities<ListItem>(async (nextLink) => {
+    await heartbeat();
+    return getListItems(localLogger, client, listInternalId, nextLink);
+  });
+
+  if (items.length > MAXIMUM_NUMBER_OF_LIST_ITEMS) {
+    // Deliberate cap, not a failure: skip the list without syncing (and without
+    // recording a cursor, so it is retried if it shrinks).
+    localLogger.info(
+      { listInternalId, itemCount: items.length },
+      `[List] List has more than ${MAXIMUM_NUMBER_OF_LIST_ITEMS} items, skipping.`
+    );
+    return new Ok(null);
+  }
+
+  await heartbeat();
+
+  const resolvers = await buildLookupResolvers(
+    localLogger,
+    client,
+    itemAPIPath,
+    columns
+  );
+
+  const rows = listItemsToRows(columns, items, resolvers);
+
+  try {
+    await upsertListTable(connector, listInternalId, list, rows);
+  } catch (err) {
+    // A rejected upload (schema/size limits) is an expected, list-specific
+    // failure: skip this list (without recording a cursor) rather than failing
+    // the whole sync. Anything else (throttling, transient upstream, unexpected)
+    // propagates to the activity boundary where it is thrown.
+    if (err instanceof TablesError) {
+      localLogger.warn(
+        { listInternalId, error: err },
+        "[List] Table upsert rejected, skipping list."
+      );
+      return new Ok(null);
+    }
+    throw err;
+  }
+
+  await upsertListInDb(connector, listInternalId, list);
+
+  localLogger.info({ listInternalId }, "[List] Done.");
+  return new Ok(null);
+}
+
+export async function deleteList(
+  dataSourceConfig: DataSourceConfig,
+  connectorId: ModelId,
+  listInternalId: string
+): Promise<void> {
+  await deleteDataSourceTable({
+    dataSourceConfig,
+    tableId: listInternalId,
+    loggerArgs: {
+      connectorId,
+      listId: listInternalId,
+    },
+  });
+}

--- a/connectors/src/connectors/microsoft/temporal/workflows.ts
+++ b/connectors/src/connectors/microsoft/temporal/workflows.ts
@@ -14,6 +14,7 @@ import uniq from "lodash/uniq";
 
 const {
   getRootNodesToSync,
+  getListNodesToSync,
   syncFiles,
   markNodeAsSeen,
   populateDeltas,
@@ -22,6 +23,11 @@ const {
   launchMicrosoftFullSyncForDrive,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "30 minutes",
+});
+
+const { syncOneListActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "120 minutes",
+  heartbeatTimeout: "5 minutes",
 });
 
 const { microsoftDeletionActivity, microsoftGarbageCollectionActivity } =
@@ -174,6 +180,18 @@ export async function fullSyncWorkflow({
     });
   }
 
+  // SharePoint lists are not part of the drive/folder BFS above: they live at
+  // the site level and are synced as standalone tables. Re-sync all selected
+  // lists once the drive sync has drained.
+  const listNodeIds = await getListNodesToSync(connectorId);
+  for (const listInternalId of listNodeIds) {
+    await syncOneListActivity({
+      connectorId,
+      listInternalId,
+      skipIfUnchanged: false,
+    });
+  }
+
   const hasPendingNodeUpdates =
     nodeIdsToSync.length > 0 || nodeIdsToDelete.length > 0;
 
@@ -290,6 +308,17 @@ export async function incrementalSyncWorkflowV2({
         gcsFilePath,
       });
     }
+  }
+
+  // Lists have no delta endpoint in this pipeline: re-sync each selected list,
+  // skipping the upload when its lastModifiedDateTime has not advanced.
+  const listNodeIds = await getListNodesToSync(connectorId);
+  for (const listInternalId of listNodeIds) {
+    await syncOneListActivity({
+      connectorId,
+      listInternalId,
+      skipIfUnchanged: true,
+    });
   }
 
   if (!fullSyncRunning) {

--- a/connectors/src/types/shared/internal_mime_types.ts
+++ b/connectors/src/types/shared/internal_mime_types.ts
@@ -97,7 +97,8 @@ export const INTERNAL_MIME_TYPES = {
     // Spreadsheets may contain many sheets, thus resemble folders and are
     // stored as such, but with the special mimeType below.
     // For files and sheets, we keep Microsoft's mime types.
-    resourceTypes: ["FOLDER", "SPREADSHEET"],
+    // LIST is a SharePoint list synced as a structured table.
+    resourceTypes: ["FOLDER", "SPREADSHEET", "LIST"],
   }),
   NOTION: generateMimeTypes({
     provider: "notion",

--- a/sdks/js/src/internal_mime_types.ts
+++ b/sdks/js/src/internal_mime_types.ts
@@ -122,7 +122,8 @@ export const CONTENT_NODE_MIME_TYPES = {
     // Spreadsheets may contain many sheets, thus resemble folders and are
     // stored as such, but with the special mimeType below.
     // For files and sheets, we keep Microsoft's mime types.
-    resourceTypes: ["FOLDER", "SPREADSHEET"],
+    // LIST is a SharePoint list synced as a structured table.
+    resourceTypes: ["FOLDER", "SPREADSHEET", "LIST"],
   }),
   NOTION: generateConnectorRelativeMimeTypes({
     provider: "notion",


### PR DESCRIPTION
## Description

Adds support for syncing **SharePoint Lists** (structured data tables) from the Microsoft connector.
fixes dust-tt/tasks#9234.

What's included:
- New `list` node type, internal-id scheme (`/sites/{siteId}/lists/{listId}`) and `MICROSOFT.LIST` internal mime type 
- Graph API: `getLists` syncs only user-created custom lists (`template === "genericList"`); document/picture/page libraries, workflow tasks, publishing system lists and hidden lists are excluded. `getListItems` fetches items with `fields` expanded.
- Picker: lists appear under a site alongside drives and are directly selectable as tables.
- Sync: each selected list is upserted as a single Dust table via a new `syncOneList` activity
- Person and Lookup columns are resolved to readable values
- Wired into both the full sync and the 5-minute incremental sync. Lists have no delta endpoint in this pipeline, so incremental re-syncs a list only when its `lastModifiedDateTime` has advanced past the value stored at the last sync. Lists are deliberately kept out of the drive-scoped delta pipeline (documented as a `@cc` contract).
- Deletion: `recursiveNodeDeletion` handles list nodes (drops the backing table) on deselection.

No new OAuth scope required — `Sites.Read.All` (already requested) covers reading list items, so no customer reconnect.

## Tests

- **Verified end-to-end against a live SharePoint tenant**: created a list with Text / Number / Choice / Date / Person / Lookup columns, selected it in the connector picker (it appears under its site alongside document libraries), and confirmed it syncs into a Dust table with correct types (int, datetime) and — after the Person/Lookup fix — resolved person/lookup values.
- New unit tests (`lists.test.ts`, 15 cases) covering the list→table transform: column filtering (`isTableColumn`), lookup-like detection (`isLookupLikeColumn`), and row extraction (`listItemsToRows`) including person/lookup id resolution, multi-value joining, raw-id fallback and null handling. All pass.
- `tsgo --noEmit` clean on both `connectors` and `sdks/js`; Biome clean.

## Risk

- Medium. New code paths are additive and gated on a list being explicitly selected; existing file sync is untouched.
- The drive-centric delta/GC pipeline is unchanged and lists are excluded from it, so no risk to existing drive/file syncs.
- Incremental change-detection relies on SharePoint last modification date
- Rollback is safe: revert the branch (the added column is nullable and inert if unused). Already-synced list tables are cleaned up on deselection or can be left as inert tables.

## Deploy Plan

- Standard connectors deploy after the migration. The SDK mime-type addition is additive; deploy `sdks/js` / `front` consumers alongside so `INTERNAL_MIME_TYPES.MICROSOFT.LIST` resolves.
- No new secrets or OAuth scopes.

## Follow-ups (out of scope for this PR)

- Proper row-level delta via `/items/delta` (needs row-level table upserts) instead of full re-sync — worthwhile for very large / frequently-edited lists.
- Broaden list-template support if customers ask (Calendar/Events, Tasks, Issue Tracking, …) — currently `genericList` only.

