### PR TITLE
Guard remaining caught error payloads

### DIFF
--- a/front/components/app/DatasetView.tsx
+++ b/front/components/app/DatasetView.tsx
@@ -16,6 +16,8 @@ import type {
   DatasetType,
   DatasetViewType,
 } from "@app/types/dataset";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isString } from "@app/types/shared/utils/general";
 import {
   Button,
   Download01,
@@ -443,26 +445,26 @@ export default function DatasetView({
     setDatasetData(data);
   };
 
-  const handleFileLoaded = (e: any) => {
-    const content = e.target.result;
-    let data = [];
-    try {
-      data = content
-        .split("\n")
-        .filter((l: string) => {
-          return l.length > 0;
-        })
-        .map((l: string, i: number) => {
-          try {
-            return JSON.parse(l);
-          } catch (e: any) {
-            e.line = i;
-            throw e;
-          }
-        });
-    } catch (e: any) {
-      window.alert(`Error parsing JSONL line ${e.line}: ${e}`);
+  /**
+   * @cc [owner:spolu,label:product;error-handling] jsonl-import-preserves-data-on-parse-failure
+   * A failed file read or JSONL parse MUST report an error and return without updating dataset state.
+   */
+  const handleFileLoaded = (e: ProgressEvent<FileReader>) => {
+    const content = e.target?.result;
+    if (!isString(content)) {
+      window.alert("Error reading JSONL file.");
       return;
+    }
+
+    const data: DatasetEntry[] = [];
+    const lines = content.split("\n").filter((line) => line.length > 0);
+    for (const [i, line] of lines.entries()) {
+      try {
+        data.push(JSON.parse(line));
+      } catch (err) {
+        window.alert(`Error parsing JSONL line ${i}: ${normalizeError(err)}`);
+        return;
+      }
     }
     if (data.length > 256) {
       window.alert("Dataset size is currently limited to 256 entries");

--- a/front/lib/metronome/errors.ts
+++ b/front/lib/metronome/errors.ts
@@ -1,0 +1,7 @@
+import { ConflictError } from "@metronome/sdk";
+
+export function isMetronomeConflictError(
+  error: unknown
+): error is ConflictError {
+  return error instanceof ConflictError;
+}

--- a/front/migrations/20250728_backfill_membership_workos.ts
+++ b/front/migrations/20250728_backfill_membership_workos.ts
@@ -1,4 +1,5 @@
 import type { OrganizationMembership } from "@workos-inc/node";
+import { RateLimitExceededException } from "@workos-inc/node";
 
 import { getWorkOS } from "@app/lib/api/workos/client";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -107,8 +108,8 @@ async function updateMembershipOriginsForWorkspace(
           }
 
           break;
-        } catch (error: any) {
-          if (error?.status === 429) {
+        } catch (error) {
+          if (error instanceof RateLimitExceededException) {
             retryCount++;
             const retryAfterSeconds = error.retryAfter || 10;
             const retryAfterMs = retryAfterSeconds * 1000;

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -58,6 +58,7 @@ import {
   getNewRateCards,
   NEW_METRICS,
 } from "@app/lib/metronome/setup_new_pricing";
+import { ConflictError } from "@metronome/sdk";
 
 if (!process.env.METRONOME_API_KEY) {
   console.error("METRONOME_API_KEY env var required");
@@ -1842,8 +1843,7 @@ async function syncAlerts(): Promise<void> {
       // alert is NOT updated — its custom_field_filters stay whatever they were
       // at creation. To apply changed filters, archive the alert first (for the
       // pool defaults: re-run with --recreate-pool-defaults).
-      const status = (err as { status?: number })?.status;
-      if (status === 409) {
+      if (err instanceof ConflictError) {
         console.log(
           `  ✓ ${desired.name} — already exists (uniqueness_key="${desired.uniqueness_key}"), NOT updated (existing filters kept). ` +
             `Re-run with --recreate-pool-defaults --execute to apply current filters to pool defaults.`

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -36,6 +36,7 @@ import {
   STRIPE_PRODUCT_ID_CUSTOM_FIELD_KEY,
   SUBSCRIPTION_SWAP_HANDLED_INLINE_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
+import { isMetronomeConflictError } from "@app/lib/metronome/errors";
 import { invalidateProductSeatTypesCache } from "@app/lib/metronome/seat_types";
 import type {
   PackageDef,
@@ -58,7 +59,6 @@ import {
   getNewRateCards,
   NEW_METRICS,
 } from "@app/lib/metronome/setup_new_pricing";
-import { ConflictError } from "@metronome/sdk";
 
 if (!process.env.METRONOME_API_KEY) {
   console.error("METRONOME_API_KEY env var required");
@@ -1843,7 +1843,7 @@ async function syncAlerts(): Promise<void> {
       // alert is NOT updated — its custom_field_filters stay whatever they were
       // at creation. To apply changed filters, archive the alert first (for the
       // pool defaults: re-run with --recreate-pool-defaults).
-      if (err instanceof ConflictError) {
+      if (isMetronomeConflictError(err)) {
         console.log(
           `  ✓ ${desired.name} — already exists (uniqueness_key="${desired.uniqueness_key}"), NOT updated (existing filters kept). ` +
             `Re-run with --recreate-pool-defaults --execute to apply current filters to pool defaults.`

--- a/tools/datadog-log-exporter/src/index.ts
+++ b/tools/datadog-log-exporter/src/index.ts
@@ -99,8 +99,15 @@ async function writeCsvHeader(
   const header = columns.join(",") + "\n";
   try {
     await fsp.writeFile(outPath, header, { flag: "wx" });
-  } catch (e: any) {
-    if (e && e.code === "EEXIST") return;
+  } catch (e) {
+    if (
+      typeof e === "object" &&
+      e !== null &&
+      "code" in e &&
+      e.code === "EEXIST"
+    ) {
+      return;
+    }
     throw e;
   }
 }

--- a/x/henry/dust-apply/src/fs_utils.ts
+++ b/x/henry/dust-apply/src/fs_utils.ts
@@ -17,7 +17,12 @@ export const fileSystem: FileSystem = {
     try {
       return await fs.readFile(filePath, "utf8");
     } catch (err) {
-      if ((err as { code?: string }).code === "ENOENT") {
+      if (
+        typeof err === "object" &&
+        err !== null &&
+        "code" in err &&
+        err.code === "ENOENT"
+      ) {
         console.debug("File not found:", filePath);
         return null;
       }


### PR DESCRIPTION
## Description

Address the six remaining candidates from the original `normalize-caught-errors` inventory across five files. Metronome conflict and WorkOS rate-limit handling now use SDK error classes, and filesystem error-code checks validate the caught value first.

The "Dust apps" dataset importer fix is low risk since mostly unused at this point.

## Tests

Local checks covered the extracted dataset import handler (valid input, failed reads, malformed JSON, frozen/non-Error failures, and the size limit), filesystem fallbacks, and SDK error classification.

## Risk

Low. All scripts.

## Deploy Plan

- deploy `front`.