### PR TITLE
chore: update code-contracts action pin

### DIFF
--- a/.github/actions/review-bot/README.md
+++ b/.github/actions/review-bot/README.md
@@ -69,9 +69,9 @@ Inline comments and review summaries invoke the action directly in their request
 the imported action does not yet accept these events as delegated requests. They still publish a
 review and progress status on the captured PR head.
 
-Each review run reports a distinct `Contract review (<run-id>)` commit status linked to the workflow,
-including progress, completion, failure, and cancellation. Success means the review completed;
-findings remain in the comment review. Concurrent runs cannot overwrite one another's status.
+Each review run reports a distinct `Review Code Contracts (<run-id>)` commit status linked to the
+workflow, including progress, completion, failure, and cancellation. Success means the review
+completed; findings remain in the comment review. Concurrent runs cannot overwrite one another's status.
 
 The request job needs `actions: write` to dispatch. Review execution needs `contents: read`,
 `pull-requests: write`, `statuses: write`, and `actions: read` to resolve delegated requesters.

--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -67,7 +67,7 @@ jobs:
       statuses: write
     steps:
       - name: Review contracts
-        uses: spolu/code-contracts/.github/actions/contract-review@c80b8e1afc7499184f84fd14a15da8d0d5406b27
+        uses: spolu/code-contracts/.github/actions/contract-review@b7b4ca3c4b6aec2672374e28ccfab48bd85fd204
         with:
           pull-request-number: ${{ inputs.pull-request-number || needs.request-reviews.outputs.pull-request-number }}
           request-run-id: ${{ inputs.request-run-id }}


### PR DESCRIPTION
## Description

Update the contract-review action pin to [b7b4ca3](https://github.com/spolu/code-contracts/commit/b7b4ca3c4b6aec2672374e28ccfab48bd85fd204). Review summaries now use `cc-verify`, and progress statuses use `Review Code Contracts (<run-id>)`. Update the review-bot README to match.

## Tests

Confirmed the upstream update preserves the action inputs and required permissions. No live review was triggered.

## Risk

Low. The upstream update only renames review summaries and progress statuses.

## Deploy Plan

Merge to main. PR branches need the updated workflow for head-branch dispatches to use the new pin.
