### PR TITLE
[front] Inline tool reference 

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -1104,7 +1104,7 @@ export const ConversationViewer = ({
       input: string,
       mentions: RichMention[],
       contentFragments: ContentFragmentsType,
-      _selectedMCPServerViewIds?: string[],
+      selectedMCPServerViewIds?: string[],
       selectedSpaceIds?: string[],
       modelSelection?: ModelSelectionType
     ): Promise<Result<undefined, DustError>> => {
@@ -1134,6 +1134,7 @@ export const ConversationViewer = ({
           clientSideMCPServerIds:
             clientSideMCPServerIds ??
             agentBuilderContext?.clientSideMCPServerIds,
+          selectedMCPServerViewIds,
           selectedSpaceIds,
           skipToolsValidation: agentBuilderContext?.skipToolsValidation,
           modelSelection,

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -270,13 +270,13 @@ export const InputBar = React.memo(function InputBar({
     workspaceId: owner.sId,
   });
 
-  const IsInlineReferenceEnabled = featureFlags.includes("inline_tool_knowledge_reference");
+  const isInlineReferenceEnabled = featureFlags.includes("inline_tool_knowledge_reference");
 
   useEffect(() => {
-    if (!IsInlineReferenceEnabled) {
+    if (!isInlineReferenceEnabled) {
       setSelectedMCPServerViews(conversationTools);
     }
-  }, [conversationTools, IsInlineReferenceEnabled]);
+  }, [conversationTools, isInlineReferenceEnabled]);
 
   const { addTool, deleteTool } = useAddDeleteConversationTool({
     conversationId: conversation?.sId,
@@ -413,7 +413,7 @@ export const InputBar = React.memo(function InputBar({
 
   const handleMCPServerViewSelect = useCallback(
     (serverView: MCPServerViewLightType) => {
-      if (!IsInlineReferenceEnabled && selectedMCPServerViewIds.has(serverView.sId)) {
+      if (!isInlineReferenceEnabled && selectedMCPServerViewIds.has(serverView.sId)) {
         return;
       }
 
@@ -422,17 +422,17 @@ export const InputBar = React.memo(function InputBar({
           ? prev
           : [...prev, serverView]
       );
-      if (!IsInlineReferenceEnabled) {
+      if (!isInlineReferenceEnabled) {
         void addTool(serverView.sId);
       }
     },
-    [addTool, IsInlineReferenceEnabled, selectedMCPServerViewIds]
+    [addTool, isInlineReferenceEnabled, selectedMCPServerViewIds]
   );
 
   const handleMCPServerViewDeselect = useCallback(
     (serverView: MCPServerViewLightType) => {
       if (
-        !IsInlineReferenceEnabled &&
+        !isInlineReferenceEnabled &&
         !selectedMCPServerViewIds.has(serverView.sId)
       ) {
         return;
@@ -441,11 +441,11 @@ export const InputBar = React.memo(function InputBar({
       setSelectedMCPServerViews((prev) =>
         prev.filter((sv) => sv.sId !== serverView.sId)
       );
-      if (!IsInlineReferenceEnabled) {
+      if (!isInlineReferenceEnabled) {
         void deleteTool(serverView.sId);
       }
     },
-    [deleteTool, IsInlineReferenceEnabled, selectedMCPServerViewIds]
+    [deleteTool, isInlineReferenceEnabled, selectedMCPServerViewIds]
   );
 
   const clearSideChannelSelections = useCallback(async () => {
@@ -455,12 +455,12 @@ export const InputBar = React.memo(function InputBar({
     setSelectedMCPServerViews([]);
     setAttachedNodes([]);
 
-    if (!IsInlineReferenceEnabled) {
+    if (!isInlineReferenceEnabled) {
       await Promise.all(
         serverViewIds.map((serverViewId) => deleteTool(serverViewId))
       );
     }
-  }, [deleteTool, IsInlineReferenceEnabled, selectedMCPServerViews]);
+  }, [deleteTool, isInlineReferenceEnabled, selectedMCPServerViews]);
 
   const handleSelectedSpaceIdsChange = useCallback(
     async (spaceIds: string[]): Promise<string[] | null> => {
@@ -561,12 +561,12 @@ export const InputBar = React.memo(function InputBar({
       mentions.some((m) => m.id === a.sId && m.type === "agent")
     );
 
-    const messageTools = IsInlineReferenceEnabled ? extractToolTags(markdown) : [];
+    const messageTools = isInlineReferenceEnabled ? extractToolTags(markdown) : [];
     const toolIdsToAttach = getToolIdsToAttach(
       messageTools,
       new Set(conversationTools.map((serverView) => serverView.sId))
     );
-    const trackedTools = IsInlineReferenceEnabled
+    const trackedTools = isInlineReferenceEnabled
       ? messageTools.map((t) => t.name)
       : selectedMCPServerViews.map((t) => t.server.name);
 
@@ -612,7 +612,7 @@ export const InputBar = React.memo(function InputBar({
             }),
             contentNodes: attachedNodes,
           },
-          IsInlineReferenceEnabled
+          isInlineReferenceEnabled
             ? toolIdsToAttach
             : selectedMCPServerViews.map((sv) => sv.sId),
           selectedSpaceIds,
@@ -623,7 +623,7 @@ export const InputBar = React.memo(function InputBar({
           clearDraft();
           resetEditorText();
           fileUploaderService.resetUpload();
-          if (IsInlineReferenceEnabled) {
+          if (isInlineReferenceEnabled) {
             setSelectedMCPServerViews([]);
           }
           setSelectedSpacesState({
@@ -663,7 +663,7 @@ export const InputBar = React.memo(function InputBar({
         clearDraft();
         fileUploaderService.resetUpload();
         setAttachedNodes([]);
-        if (IsInlineReferenceEnabled) {
+        if (isInlineReferenceEnabled) {
           setSelectedMCPServerViews([]);
         }
 
@@ -693,7 +693,7 @@ export const InputBar = React.memo(function InputBar({
   };
 
   const handleResetMCPServerViews = () => {
-    if (!IsInlineReferenceEnabled) {
+    if (!isInlineReferenceEnabled) {
       selectedMCPServerViews.forEach((sv) => void deleteTool(sv.sId));
     }
     setSelectedMCPServerViews([]);

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -270,7 +270,9 @@ export const InputBar = React.memo(function InputBar({
     workspaceId: owner.sId,
   });
 
-  const isInlineReferenceEnabled = featureFlags.includes("inline_tool_knowledge_reference");
+  const isInlineReferenceEnabled = featureFlags.includes(
+    "inline_tool_knowledge_reference"
+  );
 
   useEffect(() => {
     if (!isInlineReferenceEnabled) {
@@ -413,7 +415,10 @@ export const InputBar = React.memo(function InputBar({
 
   const handleMCPServerViewSelect = useCallback(
     (serverView: MCPServerViewLightType) => {
-      if (!isInlineReferenceEnabled && selectedMCPServerViewIds.has(serverView.sId)) {
+      if (
+        !isInlineReferenceEnabled &&
+        selectedMCPServerViewIds.has(serverView.sId)
+      ) {
         return;
       }
 
@@ -561,7 +566,9 @@ export const InputBar = React.memo(function InputBar({
       mentions.some((m) => m.id === a.sId && m.type === "agent")
     );
 
-    const messageTools = isInlineReferenceEnabled ? extractToolTags(markdown) : [];
+    const messageTools = isInlineReferenceEnabled
+      ? extractToolTags(markdown)
+      : [];
     const toolIdsToAttach = getToolIdsToAttach(
       messageTools,
       new Set(conversationTools.map((serverView) => serverView.sId))

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -270,13 +270,13 @@ export const InputBar = React.memo(function InputBar({
     workspaceId: owner.sId,
   });
 
-  const hasInlineToolChips = featureFlags.includes("inline_tool_chips");
+  const IsInlineReferenceEnabled = featureFlags.includes("inline_tool_knowledge_reference");
 
   useEffect(() => {
-    if (!hasInlineToolChips) {
+    if (!IsInlineReferenceEnabled) {
       setSelectedMCPServerViews(conversationTools);
     }
-  }, [conversationTools, hasInlineToolChips]);
+  }, [conversationTools, IsInlineReferenceEnabled]);
 
   const { addTool, deleteTool } = useAddDeleteConversationTool({
     conversationId: conversation?.sId,
@@ -413,7 +413,7 @@ export const InputBar = React.memo(function InputBar({
 
   const handleMCPServerViewSelect = useCallback(
     (serverView: MCPServerViewLightType) => {
-      if (!hasInlineToolChips && selectedMCPServerViewIds.has(serverView.sId)) {
+      if (!IsInlineReferenceEnabled && selectedMCPServerViewIds.has(serverView.sId)) {
         return;
       }
 
@@ -422,17 +422,17 @@ export const InputBar = React.memo(function InputBar({
           ? prev
           : [...prev, serverView]
       );
-      if (!hasInlineToolChips) {
+      if (!IsInlineReferenceEnabled) {
         void addTool(serverView.sId);
       }
     },
-    [addTool, hasInlineToolChips, selectedMCPServerViewIds]
+    [addTool, IsInlineReferenceEnabled, selectedMCPServerViewIds]
   );
 
   const handleMCPServerViewDeselect = useCallback(
     (serverView: MCPServerViewLightType) => {
       if (
-        !hasInlineToolChips &&
+        !IsInlineReferenceEnabled &&
         !selectedMCPServerViewIds.has(serverView.sId)
       ) {
         return;
@@ -441,11 +441,11 @@ export const InputBar = React.memo(function InputBar({
       setSelectedMCPServerViews((prev) =>
         prev.filter((sv) => sv.sId !== serverView.sId)
       );
-      if (!hasInlineToolChips) {
+      if (!IsInlineReferenceEnabled) {
         void deleteTool(serverView.sId);
       }
     },
-    [deleteTool, hasInlineToolChips, selectedMCPServerViewIds]
+    [deleteTool, IsInlineReferenceEnabled, selectedMCPServerViewIds]
   );
 
   const clearSideChannelSelections = useCallback(async () => {
@@ -455,12 +455,12 @@ export const InputBar = React.memo(function InputBar({
     setSelectedMCPServerViews([]);
     setAttachedNodes([]);
 
-    if (!hasInlineToolChips) {
+    if (!IsInlineReferenceEnabled) {
       await Promise.all(
         serverViewIds.map((serverViewId) => deleteTool(serverViewId))
       );
     }
-  }, [deleteTool, hasInlineToolChips, selectedMCPServerViews]);
+  }, [deleteTool, IsInlineReferenceEnabled, selectedMCPServerViews]);
 
   const handleSelectedSpaceIdsChange = useCallback(
     async (spaceIds: string[]): Promise<string[] | null> => {
@@ -561,12 +561,12 @@ export const InputBar = React.memo(function InputBar({
       mentions.some((m) => m.id === a.sId && m.type === "agent")
     );
 
-    const messageTools = hasInlineToolChips ? extractToolTags(markdown) : [];
+    const messageTools = IsInlineReferenceEnabled ? extractToolTags(markdown) : [];
     const toolIdsToAttach = getToolIdsToAttach(
       messageTools,
       new Set(conversationTools.map((serverView) => serverView.sId))
     );
-    const trackedTools = hasInlineToolChips
+    const trackedTools = IsInlineReferenceEnabled
       ? messageTools.map((t) => t.name)
       : selectedMCPServerViews.map((t) => t.server.name);
 
@@ -612,7 +612,7 @@ export const InputBar = React.memo(function InputBar({
             }),
             contentNodes: attachedNodes,
           },
-          hasInlineToolChips
+          IsInlineReferenceEnabled
             ? toolIdsToAttach
             : selectedMCPServerViews.map((sv) => sv.sId),
           selectedSpaceIds,
@@ -623,7 +623,7 @@ export const InputBar = React.memo(function InputBar({
           clearDraft();
           resetEditorText();
           fileUploaderService.resetUpload();
-          if (hasInlineToolChips) {
+          if (IsInlineReferenceEnabled) {
             setSelectedMCPServerViews([]);
           }
           setSelectedSpacesState({
@@ -663,7 +663,7 @@ export const InputBar = React.memo(function InputBar({
         clearDraft();
         fileUploaderService.resetUpload();
         setAttachedNodes([]);
-        if (hasInlineToolChips) {
+        if (IsInlineReferenceEnabled) {
           setSelectedMCPServerViews([]);
         }
 
@@ -693,7 +693,7 @@ export const InputBar = React.memo(function InputBar({
   };
 
   const handleResetMCPServerViews = () => {
-    if (!hasInlineToolChips) {
+    if (!IsInlineReferenceEnabled) {
       selectedMCPServerViews.forEach((sv) => void deleteTool(sv.sId));
     }
     setSelectedMCPServerViews([]);

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -28,6 +28,7 @@ import {
   useSelectableConversationSpaces,
 } from "@app/lib/swr/conversation_selected_spaces";
 import { useSpaces } from "@app/lib/swr/spaces";
+import { extractToolTags, getToolIdsToAttach } from "@app/lib/tools/format";
 import { TRACKING_AREAS, trackEvent } from "@app/lib/tracking";
 import { classNames } from "@app/lib/utils";
 import {
@@ -258,23 +259,24 @@ export const InputBar = React.memo(function InputBar({
     !!conversation &&
     getConversationGeneratingMessages(conversation.sId).length > 0;
 
-  // Tools selection
-
   const [selectedMCPServerViews, setSelectedMCPServerViews] = useState<
     MCPServerViewLightType[]
   >([]);
   const [selectedSpacesState, setSelectedSpacesState] =
     useState<SelectedSpacesState | null>(null);
 
-  const { conversationTools } = useConversationTools({
+  const { conversationTools, mutateConversationTools } = useConversationTools({
     conversationId: conversation?.sId,
     workspaceId: owner.sId,
   });
 
-  // The truth is in the conversationTools, we need to update the selectedMCPServerViewIds when the conversationTools change.
+  const hasInlineToolChips = featureFlags.includes("inline_tool_chips");
+
   useEffect(() => {
-    setSelectedMCPServerViews(conversationTools);
-  }, [conversationTools]);
+    if (!hasInlineToolChips) {
+      setSelectedMCPServerViews(conversationTools);
+    }
+  }, [conversationTools, hasInlineToolChips]);
 
   const { addTool, deleteTool } = useAddDeleteConversationTool({
     conversationId: conversation?.sId,
@@ -284,6 +286,7 @@ export const InputBar = React.memo(function InputBar({
     () => new Set(selectedMCPServerViews.map((serverView) => serverView.sId)),
     [selectedMCPServerViews]
   );
+
   const spacesSelectionKey = conversation?.sId ?? `draft:${draftKey}`;
   const draftSelectedSpaceIds = useMemo(
     () => getDraft()?.selectedSpaceIds ?? [],
@@ -410,7 +413,7 @@ export const InputBar = React.memo(function InputBar({
 
   const handleMCPServerViewSelect = useCallback(
     (serverView: MCPServerViewLightType) => {
-      if (selectedMCPServerViewIds.has(serverView.sId)) {
+      if (!hasInlineToolChips && selectedMCPServerViewIds.has(serverView.sId)) {
         return;
       }
 
@@ -419,23 +422,30 @@ export const InputBar = React.memo(function InputBar({
           ? prev
           : [...prev, serverView]
       );
-      void addTool(serverView.sId);
+      if (!hasInlineToolChips) {
+        void addTool(serverView.sId);
+      }
     },
-    [addTool, selectedMCPServerViewIds]
+    [addTool, hasInlineToolChips, selectedMCPServerViewIds]
   );
 
   const handleMCPServerViewDeselect = useCallback(
     (serverView: MCPServerViewLightType) => {
-      if (!selectedMCPServerViewIds.has(serverView.sId)) {
+      if (
+        !hasInlineToolChips &&
+        !selectedMCPServerViewIds.has(serverView.sId)
+      ) {
         return;
       }
 
       setSelectedMCPServerViews((prev) =>
         prev.filter((sv) => sv.sId !== serverView.sId)
       );
-      void deleteTool(serverView.sId);
+      if (!hasInlineToolChips) {
+        void deleteTool(serverView.sId);
+      }
     },
-    [deleteTool, selectedMCPServerViewIds]
+    [deleteTool, hasInlineToolChips, selectedMCPServerViewIds]
   );
 
   const clearSideChannelSelections = useCallback(async () => {
@@ -445,10 +455,12 @@ export const InputBar = React.memo(function InputBar({
     setSelectedMCPServerViews([]);
     setAttachedNodes([]);
 
-    await Promise.all(
-      serverViewIds.map((serverViewId) => deleteTool(serverViewId))
-    );
-  }, [deleteTool, selectedMCPServerViews]);
+    if (!hasInlineToolChips) {
+      await Promise.all(
+        serverViewIds.map((serverViewId) => deleteTool(serverViewId))
+      );
+    }
+  }, [deleteTool, hasInlineToolChips, selectedMCPServerViews]);
 
   const handleSelectedSpaceIdsChange = useCallback(
     async (spaceIds: string[]): Promise<string[] | null> => {
@@ -549,6 +561,15 @@ export const InputBar = React.memo(function InputBar({
       mentions.some((m) => m.id === a.sId && m.type === "agent")
     );
 
+    const messageTools = hasInlineToolChips ? extractToolTags(markdown) : [];
+    const toolIdsToAttach = getToolIdsToAttach(
+      messageTools,
+      new Set(conversationTools.map((serverView) => serverView.sId))
+    );
+    const trackedTools = hasInlineToolChips
+      ? messageTools.map((t) => t.name)
+      : selectedMCPServerViews.map((t) => t.server.name);
+
     trackEvent({
       area: TRACKING_AREAS.CONVERSATION,
       object: "message_send",
@@ -556,7 +577,7 @@ export const InputBar = React.memo(function InputBar({
       extra: {
         conversation_id: conversation?.sId ?? "new",
         has_attachments: attachedNodes.length > 0 || uploadedFiles.length > 0,
-        has_tools: selectedMCPServerViews.length > 0,
+        has_tools: trackedTools.length > 0,
         has_agents: mentionedAgents.length > 0,
         has_default_agent: mentionedAgents.some((a) => isGlobalAgentId(a.sId)),
         has_custom_agent: mentionedAgents.some((a) => !isGlobalAgentId(a.sId)),
@@ -564,8 +585,8 @@ export const InputBar = React.memo(function InputBar({
         agent_count: mentions.length,
         agent_ids: mentionedAgents.map((a) => a.sId).join(","),
         attachment_count: attachedNodes.length + uploadedFiles.length,
-        tool_count: selectedMCPServerViews.length,
-        tool_names: selectedMCPServerViews.map((t) => t.server.name).join(","),
+        tool_count: trackedTools.length,
+        tool_names: trackedTools.join(","),
         message_length: markdown.length,
       },
     });
@@ -591,9 +612,9 @@ export const InputBar = React.memo(function InputBar({
             }),
             contentNodes: attachedNodes,
           },
-          // Only send the selectedMCPServerViewIds if we are creating a new conversation.
-          // Once the conversation is created, the selectedMCPServerViewIds will be updated in the conversationTools hook.
-          selectedMCPServerViews.map((sv) => sv.sId),
+          hasInlineToolChips
+            ? toolIdsToAttach
+            : selectedMCPServerViews.map((sv) => sv.sId),
           selectedSpaceIds,
           modelSelectionRef.current
         );
@@ -602,6 +623,9 @@ export const InputBar = React.memo(function InputBar({
           clearDraft();
           resetEditorText();
           fileUploaderService.resetUpload();
+          if (hasInlineToolChips) {
+            setSelectedMCPServerViews([]);
+          }
           setSelectedSpacesState({
             key: spacesSelectionKey,
             spaceIds: [],
@@ -629,9 +653,7 @@ export const InputBar = React.memo(function InputBar({
             }),
             contentNodes: attachedNodes,
           },
-          // Existing conversation: MCP server views are synced via the
-          // conversationTools hook.
-          undefined,
+          toolIdsToAttach.length > 0 ? toolIdsToAttach : undefined,
           selectedSpaceIds,
           modelSelectionRef.current
         );
@@ -641,8 +663,16 @@ export const InputBar = React.memo(function InputBar({
         clearDraft();
         fileUploaderService.resetUpload();
         setAttachedNodes([]);
+        if (hasInlineToolChips) {
+          setSelectedMCPServerViews([]);
+        }
 
-        await submitPromise;
+        const r = await submitPromise;
+        if (r.isOk() && toolIdsToAttach.length > 0) {
+          // Newly attached tools are now part of the conversation's server-side set; refresh it
+          // so the next submit's diff doesn't re-send them.
+          void mutateConversationTools();
+        }
       } finally {
         setIsLocalSubmitting(false);
       }
@@ -663,10 +693,10 @@ export const InputBar = React.memo(function InputBar({
   };
 
   const handleResetMCPServerViews = () => {
-    setSelectedMCPServerViews((prev) => {
-      prev.forEach((sv) => void deleteTool(sv.sId));
-      return [];
-    });
+    if (!hasInlineToolChips) {
+      selectedMCPServerViews.forEach((sv) => void deleteTool(sv.sId));
+    }
+    setSelectedMCPServerViews([]);
   };
 
   const handleShake = useCallback(() => {

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -707,7 +707,6 @@ const InputBarContainer = ({
   };
 
   const handleToolSelect = (view: MCPServerViewLightType) => {
-    debugger;
     onMCPServerViewSelect(view);
 
     if (!isInlineReferenceEnabled) {

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -354,7 +354,7 @@ const InputBarContainer = ({
   );
   const { subscription } = useAuth();
   const { featureFlags } = useFeatureFlags();
-  const IsInlineReferenceEnabled = featureFlags.includes("inline_tool_knowledge_reference");
+  const isInlineReferenceEnabled = featureFlags.includes("inline_tool_knowledge_reference");
   const isMobile = useIsMobile();
   const clientType = useClientType();
   const {
@@ -418,10 +418,10 @@ const InputBarContainer = ({
   attachedNodesRef.current = attachedNodes;
   const selectedMCPServerViewIds = useMemo(
     () =>
-      IsInlineReferenceEnabled
+      isInlineReferenceEnabled
         ? new Set<string>()
         : new Set(selectedMCPServerViews.map((serverView) => serverView.sId)),
-    [IsInlineReferenceEnabled, selectedMCPServerViews]
+    [isInlineReferenceEnabled, selectedMCPServerViews]
   );
   const selectedMCPServerViewIdsRef = useRef(selectedMCPServerViewIds);
   selectedMCPServerViewIdsRef.current = selectedMCPServerViewIds;
@@ -708,7 +708,7 @@ const InputBarContainer = ({
     debugger;
     onMCPServerViewSelect(view);
 
-    if (!IsInlineReferenceEnabled) {
+    if (!isInlineReferenceEnabled) {
       return;
     }
 
@@ -1787,7 +1787,7 @@ const InputBarContainer = ({
             }}
           >
             <div className="mb-1 flex flex-wrap items-center px-3">
-              {!IsInlineReferenceEnabled &&
+              {!isInlineReferenceEnabled &&
                 selectedMCPServerViews.map((msv) => (
                   <Fragment key={msv.sId}>
                     {/* Two Chips: one for larger screens (desktop), one for smaller screens (mobile). */}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -354,7 +354,7 @@ const InputBarContainer = ({
   );
   const { subscription } = useAuth();
   const { featureFlags } = useFeatureFlags();
-  const hasInlineToolChips = featureFlags.includes("inline_tool_chips");
+  const IsInlineReferenceEnabled = featureFlags.includes("inline_tool_knowledge_reference");
   const isMobile = useIsMobile();
   const clientType = useClientType();
   const {
@@ -418,10 +418,10 @@ const InputBarContainer = ({
   attachedNodesRef.current = attachedNodes;
   const selectedMCPServerViewIds = useMemo(
     () =>
-      hasInlineToolChips
+      IsInlineReferenceEnabled
         ? new Set<string>()
         : new Set(selectedMCPServerViews.map((serverView) => serverView.sId)),
-    [hasInlineToolChips, selectedMCPServerViews]
+    [IsInlineReferenceEnabled, selectedMCPServerViews]
   );
   const selectedMCPServerViewIdsRef = useRef(selectedMCPServerViewIds);
   selectedMCPServerViewIdsRef.current = selectedMCPServerViewIds;
@@ -708,7 +708,7 @@ const InputBarContainer = ({
     debugger;
     onMCPServerViewSelect(view);
 
-    if (!hasInlineToolChips) {
+    if (!IsInlineReferenceEnabled) {
       return;
     }
 
@@ -1787,7 +1787,7 @@ const InputBarContainer = ({
             }}
           >
             <div className="mb-1 flex flex-wrap items-center px-3">
-              {!hasInlineToolChips &&
+              {!IsInlineReferenceEnabled &&
                 selectedMCPServerViews.map((msv) => (
                   <Fragment key={msv.sId}>
                     {/* Two Chips: one for larger screens (desktop), one for smaller screens (mobile). */}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -32,6 +32,7 @@ import {
   SELECT_TOOL_SLASH_COMMAND_ACTION,
 } from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
 import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
+import { TOOL_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/ToolNode";
 import type { CustomEditorProps } from "@app/components/editor/input_bar/useCustomEditor";
 import useCustomEditor, {
   INPUT_BAR_DEFAULT_PLACEHOLDER,
@@ -50,7 +51,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useVoiceLiveTranscriberService } from "@app/hooks/useVoiceLiveTranscriberService";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewLightType } from "@app/lib/api/mcp";
-import { useAuth } from "@app/lib/auth/AuthContext";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isNodeCandidate } from "@app/lib/connectors";
 import { useClientType } from "@app/lib/context/clientType";
@@ -103,9 +104,11 @@ import {
   TooltipTrigger,
   VoicePicker,
 } from "@dust-tt/sparkle";
-import type { Editor } from "@tiptap/react";
+import type { Editor, EditorEvents } from "@tiptap/react";
 import { EditorContent } from "@tiptap/react";
-import React, {
+import type React from "react";
+import {
+  Fragment,
   useCallback,
   useContext,
   useEffect,
@@ -183,6 +186,25 @@ function readDefaultSkillEditorState(editor: Editor): {
     return true;
   });
   return { skillIds, hasUserContent };
+}
+
+function hasAnotherAttachedNode(
+  editor: Editor,
+  nodeType: string,
+  attrName: string,
+  value: string
+): boolean {
+  let found = false;
+  editor.state.doc.descendants((node) => {
+    if (found) {
+      return false;
+    }
+    if (node.type.name === nodeType && node.attrs[attrName] === value) {
+      found = true;
+    }
+    return true;
+  });
+  return found;
 }
 
 function sameSkillIds(a: string[], b: string[]): boolean {
@@ -331,6 +353,8 @@ const InputBarContainer = ({
     null
   );
   const { subscription } = useAuth();
+  const { featureFlags } = useFeatureFlags();
+  const hasInlineToolChips = featureFlags.includes("inline_tool_chips");
   const isMobile = useIsMobile();
   const clientType = useClientType();
   const {
@@ -392,16 +416,15 @@ const InputBarContainer = ({
   const pastedAttachmentIdsRef = useRef<Set<string>>(new Set());
   const attachedNodesRef = useRef(attachedNodes);
   attachedNodesRef.current = attachedNodes;
-  const onNodeUnselectRef = useRef(onNodeUnselect);
-  onNodeUnselectRef.current = onNodeUnselect;
-  // Tracks internalIds of nodes that have a dataSourceLink chip in the editor,
-  // so we only sync removal for nodes that were created via URL paste.
-  const dataSourceLinkNodeIdsRef = useRef<Set<string>>(new Set());
   const selectedMCPServerViewIds = useMemo(
-    () => new Set(selectedMCPServerViews.map((serverView) => serverView.sId)),
-    [selectedMCPServerViews]
+    () =>
+      hasInlineToolChips
+        ? new Set<string>()
+        : new Set(selectedMCPServerViews.map((serverView) => serverView.sId)),
+    [hasInlineToolChips, selectedMCPServerViews]
   );
   const selectedMCPServerViewIdsRef = useRef(selectedMCPServerViewIds);
+  selectedMCPServerViewIdsRef.current = selectedMCPServerViewIds;
   const selectedSpaceIdsRef = useRef(selectedSpaceIds);
   const shouldEnableSlashSuggestionRef = useRef(shouldEnableSlashSuggestion);
   // The slash suggestion extension captures its options at editor initialization, while the
@@ -448,7 +471,6 @@ const InputBarContainer = ({
   >(null);
   const [selectedServerViewForDetails, setSelectedServerViewForDetails] =
     useState<MCPServerViewLightType | null>(null);
-  selectedMCPServerViewIdsRef.current = selectedMCPServerViewIds;
   shouldEnableSlashSuggestionRef.current = shouldEnableSlashSuggestion;
 
   useEffect(() => {
@@ -682,6 +704,25 @@ const InputBarContainer = ({
       .run();
   };
 
+  const handleToolSelect = (view: MCPServerViewLightType) => {
+    debugger;
+    onMCPServerViewSelect(view);
+
+    if (!hasInlineToolChips) {
+      return;
+    }
+
+    editorRef.current
+      ?.chain()
+      .focus()
+      .insertToolNode({
+        mcpServerViewId: view.sId,
+        toolName: getMcpServerViewDisplayName(view),
+        toolIcon: view.server.icon,
+      })
+      .run();
+  };
+
   const handleSlashCommandSelect = (command: InputBarSlashCommand) => {
     switch (command.id) {
       case "upload-file":
@@ -730,7 +771,7 @@ const InputBarContainer = ({
         handleSkillSelect(item.data.skill);
         break;
       case SELECT_TOOL_SLASH_COMMAND_ACTION:
-        onMCPServerViewSelect(item.data.tool.view);
+        handleToolSelect(item.data.tool.view);
         break;
       default:
         assertNeverAndIgnore(item);
@@ -1098,50 +1139,85 @@ const InputBarContainer = ({
       userMentioned,
       editorStartsWithUserMention
     );
+  }, []);
 
-    // Sync: when a dataSourceLink chip is deleted from the editor, remove
-    // the corresponding attached node so the attachment card disappears.
-    if (currentEditor && attachedNodesRef.current.length > 0) {
-      const chipNodeIds = new Set<string>();
-      currentEditor.state.doc.descendants((node) => {
-        if (node.type.name === "dataSourceLink" && node.attrs?.nodeId) {
-          chipNodeIds.add(String(node.attrs.nodeId));
-        }
-      });
+  const handleContentDeleted = useCallback(
+    (event: EditorEvents["delete"]) => {
+      if (event.type !== "node") {
+        return;
+      }
 
-      // Update the tracked set and unselect nodes whose chip was removed.
-      const prevIds = dataSourceLinkNodeIdsRef.current;
-      for (const prevId of prevIds) {
-        if (!chipNodeIds.has(prevId)) {
-          const node = attachedNodesRef.current.find(
-            (n) => n.internalId === prevId
+      const currentEditor = editorRef.current;
+      if (!currentEditor || currentEditor.isDestroyed) {
+        return;
+      }
+
+      const { node } = event;
+
+      if (node.type.name === "dataSourceLink") {
+        const nodeId = node.attrs.nodeId;
+        if (
+          typeof nodeId === "string" &&
+          !hasAnotherAttachedNode(
+            currentEditor,
+            "dataSourceLink",
+            "nodeId",
+            nodeId
+          )
+        ) {
+          const attachedNode = attachedNodesRef.current.find(
+            (n) => n.internalId === nodeId
           );
-          if (node) {
-            onNodeUnselectRef.current(node);
+          if (attachedNode) {
+            onNodeUnselect(attachedNode);
+          }
+        }
+        return;
+      }
+
+      if (node.type.name === TOOL_NODE_TYPE) {
+        const mcpServerViewId = node.attrs.mcpServerViewId;
+        if (
+          typeof mcpServerViewId === "string" &&
+          !hasAnotherAttachedNode(
+            currentEditor,
+            TOOL_NODE_TYPE,
+            "mcpServerViewId",
+            mcpServerViewId
+          )
+        ) {
+          const view = selectedMCPServerViews.find(
+            (v) => v.sId === mcpServerViewId
+          );
+          if (view) {
+            onMCPServerViewDeselect(view);
           }
         }
       }
-      dataSourceLinkNodeIdsRef.current = chipNodeIds;
-    }
-  }, []);
+    },
+    [onNodeUnselect, onMCPServerViewDeselect, selectedMCPServerViews]
+  );
 
   // Update the editor ref when the editor is created and listen for updates to the editor.
   useEffect(() => {
     if (editorRef.current) {
       editorRef.current.off("update", handleEditorUpdate);
+      editorRef.current.off("delete", handleContentDeleted);
     }
 
     if (editor) {
       editor.on("update", handleEditorUpdate);
+      editor.on("delete", handleContentDeleted);
     }
     editorRef.current = editor;
 
     return () => {
       if (editor) {
         editor.off("update", handleEditorUpdate);
+        editor.off("delete", handleContentDeleted);
       }
     };
-  }, [editor, handleEditorUpdate]);
+  }, [editor, handleEditorUpdate, handleContentDeleted]);
 
   useUrlHandler(editor, selectedNode, nodeOrUrlCandidate, handleUrlReplaced);
 
@@ -1711,30 +1787,31 @@ const InputBarContainer = ({
             }}
           >
             <div className="mb-1 flex flex-wrap items-center px-3">
-              {selectedMCPServerViews.map((msv) => (
-                <React.Fragment key={msv.sId}>
-                  {/* Two Chips: one for larger screens (desktop), one for smaller screens (mobile). */}
-                  <Chip
-                    size="xs"
-                    label={getMcpServerViewDisplayName(msv)}
-                    icon={getIcon(msv.server.icon)}
-                    className="m-0.5 hidden bg-background text-foreground xs:flex"
-                    onClick={() => setSelectedServerViewForDetails(msv)}
-                    onRemove={() => {
-                      onMCPServerViewDeselect(msv);
-                    }}
-                  />
-                  <Chip
-                    size="xs"
-                    icon={getIcon(msv.server.icon)}
-                    className="m-0.5 flex bg-background text-foreground xs:hidden"
-                    onClick={() => setSelectedServerViewForDetails(msv)}
-                    onRemove={() => {
-                      onMCPServerViewDeselect(msv);
-                    }}
-                  />
-                </React.Fragment>
-              ))}
+              {!hasInlineToolChips &&
+                selectedMCPServerViews.map((msv) => (
+                  <Fragment key={msv.sId}>
+                    {/* Two Chips: one for larger screens (desktop), one for smaller screens (mobile). */}
+                    <Chip
+                      size="xs"
+                      label={getMcpServerViewDisplayName(msv)}
+                      icon={getIcon(msv.server.icon)}
+                      className="m-0.5 hidden bg-background text-foreground xs:flex"
+                      onClick={() => setSelectedServerViewForDetails(msv)}
+                      onRemove={() => {
+                        onMCPServerViewDeselect(msv);
+                      }}
+                    />
+                    <Chip
+                      size="xs"
+                      icon={getIcon(msv.server.icon)}
+                      className="m-0.5 flex bg-background text-foreground xs:hidden"
+                      onClick={() => setSelectedServerViewForDetails(msv)}
+                      onRemove={() => {
+                        onMCPServerViewDeselect(msv);
+                      }}
+                    />
+                  </Fragment>
+                ))}
               {selectedSpaces.map((selectedSpace) => (
                 <Chip
                   key={selectedSpace.sId}
@@ -1782,7 +1859,7 @@ const InputBarContainer = ({
                       isInputDisabled={disableInput}
                       lastRequestedModel={lastRequestedModel}
                       onAgentRemove={handleAgentRemove}
-                      onMCPServerViewSelect={onMCPServerViewSelect}
+                      onMCPServerViewSelect={handleToolSelect}
                       modelSelectionRef={modelSelectionRef}
                       modelSelectionCommitRef={modelSelectionCommitRef}
                       onNodeSelect={onNodeSelect}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -354,7 +354,9 @@ const InputBarContainer = ({
   );
   const { subscription } = useAuth();
   const { featureFlags } = useFeatureFlags();
-  const isInlineReferenceEnabled = featureFlags.includes("inline_tool_knowledge_reference");
+  const isInlineReferenceEnabled = featureFlags.includes(
+    "inline_tool_knowledge_reference"
+  );
   const isMobile = useIsMobile();
   const clientType = useClientType();
   const {

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -14,6 +14,7 @@ import { URLDetectionExtension } from "@app/components/editor/extensions/input_b
 import { URLStorageExtension } from "@app/components/editor/extensions/input_bar/URLStorageExtension";
 import { MentionExtension } from "@app/components/editor/extensions/MentionExtension";
 import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
+import { ToolNodeWithView } from "@app/components/editor/extensions/skill_builder/ToolNodeWithView";
 import { VoicePartialNode } from "@app/components/editor/extensions/VoicePartialExtension";
 import { BlockquoteExtension } from "@app/components/editor/input_bar/BlockquoteExtension";
 import { cleanupPastedHTML } from "@app/components/editor/input_bar/cleanupPastedHTML";
@@ -476,6 +477,7 @@ export const buildEditorExtensions = ({
     SkillNode.configure({
       onSkillDetails: slashSuggestion?.onSkillDetails,
     }),
+    ToolNodeWithView,
     VoicePartialNode,
     createEmojiExtension({ onActiveChange: notifySuggestionActiveChange }),
     Placeholder.configure({
@@ -507,6 +509,8 @@ export const buildEditorExtensions = ({
         onModelSelectRef: slashSuggestion.onModelSelectRef,
         onNodeSelectRef: slashSuggestion.onNodeSelectRef,
         onActiveChangeRef: onSuggestionActiveChangeRef,
+        selectedMCPServerViewIdsRef:
+          slashSuggestion.selectedMCPServerViewIdsRef,
         slashCommandsRef: slashSuggestion.slashCommandsRef,
         includeAttachKnowledgeRef: slashSuggestion.includeAttachKnowledgeRef,
         includePickModelRef: slashSuggestion.includePickModelRef,

--- a/front/hooks/useSubmitMessage.ts
+++ b/front/hooks/useSubmitMessage.ts
@@ -36,6 +36,7 @@ export function useSubmitMessage({
       mentions: MentionType[];
       contentFragments: ContentFragmentsType;
       clientSideMCPServerIds?: string[];
+      selectedMCPServerViewIds?: string[];
       selectedSpaceIds?: string[];
       origin?: ClientMessageOrigin;
       skipToolsValidation?: boolean;
@@ -54,6 +55,7 @@ export function useSubmitMessage({
         mentions,
         contentFragments,
         clientSideMCPServerIds,
+        selectedMCPServerViewIds,
         selectedSpaceIds,
         origin: messageOrigin,
         skipToolsValidation,
@@ -130,6 +132,7 @@ export function useSubmitMessage({
                 Intl.DateTimeFormat().resolvedOptions().timeZone || "Etc/UTC",
               profilePictureUrl: user.image,
               clientSideMCPServerIds,
+              selectedMCPServerViewIds,
               selectedSpaceIds,
               origin,
             },

--- a/front/lib/tools/format.ts
+++ b/front/lib/tools/format.ts
@@ -68,6 +68,15 @@ function serializeToolTagAttributes({ icon, id, name }: ToolReference): string {
   return `id="${escapeXml(id)}" name="${escapeXml(name)}"${iconAttribute}`;
 }
 
+export function getToolIdsToAttach(
+  messageTools: ToolReference[],
+  attachedToolIds: Set<string>
+): string[] {
+  return [...new Set(messageTools.map((messageTool) => messageTool.id))].filter(
+    (id) => !attachedToolIds.has(id)
+  );
+}
+
 export function stripToolTagPresentationAttributes(content: string): string {
   return content
     .replace(TOOL_ELEMENT_REGEX, (tag, attributes: string) => {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -335,9 +335,9 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "dust_only",
     owner: "fontanierh",
   },
-  inline_tool_chips: {
+  inline_tool_knowledge_reference: {
     description:
-      "Insert selected tools as inline chips in the conversation input bar and attach them to the conversation at message submit.",
+      "Insert selected tools and knowledge as inline chips in the conversation input bar and attach them to the conversation at message submit.",
     stage: "dust_only",
     owner: "ykmsd",
   },

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -335,6 +335,12 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "dust_only",
     owner: "fontanierh",
   },
+  inline_tool_chips: {
+    description:
+      "Insert selected tools as inline chips in the conversation input bar and attach them to the conversation at message submit.",
+    stage: "dust_only",
+    owner: "ykmsd",
+  },
   disable_formatting_prompt: {
     description:
       "Skip injecting the OpenAI formatting meta prompt entirely (no markdown/paragraph style guidance)",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -859,6 +859,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "group_permissions_shadow"
   | "http_client_tool"
   | "index_private_slack_channel"
+  | "inline_tool_knowledge_reference"
   | "labs_mcp_actions_dashboard"
   | "labs_transcripts"
   | "legacy_dust_apps"


### PR DESCRIPTION
## Description
This PR is to support inline tool reference in the composer. Previously we create a conversation with selected tools, but for existing conversations we make a post request on the moment we modify the tool selection instead of submit time. In this PR you can no longer delete the tool once you attach, and we send it to alongside with a message instead of updating live when it's added. 

Note that clicking a chip does nothing right now, this will be supported in my next PR 🫡

If you want to test it, you can enable the ff `inline_tool_knowledge_reference` from my dev console tool and most likely you need to reload the page. 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://app.notion.com/p/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
