### PR TITLE
[LLM] Add AWS Bedrock host with Claude Opus 5 and GPT-5.6 Sol endpoints

### DIFF
--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -20,6 +20,7 @@ import { FIREWORKS_MODEL_PREFIX } from "@app/lib/model_constructors/providers/fi
 import type { Host } from "@app/lib/model_constructors/types/hosts";
 import {
   AGENT_PLATFORM_HOST,
+  BEDROCK_HOST,
   GOOGLE_AI_STUDIO_HOST,
 } from "@app/lib/model_constructors/types/hosts";
 import type { Lab } from "@app/lib/model_constructors/types/labs";
@@ -134,7 +135,8 @@ function getLabAndHostFilter(
  * @cc [owner:pmilliotte,label:security;product] byok-never-routes-to-dust-hosted-inference
  * A workspace on a BYOK plan (`plan.isByok`) must only reach endpoints served by the model lab's
  * own API, using the credentials the workspace provided. Endpoints hosted on Dust's infrastructure
- * — `agent-platform` (Vertex, keyed by `AGENT_PLATFORM_PROJECT_ID`) today — must be filtered out
+ * — `agent-platform` (Vertex, keyed by `AGENT_PLATFORM_PROJECT_ID`) and `bedrock` (keyed by
+ * `AWS_BEARER_TOKEN_BEDROCK`) today — must be filtered out
  * here, not merely made unreachable by an endpoint's `endpointFilter`: plan and feature-flag
  * conditions can change, the BYOK guarantee cannot.
  *
@@ -150,7 +152,7 @@ export function getWorkspaceFilter(auth: Authenticator): Where<EndpointConfig> {
     region: getRegionFilter(auth),
     // Conversely we route all non-byok gemini requests to agent platform.
     ...(byok
-      ? { not: { host: { eq: AGENT_PLATFORM_HOST } } }
+      ? { not: { host: { in: [AGENT_PLATFORM_HOST, BEDROCK_HOST] } } }
       : { not: { host: { eq: GOOGLE_AI_STUDIO_HOST } } }),
   };
 }

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -47,6 +47,7 @@ import { NoopNoopGlobalNoopStream } from "@app/lib/model_constructors/stream/end
 import type { Host } from "@app/lib/model_constructors/types/hosts";
 import {
   AGENT_PLATFORM_HOST,
+  BEDROCK_HOST,
   OPENAI_RESPONSES_HOST,
   XAI_HOST,
 } from "@app/lib/model_constructors/types/hosts";
@@ -872,9 +873,11 @@ export class StreamEndpointTransition extends BaseTransition {
     metadata?: LLMStreamMetadata
   ) {
     const { host: api } = this.model.metadata();
-    // Agent-platform (Vertex) has no request-level automatic cache_control, so it
-    // needs an explicit breakpoint on the conversation tail (legacy's isLast).
-    const explicitTailBreakpoint = api === AGENT_PLATFORM_HOST;
+    // Agent-platform (Vertex) and Bedrock have no request-level automatic
+    // cache_control, so they need an explicit breakpoint on the conversation
+    // tail (legacy's isLast).
+    const explicitTailBreakpoint =
+      api === AGENT_PLATFORM_HOST || api === BEDROCK_HOST;
     // OpenAI-compatible Responses hosts consume `prompt_cache_key`. Use the
     // workspace and agent configuration so requests can reuse cached prefixes
     // across conversations. xAI recommends always setting it to route stable

--- a/front/lib/api/provider_credentials.ts
+++ b/front/lib/api/provider_credentials.ts
@@ -42,6 +42,8 @@ function dustManagedOtherProviderKeys() {
     DEEPSEEK_API_KEY: env("DUST_MANAGED_DEEPSEEK_API_KEY"),
     FIREWORKS_API_KEY: env("DUST_MANAGED_FIREWORKS_API_KEY"),
     XAI_API_KEY: env("DUST_MANAGED_XAI_API_KEY"),
+    // AWS-standard env var name, so the same token works with AWS tooling.
+    AWS_BEARER_TOKEN_BEDROCK: env("AWS_BEARER_TOKEN_BEDROCK"),
   };
 }
 

