### PR TITLE
fix(egress): correct the settle contract and keep credentials consistent across transports

### DIFF
--- a/front/lib/egress/client.ts
+++ b/front/lib/egress/client.ts
@@ -71,7 +71,7 @@ async function resolveRequest<T extends RequestInfo | URL>(
 
   return {
     url: resolveUrl(input, baseUrl),
-    init: defaults ? { ...defaults, ...init, headers } : init,
+    init: defaults ? { ...defaults, ...init, credentials, headers } : init,
     headers,
     withCredentials:
       credentials === undefined ? undefined : credentials === "include",
@@ -120,11 +120,9 @@ export async function clientEventSource(
  */
 /**
  * @cc [owner:Nils-Fedrigo,label:error-handling] upload-promise-always-settles
- * The promise returned by `clientUpload` MUST settle for every outcome of the underlying
- * `XMLHttpRequest`. Its event handlers are dispatched by the event loop, outside the promise
- * executor, so anything they throw escapes the promise instead of rejecting it: every handler MUST
- * therefore be total. A promise that neither resolves nor rejects strands the caller's upload state
- * for good: the attachment card spins forever and no error is ever surfaced.
+ * `clientUpload`'s promise MUST settle for every `XMLHttpRequest` outcome. Handlers run outside the
+ * promise executor, so a throw escapes instead of rejecting: those that settle (`onload`,
+ * `onerror`, `ontimeout`, `onabort`) MUST be total, or the upload state is stranded for good.
  */
 /**
  * @cc [owner:Nils-Fedrigo,label:coding] upload-progress-is-bytes-sent


### PR DESCRIPTION
## Description

Two review follow-ups on the `clientUpload` egress helper, both in `front/lib/egress/client.ts`.

**`resolveRequest` returned an inconsistent credentials mode.** `credentials` was resolved as
`init?.credentials ?? defaults?.credentials`, but the `init` handed to `fetch` was built by
spreading the caller's object over the defaults. A caller passing `credentials: undefined`
explicitly (easy to do when forwarding an optional field) therefore overwrote the context default:
`fetch` fell back to `same-origin` while `withCredentials` was computed as `true`. Cross-origin,
that means `fetch` silently omits the cookies the `XMLHttpRequest` transports send — the exact
divergence `single-request-resolution-point` exists to prevent. The merged init now carries the
already-resolved `credentials`, so all three returned shapes agree.

No caller passes `credentials` today, so this is a latent bug rather than a live one, and it fails
closed (cookies omitted, visible 401) rather than leaking anything.

**Corrected the `upload-promise-always-settles` contract.** It required *every* handler to be
total, justified by a promise that never settles. That over-stated the rule: `xhr.upload.onprogress`
settles nothing, and `onload` still fires after it throws, so a throwing `onProgress` cannot strand
the promise. The requirement is now scoped to the handlers that actually settle, which leaves
`onprogress` out of scope by construction.

## Tests

`npm run test -- lib/egress/client.test.ts` — 14 passing, unchanged. No new test: the credentials
path is a one-line consistency fix with no caller exercising it today.
