### PR TITLE
Groups: prevents removing the last member of a manual group

### DIFF
--- a/front-api/routes/w/[wId]/groups.test.ts
+++ b/front-api/routes/w/[wId]/groups.test.ts
@@ -469,7 +469,7 @@ describe("PATCH /api/w/:wId/groups/:groupId", () => {
     );
   });
 
-  it("clears all members with an empty array", async () => {
+  it("refuses to clear all members with an empty array", async () => {
     const { workspace, user, auth } = await createPrivateApiMockRequest({
       method: "PATCH",
       role: "admin",
@@ -486,9 +486,12 @@ describe("PATCH /api/w/:wId/groups/:groupId", () => {
       memberIds: [],
     });
 
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.members).toEqual([]);
+    expect(response.status).toBe(400);
+    const { error } = await response.json();
+    expect(error.type).toBe("invalid_request_error");
+
+    const members = await group.getActiveMembers(auth);
+    expect(members.map((m) => m.sId)).toEqual([user.sId]);
   });
 
   it("renames and sets members in a single request", async () => {

--- a/front-api/routes/w/[wId]/groups/[groupId]/index.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/index.ts
@@ -181,6 +181,7 @@ app.patch(
         case "user_not_member":
         case "user_already_member":
         case "group_requirements_not_met":
+        case "last_group_member":
         case "system_or_global_group":
           return apiError(ctx, {
             status_code: 400,

--- a/front-api/routes/w/[wId]/members/[uId]/groups.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/groups.test.ts
@@ -199,9 +199,11 @@ describe("DELETE /api/w/:wId/members/:uId/groups/:groupId", () => {
       method: "DELETE",
       role: "admin",
     });
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
     const group = await GroupFactory.regularManual(workspace, "Billing");
     const addRes = await group.dangerouslyAddMembers(auth, {
-      users: [user.toJSON()],
+      users: [user.toJSON(), otherUser.toJSON()],
     });
     if (addRes.isErr()) {
       throw addRes.error;
@@ -213,7 +215,34 @@ describe("DELETE /api/w/:wId/members/:uId/groups/:groupId", () => {
     expect(await response.json()).toEqual({ success: true });
 
     const members = await group.getActiveMembers(auth);
-    expect(members).toEqual([]);
+    expect(members.map((m) => m.sId)).toEqual([otherUser.sId]);
+  });
+
+  it("returns 400 when removing the last member of a manual group", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "admin",
+    });
+    const group = await GroupFactory.regularManual(workspace, "Billing");
+    const addRes = await group.dangerouslyAddMembers(auth, {
+      users: [user.toJSON()],
+    });
+    if (addRes.isErr()) {
+      throw addRes.error;
+    }
+
+    const response = await deleteMemberGroup(workspace, user.sId, group.sId);
+
+    expect(response.status).toBe(400);
+    const { error } = await response.json();
+    expect(error.type).toBe("invalid_request_error");
+    expect(error.message).toBe(
+      "A group must always keep at least one member. To remove everyone, " +
+        "delete the group instead."
+    );
+
+    const members = await group.getActiveMembers(auth);
+    expect(members.map((m) => m.sId)).toEqual([user.sId]);
   });
 
   it("returns 400 when the member is not in the group", async () => {

--- a/front-api/routes/w/[wId]/members/[uId]/groups.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/groups.ts
@@ -48,6 +48,7 @@ function toApiError(
       };
     case "group_requirements_not_met":
     case "invalid_group_id":
+    case "last_group_member":
     case "system_or_global_group":
     case "user_already_member":
     case "user_not_member":

--- a/front/lib/api/groups/members.ts
+++ b/front/lib/api/groups/members.ts
@@ -11,6 +11,7 @@ type GroupMembershipErrorType =
   | "group_not_found"
   | "group_requirements_not_met"
   | "invalid_group_id"
+  | "last_group_member"
   | "system_or_global_group"
   | "unauthorized"
   | "user_already_member"

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -39,6 +39,7 @@ export type DustErrorCode =
   | "group_requirements_not_met"
   | "group_not_found"
   | "invalid_group_kind"
+  | "last_group_member"
   // MCP Server errors
   | "remote_server_not_found"
   | "internal_server_not_found"

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -491,6 +491,90 @@ describe("GroupResource", () => {
     });
   });
 
+  describe("manual groups keep at least one member", () => {
+    async function makeManualGroup(members: UserResource[]) {
+      const group = await GroupResource.makeNew({
+        name: "Last Member Test Group",
+        workspaceId: workspace.id,
+        kind: "regular_manual",
+      });
+      await group.dangerouslyAddMembers(authenticator, {
+        users: members.map((m) => m.toJSON()),
+      });
+      return group;
+    }
+
+    it("refuses to remove the last member", async () => {
+      const group = await makeManualGroup([user]);
+
+      const res = await group.updateRegularManualGroupMembers(authenticator, {
+        addUserIds: [],
+        removeUserIds: [user.sId],
+      });
+
+      expect(res.isErr()).toBe(true);
+      if (res.isErr()) {
+        expect(res.error.code).toBe("last_group_member");
+      }
+      expect(
+        (await group.getActiveMembers(authenticator)).map((m) => m.sId)
+      ).toEqual([user.sId]);
+    });
+
+    it("allows removing a member when others remain", async () => {
+      const other = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, other, { role: "user" });
+      const group = await makeManualGroup([user, other]);
+
+      const res = await group.updateRegularManualGroupMembers(authenticator, {
+        addUserIds: [],
+        removeUserIds: [user.sId],
+      });
+
+      expect(res.isOk()).toBe(true);
+      expect(
+        (await group.getActiveMembers(authenticator)).map((m) => m.sId)
+      ).toEqual([other.sId]);
+    });
+
+    it("allows swapping the last member out for a new one", async () => {
+      const other = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, other, { role: "user" });
+      const group = await makeManualGroup([user]);
+
+      const res = await group.updateRegularManualGroupMembers(authenticator, {
+        addUserIds: [other.sId],
+        removeUserIds: [user.sId],
+      });
+
+      expect(res.isOk()).toBe(true);
+      expect(
+        (await group.getActiveMembers(authenticator)).map((m) => m.sId)
+      ).toEqual([other.sId]);
+    });
+
+    it("refuses an empty memberIds list", async () => {
+      const group = await makeManualGroup([user]);
+
+      const res = await group.updateRegularManualGroup(authenticator, {
+        memberIds: [],
+      });
+
+      expect(res.isErr()).toBe(true);
+      if (res.isErr()) {
+        expect(res.error.code).toBe("last_group_member");
+      }
+
+      const refetched = await GroupResource.fetchById(authenticator, group.sId);
+      if (refetched.isErr()) {
+        throw refetched.error;
+      }
+      expect(
+        (await group.getActiveMembers(authenticator)).map((m) => m.sId)
+      ).toEqual([user.sId]);
+    });
+  });
+
   // Nothing suspends memberships any more, so the tests below suspend the row by hand.
   async function suspendMemberships(group: GroupResource) {
     await GroupMembershipModel.update(

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -66,6 +66,9 @@ import type {
 } from "sequelize";
 import { col, fn, Op, QueryTypes } from "sequelize";
 
+const LAST_GROUP_MEMBER_ERROR_MESSAGE =
+  "A group must always keep at least one member. To remove everyone, delete the group instead.";
+
 type CachedGroup = {
   id: ModelId;
   name: string;
@@ -2241,6 +2244,11 @@ export class GroupResource extends BaseResource<GroupModel> {
     return new Ok(undefined);
   }
 
+  /**
+   * @cc [owner:fabiencelier,label:product] manual-group-never-emptied
+   * A `regular_manual` group MUST keep at least one active member: an empty `memberIds` list
+   * MUST fail with `last_group_member`.
+   */
   async updateRegularManualGroup(
     auth: Authenticator,
     { name, memberIds }: { name?: string; memberIds?: string[] }
@@ -2255,6 +2263,7 @@ export class GroupResource extends BaseResource<GroupModel> {
         | "user_already_member"
         | "group_not_found"
         | "group_requirements_not_met"
+        | "last_group_member"
         | "system_or_global_group"
       >
     >
@@ -2285,6 +2294,13 @@ export class GroupResource extends BaseResource<GroupModel> {
           "unauthorized",
           "Only workspace admins can manage members of a group that grants the admin role."
         )
+      );
+    }
+
+    // Checked before any mutation so a rejected update leaves both name and members untouched.
+    if (memberIds !== undefined && memberIds.length === 0) {
+      return new Err(
+        new DustError("last_group_member", LAST_GROUP_MEMBER_ERROR_MESSAGE)
       );
     }
 
@@ -2332,7 +2348,43 @@ export class GroupResource extends BaseResource<GroupModel> {
   }
 
   /**
+   * Whether applying `addUserIds` then `removeUserIds` could leave the group without any active
+   * member. `addUserIds` and `removeUserIds` must be deduplicated; a user in both lists ends up
+   * removed, since members are added first and removed second.
+   *
+   * Only reads the current members when the answer is not already settled by the two lists, so
+   * the common add-only and add-and-remove cases cost no query.
+   */
+  private async wouldBeEmptyAfterMemberChange(
+    auth: Authenticator,
+    {
+      addUserIds,
+      removeUserIds,
+    }: { addUserIds: string[]; removeUserIds: string[] }
+  ): Promise<boolean> {
+    // Removing nothing can only grow the group.
+    if (removeUserIds.length === 0) {
+      return false;
+    }
+
+    // Any added user that is not removed again survives the change.
+    const removedUserIds = new Set(removeUserIds);
+    if (addUserIds.some((userId) => !removedUserIds.has(userId))) {
+      return false;
+    }
+
+    const currentMembers = await this.getActiveMembers(auth);
+    return currentMembers.every((member) => removedUserIds.has(member.sId));
+  }
+
+  /**
    * Adds and/or removes members of a manually-managed group, leaving the other members untouched.
+   */
+  /**
+   * @cc [owner:fabiencelier,label:product] manual-group-never-emptied
+   * A `regular_manual` group MUST keep at least one active member: when the requested
+   * add/remove combination would leave the group with no active member, the whole update MUST
+   * fail with `last_group_member` and no membership change MUST be persisted.
    */
   async updateRegularManualGroupMembers(
     auth: Authenticator,
@@ -2350,6 +2402,7 @@ export class GroupResource extends BaseResource<GroupModel> {
         | "user_not_member"
         | "user_already_member"
         | "group_requirements_not_met"
+        | "last_group_member"
         | "system_or_global_group"
       >
     >
@@ -2400,6 +2453,18 @@ export class GroupResource extends BaseResource<GroupModel> {
     ) {
       return new Err(
         new DustError("user_not_found", "Some users were not found.")
+      );
+    }
+
+    // Checked before any mutation so a rejected update leaves the members untouched.
+    if (
+      await this.wouldBeEmptyAfterMemberChange(auth, {
+        addUserIds: uniqueAddUserIds,
+        removeUserIds: uniqueRemoveUserIds,
+      })
+    ) {
+      return new Err(
+        new DustError("last_group_member", LAST_GROUP_MEMBER_ERROR_MESSAGE)
       );
     }
 


### PR DESCRIPTION
## Description

Refuse removing the last member of a manual group.
2 reasons:
 - to be consistent with the group management page where it is not possible
 - to prevent removing the last admin from the admin group

## Tests

 - added unit tests
 - tested locally

<img width="450" height="845" alt="image" src="https://github.com/user-attachments/assets/3e1bba04-fd08-4481-8138-b9bea437b5a7" />


## Risk

low. May block people trying to just remove someone from a group but they can just delete the group instead.

## Deploy Plan

deploy front
