### PR TITLE
Uniformize spacing between credit cards, cycle history and members table on the usage page

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -1340,8 +1340,9 @@ export function UsagePage() {
                   : "members"
               )
             }
+            className="flex flex-col gap-4"
           >
-            <TabsList className="mb-4">
+            <TabsList>
               <TabsTrigger value="members" label="Members" />
               <TabsTrigger value="groups" label="Groups" />
               {isWorkspaceAdmin && isCreditPriced && (
@@ -1353,7 +1354,7 @@ export function UsagePage() {
             </TabsList>
 
             <TabsContent value="members" className={TAB_CONTENT_CLASS}>
-              <Page.Vertical gap="sm" align="stretch">
+              <div className="flex flex-col items-stretch gap-4">
                 {searchRow}
                 <div className="flex flex-col gap-2">
                   <div className="flex flex-row items-center justify-between gap-2">
@@ -1412,7 +1413,7 @@ export function UsagePage() {
                     )}
                   </div>
                 </div>
-              </Page.Vertical>
+              </div>
             </TabsContent>
             <TabsContent value="groups" className={TAB_CONTENT_CLASS}>
               <GroupsUsageTable

--- a/front/components/workspace/EditMemberSpendLimitModal.tsx
+++ b/front/components/workspace/EditMemberSpendLimitModal.tsx
@@ -320,7 +320,7 @@ function MemberSpendLimitForm({
                   ? "Only workspace admins can edit the workspace default limit."
                   : undefined
               }
-              isActive={false}
+              isActive={isDefaultActive}
               validationMessage={
                 defaultUserSpendLimit.status === "error"
                   ? "The workspace default limit could not be loaded."

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -18,7 +18,6 @@ import {
   ContentMessage,
   cn,
   DataTable,
-  Page,
   Spinner,
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
@@ -289,8 +288,10 @@ export function WorkspaceCreditPoolSection({
     return null;
   }
 
+  // Matches the gap the usage page keeps between this section and the tabs
+  // below it, so cards, cycle history and member table are evenly spaced.
   return (
-    <Page.Vertical gap="xs" align="stretch">
+    <div className="flex flex-col items-stretch gap-10">
       {cardsStatus === "error" ? (
         <ContentMessage
           title="Failed to load Workspace Credits Pool"
@@ -321,7 +322,7 @@ export function WorkspaceCreditPoolSection({
           />
         </>
       )}
-    </Page.Vertical>
+    </div>
   );
 }
 

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -288,8 +288,6 @@ export function WorkspaceCreditPoolSection({
     return null;
   }
 
-  // Matches the gap the usage page keeps between this section and the tabs
-  // below it, so cards, cycle history and member table are evenly spaced.
   return (
     <div className="flex flex-col items-stretch gap-10">
       {cardsStatus === "error" ? (


### PR DESCRIPTION
## Description

Uniformize spacing between credit cards, cycle history and members table on the usage page

Show the Active chip on the workspace default limit in the member spend limit modal

Even out spacing between the usage tabs, the member search bar and the members toggle

## Tests


## Risk

Low pure front addition

## Deploy Plan

Deploy front