--- a/front/lib/llms/stream/endpoints/anthropic_claude_opus_five_global_bedrock.ts
+++ b/front/lib/llms/stream/endpoints/anthropic_claude_opus_five_global_bedrock.ts
@@ -1,0 +1,11 @@
+import { WithDustClaudeOpusFiveConfig } from "@app/lib/llms/providers/anthropic/models/claude_opus_five";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { AnthropicClaudeOpusFiveGlobalBedrockStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_five_global_bedrock";
+
+export class DustAnthropicClaudeOpusFiveGlobalBedrockStream extends WithDustClaudeOpusFiveConfig(
+  AnthropicClaudeOpusFiveGlobalBedrockStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustAnthropicClaudeOpusFiveGlobalBedrockStream);

--- a/front/lib/llms/stream/endpoints/openai_gpt_five_dot_six_sol_global_bedrock.ts
+++ b/front/lib/llms/stream/endpoints/openai_gpt_five_dot_six_sol_global_bedrock.ts
@@ -1,0 +1,11 @@
+import { WithDustGptFiveDotSixSolConfig } from "@app/lib/llms/providers/openai/models/gpt_five_dot_six_sol";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { OpenAIGptFiveDotSixSolGlobalBedrockStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_sol_global_bedrock";
+
+export class DustOpenAIGptFiveDotSixSolGlobalBedrockStream extends WithDustGptFiveDotSixSolConfig(
+  OpenAIGptFiveDotSixSolGlobalBedrockStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustOpenAIGptFiveDotSixSolGlobalBedrockStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -3,6 +3,7 @@ import { DustAnthropicClaudeFableFiveGlobalAnthropicStream } from "@app/lib/llms
 import { DustAnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStream } from "@app/lib/llms/stream/endpoints/anthropic_claude_haiku_four_dot_five_eu_agent_platform";
 import { DustAnthropicClaudeHaikuFourDotFiveGlobalAnthropicStream } from "@app/lib/llms/stream/endpoints/anthropic_claude_haiku_four_dot_five_global_anthropic";
 import { DustAnthropicClaudeOpusFiveGlobalAnthropicStream } from "@app/lib/llms/stream/endpoints/anthropic_claude_opus_five_global_anthropic";
+import { DustAnthropicClaudeOpusFiveGlobalBedrockStream } from "@app/lib/llms/stream/endpoints/anthropic_claude_opus_five_global_bedrock";
 import { DustAnthropicClaudeOpusFourDotEightEuropeAgentPlatformStream } from "@app/lib/llms/stream/endpoints/anthropic_claude_opus_four_dot_eight_eu_agent_platform";
 import { DustAnthropicClaudeOpusFourDotEightGlobalAnthropicStream } from "@app/lib/llms/stream/endpoints/anthropic_claude_opus_four_dot_eight_global_anthropic";
 import { DustAnthropicClaudeOpusFourDotSevenEuropeAgentPlatformStream } from "@app/lib/llms/stream/endpoints/anthropic_claude_opus_four_dot_seven_eu_agent_platform";
@@ -118,6 +119,10 @@ export const DUST_STREAM_ENDPOINTS = {
     DustAnthropicClaudeFableFiveGlobalAnthropicStream,
   [DustAnthropicClaudeHaikuFourDotFiveGlobalAnthropicStream.id]:
     DustAnthropicClaudeHaikuFourDotFiveGlobalAnthropicStream,
+  // Registered before the direct Anthropic endpoint: both are `global`, so the
+  // region sort leaves them tied and registration order decides which one wins.
+  [DustAnthropicClaudeOpusFiveGlobalBedrockStream.id]:
+    DustAnthropicClaudeOpusFiveGlobalBedrockStream,
   [DustAnthropicClaudeOpusFiveGlobalAnthropicStream.id]:
     DustAnthropicClaudeOpusFiveGlobalAnthropicStream,
   [DustAnthropicClaudeOpusFourDotEightGlobalAnthropicStream.id]:

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -54,6 +54,7 @@ import { DustOpenAIGptFiveDotOneGlobalOpenAIResponsesStream } from "@app/lib/llm
 import { DustOpenAIGptFiveDotSixLunaEuropeOpenAIResponsesStream } from "@app/lib/llms/stream/endpoints/openai_gpt_five_dot_six_luna_eu_openai_responses";
 import { DustOpenAIGptFiveDotSixLunaGlobalOpenAIResponsesStream } from "@app/lib/llms/stream/endpoints/openai_gpt_five_dot_six_luna_global_openai_responses";
 import { DustOpenAIGptFiveDotSixSolEuropeOpenAIResponsesStream } from "@app/lib/llms/stream/endpoints/openai_gpt_five_dot_six_sol_eu_openai_responses";
+import { DustOpenAIGptFiveDotSixSolGlobalBedrockStream } from "@app/lib/llms/stream/endpoints/openai_gpt_five_dot_six_sol_global_bedrock";
 import { DustOpenAIGptFiveDotSixSolGlobalOpenAIResponsesStream } from "@app/lib/llms/stream/endpoints/openai_gpt_five_dot_six_sol_global_openai_responses";
 import { DustOpenAIGptFiveDotSixTerraEuropeOpenAIResponsesStream } from "@app/lib/llms/stream/endpoints/openai_gpt_five_dot_six_terra_eu_openai_responses";
 import { DustOpenAIGptFiveDotSixTerraGlobalOpenAIResponsesStream } from "@app/lib/llms/stream/endpoints/openai_gpt_five_dot_six_terra_global_openai_responses";
@@ -225,6 +226,10 @@ export const DUST_STREAM_ENDPOINTS = {
     DustOpenAIGptFiveDotSixLunaGlobalOpenAIResponsesStream,
   [DustOpenAIGptSixAstraGlobalOpenAIResponsesStream.id]:
     DustOpenAIGptSixAstraGlobalOpenAIResponsesStream,
+  // Before the direct OpenAI endpoint: both are `global`, so registration
+  // order decides which one wins (see the Opus 5 Bedrock note above).
+  [DustOpenAIGptFiveDotSixSolGlobalBedrockStream.id]:
+    DustOpenAIGptFiveDotSixSolGlobalBedrockStream,
   [DustOpenAIGptFiveDotSixSolGlobalOpenAIResponsesStream.id]:
     DustOpenAIGptFiveDotSixSolGlobalOpenAIResponsesStream,
   [DustOpenAIGptFiveDotSixTerraGlobalOpenAIResponsesStream.id]:

--- a/front/lib/model_constructors/stream/clients/bedrock.ts
+++ b/front/lib/model_constructors/stream/clients/bedrock.ts
@@ -1,0 +1,97 @@
+import AnthropicClient from "@anthropic-ai/sdk";
+import type {
+  BetaMessageStreamParams,
+  BetaRawMessageStreamEvent,
+} from "@anthropic-ai/sdk/resources/beta/messages/messages";
+import type {
+  Model as HostModel,
+  MessageCreateParamsNonStreaming,
+} from "@anthropic-ai/sdk/resources/messages/messages";
+import type { AnthropicInputConfig } from "@app/lib/model_constructors/providers/anthropic/inputConfig";
+import { anthropicConfigSchema } from "@app/lib/model_constructors/providers/anthropic/inputConfig";
+import { WithAnthropicAIInputConverter } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input";
+import { imageUrlToBase64ImageBlock } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/utils";
+import { WithAnthropicAIOutputConverter } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/output";
+import { rawOutputToEvents } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/output/utils";
+import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import { BEDROCK_HOST } from "@app/lib/model_constructors/types/hosts";
+import { ANTHROPIC_LAB } from "@app/lib/model_constructors/types/labs";
+import type { Model } from "@app/lib/model_constructors/types/models";
+import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import logger from "@app/logger/logger";
+
+// "Claude in Amazon Bedrock" serves the native Messages API on the
+// `bedrock-mantle` endpoint, so we reuse the Anthropic SDK with a Bedrock base
+// URL and a bearer token instead of the AWS SDK and SigV4 signing. The SDK
+// appends `/v1/messages` to the base URL.
+// https://platform.claude.com/docs/en/build-with-claude/claude-in-amazon-bedrock
+// (verified 2026-09-10): "set base_url to
+// https://bedrock-mantle.{region}.api.aws/anthropic and pass your bearer token
+// as api_key. This path supports bearer-token authentication only."
+//
+// ponytail: single region hard-coded. `bedrock-mantle` serves Opus 5 from
+// us-east-1 (plus eu-north-1, eu-west-1, ap-southeast-4, us-gov-west-1); make
+// the region a per-endpoint static when we need a second one.
+const BEDROCK_MANTLE_BASE_URL =
+  "https://bedrock-mantle.us-east-1.api.aws/anthropic";
+
+export abstract class BedrockStream extends WithAnthropicAIInputConverter(
+  WithAnthropicAIOutputConverter(
+    StreamEndpoint<
+      MessageCreateParamsNonStreaming,
+      BetaRawMessageStreamEvent,
+      AnthropicInputConfig
+    >
+  )
+) {
+  static readonly lab = ANTHROPIC_LAB;
+  static readonly host = BEDROCK_HOST;
+
+  static readonly configSchema = anthropicConfigSchema;
+
+  private readonly client: AnthropicClient;
+
+  constructor({ AWS_BEARER_TOKEN_BEDROCK }: Credentials) {
+    super();
+    this.client = new AnthropicClient({
+      apiKey: AWS_BEARER_TOKEN_BEDROCK,
+      baseURL: BEDROCK_MANTLE_BASE_URL,
+      // The agent loop owns retries so every attempt is observable and billed
+      // from the usage reported by that exact attempt.
+      maxRetries: 0,
+    });
+  }
+
+  // Bedrock model ids carry an `anthropic.` provider prefix (no geo prefix on
+  // `bedrock-mantle`, unlike the `bedrock-runtime` inference profiles).
+  // https://platform.claude.com/docs/en/build-with-claude/claude-in-amazon-bedrock
+  modelToHostModel = (modelId: Model): HostModel => `anthropic.${modelId}`;
+
+  // Bedrock does not support URL image sources, so inline images as base64.
+  imageUrlToImageBlock = imageUrlToBase64ImageBlock;
+
+  async *streamRaw(
+    input: MessageCreateParamsNonStreaming
+  ): AsyncGenerator<BetaRawMessageStreamEvent> {
+    // ponytail: loud temporary marker while we validate the Bedrock path.
+    logger.info(
+      { model: input.model, baseUrl: BEDROCK_MANTLE_BASE_URL },
+      "🟢🟢🟢 Calling the AWS Bedrock (bedrock-mantle) Messages API 🟢🟢🟢"
+    );
+
+    const streamingInput: BetaMessageStreamParams = { ...input };
+    const stream = this.client.beta.messages.stream(streamingInput);
+
+    // SDK mutates/reuses events; deep-copy.
+    for await (const event of stream) {
+      yield structuredClone(event);
+    }
+  }
+
+  async *rawStreamOutputToEvents(
+    stream: AsyncGenerator<BetaRawMessageStreamEvent>
+  ): AsyncGenerator<ModelResponseEvent> {
+    yield* rawOutputToEvents(stream, this.metadata(), this);
+  }
+}

--- a/front/lib/model_constructors/stream/clients/openai_responses_bedrock.ts
+++ b/front/lib/model_constructors/stream/clients/openai_responses_bedrock.ts
@@ -1,0 +1,115 @@
+import { OPENAI_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/openai/reasoning_efforts";
+import { openAIReasoningSummaryForModel } from "@app/lib/model_constructors/providers/openai/reasoning_summary";
+import { WithOpenAIResponsesInputConverter } from "@app/lib/model_constructors/sdk/openai_responses/converters/input";
+import { WithOpenAIResponsesOutputConverter } from "@app/lib/model_constructors/sdk/openai_responses/converters/output";
+import { rawOutputToEvents } from "@app/lib/model_constructors/sdk/openai_responses/converters/output/utils";
+import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import { BEDROCK_HOST } from "@app/lib/model_constructors/types/hosts";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import { OPENAI_LAB } from "@app/lib/model_constructors/types/labs";
+import type { Model } from "@app/lib/model_constructors/types/models";
+import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import logger from "@app/logger/logger";
+import OpenAI from "openai";
+import type {
+  ResponseCreateParams,
+  ResponseCreateParamsStreaming,
+  ResponseStreamEvent,
+} from "openai/resources/responses/responses";
+import { z } from "zod";
+
+// Bedrock serves OpenAI models through the OpenAI Responses API at
+// `/openai/v1`, so this reuses the OpenAI Responses converters and SDK and
+// only swaps the base URL, credential and model id.
+//
+// `bedrock-runtime` (not `bedrock-mantle`) is the endpoint that offers global
+// cross-Region inference for these models: on `bedrock-mantle` the geo and
+// global inference ids are "Not supported" and only in-Region us-east-1 /
+// us-east-2 are served. AWS also recommends `bedrock-runtime` for new
+// applications.
+// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html
+// (verified 2026-09-10)
+const BEDROCK_RUNTIME_OPENAI_BASE_URL =
+  "https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1";
+
+// Same shape as the direct OpenAI Responses client's schema. Kept separate
+// rather than shared because this host does not sit under that client (see
+// `OpenAIResponsesBedrockStream`); per-model schemas narrow it anyway.
+const configSchema = inputConfigSchema.extend({
+  reasoning: z
+    .object({
+      effort: z.enum(OPENAI_SUPPORTED_REASONING_EFFORTS),
+    })
+    .optional(),
+});
+
+type OpenAIInputConfig = z.infer<typeof configSchema>;
+
+// Deliberately not a subclass of `OpenAIResponsesStream`: that client pins
+// `static host` to the literal `openai-responses`, which every endpoint id is
+// built from, and it carries the flex-processing fallback that Bedrock has no
+// use for (Standard is the only service tier these models are served on).
+export abstract class OpenAIResponsesBedrockStream extends WithOpenAIResponsesInputConverter(
+  WithOpenAIResponsesOutputConverter(
+    StreamEndpoint<ResponseCreateParams, ResponseStreamEvent>
+  )
+) {
+  static readonly lab = OPENAI_LAB;
+  static readonly host = BEDROCK_HOST;
+
+  static readonly configSchema: z.ZodType<OpenAIInputConfig> = configSchema;
+
+  private readonly client: OpenAI;
+
+  constructor({ AWS_BEARER_TOKEN_BEDROCK }: Credentials) {
+    super();
+    this.client = new OpenAI({
+      // Bedrock's OpenAI-compatible surface authenticates with a bearer token
+      // in the same header the OpenAI SDK uses for its own key.
+      apiKey: AWS_BEARER_TOKEN_BEDROCK,
+      baseURL: BEDROCK_RUNTIME_OPENAI_BASE_URL,
+      // The agent loop owns retries so every attempt gets its own Dust trace.
+      maxRetries: 0,
+    });
+  }
+
+  protected override reasoningSummaryForModel(
+    model: Model,
+    conciseReasoningSummary: boolean
+  ) {
+    return openAIReasoningSummaryForModel(model, conciseReasoningSummary);
+  }
+
+  // The base URL is regional, but the model id is what selects routing: the
+  // `global.openai.` prefix names the global cross-Region inference profile,
+  // which routes worldwide and is priced below in-Region inference.
+  modelToHostModel = (modelId: Model): string => `global.openai.${modelId}`;
+
+  async *streamRaw(
+    input: ResponseCreateParams
+  ): AsyncGenerator<ResponseStreamEvent> {
+    // ponytail: loud temporary marker while we validate the Bedrock path.
+    logger.info(
+      { model: input.model, baseUrl: BEDROCK_RUNTIME_OPENAI_BASE_URL },
+      "🟢🟢🟢 Calling the AWS Bedrock (bedrock-runtime) Responses API 🟢🟢🟢"
+    );
+
+    // `buildRequestPayload` is shared with batch and omits `stream`; opt in here.
+    const streamingInput: ResponseCreateParamsStreaming = {
+      ...input,
+      stream: true,
+    };
+
+    const stream = await this.client.responses.create(streamingInput);
+    for await (const event of stream) {
+      yield event;
+    }
+  }
+
+  async *rawStreamOutputToEvents(
+    stream: AsyncGenerator<ResponseStreamEvent>
+  ): AsyncGenerator<ModelResponseEvent> {
+    yield* rawOutputToEvents(stream, this.metadata(), this);
+  }
+}

--- a/front/lib/model_constructors/stream/endpoints/anthropic_claude_opus_five_global_bedrock.ts
+++ b/front/lib/model_constructors/stream/endpoints/anthropic_claude_opus_five_global_bedrock.ts
@@ -1,0 +1,46 @@
+import type { MessageCreateParamsNonStreaming } from "@anthropic-ai/sdk/resources";
+import type { BetaRawMessageStreamEvent } from "@anthropic-ai/sdk/resources/beta/messages/messages";
+import { WithAnthropicClaudeOpusFiveConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_five";
+import type { AnthropicOpusInputConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config";
+import { BedrockStream } from "@app/lib/model_constructors/stream/clients/bedrock";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+// Claude Opus 5 on the Bedrock `bedrock-mantle` endpoint. Model id
+// `anthropic.claude-opus-5`, 1M context / 128k output, adaptive thinking.
+// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-5.html
+// (verified 2026-09-10)
+//
+// `region` is GLOBAL: `bedrock-mantle` model ids carry no geo prefix and Bedrock
+// routes globally by default ("Global: dynamic routing across all available
+// regions... No pricing premium", regional routing being the one that costs 10%
+// more).
+// https://platform.claude.com/docs/en/build-with-claude/claude-in-amazon-bedrock#regions
+export class AnthropicClaudeOpusFiveGlobalBedrockStream extends WithAnthropicClaudeOpusFiveConfig(
+  BedrockStream
+) {
+  // AWS bills Claude through the Marketplace and publishes no per-model table
+  // we can read, so these mirror Anthropic's list prices, which the global
+  // Bedrock endpoint matches (no premium, see the region note above).
+  // https://platform.claude.com/docs/en/about-claude/pricing
+  // TODO(bedrock): confirm against an actual Bedrock invoice before shipping.
+  static readonly tokenPricing = {
+    cacheCreated: 6.25,
+    // 5m cache write = 1.25x base input; 1h cache write = 2x base input.
+    shortCacheCreated: 6.25,
+    longCacheCreated: 10.0,
+    cacheHit: 0.5,
+    standardInput: 5.0,
+    standardOutput: 25.0,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+AnthropicClaudeOpusFiveGlobalBedrockStream satisfies StreamEndpointConstructor<
+  MessageCreateParamsNonStreaming,
+  BetaRawMessageStreamEvent,
+  AnthropicOpusInputConfig
+>;

--- a/front/lib/model_constructors/stream/endpoints/anthropic_claude_opus_five_global_bedrock.ts
+++ b/front/lib/model_constructors/stream/endpoints/anthropic_claude_opus_five_global_bedrock.ts
@@ -19,11 +19,12 @@ import { GLOBAL } from "@app/lib/model_constructors/types/regions";
 export class AnthropicClaudeOpusFiveGlobalBedrockStream extends WithAnthropicClaudeOpusFiveConfig(
   BedrockStream
 ) {
-  // AWS bills Claude through the Marketplace and publishes no per-model table
-  // we can read, so these mirror Anthropic's list prices, which the global
-  // Bedrock endpoint matches (no premium, see the region note above).
-  // https://platform.claude.com/docs/en/about-claude/pricing
-  // TODO(bedrock): confirm against an actual Bedrock invoice before shipping.
+  // Verified 2026-09-10 against the model's AWS Marketplace rate card
+  // (`bedrock:ListFoundationModelAgreementOffers` →
+  // `termDetails.usageBasedPricingTerm`), on the `*_global_standard`
+  // dimensions. They match Anthropic's own list prices; the in-region
+  // dimensions are 10% higher (5.5 / 27.5 / 0.55 / 6.875 / 11), which is the
+  // premium the region note above refers to.
   static readonly tokenPricing = {
     cacheCreated: 6.25,
     // 5m cache write = 1.25x base input; 1h cache write = 2x base input.

--- a/front/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_sol_global_bedrock.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_sol_global_bedrock.ts
@@ -1,0 +1,35 @@
+import { WithOpenAIGptFiveDotSixSolConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_dot_six_sol";
+import { OpenAIResponsesBedrockStream } from "@app/lib/model_constructors/stream/clients/openai_responses_bedrock";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+// GPT-5.6 Sol on Bedrock, model id `global.openai.gpt-5.6-sol` (the global
+// cross-Region inference profile).
+// https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html
+// (verified 2026-09-10)
+export class OpenAIGptFiveDotSixSolGlobalBedrockStream extends WithOpenAIGptFiveDotSixSolConfig(
+  OpenAIResponsesBedrockStream
+) {
+  // Global CRIS rates for the short (272k) context window, which is the window
+  // the shared Sol config exposes. The 1M window is billed at twice that
+  // ($8/$30) and would need its own endpoint, as it does on OpenAI direct.
+  // Bedrock also bills cache writes at $5.00/1M (30m TTL), which the Responses
+  // API does not report separately, so `tokenPricing` cannot model it — cost
+  // accounting under-reports the first request of each cached prefix.
+  // https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html
+  // (verified 2026-09-10)
+  static readonly tokenPricing = {
+    cacheHit: 0.4,
+    standardInput: 4.0,
+    standardOutput: 20.0,
+  };
+
+  // Bedrock serves this model on the Standard tier only: Priority, Flex and
+  // Reserved are unsupported, so `supportsFlexProcessing` stays unset.
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+OpenAIGptFiveDotSixSolGlobalBedrockStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -54,6 +54,7 @@ import { OpenAIGptFiveDotOneGlobalOpenAIResponsesStream } from "@app/lib/model_c
 import { OpenAIGptFiveDotSixLunaEuropeOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_luna_eu_openai_responses";
 import { OpenAIGptFiveDotSixLunaGlobalOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_luna_global_openai_responses";
 import { OpenAIGptFiveDotSixSolEuropeOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_sol_eu_openai_responses";
+import { OpenAIGptFiveDotSixSolGlobalBedrockStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_sol_global_bedrock";
 import { OpenAIGptFiveDotSixSolGlobalOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_sol_global_openai_responses";
 import { OpenAIGptFiveDotSixTerraEuropeOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_terra_eu_openai_responses";
 import { OpenAIGptFiveDotSixTerraGlobalOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_terra_global_openai_responses";
@@ -206,6 +207,8 @@ export const STREAM_ENDPOINTS = {
     OpenAIGptFiveDotSixLunaGlobalOpenAIResponsesStream,
   [OpenAIGptSixAstraGlobalOpenAIResponsesStream.id]:
     OpenAIGptSixAstraGlobalOpenAIResponsesStream,
+  [OpenAIGptFiveDotSixSolGlobalBedrockStream.id]:
+    OpenAIGptFiveDotSixSolGlobalBedrockStream,
   [OpenAIGptFiveDotSixSolGlobalOpenAIResponsesStream.id]:
     OpenAIGptFiveDotSixSolGlobalOpenAIResponsesStream,
   [OpenAIGptFiveDotSixTerraGlobalOpenAIResponsesStream.id]:

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -3,6 +3,7 @@ import { AnthropicClaudeFableFiveGlobalAnthropicStream } from "@app/lib/model_co
 import { AnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_haiku_four_dot_five_eu_agent_platform";
 import { AnthropicClaudeHaikuFourDotFiveGlobalAnthropicStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_haiku_four_dot_five_global_anthropic";
 import { AnthropicClaudeOpusFiveGlobalAnthropicStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_five_global_anthropic";
+import { AnthropicClaudeOpusFiveGlobalBedrockStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_five_global_bedrock";
 import { AnthropicClaudeOpusFourDotEightEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_four_dot_eight_eu_agent_platform";
 import { AnthropicClaudeOpusFourDotEightGlobalAnthropicStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_four_dot_eight_global_anthropic";
 import { AnthropicClaudeOpusFourDotSevenEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_four_dot_seven_eu_agent_platform";
@@ -111,6 +112,8 @@ export const STREAM_ENDPOINTS = {
     AnthropicClaudeFableFiveGlobalAnthropicStream,
   [AnthropicClaudeHaikuFourDotFiveGlobalAnthropicStream.id]:
     AnthropicClaudeHaikuFourDotFiveGlobalAnthropicStream,
+  [AnthropicClaudeOpusFiveGlobalBedrockStream.id]:
+    AnthropicClaudeOpusFiveGlobalBedrockStream,
   [AnthropicClaudeOpusFiveGlobalAnthropicStream.id]:
     AnthropicClaudeOpusFiveGlobalAnthropicStream,
   [AnthropicClaudeOpusFourDotEightGlobalAnthropicStream.id]:

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_five_global_bedrock.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_five_global_bedrock.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment node
+
+import { AnthropicClaudeOpusFiveGlobalBedrockStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_five_global_bedrock";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const AnthropicClaudeOpusFiveGlobalBedrockStreamSetup: StreamSetup = {
+  createInstance: () =>
+    new AnthropicClaudeOpusFiveGlobalBedrockStream({
+      AWS_BEARER_TOKEN_BEDROCK: process.env.AWS_BEARER_TOKEN_BEDROCK ?? "",
+    }),
+  // UNVERIFIED: this suite has not been run against Bedrock yet (no bearer
+  // token available at authoring time). The expectations below are inherited
+  // from the direct Anthropic Opus 5 endpoint, which shares the same
+  // `configSchema`, so the `INPUT_CONFIGURATION_ERROR` markers are the ones our
+  // own zod produces and are host-independent. What is *not* verified is
+  // whether Bedrock accepts everything the Anthropic API does. Two known
+  // divergences to characterize before this ships:
+  //
+  //   - Structured outputs are documented as unsupported on Bedrock
+  //     (https://platform.claude.com/docs/en/build-with-claude/claude-in-amazon-bedrock,
+  //     "Features not supported"), so the two `output-format/json-schema` cases
+  //     may come back as provider errors. If they do, the fix is a host-level
+  //     narrowing of `outputFormat`, not a marker here.
+  //   - Prompt caching is explicit-breakpoint only (no request-level automatic
+  //     `cache_control`), which is why the transition sets
+  //     `explicitTailBreakpoint` for this host.
+  tests: {
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-default/r-xhigh": null,
+    "simple/no-tools/t-default/r-maximal": null,
+    "simple/no-tools/t-0/r-default": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-xhigh": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-default": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-xhigh": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+    "simple/no-tools/t-1/r-xhigh": null,
+    "simple/no-tools/t-1/r-maximal": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-0.1/r-medium": [INPUT_CONFIGURATION_ERROR],
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-default/force-tool": null,
+    "calc/calc/t-default/r-high/force-tool": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    "reasoning/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true AWS_BEARER_TOKEN_BEDROCK=... npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/anthropic_claude_opus_five_global_bedrock.test.ts
+runStreamEndpointTests(
+  AnthropicClaudeOpusFiveGlobalBedrockStream,
+  AnthropicClaudeOpusFiveGlobalBedrockStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/openai_gpt_five_dot_six_sol_global_bedrock.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_gpt_five_dot_six_sol_global_bedrock.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment node
+
+import { OpenAIGptFiveDotSixSolGlobalBedrockStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_sol_global_bedrock";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+export const OpenAIGptFiveDotSixSolGlobalBedrockStreamSetup: StreamSetup = {
+  createInstance: () =>
+    new OpenAIGptFiveDotSixSolGlobalBedrockStream({
+      AWS_BEARER_TOKEN_BEDROCK: process.env.AWS_BEARER_TOKEN_BEDROCK ?? "",
+    }),
+  // UNVERIFIED: not yet run against Bedrock. The expectations are inherited
+  // from the OpenAI-direct Sol endpoint, which shares the same `configSchema`,
+  // so the `INPUT_CONFIGURATION_ERROR` markers are the ones our own zod
+  // produces and are host-independent. What is *not* verified is whether
+  // Bedrock accepts everything the OpenAI Responses API does. Known
+  // divergences to characterize before this ships:
+  //
+  //   - Structured outputs are documented as unsupported on `bedrock-runtime`,
+  //     so the two `output-format/json-schema` cases may come back as provider
+  //     errors. If they do, the fix is a host-level narrowing of
+  //     `outputFormat`, not a marker here.
+  //   - Server-side tool use is unsupported on `bedrock-runtime` (Dust sends
+  //     only client-side tools, so this suite should not notice).
+  //   - Only the Standard service tier exists, hence no flex on the endpoint.
+  tests: {
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-default/r-xhigh": null,
+    "simple/no-tools/t-default/r-maximal": null,
+    "simple/no-tools/t-0/r-default": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-xhigh": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-default": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-xhigh": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+    "simple/no-tools/t-1/r-xhigh": null,
+    "simple/no-tools/t-1/r-maximal": null,
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-0.1/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-default/force-tool": null,
+    "calc/calc/t-default/r-high/force-tool": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+    "reasoning/no-tools/t-default/r-none": null,
+    "reasoning/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "reasoning/no-tools/t-default/r-low": null,
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+    "following/no-tools/t-default/r-default": null,
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true AWS_BEARER_TOKEN_BEDROCK=... npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_gpt_five_dot_six_sol_global_bedrock.test.ts
+runStreamEndpointTests(
+  OpenAIGptFiveDotSixSolGlobalBedrockStream,
+  OpenAIGptFiveDotSixSolGlobalBedrockStreamSetup
+);

--- a/front/lib/model_constructors/test/endpoints/setups.ts
+++ b/front/lib/model_constructors/test/endpoints/setups.ts
@@ -58,6 +58,7 @@ import { OpenAIGptFiveDotOneGlobalOpenAIResponsesStream } from "@app/lib/model_c
 import { OpenAIGptFiveDotSixLunaEuropeOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_luna_eu_openai_responses";
 import { OpenAIGptFiveDotSixLunaGlobalOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_luna_global_openai_responses";
 import { OpenAIGptFiveDotSixSolEuropeOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_sol_eu_openai_responses";
+import { OpenAIGptFiveDotSixSolGlobalBedrockStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_sol_global_bedrock";
 import { OpenAIGptFiveDotSixSolGlobalOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_sol_global_openai_responses";
 import { OpenAIGptFiveDotSixTerraEuropeOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_terra_eu_openai_responses";
 import { OpenAIGptFiveDotSixTerraGlobalOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_terra_global_openai_responses";
@@ -133,6 +134,7 @@ import { OpenAIGptFiveDotOneGlobalOpenAIResponsesStreamSetup } from "@app/lib/mo
 import { OpenAIGptFiveDotSixLunaEuropeOpenAIResponsesStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_gpt_five_dot_six_luna_eu_openai_responses.test";
 import { OpenAIGptFiveDotSixLunaGlobalOpenAIResponsesStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_gpt_five_dot_six_luna_global_openai_responses.test";
 import { OpenAIGptFiveDotSixSolEuropeOpenAIResponsesStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_gpt_five_dot_six_sol_eu_openai_responses.test";
+import { OpenAIGptFiveDotSixSolGlobalBedrockStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_gpt_five_dot_six_sol_global_bedrock.test";
 import { OpenAIGptFiveDotSixSolGlobalOpenAIResponsesStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_gpt_five_dot_six_sol_global_openai_responses.test";
 import { OpenAIGptFiveDotSixTerraEuropeOpenAIResponsesStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_gpt_five_dot_six_terra_eu_openai_responses.test";
 import { OpenAIGptFiveDotSixTerraGlobalOpenAIResponsesStreamSetup } from "@app/lib/model_constructors/test/endpoints/openai_gpt_five_dot_six_terra_global_openai_responses.test";
@@ -287,6 +289,8 @@ export const STREAM_ENDPOINT_SETUPS = {
     OpenAIGptFiveDotSixLunaGlobalOpenAIResponsesStreamSetup,
   [OpenAIGptSixAstraGlobalOpenAIResponsesStream.id]:
     OpenAIGptSixAstraGlobalOpenAIResponsesStreamSetup,
+  [OpenAIGptFiveDotSixSolGlobalBedrockStream.id]:
+    OpenAIGptFiveDotSixSolGlobalBedrockStreamSetup,
   [OpenAIGptFiveDotSixSolGlobalOpenAIResponsesStream.id]:
     OpenAIGptFiveDotSixSolGlobalOpenAIResponsesStreamSetup,
   [OpenAIGptFiveDotSixTerraGlobalOpenAIResponsesStream.id]:

--- a/front/lib/model_constructors/test/endpoints/setups.ts
+++ b/front/lib/model_constructors/test/endpoints/setups.ts
@@ -7,6 +7,7 @@ import { AnthropicClaudeFableFiveGlobalAnthropicStream } from "@app/lib/model_co
 import { AnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_haiku_four_dot_five_eu_agent_platform";
 import { AnthropicClaudeHaikuFourDotFiveGlobalAnthropicStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_haiku_four_dot_five_global_anthropic";
 import { AnthropicClaudeOpusFiveGlobalAnthropicStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_five_global_anthropic";
+import { AnthropicClaudeOpusFiveGlobalBedrockStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_five_global_bedrock";
 import { AnthropicClaudeOpusFourDotEightEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_four_dot_eight_eu_agent_platform";
 import { AnthropicClaudeOpusFourDotEightGlobalAnthropicStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_four_dot_eight_global_anthropic";
 import { AnthropicClaudeOpusFourDotSevenEuropeAgentPlatformStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_claude_opus_four_dot_seven_eu_agent_platform";
@@ -81,6 +82,7 @@ import { AnthropicClaudeFableFiveGlobalAnthropicStreamSetup } from "@app/lib/mod
 import { AnthropicClaudeHaikuFourDotFiveEuropeAgentPlatformStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_haiku_four_dot_five_eu_agent_platform.test";
 import { AnthropicClaudeHaikuFourDotFiveGlobalAnthropicStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_haiku_four_dot_five_global_anthropic.test";
 import { AnthropicClaudeOpusFiveGlobalAnthropicStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_opus_five_global_anthropic.test";
+import { AnthropicClaudeOpusFiveGlobalBedrockStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_opus_five_global_bedrock.test";
 import { AnthropicClaudeOpusFourDotEightEuropeAgentPlatformStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_eight_eu_agent_platform.test";
 import { AnthropicClaudeOpusFourDotEightGlobalAnthropicStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_eight_global_anthropic.test";
 import { AnthropicClaudeOpusFourDotSevenEuropeAgentPlatformStreamSetup } from "@app/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_seven_eu_agent_platform.test";
@@ -192,6 +194,8 @@ export const STREAM_ENDPOINT_SETUPS = {
     AnthropicClaudeHaikuFourDotFiveGlobalAnthropicStreamSetup,
   [AnthropicClaudeOpusFiveGlobalAnthropicStream.id]:
     AnthropicClaudeOpusFiveGlobalAnthropicStreamSetup,
+  [AnthropicClaudeOpusFiveGlobalBedrockStream.id]:
+    AnthropicClaudeOpusFiveGlobalBedrockStreamSetup,
   [AnthropicClaudeOpusFourDotEightGlobalAnthropicStream.id]:
     AnthropicClaudeOpusFourDotEightGlobalAnthropicStreamSetup,
   [AnthropicClaudeOpusFourDotSevenGlobalAnthropicStream.id]:

--- a/front/lib/model_constructors/types/credentials.ts
+++ b/front/lib/model_constructors/types/credentials.ts
@@ -6,4 +6,5 @@ export type Credentials = {
   MISTRAL_API_KEY?: string;
   FIREWORKS_API_KEY?: string;
   XAI_API_KEY?: string;
+  AWS_BEARER_TOKEN_BEDROCK?: string;
 };

--- a/front/lib/model_constructors/types/hosts.ts
+++ b/front/lib/model_constructors/types/hosts.ts
@@ -2,6 +2,7 @@ export const OPENAI_RESPONSES_HOST = "openai-responses" as const;
 export const ANTHROPIC_HOST = "anthropic" as const;
 export const GOOGLE_AI_STUDIO_HOST = "google-ai-studio" as const;
 export const AGENT_PLATFORM_HOST = "agent-platform" as const;
+export const BEDROCK_HOST = "bedrock" as const;
 export const MISTRAL_HOST = "mistral" as const;
 export const FIREWORKS_HOST = "fireworks" as const;
 export const XAI_HOST = "xai" as const;
@@ -12,6 +13,7 @@ const HOSTS = [
   ANTHROPIC_HOST,
   GOOGLE_AI_STUDIO_HOST,
   AGENT_PLATFORM_HOST,
+  BEDROCK_HOST,
   MISTRAL_HOST,
   FIREWORKS_HOST,
   XAI_HOST,

--- a/front/types/provider_credential.ts
+++ b/front/types/provider_credential.ts
@@ -22,6 +22,9 @@ export type LLMCredentialsType = {
   AI21_API_KEY?: string;
   FIREWORKS_API_KEY?: string;
   AGENT_PLATFORM_PROJECT_ID?: string;
+  // Bedrock API key, minted per the AWS-standard env var name so the value can
+  // be reused as-is by AWS tooling. Dust-hosted only: never workspace-provided.
+  AWS_BEARER_TOKEN_BEDROCK?: string;
 };
 
 export type ProviderCredentialType = {


### PR DESCRIPTION
## Description

Adds a `bedrock` host to the endpoint router, serving Claude Opus 5 through `bedrock-mantle` (native Messages API) and GPT-5.6 Sol through `bedrock-runtime` (OpenAI Responses API), both authenticated with a Dust-managed `AWS_BEARER_TOKEN_BEDROCK` and routed on the global cross-Region inference profiles.

## Tests

Not working end to end yet: every inference call returns `403 "<model> is not available for this account"` on both endpoints, which we suspect is an expired billing payment method on the AWS account — still to test once that is sorted. What is verified: the Marketplace agreements were created and report `agreementAvailability: AVAILABLE`, `authorizationStatus: AUTHORIZED`; Amazon Nova invokes fine with the same credential, so the account and token work; and both clients demonstrably reach the right host with the right model id (an unknown model returns a `404 not_found_error` rather than a permission error, so authorization passes and the failure is purely entitlement). Pricing was confirmed against the Marketplace rate card. Both endpoint suites currently inherit their expectations from the direct lab endpoints and are marked UNVERIFIED; the `🟢` marker logs in the two clients are temporary and should come out before merge.

## Risk

Both Bedrock endpoints are registered ahead of their direct lab endpoints and are not feature-flagged, so on merge all non-BYOK Opus 5 and GPT-5.6 Sol traffic would route to Bedrock — this must not ship until the 403s are resolved or the endpoints are gated.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`
