### PR TITLE
feat(connectors): sync SharePoint text files reported as octet-stream

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -52,7 +52,10 @@ import {
   updateDescendantsParentsInCore,
   // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
 } from "@connectors/connectors/microsoft/temporal/file";
-import { getMimeTypesToSync } from "@connectors/connectors/microsoft/temporal/mime_types";
+import {
+  getMimeTypesToSync,
+  resolveMicrosoftMimeType,
+} from "@connectors/connectors/microsoft/temporal/mime_types";
 import { connectorsConfig } from "@connectors/connectors/shared/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import {
@@ -748,10 +751,10 @@ export async function syncFiles({
       pdfEnabled: providerConfig.pdfEnabled || false,
       csvEnabled: providerConfig.csvEnabled || false,
     });
-    const filesToSync = children.filter(
-      (item) =>
-        item.file?.mimeType && mimeTypesToSync.includes(item.file.mimeType)
-    );
+    const filesToSync = children.filter((item) => {
+      const mimeType = resolveMicrosoftMimeType(item);
+      return mimeType != null && mimeTypesToSync.includes(mimeType);
+    });
 
     const concurrency = getAdaptiveConcurrency(
       filesToSync,

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -15,7 +15,10 @@ import {
   typeAndPathFromInternalId,
 } from "@connectors/connectors/microsoft/lib/utils";
 import { isSiteNotFoundError } from "@connectors/connectors/microsoft/temporal/cast_known_errors";
-import { getMimeTypesToSync } from "@connectors/connectors/microsoft/temporal/mime_types";
+import {
+  getMimeTypesToSync,
+  resolveMicrosoftMimeType,
+} from "@connectors/connectors/microsoft/temporal/mime_types";
 import {
   deleteAllSheets,
   handleSpreadSheet,
@@ -212,7 +215,7 @@ export async function syncOneFile({
     csvEnabled: providerConfig.csvEnabled || false,
   });
 
-  const mimeType = file.file.mimeType;
+  const mimeType = resolveMicrosoftMimeType(file);
   if (!mimeType || !mimeTypesToSync.includes(mimeType)) {
     localLogger.info("Type not supported, skipping file.");
     return false;
@@ -405,7 +408,7 @@ export async function syncOneFile({
     nodeType: "file",
     name: file.name ?? "",
     parentInternalId,
-    mimeType: file.file.mimeType ?? "",
+    mimeType,
     webUrl: file.webUrl ?? null,
   };
 
@@ -573,7 +576,7 @@ export async function syncOneFile({
               sync_type: isBatchSync ? "batch" : "incremental",
             },
             title: file.name ?? "",
-            mimeType: file.file.mimeType ?? "application/octet-stream",
+            mimeType,
             async: true,
           });
 

--- a/connectors/src/connectors/microsoft/temporal/mime_types.test.ts
+++ b/connectors/src/connectors/microsoft/temporal/mime_types.test.ts
@@ -1,0 +1,74 @@
+import type { DriveItem } from "@connectors/connectors/microsoft/lib/types";
+import { resolveMicrosoftMimeType } from "@connectors/connectors/microsoft/temporal/mime_types";
+import { describe, expect, it } from "vitest";
+
+function makeItem(name: string | undefined, mimeType?: string): DriveItem {
+  return {
+    name,
+    file: mimeType === undefined ? {} : { mimeType },
+    "@microsoft.graph.downloadUrl": "",
+  };
+}
+
+describe("resolveMicrosoftMimeType", () => {
+  it("returns the raw mime type when it is a real (non-octet-stream) type", () => {
+    expect(resolveMicrosoftMimeType(makeItem("notes.txt", "text/plain"))).toBe(
+      "text/plain"
+    );
+    expect(
+      resolveMicrosoftMimeType(makeItem("data.bin", "application/pdf"))
+    ).toBe("application/pdf");
+  });
+
+  it("maps known text extensions when Graph reports application/octet-stream", () => {
+    expect(
+      resolveMicrosoftMimeType(
+        makeItem("ACH75VI2.txt", "application/octet-stream")
+      )
+    ).toBe("text/plain");
+    expect(
+      resolveMicrosoftMimeType(
+        makeItem("README.md", "application/octet-stream")
+      )
+    ).toBe("text/markdown");
+    expect(
+      resolveMicrosoftMimeType(
+        makeItem("doc.markdown", "application/octet-stream")
+      )
+    ).toBe("text/markdown");
+  });
+
+  it("is case-insensitive on the extension", () => {
+    expect(
+      resolveMicrosoftMimeType(
+        makeItem("LEGACY.TXT", "application/octet-stream")
+      )
+    ).toBe("text/plain");
+  });
+
+  it("does not apply the extension fallback when the mime type is absent", () => {
+    expect(
+      resolveMicrosoftMimeType(makeItem("notes.txt", undefined))
+    ).toBeUndefined();
+  });
+
+  it("leaves octet-stream unchanged for unknown extensions", () => {
+    expect(
+      resolveMicrosoftMimeType(
+        makeItem("archive.zip", "application/octet-stream")
+      )
+    ).toBe("application/octet-stream");
+    expect(
+      resolveMicrosoftMimeType(makeItem("noext", "application/octet-stream"))
+    ).toBe("application/octet-stream");
+  });
+
+  it("returns undefined when the mime type is absent and no extension matches", () => {
+    expect(
+      resolveMicrosoftMimeType(makeItem("archive.zip", undefined))
+    ).toBeUndefined();
+    expect(
+      resolveMicrosoftMimeType(makeItem(undefined, undefined))
+    ).toBeUndefined();
+  });
+});

--- a/connectors/src/connectors/microsoft/temporal/mime_types.ts
+++ b/connectors/src/connectors/microsoft/temporal/mime_types.ts
@@ -1,3 +1,5 @@
+import type { DriveItem } from "@connectors/connectors/microsoft/lib/types";
+
 export async function getMimeTypesToSync({
   pdfEnabled,
   csvEnabled,
@@ -21,4 +23,48 @@ export async function getMimeTypesToSync({
   }
 
   return mimeTypes;
+}
+
+// SharePoint sometimes exposes plain-text files (e.g. legacy source code) with a
+// per-file content-type of "application/octet-stream" — the generic binary default —
+// instead of "text/plain". Those files would otherwise be silently skipped by the
+// mime-type gate. For a small set of known text extensions we treat such files as
+// text so they get synced. Binary files that happen to carry a text extension are
+// still rejected downstream by the letter-ratio heuristic in `handleTextFile`.
+const TEXT_EXTENSION_TO_MIME_TYPE: Record<string, string> = {
+  ".txt": "text/plain",
+  ".md": "text/markdown",
+  ".markdown": "text/markdown",
+};
+
+const OCTET_STREAM_MIME_TYPE = "application/octet-stream";
+
+/**
+ * @cc [owner:tdraier,label:backend] octet-stream-text-extension-fallback
+ * The extension fallback MUST apply only when `item.file.mimeType` is exactly
+ * "application/octet-stream": in that case, if `item.name` ends with a known text
+ * extension (`.txt`, `.md`, `.markdown`), the returned mime type MUST be the mapped
+ * text type (`text/plain`/`text/markdown`). For any other raw mime type — including
+ * a missing (`null`/`undefined`) one — the raw `item.file.mimeType` MUST be returned
+ * unchanged (returning `undefined` when it is absent), regardless of the extension.
+ * This resolver MUST be used by every mime-type sync gate (pre-filter and per-file),
+ * so a file's accept/skip decision and its downstream handler routing agree.
+ */
+export function resolveMicrosoftMimeType(item: DriveItem): string | undefined {
+  const rawMimeType = item.file?.mimeType ?? undefined;
+  if (rawMimeType !== OCTET_STREAM_MIME_TYPE) {
+    return rawMimeType;
+  }
+
+  const name = item.name?.toLowerCase();
+  if (name) {
+    const ext = Object.keys(TEXT_EXTENSION_TO_MIME_TYPE).find((e) =>
+      name.endsWith(e)
+    );
+    if (ext) {
+      return TEXT_EXTENSION_TO_MIME_TYPE[ext];
+    }
+  }
+
+  return rawMimeType;
 }


### PR DESCRIPTION
## Description

When SharePoint reports a `.txt` file's content-type via Microsoft Graph as `application/octet-stream` (the generic binary default) instead of `text/plain`, the Microsoft connector silently skips it. At ICF Habitat, 31 of 38 legacy COBOL `.txt` source files never sync for this reason, with no user-facing error. Re-encoding/re-uploading doesn't help — the customer can't control the per-file content-type SharePoint assigns.

This adds an **extension-based MIME fallback** (`resolveMicrosoftMimeType`): when Graph reports `application/octet-stream` (or no type) **and** the filename ends in a known text extension (`.txt`, `.md`, `.markdown`), the file is treated as `text/plain`/`text/markdown`. Any other type is returned unchanged, so unknown-extension binaries are still skipped exactly as before.

The resolver is used by **both** mime-type sync gates — the `syncFiles` pre-filter (`activities.ts`) and the per-file `syncOneFile` gate (`file.ts`) — so the accept/skip decision and the downstream handler routing agree, and the resolved type is what gets stored on the node and upserted to core.

We deliberately do **not** whitelist `application/octet-stream` broadly (rejected on dust-tt/tasks#9014): only explicit text extensions are reclassified, and `handleTextFile`'s existing letter-ratio heuristic still rejects any binary that happens to carry a text extension.

Relates to dust-tt/tasks#9122 (follow-up to dust-tt/tasks#9014).

## Tests

- New unit tests `connectors/src/connectors/microsoft/temporal/mime_types.test.ts` (6 cases): real types pass through, octet-stream/absent + known extension → text, case-insensitive extension, unknown extension + octet-stream stays octet-stream, absent type + no match → undefined.
- `npx tsgo --noEmit` clean; `biome check` clean; all 6 tests pass.

## Risk

Low. Purely widens which files are accepted; no schema or API changes. Only files that (a) are reported as `octet-stream`/untyped and (b) carry a `.txt`/`.md`/`.markdown` extension are newly considered — and they still pass through the same content heuristics before upsert. Fully rollback-safe (revert only); no data migration. Worst case a genuinely-binary `.txt` is downloaded and then rejected by `handleTextFile`.

## Deploy Plan

Standard connectors deploy. Newly-eligible files sync on the next incremental/batch sync of affected Microsoft connections; no backfill step required.