### PR TITLE
Add workspace isolation contracts

### DIFF
--- a/front/CONTRACTS
+++ b/front/CONTRACTS
@@ -3,6 +3,12 @@ Code MUST NOT allow a workspace to read or modify another workspace's data.
 
 @cc [owner:spolu,notify:spolu;flvndvd,label:security;backend] workspace-aware-models
 Models storing workspace-specific data MUST inherit from `WorkspaceAwareModel`.
+
+Inheritance exceptions (workspace isolation still applies): `WorkspaceModel`, `UserModel`,
+`UserMetadataModel`, `PluginRunModel`, `PlanModel`, `TemplateModel`, `CouponModel`,
+`GlobalFeatureFlagModel`, `KillSwitchModel`, `ModelDegradationModel`, `AcademyChapterVisitModel`,
+and `AcademyQuizAttemptModel`.
+
 Every use of `dangerouslyBypassWorkspaceIsolationSecurity` MUST have a preceding
 `WORKSPACE_ISOLATION_BYPASS:` comment explaining why the bypass is necessary.
 

--- a/front/CONTRACTS
+++ b/front/CONTRACTS
@@ -1,3 +1,11 @@
+@cc [owner:spolu,notify:spolu;flvndvd,label:security;backend] workspace-isolation
+Code MUST NOT allow a workspace to read or modify another workspace's data.
+
+@cc [owner:spolu,notify:spolu;flvndvd,label:security;backend] workspace-aware-models
+Models storing workspace-specific data MUST inherit from `WorkspaceAwareModel`.
+Every use of `dangerouslyBypassWorkspaceIsolationSecurity` MUST have a preceding
+`WORKSPACE_ISOLATION_BYPASS:` comment explaining why the bypass is necessary.
+
 @cc [owner:flvndvd,label:backend] api-routes-use-resources
 API routes must not interact with Sequelize models directly. Use `lib/api/*` interfaces (creating
 them if missing). Direct Resource interactions are acceptable.

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -224,7 +224,9 @@ export class FileResource extends BaseResource<FileModel> {
     }
 
     const frames = await this.model.findAll({
-      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified: the sandbox reaper operates across workspaces and the ids come from workspace-scoped owner links.
+      // WORKSPACE_ISOLATION_BYPASS: The sandbox reaper operates across workspaces; these IDs come
+      // from workspace-scoped sandbox ownership rows.
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
       dangerouslyBypassWorkspaceIsolationSecurity: true,
       where: {
         contentType: frameV2ContentType,

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -1452,7 +1452,8 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     const subscription = await SubscriptionResource.model.findOne({
       where: { id: subscriptionModelId },
       include: [WorkspaceModel],
-      // subscription ID is already trusted.
+      // WORKSPACE_ISOLATION_BYPASS: Billing flows supply a trusted subscription ID before its
+      // workspace is resolved by this query.
       // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
       dangerouslyBypassWorkspaceIsolationSecurity: true,
     });

--- a/front/migrations/20260617_cleanup_revoked_authorized_file_access.ts
+++ b/front/migrations/20260617_cleanup_revoked_authorized_file_access.ts
@@ -17,7 +17,9 @@ makeScript({}, async ({ execute }, logger) => {
   if (execute) {
     const deletedCount = await AuthorizedFileAccessModel.destroy({
       where,
-      // @ts-expect-error -- It's a one-off script that operates across all workspaces
+      // WORKSPACE_ISOLATION_BYPASS: This migration removes revoked access rows across all workspaces.
+      // @ts-expect-error -- This migration operates across all workspaces.
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
       dangerouslyBypassWorkspaceIsolationSecurity: true,
     });
     logger.info(
@@ -27,7 +29,9 @@ makeScript({}, async ({ execute }, logger) => {
   } else {
     const count = await AuthorizedFileAccessModel.count({
       where,
-      // @ts-expect-error -- It's a one-off script that operates across all workspaces
+      // WORKSPACE_ISOLATION_BYPASS: The dry run counts revoked access rows across all workspaces.
+      // @ts-expect-error -- This migration operates across all workspaces.
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
       dangerouslyBypassWorkspaceIsolationSecurity: true,
     });
     logger.info(


### PR DESCRIPTION
## Description

Add two contracts in `front/CONTRACTS`: a workspace must never access another workspace's data, and models storing workspace data must inherit from `WorkspaceAwareModel`. Document every `dangerouslyBypassWorkspaceIsolationSecurity` use with a preceding `WORKSPACE_ISOLATION_BYPASS:` explanation. Both contracts notify `spolu` and `flvndvd`.

Explicitly list the 12 existing inheritance exceptions, including the mixed-scope `UserMetadataModel` and `PluginRunModel`. The workspace-isolation requirement still applies to all exceptions. Add the required documentation marker to four existing workspace-isolation bypasses.

This is one of the key-use of code contracts, esp the notify convention which should notify on potential violations in the future.

## Tests

N/A, contracts and comments only. Inspected model inheritance and the existing workspace-scoping and bypass mechanisms.

## Risk

Low. No runtime changes.

## Deploy Plan

None.
