### PR TITLE
Sort the compact usage table by pool-only credits on the new usage page

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -282,7 +282,9 @@ export function UsagePage() {
     sort?.id === "email" || sort?.id === "seatUsage"
       ? sort.id
       : sort?.id === "consumedFromPoolAwuCredits"
-        ? "consumedAwuCredits"
+        ? isNewUsagePage
+          ? "consumedFromPoolAwuCredits"
+          : "consumedAwuCredits"
         : "name";
   const membersOrderDirection = sort?.desc ? "desc" : "asc";
 


### PR DESCRIPTION
## Description

On the new usage page (behind `enable_new_usage_page`), the members table uses the compact variant, whose usage column displays pool-only consumption. Sorting on that column was remapped to total consumption (allowance + pool) regardless of the flag, so the row order did not match the values shown. The remap now only applies to the legacy page, which displays the total. Poke's compact table already sorts by the pool-only column, and the members-usage API accepts both.

## Tests

- `tsgo` typecheck and Biome pass (pre-commit hook).
- Not tested in the browser. To verify manually: on a flagged workspace where members have both seat allowance and pool consumption, sort "Pool usage" descending and check the order follows the pool bar.

## Risk

Low. Three-line change to the sort column selection, only active when the flag is on. Legacy page behavior is unchanged. Safe to roll back.

## Deploy Plan

Standard front deploy. No migration.
