### PR TITLE
[front] fix: use exported code icon in Poke conversation

### DIFF
--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -38,7 +38,7 @@ import {
   Chip,
   Clipboard,
   ClipboardCheck,
-  Code02,
+  Code01,
   CodeBlock,
   Collapsible,
   CollapsibleContent,
@@ -1366,7 +1366,7 @@ export function ConversationPage() {
                   )}
                   <div className="ml-auto shrink-0 rounded-2xl border border-border-dark bg-background p-1">
                     <NavTabPillList>
-                      <NavTabPillTrigger value="raw" icon={Code02}>
+                      <NavTabPillTrigger value="raw" icon={Code01}>
                         Raw text
                       </NavTabPillTrigger>
                       <NavTabPillTrigger value="markdown" icon={File02}>


### PR DESCRIPTION
## Description

The Poke conversation page imports the wrong `Code02` icon instead of `Code01` (for some reason had it built locally).

## Tests

- tsgo

## Risk

- Low.

## Deploy Plan

- Deploy front.
