### PR TITLE
[front] feat: provider-native web search behind a feature flag

### DIFF
--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -1,5 +1,8 @@
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
-import { INTERNAL_SERVERS_WITH_WEBSEARCH } from "@app/lib/actions/mcp_internal_actions/constants";
+import {
+  INTERNAL_SERVERS_WITH_WEBSEARCH,
+  WEBSEARCH_TOOL_NAME,
+} from "@app/lib/actions/mcp_internal_actions/constants";
 import type { StepContext } from "@app/lib/actions/types";
 import { isServerSideMCPToolConfigurationWithName } from "@app/lib/actions/types/guards";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
@@ -67,6 +70,23 @@ function getRetrievalTopK({
  * websearch actions in the same step we get the maximum number of results and divide it by The
  * number of websearch actions in the step.
  */
+/**
+ * Dust's own `websearch` tool, on either internal server that mounts it. Matches
+ * on `originalName` plus the internal server name rather than the prefixed tool
+ * name, which changes when server names are disambiguated by space.
+ *
+ * `webbrowser` is deliberately excluded: a provider's native search returns
+ * snippets only, so reading a full page still goes through Dust's browser.
+ */
+export function isDustWebsearchTool(tool: MCPToolConfigurationType): boolean {
+  return (
+    tool.originalName === WEBSEARCH_TOOL_NAME &&
+    INTERNAL_SERVERS_WITH_WEBSEARCH.some((n) =>
+      isServerSideMCPToolConfigurationWithName(tool, n)
+    )
+  );
+}
+
 function getWebsearchNumResults({
   stepActions,
 }: {

--- a/front/lib/actions/websearch_tool.test.ts
+++ b/front/lib/actions/websearch_tool.test.ts
@@ -1,0 +1,89 @@
+import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
+import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import { isDustWebsearchTool } from "@app/lib/actions/utils";
+import { describe, expect, it } from "vitest";
+
+function makeTool({
+  originalName,
+  serverName,
+}: {
+  originalName: string;
+  serverName: InternalMCPServerNameType | null;
+}): MCPToolConfigurationType {
+  return {
+    id: -1,
+    sId: `tool_${originalName}`,
+    type: "mcp_configuration",
+    // The name the model sees is prefixed and can be disambiguated by space, so
+    // the predicate must not rely on it.
+    name: `some_prefix__${originalName}`,
+    description: `Description of ${originalName}`,
+    inputSchema: { type: "object", properties: {}, required: [] },
+    dataSources: null,
+    tables: null,
+    childAgentId: null,
+    timeFrame: null,
+    jsonSchema: null,
+    additionalConfiguration: {},
+    mcpServerViewId: "view_1",
+    dustAppConfiguration: null,
+    secretName: null,
+    dustProject: null,
+    internalMCPServerId:
+      serverName === null
+        ? null
+        : internalMCPServerNameToSId({
+            name: serverName,
+            workspaceId: 1,
+            prefix: 0,
+          }),
+    originalName,
+    mcpServerName: "server",
+    availability: "auto",
+    permission: "never_ask",
+    toolServerId: "server_id",
+    retryPolicy: "no_retry",
+  };
+}
+
+describe("isDustWebsearchTool", () => {
+  // The same two tools are registered on both internal servers, so both
+  // mountings have to be recognized.
+  it("matches websearch on both servers that mount it", () => {
+    for (const serverName of ["web_search_&_browse", "http_client"] as const) {
+      expect(
+        isDustWebsearchTool(makeTool({ originalName: "websearch", serverName }))
+      ).toBe(true);
+    }
+  });
+
+  // The provider's native search returns snippets only, so reading a full page
+  // still goes through Dust's browser.
+  it("does not match webbrowser", () => {
+    expect(
+      isDustWebsearchTool(
+        makeTool({
+          originalName: "webbrowser",
+          serverName: "web_search_&_browse",
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("does not match a same-named tool from another internal server", () => {
+    expect(
+      isDustWebsearchTool(
+        makeTool({ originalName: "websearch", serverName: "search" })
+      )
+    ).toBe(false);
+  });
+
+  it("does not match a same-named tool from a remote server", () => {
+    expect(
+      isDustWebsearchTool(
+        makeTool({ originalName: "websearch", serverName: null })
+      )
+    ).toBe(false);
+  });
+});

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -309,17 +309,24 @@ function constructPastedContentSection(): string {
 
 function constructGuidelinesSection({
   agentConfiguration,
+  nativeWebSearchEnabled,
 }: {
   agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
+  nativeWebSearchEnabled: boolean;
 }): string {
   let guidelinesSection = "# GUIDELINES\n";
 
   const canRetrieveDocuments = agentConfiguration.actions.some(
     (action) =>
       areDataSourcesConfigured(action) ||
-      INTERNAL_SERVERS_WITH_WEBSEARCH.some((n) =>
-        isServerSideMCPServerConfigurationWithName(action, n)
-      ) ||
+      // The provider's native web search produces no Dust citation refs, so a
+      // web-search-only agent gets no citation guidance. `webbrowser` still
+      // lives on these servers and still produces refs, hence the OR below
+      // rather than dropping the clause outright.
+      (!nativeWebSearchEnabled &&
+        INTERNAL_SERVERS_WITH_WEBSEARCH.some((n) =>
+          isServerSideMCPServerConfigurationWithName(action, n)
+        )) ||
       isServerSideMCPServerConfigurationWithName(action, "run_agent") ||
       isServerSideMCPServerConfigurationWithName(action, "slack") ||
       isServerSideMCPServerConfigurationWithName(action, "notion")
@@ -393,6 +400,7 @@ export function constructPromptMultiActions(
     hasSandboxTools = false,
     disableFormattingPrompt = false,
     hasSelectedSpacesOutsideAgentScope = false,
+    nativeWebSearchEnabled = false,
   }: {
     userMessage: AgentLoopExecutionData["userMessage"];
     agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
@@ -410,6 +418,7 @@ export function constructPromptMultiActions(
     hasSandboxTools?: boolean;
     disableFormattingPrompt?: boolean;
     hasSelectedSpacesOutsideAgentScope?: boolean;
+    nativeWebSearchEnabled?: boolean;
   }
 ): SystemPromptSections {
   const owner = auth.workspace();
@@ -461,7 +470,10 @@ export function constructPromptMultiActions(
       })
     : constructAttachmentsSection({ hasSandboxTools, isComputerAlwaysActive });
   const pastedContentSection = constructPastedContentSection();
-  const guidelinesSection = constructGuidelinesSection({ agentConfiguration });
+  const guidelinesSection = constructGuidelinesSection({
+    agentConfiguration,
+    nativeWebSearchEnabled,
+  });
 
   if (hasStaticInstructions) {
     // Structured form with 3 cache tiers, ordered from most stable to most volatile.

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -788,6 +788,7 @@ abstract class BaseTransition extends LLM {
       forceToolCall,
       disableToolUse,
       toolSearchEnabled,
+      nativeWebSearchEnabled,
       previousMessageId,
     } = streamParameters;
 
@@ -816,6 +817,7 @@ abstract class BaseTransition extends LLM {
       forceTool: forceToolCall,
       disableToolUse,
       toolSearchEnabled,
+      nativeWebSearchEnabled,
       outputFormat: parseResponseFormatSchema(
         this.responseFormat,
         this.metadata.clientId

--- a/front/lib/api/llm/types/options.ts
+++ b/front/lib/api/llm/types/options.ts
@@ -150,6 +150,9 @@ interface LLMStreamParametersBase {
   // When true, supporting provider clients defer non-eager tools behind tool
   // search.
   toolSearchEnabled?: boolean;
+  // When true, supporting provider clients add the provider's own server-side
+  // web search tool, replacing Dust's `websearch` tool.
+  nativeWebSearchEnabled?: boolean;
   prompt: SystemPromptInput;
   specifications: AgentActionSpecification[];
   omittedThinking?: boolean;

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/index.ts
@@ -7,10 +7,14 @@ import type {
 import type { Client } from "@app/lib/model_constructors/client";
 import type { AnthropicInputConfig } from "@app/lib/model_constructors/providers/anthropic/inputConfig";
 import {
+  ANTHROPIC_NATIVE_WEB_SEARCH_INSTRUCTION,
+  includesAnthropicWebSearchTool,
+} from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/native_web_search";
+import { stripUnreplayableServerToolBlocks } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/server_tool_passthrough";
+import {
   ANTHROPIC_TOOL_SEARCH_INSTRUCTION,
   includesToolSearchTool,
 } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search";
-import { stripUnreplayableToolSearchBlocks } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search_passthrough";
 import type { MessageBlockConverters } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/utils";
 import {
   assistantProviderPassthroughMessageToBlocks,
@@ -81,6 +85,7 @@ export function WithAnthropicAIInputConverter<
         reasoning,
         forceTool,
         toolSearchEnabled,
+        nativeWebSearchEnabled,
         outputFormat,
       } = config;
 
@@ -98,25 +103,43 @@ export function WithAnthropicAIInputConverter<
       const anthropicTools = toolSpecsToAnthropicAITools(tools, {
         forceTool,
         toolSearchEnabled: toolSearchEnabled ?? false,
+        nativeWebSearchEnabled: nativeWebSearchEnabled ?? false,
       });
+      const toolSearchInRequest = includesToolSearchTool(anthropicTools);
+      const nativeWebSearchInRequest =
+        includesAnthropicWebSearchTool(anthropicTools);
 
       const system = this.systemMessagesToSystemParam(conversation.system);
 
       const renderedMessages = await this.conversationToMessages(conversation);
-      const messages = stripUnreplayableToolSearchBlocks(renderedMessages, {
-        toolSearchInRequest: includesToolSearchTool(anthropicTools),
+      const messages = stripUnreplayableServerToolBlocks(renderedMessages, {
+        toolSearchInRequest,
+        nativeWebSearchInRequest,
       });
 
       return {
         model: this.modelToHostModel(this.constructor.model),
         max_tokens: this.constructor.maxOutputTokens,
         messages,
-        system: includesToolSearchTool(anthropicTools)
-          ? [
-              ...system,
-              { type: "text", text: ANTHROPIC_TOOL_SEARCH_INSTRUCTION },
-            ]
-          : system,
+        system: [
+          ...system,
+          ...(toolSearchInRequest
+            ? [
+                {
+                  type: "text" as const,
+                  text: ANTHROPIC_TOOL_SEARCH_INSTRUCTION,
+                },
+              ]
+            : []),
+          ...(nativeWebSearchInRequest
+            ? [
+                {
+                  type: "text" as const,
+                  text: ANTHROPIC_NATIVE_WEB_SEARCH_INSTRUCTION,
+                },
+              ]
+            : []),
+        ],
         // Omit the key entirely when the config carries no thinking, so the
         // model applies its own default instead of being told "disabled".
         ...("thinking" in thinkingConfig

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/message_blocks.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/message_blocks.ts
@@ -1,0 +1,41 @@
+import type {
+  ContentBlockParam,
+  MessageParam,
+} from "@anthropic-ai/sdk/resources/messages/messages.mjs";
+
+// Shared helpers for the replay sanitizers that strip provider server-tool
+// blocks (tool search, native web search) from a rendered conversation.
+
+export function toContentBlocks(
+  content: MessageParam["content"]
+): ContentBlockParam[] {
+  return typeof content === "string"
+    ? [{ type: "text", text: content }]
+    : content;
+}
+
+// Anthropic rejects consecutive same-role messages, so re-merge neighbors after a message was
+// dropped entirely. O(n) in messages. Merging a run of same-role messages re-copies the merged
+// content at each step, but the input arrives with no same-role neighbors (the renderers already
+// merged them), so runs only form around dropped messages and stay short.
+export function mergeConsecutiveSameRoleMessages(
+  messages: MessageParam[]
+): MessageParam[] {
+  const merged: MessageParam[] = [];
+  for (const message of messages) {
+    const previous = merged[merged.length - 1];
+    if (previous && previous.role === message.role) {
+      merged[merged.length - 1] = {
+        ...previous,
+        content: [
+          ...toContentBlocks(previous.content),
+          ...toContentBlocks(message.content),
+        ],
+      };
+    } else {
+      merged.push(message);
+    }
+  }
+
+  return merged;
+}

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/native_web_search.test.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/native_web_search.test.ts
@@ -1,0 +1,89 @@
+import {
+  ANTHROPIC_WEB_SEARCH_TOOL,
+  includesAnthropicWebSearchTool,
+} from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/native_web_search";
+import { TOOL_SEARCH_TOOL } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search";
+import { toolSpecsToAnthropicAITools } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/utils";
+import type { ToolSpecification } from "@app/lib/model_constructors/types/input/configuration";
+import { describe, expect, it } from "vitest";
+
+const eagerTool: ToolSpecification = {
+  name: "eager",
+  description: "An eager tool.",
+  inputSchema: { type: "object", properties: {} },
+  eager: true,
+};
+
+const deferrableTool: ToolSpecification = {
+  name: "deferrable",
+  description: "A deferrable tool.",
+  inputSchema: { type: "object", properties: {} },
+};
+
+describe("toolSpecsToAnthropicAITools with native web search", () => {
+  it("prepends the web search tool when enabled", () => {
+    const tools = toolSpecsToAnthropicAITools([eagerTool], {
+      forceTool: undefined,
+      toolSearchEnabled: false,
+      nativeWebSearchEnabled: true,
+    });
+
+    expect(tools[0]).toEqual(ANTHROPIC_WEB_SEARCH_TOOL);
+    expect(includesAnthropicWebSearchTool(tools)).toBe(true);
+  });
+
+  it("omits the web search tool when disabled", () => {
+    const tools = toolSpecsToAnthropicAITools([eagerTool], {
+      forceTool: undefined,
+      toolSearchEnabled: false,
+      nativeWebSearchEnabled: false,
+    });
+
+    expect(includesAnthropicWebSearchTool(tools)).toBe(false);
+  });
+
+  // A server tool cannot be a tool_choice target, and its interaction with a
+  // non-auto tool_choice is unspecified, so force-called requests stay clean.
+  it("omits the web search tool when a tool is force-called", () => {
+    const tools = toolSpecsToAnthropicAITools([eagerTool], {
+      forceTool: "eager",
+      toolSearchEnabled: false,
+      nativeWebSearchEnabled: true,
+    });
+
+    expect(includesAnthropicWebSearchTool(tools)).toBe(false);
+  });
+
+  // Order is fixed so the serialized tools prefix stays byte-stable for prompt
+  // caching across steps.
+  it("orders tool search before web search before function tools", () => {
+    const tools = toolSpecsToAnthropicAITools([deferrableTool], {
+      forceTool: undefined,
+      toolSearchEnabled: true,
+      nativeWebSearchEnabled: true,
+    });
+
+    expect(tools).toHaveLength(3);
+    expect(tools[0]).toEqual(TOOL_SEARCH_TOOL);
+    expect(tools[1]).toEqual(ANTHROPIC_WEB_SEARCH_TOOL);
+    expect(tools[2]).toMatchObject({ name: "deferrable" });
+  });
+
+  // The tool replaces one the model previously always saw, so it must never be
+  // something the model has to discover through tool search first.
+  it("never defers the web search tool", () => {
+    const tools = toolSpecsToAnthropicAITools([deferrableTool], {
+      forceTool: undefined,
+      toolSearchEnabled: true,
+      nativeWebSearchEnabled: true,
+    });
+
+    expect(tools[1]).not.toHaveProperty("defer_loading");
+  });
+});
+
+describe("includesAnthropicWebSearchTool", () => {
+  it("is false for an unrelated tool", () => {
+    expect(includesAnthropicWebSearchTool([{ type: "custom" }])).toBe(false);
+  });
+});

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/native_web_search.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/native_web_search.ts
@@ -1,0 +1,36 @@
+import type { WebSearchTool20250305 } from "@anthropic-ai/sdk/resources/messages/messages";
+import { NATIVE_WEB_SEARCH_INSTRUCTION } from "@app/lib/model_constructors/types/native_web_search";
+
+// The name Anthropic reports on `server_tool_use` blocks for web search. It is
+// the same across every tool version, so output handling stays version
+// independent.
+export const ANTHROPIC_WEB_SEARCH_TOOL_NAME = "web_search" as const;
+
+// `web_search_20250305` is the version every Claude model we run supports, and
+// the only one documented outside the first-party API, which keeps the door open
+// for the Vertex host. The later versions (20260209, 20260318) only add
+// `response_inclusion`, which matters solely when the search is nested inside a
+// code_execution call — something we never do. Bumping is one line here.
+//
+// Optional fields (`user_location`, `allowed_domains`, `blocked_domains`) are
+// deliberately omitted so the serialized tool stays byte-stable for prompt
+// caching. `defer_loading` is never set either: this tool replaces one the model
+// previously always saw, so it stays in the eager cached prefix rather than
+// something the model has to discover through tool search.
+export const ANTHROPIC_WEB_SEARCH_TOOL = {
+  type: "web_search_20250305",
+  name: ANTHROPIC_WEB_SEARCH_TOOL_NAME,
+  // Hard per-request ceiling. Each search carries a provider fee that Dust does
+  // not meter yet, and Dust's own websearch returned 16 results per call, so
+  // eight native searches per turn is generous.
+  max_uses: 8,
+} as const satisfies WebSearchTool20250305;
+
+export function includesAnthropicWebSearchTool(
+  tools: ReadonlyArray<{ type?: string | null }>
+): boolean {
+  return tools.some((tool) => tool.type === ANTHROPIC_WEB_SEARCH_TOOL.type);
+}
+
+export const ANTHROPIC_NATIVE_WEB_SEARCH_INSTRUCTION =
+  NATIVE_WEB_SEARCH_INSTRUCTION;

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/native_web_search_passthrough.test.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/native_web_search_passthrough.test.ts
@@ -1,0 +1,159 @@
+import type { MessageParam } from "@anthropic-ai/sdk/resources/messages/messages";
+import {
+  parseAnthropicWebSearchBlock,
+  stripWebSearchBlocks,
+} from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/native_web_search_passthrough";
+import { describe, expect, it } from "vitest";
+
+const serverToolUse = {
+  type: "server_tool_use" as const,
+  id: "srvtoolu_1",
+  name: "web_search" as const,
+  input: { query: "who won the last world cup" },
+};
+
+const toolResult = {
+  type: "web_search_tool_result" as const,
+  tool_use_id: "srvtoolu_1",
+  content: [
+    {
+      type: "web_search_result" as const,
+      url: "https://example.com/wc",
+      title: "World Cup",
+      encrypted_content: "opaque",
+      page_age: "2 days ago",
+    },
+  ],
+};
+
+describe("parseAnthropicWebSearchBlock", () => {
+  it("round-trips a web search server_tool_use", () => {
+    expect(parseAnthropicWebSearchBlock(serverToolUse)).toEqual(serverToolUse);
+  });
+
+  it("round-trips a results block", () => {
+    expect(parseAnthropicWebSearchBlock(toolResult)).toEqual(toolResult);
+  });
+
+  // `page_age` is nullable on the wire but optional on the param type, so a null
+  // must not be replayed as an explicit null.
+  it("drops a null page_age rather than replaying it", () => {
+    const parsed = parseAnthropicWebSearchBlock({
+      ...toolResult,
+      content: [{ ...toolResult.content[0], page_age: null }],
+    });
+
+    expect(parsed).toEqual({
+      ...toolResult,
+      content: [
+        {
+          type: "web_search_result",
+          url: "https://example.com/wc",
+          title: "World Cup",
+          encrypted_content: "opaque",
+        },
+      ],
+    });
+  });
+
+  it("round-trips an error result", () => {
+    const errorResult = {
+      type: "web_search_tool_result" as const,
+      tool_use_id: "srvtoolu_1",
+      content: {
+        type: "web_search_tool_result_error" as const,
+        error_code: "max_uses_exceeded" as const,
+      },
+    };
+
+    expect(parseAnthropicWebSearchBlock(errorResult)).toEqual(errorResult);
+  });
+
+  // The two families must stay separate: their error vocabularies differ.
+  it("rejects a tool-search block", () => {
+    expect(
+      parseAnthropicWebSearchBlock({
+        type: "server_tool_use",
+        id: "srvtoolu_2",
+        name: "tool_search_tool_bm25",
+        input: {},
+      })
+    ).toBeNull();
+  });
+
+  it("rejects an unknown block", () => {
+    expect(parseAnthropicWebSearchBlock({ type: "nonsense" })).toBeNull();
+  });
+});
+
+describe("stripWebSearchBlocks", () => {
+  it("returns the same array when there is nothing to strip", () => {
+    const messages: MessageParam[] = [
+      { role: "assistant", content: [{ type: "text", text: "hi" }] },
+    ];
+
+    // Identity, not just equality: the common path must stay byte-identical for
+    // prompt caching.
+    expect(stripWebSearchBlocks(messages)).toBe(messages);
+  });
+
+  it("strips the use and result pair together, keeping the rest", () => {
+    const messages: MessageParam[] = [
+      {
+        role: "assistant",
+        content: [serverToolUse, toolResult, { type: "text", text: "answer" }],
+      },
+    ];
+
+    expect(stripWebSearchBlocks(messages)).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "answer" }] },
+    ]);
+  });
+
+  it("leaves tool-search blocks alone", () => {
+    const toolSearchUse = {
+      type: "server_tool_use" as const,
+      id: "srvtoolu_2",
+      name: "tool_search_tool_bm25" as const,
+      input: {},
+    };
+    const messages: MessageParam[] = [
+      { role: "assistant", content: [toolSearchUse, serverToolUse] },
+    ];
+
+    expect(stripWebSearchBlocks(messages)).toEqual([
+      { role: "assistant", content: [toolSearchUse] },
+    ]);
+  });
+
+  // Anthropic rejects consecutive same-role messages, so dropping a message
+  // whole has to re-merge its neighbours.
+  it("drops an emptied message and re-merges same-role neighbours", () => {
+    const messages: MessageParam[] = [
+      { role: "assistant", content: [{ type: "text", text: "before" }] },
+      { role: "assistant", content: [serverToolUse, toolResult] },
+      { role: "assistant", content: [{ type: "text", text: "after" }] },
+    ];
+
+    expect(stripWebSearchBlocks(messages)).toEqual([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "before" },
+          { type: "text", text: "after" },
+        ],
+      },
+    ]);
+  });
+
+  it("never touches user messages", () => {
+    const messages: MessageParam[] = [
+      { role: "user", content: [{ type: "text", text: "q" }] },
+      { role: "assistant", content: [serverToolUse, toolResult] },
+    ];
+
+    expect(stripWebSearchBlocks(messages)).toEqual([
+      { role: "user", content: [{ type: "text", text: "q" }] },
+    ]);
+  });
+});

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/native_web_search_passthrough.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/native_web_search_passthrough.ts
@@ -1,0 +1,183 @@
+import type {
+  ContentBlockParam,
+  MessageParam,
+  ServerToolUseBlockParam,
+  WebSearchToolResultBlockParam,
+} from "@anthropic-ai/sdk/resources/messages/messages.mjs";
+import { mergeConsecutiveSameRoleMessages } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/message_blocks";
+import { ANTHROPIC_WEB_SEARCH_TOOL_NAME } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/native_web_search";
+import logger from "@app/logger/logger";
+import { z } from "zod";
+
+// Anthropic runs its native web search server-side inside a single assistant
+// turn, emitting a `server_tool_use` block and a `web_search_tool_result` block
+// interleaved with the thinking blocks. Those must be replayed verbatim on the
+// next request or the thinking-block signatures are rejected, and the results
+// carry the `encrypted_content` the model needs to keep citing them. We persist
+// them opaquely in the generic content layer (as provider passthrough) and parse
+// them back here with full typing.
+//
+// The schemas mirror the Anthropic SDK param shapes so a parsed block is
+// directly assignable to BetaContentBlockParam, no cast required. They are kept
+// separate from the tool-search schemas rather than merged: the error-code
+// vocabularies differ, and the replay rules do too (see below).
+
+const webSearchServerToolUseSchema = z.object({
+  type: z.literal("server_tool_use"),
+  id: z.string(),
+  name: z.literal(ANTHROPIC_WEB_SEARCH_TOOL_NAME),
+  input: z.unknown(),
+});
+
+const webSearchResultSchema = z.object({
+  type: z.literal("web_search_result"),
+  url: z.string(),
+  title: z.string(),
+  // Opaque provider blob. Required on replay for the model to keep citing the
+  // result: the underlying page content never reaches us in the clear.
+  encrypted_content: z.string(),
+  page_age: z.string().nullish(),
+});
+
+const webSearchToolResultSchema = z.object({
+  type: z.literal("web_search_tool_result"),
+  tool_use_id: z.string(),
+  content: z.union([
+    z.object({
+      type: z.literal("web_search_tool_result_error"),
+      error_code: z.enum([
+        "invalid_tool_input",
+        "unavailable",
+        "max_uses_exceeded",
+        "too_many_requests",
+        "query_too_long",
+        "request_too_large",
+      ]),
+    }),
+    z.array(webSearchResultSchema),
+  ]),
+});
+
+export const anthropicWebSearchBlockSchema = z.discriminatedUnion("type", [
+  webSearchServerToolUseSchema,
+  webSearchToolResultSchema,
+]);
+
+export type AnthropicWebSearchBlock = z.infer<
+  typeof anthropicWebSearchBlockSchema
+>;
+
+// Parses an opaque persisted block back into a typed Anthropic block param.
+// Returns null silently when the block is not a web-search block:
+// `parseAnthropicServerToolBlock` tries every server-tool family and owns the
+// "unparseable" warning.
+export function parseAnthropicWebSearchBlock(
+  block: unknown
+): ServerToolUseBlockParam | WebSearchToolResultBlockParam | null {
+  const r = anthropicWebSearchBlockSchema.safeParse(block);
+  if (!r.success) {
+    return null;
+  }
+
+  // Reconstruct the param explicitly so required fields are present, since zod
+  // infers `z.unknown()` keys as optional. `caller` is optional on both params
+  // and carries no replay meaning, so it is not reconstructed.
+  if (r.data.type === "server_tool_use") {
+    return {
+      type: "server_tool_use",
+      id: r.data.id,
+      name: r.data.name,
+      input: r.data.input,
+    };
+  }
+
+  const { content } = r.data;
+  return {
+    type: "web_search_tool_result",
+    tool_use_id: r.data.tool_use_id,
+    content: Array.isArray(content)
+      ? content.map((result) => ({
+          type: "web_search_result" as const,
+          url: result.url,
+          title: result.title,
+          encrypted_content: result.encrypted_content,
+          ...(result.page_age != null ? { page_age: result.page_age } : {}),
+        }))
+      : content,
+  };
+}
+
+// -- Replay sanitation --
+//
+// Simpler than tool search: a web search always completes inside the turn that
+// issued it, so there is no resumable-dangling-search case to preserve. The one
+// rule is that without the web search tool in the request — auxiliary calls such
+// as title generation, which build their own specifications — no web-search
+// block is replayable at all, because the API cannot expand results for a tool
+// it was not given.
+//
+// Returns the input array untouched when nothing needs stripping, so the common
+// path is allocation free and byte identical for prompt caching.
+
+function isWebSearchServerToolUseBlock(
+  block: ContentBlockParam
+): block is ServerToolUseBlockParam {
+  return (
+    block.type === "server_tool_use" &&
+    block.name === ANTHROPIC_WEB_SEARCH_TOOL_NAME
+  );
+}
+
+function isWebSearchToolResultBlock(
+  block: ContentBlockParam
+): block is WebSearchToolResultBlockParam {
+  return block.type === "web_search_tool_result";
+}
+
+export function stripWebSearchBlocks(messages: MessageParam[]): MessageParam[] {
+  let strippedCount = 0;
+  let droppedMessageCount = 0;
+
+  const sanitized: MessageParam[] = [];
+  for (const message of messages) {
+    if (message.role !== "assistant" || typeof message.content === "string") {
+      sanitized.push(message);
+      continue;
+    }
+
+    const content = message.content.filter((block) => {
+      const isWebSearchBlock =
+        isWebSearchServerToolUseBlock(block) ||
+        isWebSearchToolResultBlock(block);
+      if (isWebSearchBlock) {
+        strippedCount++;
+      }
+
+      return !isWebSearchBlock;
+    });
+
+    if (content.length === 0) {
+      droppedMessageCount++;
+      continue;
+    }
+
+    sanitized.push(
+      content.length === message.content.length
+        ? message
+        : { ...message, content }
+    );
+  }
+
+  if (strippedCount === 0) {
+    return messages;
+  }
+
+  logger.info(
+    { strippedCount, droppedMessageCount },
+    "[native-web-search] Stripped web search blocks from replay"
+  );
+
+  return droppedMessageCount > 0
+    ? mergeConsecutiveSameRoleMessages(sanitized)
+    : sanitized;
+}

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/server_tool_passthrough.test.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/server_tool_passthrough.test.ts
@@ -1,0 +1,150 @@
+import type { MessageParam } from "@anthropic-ai/sdk/resources/messages/messages";
+import {
+  parseAnthropicServerToolBlock,
+  stripUnreplayableServerToolBlocks,
+} from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/server_tool_passthrough";
+import logger from "@app/logger/logger";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const webSearchUse = {
+  type: "server_tool_use" as const,
+  id: "srvtoolu_web",
+  name: "web_search" as const,
+  input: { query: "q" },
+};
+
+const webSearchResult = {
+  type: "web_search_tool_result" as const,
+  tool_use_id: "srvtoolu_web",
+  content: [
+    {
+      type: "web_search_result" as const,
+      url: "https://example.com",
+      title: "T",
+      encrypted_content: "opaque",
+    },
+  ],
+};
+
+const toolSearchUse = {
+  type: "server_tool_use" as const,
+  id: "srvtoolu_search",
+  name: "tool_search_tool_bm25" as const,
+  input: { query: "q" },
+};
+
+const toolSearchResult = {
+  type: "tool_search_tool_result" as const,
+  tool_use_id: "srvtoolu_search",
+  content: {
+    type: "tool_search_tool_search_result" as const,
+    tool_references: [{ type: "tool_reference" as const, tool_name: "a_tool" }],
+  },
+};
+
+describe("parseAnthropicServerToolBlock", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("routes a tool-search block to its parser", () => {
+    expect(parseAnthropicServerToolBlock(toolSearchResult)).toEqual(
+      toolSearchResult
+    );
+  });
+
+  it("routes a web-search block to its parser", () => {
+    expect(parseAnthropicServerToolBlock(webSearchResult)).toEqual(
+      webSearchResult
+    );
+  });
+
+  // Regression guard: before the dispatcher existed, a valid web-search block
+  // was rejected by the tool-search parser and logged as unparseable.
+  it("does not warn for a valid block of either family", () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => logger);
+
+    parseAnthropicServerToolBlock(toolSearchUse);
+    parseAnthropicServerToolBlock(webSearchUse);
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns exactly once and returns null for an unknown block", () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => logger);
+
+    expect(parseAnthropicServerToolBlock({ type: "nonsense" })).toBeNull();
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("stripUnreplayableServerToolBlocks", () => {
+  it("keeps both families when both tools are in the request", () => {
+    const messages: MessageParam[] = [
+      {
+        role: "assistant",
+        content: [
+          toolSearchUse,
+          toolSearchResult,
+          webSearchUse,
+          webSearchResult,
+        ],
+      },
+    ];
+
+    expect(
+      stripUnreplayableServerToolBlocks(messages, {
+        toolSearchInRequest: true,
+        nativeWebSearchInRequest: true,
+      })
+    ).toBe(messages);
+  });
+
+  // The last step and auxiliary calls (title generation) carry neither tool.
+  it("strips both families when neither tool is in the request", () => {
+    const messages: MessageParam[] = [
+      {
+        role: "assistant",
+        content: [
+          toolSearchUse,
+          toolSearchResult,
+          webSearchUse,
+          webSearchResult,
+          { type: "text", text: "answer" },
+        ],
+      },
+    ];
+
+    expect(
+      stripUnreplayableServerToolBlocks(messages, {
+        toolSearchInRequest: false,
+        nativeWebSearchInRequest: false,
+      })
+    ).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "answer" }] },
+    ]);
+  });
+
+  it("strips only web search when only tool search is in the request", () => {
+    const messages: MessageParam[] = [
+      {
+        role: "assistant",
+        content: [
+          toolSearchUse,
+          toolSearchResult,
+          webSearchUse,
+          webSearchResult,
+        ],
+      },
+    ];
+
+    expect(
+      stripUnreplayableServerToolBlocks(messages, {
+        toolSearchInRequest: true,
+        nativeWebSearchInRequest: false,
+      })
+    ).toEqual([
+      { role: "assistant", content: [toolSearchUse, toolSearchResult] },
+    ]);
+  });
+});

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/server_tool_passthrough.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/server_tool_passthrough.ts
@@ -1,0 +1,84 @@
+import type {
+  MessageParam,
+  ServerToolUseBlockParam,
+  ToolSearchToolResultBlockParam,
+  WebSearchToolResultBlockParam,
+} from "@anthropic-ai/sdk/resources/messages/messages.mjs";
+import {
+  parseAnthropicWebSearchBlock,
+  stripWebSearchBlocks,
+} from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/native_web_search_passthrough";
+import {
+  parseAnthropicToolSearchBlock,
+  stripUnreplayableToolSearchBlocks,
+} from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search_passthrough";
+import logger from "@app/logger/logger";
+
+// Dispatch across the Anthropic server-tool families whose blocks Dust persists
+// as opaque provider passthrough. Each family owns its own schemas and replay
+// rules (they genuinely differ); this module is only the router, so callers do
+// not have to know which server tool produced a stored block.
+
+export type AnthropicServerToolBlockParam =
+  | ServerToolUseBlockParam
+  | ToolSearchToolResultBlockParam
+  | WebSearchToolResultBlockParam;
+
+function hasBlockType(value: unknown): value is { type: unknown } {
+  return typeof value === "object" && value !== null && "type" in value;
+}
+
+/**
+ * Parses an opaque persisted block back into a typed Anthropic block param,
+ * trying each server-tool family in turn.
+ */
+export function parseAnthropicServerToolBlock(
+  block: unknown
+): AnthropicServerToolBlockParam | null {
+  const toolSearchBlock = parseAnthropicToolSearchBlock(block);
+  if (toolSearchBlock) {
+    return toolSearchBlock;
+  }
+
+  const webSearchBlock = parseAnthropicWebSearchBlock(block);
+  if (webSearchBlock) {
+    return webSearchBlock;
+  }
+
+  // We only ever store blocks we captured ourselves, so a parse failure means
+  // storage drift or a newly enabled server tool no schema knows. Surface it:
+  // dropping the block would re-break interleaved thinking.
+  logger.warn(
+    { blockType: hasBlockType(block) ? block.type : undefined },
+    "[server-tool] Dropping unparseable Anthropic passthrough block"
+  );
+  return null;
+}
+
+interface StripUnreplayableServerToolBlocksOptions {
+  // Whether the request being built carries the tool search server tool.
+  toolSearchInRequest: boolean;
+  // Whether the request being built carries the native web search server tool.
+  nativeWebSearchInRequest: boolean;
+}
+
+/**
+ * Strips every server-tool block the API would reject from the replay. Each
+ * family's pass returns its input untouched when it has nothing to strip, so the
+ * common path stays byte identical for prompt caching.
+ */
+export function stripUnreplayableServerToolBlocks(
+  messages: MessageParam[],
+  {
+    toolSearchInRequest,
+    nativeWebSearchInRequest,
+  }: StripUnreplayableServerToolBlocksOptions
+): MessageParam[] {
+  const withoutToolSearch = stripUnreplayableToolSearchBlocks(messages, {
+    toolSearchInRequest,
+  });
+
+  return nativeWebSearchInRequest
+    ? withoutToolSearch
+    : stripWebSearchBlocks(withoutToolSearch);
+}

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search.test.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search.test.ts
@@ -29,6 +29,7 @@ describe("includesToolSearchTool", () => {
         toolSpecsToAnthropicAITools([hot], {
           forceTool: undefined,
           toolSearchEnabled: true,
+          nativeWebSearchEnabled: false,
         })
       )
     ).toBe(false);
@@ -40,6 +41,7 @@ describe("includesToolSearchTool", () => {
         toolSpecsToAnthropicAITools([hot, cold], {
           forceTool: undefined,
           toolSearchEnabled: false,
+          nativeWebSearchEnabled: false,
         })
       )
     ).toBe(false);
@@ -51,6 +53,7 @@ describe("includesToolSearchTool", () => {
         toolSpecsToAnthropicAITools([hot, cold], {
           forceTool: undefined,
           toolSearchEnabled: true,
+          nativeWebSearchEnabled: false,
         })
       )
     ).toBe(true);
@@ -62,6 +65,7 @@ describe("includesToolSearchTool", () => {
         toolSpecsToAnthropicAITools([cold], {
           forceTool: "cold",
           toolSearchEnabled: true,
+          nativeWebSearchEnabled: false,
         })
       )
     ).toBe(false);

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search_passthrough.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search_passthrough.ts
@@ -4,6 +4,7 @@ import type {
   ServerToolUseBlockParam,
   ToolSearchToolResultBlockParam,
 } from "@anthropic-ai/sdk/resources/messages/messages.mjs";
+import { mergeConsecutiveSameRoleMessages } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/message_blocks";
 import logger from "@app/logger/logger";
 import { z } from "zod";
 
@@ -64,10 +65,6 @@ export type AnthropicToolSearchBlock = z.infer<
   typeof anthropicToolSearchBlockSchema
 >;
 
-function hasBlockType(value: unknown): value is { type: unknown } {
-  return typeof value === "object" && value !== null && "type" in value;
-}
-
 // Parses an opaque persisted block back into a typed Anthropic block param.
 // Returns null when the block is not a recognized tool-search block so the
 // caller can skip it rather than send a malformed request.
@@ -76,13 +73,8 @@ export function parseAnthropicToolSearchBlock(
 ): ServerToolUseBlockParam | ToolSearchToolResultBlockParam | null {
   const r = anthropicToolSearchBlockSchema.safeParse(block);
   if (!r.success) {
-    // We only ever store blocks we captured ourselves, so a parse failure means
-    // storage drift or a newly enabled server tool the schema does not know.
-    // Surface it: dropping the block would re-break interleaved thinking.
-    logger.warn(
-      { blockType: hasBlockType(block) ? block.type : undefined },
-      "[tool-search] Dropping unparseable Anthropic passthrough block"
-    );
+    // Silent: the block may be another server tool's. `parseAnthropicServerToolBlock`
+    // tries every family and owns the "unparseable" warning.
     return null;
   }
   // Reconstruct the param explicitly so required fields (e.g. `input`) are
@@ -186,40 +178,6 @@ function findResumableAssistantIndex(messages: MessageParam[]): number {
   }
 
   return -1;
-}
-
-function toContentBlocks(
-  content: MessageParam["content"]
-): ContentBlockParam[] {
-  return typeof content === "string"
-    ? [{ type: "text", text: content }]
-    : content;
-}
-
-// Anthropic rejects consecutive same-role messages, so re-merge neighbors after a message was
-// dropped entirely. O(n) in messages. Merging a run of same-role messages re-copies the merged
-// content at each step, but the input arrives with no same-role neighbors (the renderers already
-// merged them), so runs only form around dropped messages and stay short.
-function mergeConsecutiveSameRoleMessages(
-  messages: MessageParam[]
-): MessageParam[] {
-  const merged: MessageParam[] = [];
-  for (const message of messages) {
-    const previous = merged[merged.length - 1];
-    if (previous && previous.role === message.role) {
-      merged[merged.length - 1] = {
-        ...previous,
-        content: [
-          ...toContentBlocks(previous.content),
-          ...toContentBlocks(message.content),
-        ],
-      };
-    } else {
-      merged.push(message);
-    }
-  }
-
-  return merged;
 }
 
 interface StripUnreplayableToolSearchBlocksOptions {

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.ts
@@ -18,8 +18,9 @@ import type {
 } from "@anthropic-ai/sdk/resources/messages/messages";
 import type { AnthropicInputConfig } from "@app/lib/model_constructors/providers/anthropic/inputConfig";
 import type { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
+import { ANTHROPIC_WEB_SEARCH_TOOL } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/native_web_search";
+import { parseAnthropicServerToolBlock } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/server_tool_passthrough";
 import { TOOL_SEARCH_TOOL } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search";
-import { parseAnthropicToolSearchBlock } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search_passthrough";
 import type {
   OutputFormat,
   ToolChoiceInput,
@@ -250,14 +251,14 @@ export function assistantToolCallRequestToToolUseBlock(
 export function assistantProviderPassthroughMessageToBlocks(
   message: BaseAssistantProviderPassthroughMessage
 ): MessageParam["content"] {
-  // Replay the provider's own tool-search blocks verbatim so interleaved
+  // Replay the provider's own server-tool blocks verbatim so interleaved
   // thinking signatures stay valid. Skip blocks tagged for another provider or
   // that fail to parse.
   if (message.content.provider !== ANTHROPIC_LAB) {
     return [];
   }
 
-  const parsed = parseAnthropicToolSearchBlock(message.content.block);
+  const parsed = parseAnthropicServerToolBlock(message.content.block);
   return parsed ? [parsed] : [];
 }
 
@@ -432,8 +433,13 @@ export function toolSpecsToAnthropicAITools(
   {
     forceTool,
     toolSearchEnabled,
-  }: { forceTool: string | undefined; toolSearchEnabled: boolean }
-): Array<Tool | typeof TOOL_SEARCH_TOOL> {
+    nativeWebSearchEnabled,
+  }: {
+    forceTool: string | undefined;
+    toolSearchEnabled: boolean;
+    nativeWebSearchEnabled: boolean;
+  }
+): Array<Tool | typeof TOOL_SEARCH_TOOL | typeof ANTHROPIC_WEB_SEARCH_TOOL> {
   const converted = tools.map((tool) =>
     // A forced tool cannot be deferred: the API requires the tool_choice target
     // to be loaded, so treat it as eager.
@@ -443,10 +449,23 @@ export function toolSpecsToAnthropicAITools(
     )
   );
 
-  // The tool search tool is only needed when at least one tool is actually deferred.
-  return converted.some((tool) => tool.defer_loading)
-    ? [TOOL_SEARCH_TOOL, ...converted]
-    : converted;
+  // Server tools go first, in a fixed order, so the serialized tools prefix
+  // stays byte-stable across steps for prompt caching.
+  return [
+    // The tool search tool is only needed when at least one tool is actually deferred.
+    ...(converted.some((tool) => tool.defer_loading) ? [TOOL_SEARCH_TOOL] : []),
+    // A forced tool_choice targets a client tool; a server tool cannot be the
+    // target, and its interaction with a non-auto tool_choice is unspecified, so
+    // keep force-called requests (auxiliary calls only) free of server tools.
+    // `disableToolUse` deliberately does NOT drop it: tool_choice "none" already
+    // forbids every tool, and removing it would both invalidate the cached tools
+    // prefix on the last step and force the replay sanitizer to strip the search
+    // results the model needs to write its answer.
+    ...(nativeWebSearchEnabled && !forceTool
+      ? [ANTHROPIC_WEB_SEARCH_TOOL]
+      : []),
+    ...converted,
+  ];
 }
 
 export function forceToolNameToToolChoice(

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/native_web_search.test.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/native_web_search.test.ts
@@ -1,0 +1,392 @@
+import type {
+  BetaMessage,
+  BetaRawContentBlockDeltaEvent,
+  BetaRawContentBlockStartEvent,
+  BetaRawContentBlockStopEvent,
+} from "@anthropic-ai/sdk/resources/beta/messages/messages";
+import type { OutputEventConverters } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/output/utils";
+import {
+  accumulatedReasoningToReasoningEvent,
+  accumulatedTextToTextEvent,
+  accumulatedToolCallToToolCallEvent,
+  contentBlockDeltaToEvents,
+  contentBlockStartToEvents,
+  contentBlockStopToEvents,
+  inputJsonDeltaToToolCallDeltaEvent,
+  invalidJsonToolCallToToolCallEvent,
+  messageDeltaUsageToTokenUsageEvent,
+  messageStartToResponseIdEvent,
+  messageToEvents,
+  reasoningDeltaToReasoningDeltaEvent,
+  serverToolBlockToProviderPassthroughEvent,
+  stopReasonToErrorEvent,
+  streamErrorToErrorEvent,
+  textDeltaToTextDeltaEvent,
+  toolUseBlockStartToToolCallStartedEvent,
+} from "@app/lib/model_constructors/sdk/anthropic_ai/converters/output/utils";
+import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
+import { describe, expect, it } from "vitest";
+
+const metadata: EndpointMetadata = {
+  lab: "anthropic",
+  host: "anthropic",
+  region: "us",
+  model: "claude-sonnet-4-6",
+};
+
+const realConverters: OutputEventConverters = {
+  messageStartToResponseIdEvent,
+  textDeltaToTextDeltaEvent,
+  reasoningDeltaToReasoningDeltaEvent,
+  accumulatedTextToTextEvent,
+  accumulatedReasoningToReasoningEvent,
+  toolUseBlockStartToToolCallStartedEvent,
+  inputJsonDeltaToToolCallDeltaEvent,
+  accumulatedToolCallToToolCallEvent,
+  invalidJsonToolCallToToolCallEvent,
+  serverToolBlockToProviderPassthroughEvent,
+  messageDeltaUsageToTokenUsageEvent,
+  stopReasonToErrorEvent,
+  streamErrorToErrorEvent,
+};
+
+const searchResult = {
+  type: "web_search_result" as const,
+  url: "https://example.com/wc",
+  title: "World Cup",
+  encrypted_content: "opaque",
+  page_age: null,
+};
+
+describe("contentBlockStartToEvents for native web search", () => {
+  it("opens a native_web_search cursor for a web_search server_tool_use", () => {
+    const event = {
+      type: "content_block_start",
+      index: 2,
+      content_block: {
+        type: "server_tool_use",
+        id: "srvtoolu_1",
+        name: "web_search",
+        input: {},
+      },
+    } as BetaRawContentBlockStartEvent;
+
+    const [events, nextState] = contentBlockStartToEvents(
+      event,
+      null,
+      metadata,
+      realConverters
+    );
+
+    expect(events).toEqual([]);
+    expect(nextState).toEqual({
+      index: 2,
+      accumulator: "",
+      type: "native_web_search",
+      toolId: "srvtoolu_1",
+    });
+  });
+
+  // Guard against the web-search branch swallowing tool search.
+  it("still opens a tool_search cursor for a tool search server_tool_use", () => {
+    const event = {
+      type: "content_block_start",
+      index: 0,
+      content_block: {
+        type: "server_tool_use",
+        id: "srvtoolu_2",
+        name: "tool_search_tool_bm25",
+        input: {},
+      },
+    } as BetaRawContentBlockStartEvent;
+
+    const [, nextState] = contentBlockStartToEvents(
+      event,
+      null,
+      metadata,
+      realConverters
+    );
+
+    expect(nextState).toMatchObject({
+      type: "tool_search",
+      toolName: "tool_search_tool_bm25",
+    });
+  });
+
+  it("passes a web_search_tool_result through for verbatim replay", () => {
+    const event = {
+      type: "content_block_start",
+      index: 3,
+      content_block: {
+        type: "web_search_tool_result",
+        tool_use_id: "srvtoolu_1",
+        content: [searchResult],
+      },
+    } as BetaRawContentBlockStartEvent;
+
+    const [events, nextState] = contentBlockStartToEvents(
+      event,
+      null,
+      metadata,
+      realConverters
+    );
+
+    expect(events).toEqual([
+      {
+        type: "provider_passthrough",
+        content: {
+          provider: "anthropic",
+          block: {
+            type: "web_search_tool_result",
+            tool_use_id: "srvtoolu_1",
+            content: [searchResult],
+          },
+        },
+        metadata,
+      },
+    ]);
+    expect(nextState).toBeNull();
+  });
+});
+
+describe("contentBlockStopToEvents for native web search", () => {
+  const stopEvent = {
+    type: "content_block_stop",
+    index: 2,
+  } as BetaRawContentBlockStopEvent;
+
+  it("emits the server_tool_use block with the parsed query", () => {
+    const [events, nextState] = contentBlockStopToEvents(
+      stopEvent,
+      {
+        index: 2,
+        accumulator: '{"query":"who won the last world cup"}',
+        type: "native_web_search",
+        toolId: "srvtoolu_1",
+      },
+      metadata,
+      realConverters
+    );
+
+    expect(events).toEqual([
+      {
+        type: "provider_passthrough",
+        content: {
+          provider: "anthropic",
+          block: {
+            type: "server_tool_use",
+            id: "srvtoolu_1",
+            name: "web_search",
+            input: { query: "who won the last world cup" },
+          },
+        },
+        metadata,
+      },
+    ]);
+    expect(nextState).toBeNull();
+  });
+
+  it("falls back to an empty input when the query fails to parse", () => {
+    const [events] = contentBlockStopToEvents(
+      stopEvent,
+      {
+        index: 2,
+        accumulator: '{"query":',
+        type: "native_web_search",
+        toolId: "srvtoolu_1",
+      },
+      metadata,
+      realConverters
+    );
+
+    expect(events[0]).toMatchObject({
+      content: { block: { input: {} } },
+    });
+  });
+});
+
+describe("contentBlockDeltaToEvents for web search citations", () => {
+  function citationDelta(): BetaRawContentBlockDeltaEvent {
+    return {
+      type: "content_block_delta",
+      index: 0,
+      delta: {
+        type: "citations_delta",
+        citation: {
+          type: "web_search_result_location",
+          cited_text: "Argentina won",
+          encrypted_index: "idx",
+          title: "World Cup",
+          url: "https://example.com/wc",
+        },
+      },
+    } as BetaRawContentBlockDeltaEvent;
+  }
+
+  // The link is emitted as a delta AND appended to the accumulator, so the final
+  // aggregated text is byte-identical to what the user saw stream past.
+  it("emits the source as a markdown link and extends the accumulator", () => {
+    const [events, nextState] = contentBlockDeltaToEvents(
+      citationDelta(),
+      { index: 0, accumulator: "Argentina won", type: "text" },
+      metadata,
+      realConverters
+    );
+
+    const link = " ([World Cup](https://example.com/wc))";
+    expect(events).toEqual([
+      { type: "text_delta", content: { value: link }, metadata },
+    ]);
+    expect(nextState).toEqual({
+      index: 0,
+      accumulator: "Argentina won" + link,
+      type: "text",
+    });
+  });
+
+  it("suppresses a citation repeated immediately after itself", () => {
+    const link = " ([World Cup](https://example.com/wc))";
+    const state = {
+      index: 0,
+      accumulator: "Argentina won" + link,
+      type: "text" as const,
+    };
+
+    const [events, nextState] = contentBlockDeltaToEvents(
+      citationDelta(),
+      state,
+      metadata,
+      realConverters
+    );
+
+    expect(events).toEqual([]);
+    expect(nextState).toBe(state);
+  });
+
+  it("ignores a non-web-search citation", () => {
+    const event = {
+      type: "content_block_delta",
+      index: 0,
+      delta: {
+        type: "citations_delta",
+        citation: {
+          type: "char_location",
+          cited_text: "x",
+          document_index: 0,
+          document_title: null,
+          start_char_index: 0,
+          end_char_index: 1,
+        },
+      },
+    } as BetaRawContentBlockDeltaEvent;
+    const state = { index: 0, accumulator: "x", type: "text" as const };
+
+    const [events, nextState] = contentBlockDeltaToEvents(
+      event,
+      state,
+      metadata,
+      realConverters
+    );
+
+    expect(events).toEqual([]);
+    expect(nextState).toBe(state);
+  });
+
+  it("ignores a web-search citation outside a text block", () => {
+    const state = {
+      index: 0,
+      accumulator: "",
+      type: "reasoning" as const,
+    };
+
+    const [events, nextState] = contentBlockDeltaToEvents(
+      citationDelta(),
+      state,
+      metadata,
+      realConverters
+    );
+
+    expect(events).toEqual([]);
+    expect(nextState).toBe(state);
+  });
+});
+
+describe("messageToEvents for native web search", () => {
+  function messageWith(overrides: Partial<BetaMessage>): BetaMessage {
+    return {
+      id: "msg_1",
+      type: "message",
+      role: "assistant",
+      model: "claude-sonnet-4-6",
+      content: [],
+      stop_reason: "end_turn",
+      stop_sequence: null,
+      usage: {
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        input_tokens: 4,
+        output_tokens: 6,
+        output_tokens_details: null,
+        server_tool_use: null,
+      },
+      ...overrides,
+    } as BetaMessage;
+  }
+
+  it("passes both web search blocks through and appends citation links", () => {
+    const message = messageWith({
+      content: [
+        {
+          type: "server_tool_use",
+          id: "srvtoolu_1",
+          name: "web_search",
+          input: { query: "q" },
+          caller: { type: "direct" },
+        },
+        {
+          type: "web_search_tool_result",
+          tool_use_id: "srvtoolu_1",
+          content: [searchResult],
+          caller: { type: "direct" },
+        },
+        {
+          type: "text",
+          text: "Argentina won.",
+          citations: [
+            {
+              type: "web_search_result_location",
+              cited_text: "Argentina won",
+              encrypted_index: "idx",
+              title: "World Cup",
+              url: "https://example.com/wc",
+            },
+          ],
+        },
+      ],
+    } as Partial<BetaMessage>);
+
+    const events = messageToEvents(message, metadata, realConverters);
+
+    expect(
+      events.filter((event) => event.type === "provider_passthrough")
+    ).toHaveLength(2);
+
+    expect(events.find((event) => event.type === "text")).toMatchObject({
+      content: {
+        value: "Argentina won. ([World Cup](https://example.com/wc))",
+      },
+    });
+  });
+
+  it("leaves a text block with no web search citations untouched", () => {
+    const message = messageWith({
+      content: [{ type: "text", text: "plain", citations: [] }],
+    } as Partial<BetaMessage>);
+
+    const events = messageToEvents(message, metadata, realConverters);
+
+    expect(events.find((event) => event.type === "text")).toMatchObject({
+      content: { value: "plain" },
+    });
+  });
+});

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/native_web_search_logging.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/native_web_search_logging.ts
@@ -1,0 +1,76 @@
+import type { WebSearchToolResultBlockContent } from "@anthropic-ai/sdk/resources/messages/messages";
+import {
+  logNativeWebSearchError,
+  logNativeWebSearchRequest,
+  logNativeWebSearchResults,
+} from "@app/lib/model_constructors/utils/native_web_search_logging";
+import { isRecord, isString } from "@app/types/shared/utils/general";
+import { safeParseJSON } from "@app/types/shared/utils/json_utils";
+
+// Anthropic-specific parsing for the native web search server tool. Callers map
+// their metadata into StatsD tags and structured log fields; the
+// provider-independent log shape and metric live in the shared utility.
+
+// Logs the query the model issued against the native web search tool and
+// increments a per-search counter. The query arrives as accumulated
+// input_json_delta JSON: `{"query":"..."}`.
+export function logAnthropicWebSearchQuery({
+  rawInput,
+  tags,
+  logFields,
+}: {
+  rawInput: string;
+  tags: string[];
+  logFields: Record<string, unknown>;
+}): string | undefined {
+  let query: string | undefined;
+  const parsed = safeParseJSON(rawInput);
+  if (
+    parsed.isOk() &&
+    parsed.value !== null &&
+    isRecord(parsed.value) &&
+    isString(parsed.value.query)
+  ) {
+    query = parsed.value.query;
+  }
+
+  logNativeWebSearchRequest({
+    providerName: "Anthropic",
+    details: {
+      query,
+      // Keep the raw payload only when parsing failed, to debug malformed input.
+      rawInput: query === undefined ? rawInput : undefined,
+    },
+    tags,
+    logFields,
+  });
+
+  return query;
+}
+
+// Logs how many results a search returned, or the error code when the search
+// failed (e.g. too_many_requests, max_uses_exceeded).
+export function logAnthropicWebSearchResult({
+  content,
+  query,
+  logFields,
+}: {
+  content: WebSearchToolResultBlockContent;
+  query: string | undefined;
+  logFields: Record<string, unknown>;
+}): void {
+  if (!Array.isArray(content)) {
+    logNativeWebSearchError({
+      providerName: "Anthropic",
+      details: { query, errorCode: content.error_code },
+      logFields,
+    });
+    return;
+  }
+
+  logNativeWebSearchResults({
+    providerName: "Anthropic",
+    details: { query, resultCount: content.length },
+    logFields,
+  });
+}

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
@@ -16,8 +16,14 @@ import type {
   BetaRawMessageDeltaEvent,
   BetaRawMessageStartEvent,
   BetaRawMessageStreamEvent,
+  BetaTextBlock,
 } from "@anthropic-ai/sdk/resources/beta/messages/messages";
+import { ANTHROPIC_WEB_SEARCH_TOOL_NAME } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/native_web_search";
 import { parseToolArguments } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/utils";
+import {
+  logAnthropicWebSearchQuery,
+  logAnthropicWebSearchResult,
+} from "@app/lib/model_constructors/sdk/anthropic_ai/converters/output/native_web_search_logging";
 import {
   logToolSearchQuery,
   logToolSearchResult,
@@ -48,6 +54,7 @@ import {
   httpErrorMessage,
 } from "@app/lib/model_constructors/utils/classify_http_status";
 import { classifyStreamError } from "@app/lib/model_constructors/utils/classify_stream_error";
+import { formatWebSearchCitationLink } from "@app/lib/model_constructors/utils/web_search_citation";
 import logger from "@app/logger/logger";
 import {
   assertNever,
@@ -167,6 +174,16 @@ export type BlockState =
       accumulator: string;
       type: "tool_search";
       toolName: string;
+      // The server_tool_use block id, needed to replay the block verbatim.
+      toolId: string;
+    }
+  // The provider's native web search. Same server_tool_use shape as tool search,
+  // kept as its own variant because the two have different result blocks, log
+  // lines and replay rules.
+  | {
+      index: number;
+      accumulator: string;
+      type: "native_web_search";
       // The server_tool_use block id, needed to replay the block verbatim.
       toolId: string;
     };
@@ -525,7 +542,8 @@ export function contentBlockStartToEvents(
   state: BlockState | null,
   metadata: EndpointMetadata,
   converters: OutputEventConverters,
-  toolSearchQuery?: string
+  toolSearchQuery?: string,
+  nativeWebSearchQuery?: string
 ): [ModelResponseEvent[], BlockState | null] {
   const block = event.content_block;
   switch (block.type) {
@@ -553,8 +571,20 @@ export function contentBlockStartToEvents(
       ];
 
     case "server_tool_use":
-      // The only server tool we enable is tool search. Accumulate the query
-      // deltas, then emit the block as passthrough at content_block_stop.
+      // Accumulate the query deltas, then emit the block as passthrough at
+      // content_block_stop. Which server tool it is decides the state variant:
+      // native web search and tool search have different result blocks and logs.
+      if (block.name === ANTHROPIC_WEB_SEARCH_TOOL_NAME) {
+        return [
+          [],
+          {
+            index: event.index,
+            accumulator: "",
+            type: "native_web_search",
+            toolId: block.id,
+          },
+        ];
+      }
       return [
         [],
         {
@@ -572,7 +602,7 @@ export function contentBlockStartToEvents(
       logToolSearchResult({
         content: block.content,
         query: toolSearchQuery,
-        logFields: toolSearchLogFields(metadata),
+        logFields: serverToolLogFields(metadata),
       });
       return [
         [
@@ -585,11 +615,31 @@ export function contentBlockStartToEvents(
         null,
       ];
 
+    case "web_search_tool_result":
+      // Search results arrive inline (no deltas). Emit a passthrough so they
+      // replay verbatim on the next request: they carry the `encrypted_content`
+      // the model needs to keep citing them, and dropping them would invalidate
+      // interleaved thinking signatures. State stays null, so the stop is a no-op.
+      logAnthropicWebSearchResult({
+        content: block.content,
+        query: nativeWebSearchQuery,
+        logFields: serverToolLogFields(metadata),
+      });
+      return [
+        [
+          converters.serverToolBlockToProviderPassthroughEvent(metadata, {
+            type: "web_search_tool_result",
+            tool_use_id: block.tool_use_id,
+            content: block.content,
+          }),
+        ],
+        null,
+      ];
+
     // Block types we don't surface: redacted thinking, other server tools, and
     // their result / container blocks. Listed explicitly so the default stays
     // exhaustive.
     case "redacted_thinking":
-    case "web_search_tool_result":
     case "web_fetch_tool_result":
     case "code_execution_tool_result":
     case "bash_code_execution_tool_result":
@@ -649,7 +699,35 @@ export function contentBlockDeltaToEvents(
         ];
       }
       return [[], state];
-    case "citations_delta":
+    case "citations_delta": {
+      // Native web search attaches its sources here rather than writing them in
+      // the text. Dust's `:cite[REF]` scheme cannot carry them (refs are keyed on
+      // a persisted MCP action row, and a server-side search produces none), so
+      // splice each source in as a markdown link. The delta arrives immediately
+      // after the span it cites, so appending at arrival time puts the link in
+      // the right place. The accumulator is extended in lockstep, keeping the
+      // final aggregated text byte-identical to what was streamed.
+      if (
+        state.type !== "text" ||
+        delta.citation.type !== "web_search_result_location"
+      ) {
+        return [[], state];
+      }
+      const link = formatWebSearchCitationLink({
+        title: delta.citation.title,
+        url: delta.citation.url,
+      });
+      // Anthropic repeats a source across adjacent spans; emitting the same link
+      // twice in a row is noise, not a second citation. The accumulator is the
+      // state, so no extra bookkeeping is needed.
+      if (state.accumulator.endsWith(link)) {
+        return [[], state];
+      }
+      return [
+        [converters.textDeltaToTextDeltaEvent(metadata, link)],
+        { ...state, accumulator: state.accumulator + link },
+      ];
+    }
     case "compaction_delta":
       return [[], state];
     default:
@@ -744,14 +822,55 @@ export function contentBlockStopToEvents(
       ];
     }
 
+    case "native_web_search": {
+      // Same verbatim replay as tool search: the result block references this
+      // block's id, so the pair has to survive together.
+      const parsedInput = safeParseJSON(block.accumulator);
+      return [
+        [
+          converters.serverToolBlockToProviderPassthroughEvent(metadata, {
+            type: "server_tool_use",
+            id: block.toolId,
+            name: ANTHROPIC_WEB_SEARCH_TOOL_NAME,
+            input: parsedInput.isOk() ? parsedInput.value : {},
+          }),
+        ],
+        null,
+      ];
+    }
+
     default:
       assertNever(block);
   }
 }
 
-// Maps endpoint metadata into the structured log fields shared by both tool
-// search log lines.
-function toolSearchLogFields(metadata: EndpointMetadata) {
+// Concatenates the markdown links for a completed text block's native web
+// search citations. Other citation kinds (documents, search results) are already
+// carried by Dust's own ref system, so only web results are spliced in here.
+function webSearchCitationLinks(citations: BetaTextBlock["citations"]): string {
+  if (!citations) {
+    return "";
+  }
+
+  // These all land at the end of the block, so the same source appearing twice
+  // would be pure noise: dedupe by link rather than only consecutively.
+  const links = new Set(
+    citations
+      .filter((citation) => citation.type === "web_search_result_location")
+      .map((citation) =>
+        formatWebSearchCitationLink({
+          title: citation.title,
+          url: citation.url,
+        })
+      )
+  );
+
+  return [...links].join("");
+}
+
+// Maps endpoint metadata into the structured log fields shared by every
+// server-tool log line (tool search and native web search).
+function serverToolLogFields(metadata: EndpointMetadata) {
   return {
     providerId: metadata.lab,
     api: metadata.host,
@@ -806,6 +925,7 @@ export async function* rawOutputToEvents(
   let tokenUsage: BetaMessageDeltaUsage | null = null;
   let stopReason: string | null = null;
   const toolSearchQueriesByToolUseId = new Map<string, string | undefined>();
+  const webSearchQueriesByToolUseId = new Map<string, string | undefined>();
   // The per-TTL cache-creation breakdown is only emitted on `message_start`;
   // capture it so the trailing `message_delta` usage can be split by TTL.
   let cacheCreation: BetaCacheCreation | null = null;
@@ -864,15 +984,23 @@ export async function* rawOutputToEvents(
           event.content_block.type === "tool_search_tool_result"
             ? toolSearchQueriesByToolUseId.get(event.content_block.tool_use_id)
             : undefined;
+        const nativeWebSearchQuery =
+          event.content_block.type === "web_search_tool_result"
+            ? webSearchQueriesByToolUseId.get(event.content_block.tool_use_id)
+            : undefined;
         const [events, nextState] = contentBlockStartToEvents(
           event,
           blockState,
           metadata,
           converters,
-          toolSearchQuery
+          toolSearchQuery,
+          nativeWebSearchQuery
         );
         if (event.content_block.type === "tool_search_tool_result") {
           toolSearchQueriesByToolUseId.delete(event.content_block.tool_use_id);
+        }
+        if (event.content_block.type === "web_search_tool_result") {
+          webSearchQueriesByToolUseId.delete(event.content_block.tool_use_id);
         }
         outputEvents = events;
         blockState = nextState;
@@ -890,18 +1018,29 @@ export async function* rawOutputToEvents(
         break;
       }
       case "content_block_stop": {
+        const serverToolTags = [
+          `provider_id:${metadata.lab}`,
+          `api:${metadata.host}`,
+          `model_id:${metadata.model}`,
+        ];
         if (blockState?.type === "tool_search") {
           const query = logToolSearchQuery({
             rawInput: blockState.accumulator,
             toolName: blockState.toolName,
-            tags: [
-              `provider_id:${metadata.lab}`,
-              `api:${metadata.host}`,
-              `model_id:${metadata.model}`,
-            ],
-            logFields: toolSearchLogFields(metadata),
+            tags: serverToolTags,
+            logFields: serverToolLogFields(metadata),
           });
           toolSearchQueriesByToolUseId.set(blockState.toolId, query);
+        }
+        if (blockState?.type === "native_web_search") {
+          // Stash the query so the result block, which arrives later, can log
+          // query and result count together.
+          const query = logAnthropicWebSearchQuery({
+            rawInput: blockState.accumulator,
+            tags: serverToolTags,
+            logFields: serverToolLogFields(metadata),
+          });
+          webSearchQueriesByToolUseId.set(blockState.toolId, query);
         }
         const [events, nextState] = contentBlockStopToEvents(
           event,
@@ -979,9 +1118,13 @@ export function messageToEvents(
   message.content.forEach((block, index) => {
     switch (block.type) {
       case "text": {
+        // Mirrors the streaming `citations_delta` handling: native web search
+        // sources are appended as markdown links. Without per-span offsets on
+        // this path they all land at the end of the block, which is the best
+        // available placement.
         const event = converters.accumulatedTextToTextEvent(
           metadata,
-          block.text
+          block.text + webSearchCitationLinks(block.citations)
         );
         aggregated.push(event);
         events.push(event);
@@ -1020,8 +1163,9 @@ export function messageToEvents(
       }
       case "server_tool_use":
       case "tool_search_tool_result":
-        // Replay tool-search blocks verbatim so interleaved thinking signatures
-        // stay valid.
+      case "web_search_tool_result":
+        // Replay server-tool blocks verbatim so interleaved thinking signatures
+        // stay valid and web search results keep their citable content.
         events.push(
           converters.serverToolBlockToProviderPassthroughEvent(metadata, block)
         );
@@ -1030,7 +1174,6 @@ export function messageToEvents(
       // their result / container blocks. Listed explicitly so the default stays
       // exhaustive.
       case "redacted_thinking":
-      case "web_search_tool_result":
       case "web_fetch_tool_result":
       case "code_execution_tool_result":
       case "bash_code_execution_tool_result":

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/index.ts
@@ -1,4 +1,5 @@
 import type { Client } from "@app/lib/model_constructors/client";
+import { includesOpenAIWebSearchTool } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/native_web_search";
 import { includesOpenAIToolSearchTool } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/tool_search";
 import type {
   MessageItemConverters,
@@ -26,6 +27,7 @@ import type {
   SystemTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
 import type { Model } from "@app/lib/model_constructors/types/models";
+import { NATIVE_WEB_SEARCH_INSTRUCTION } from "@app/lib/model_constructors/types/native_web_search";
 import { TOOL_SEARCH_INSTRUCTION } from "@app/lib/model_constructors/types/tool_search";
 import type {
   ResponseCreateParams,
@@ -89,6 +91,7 @@ export function WithOpenAIResponsesInputConverter<
         cacheKey,
         forceTool,
         toolSearchEnabled,
+        nativeWebSearchEnabled,
         conciseReasoningSummary = false,
       } = config;
 
@@ -102,6 +105,7 @@ export function WithOpenAIResponsesInputConverter<
       const openAITools = toolSpecsToOpenAITools(tools, {
         forceTool,
         toolSearchEnabled: toolSearchEnabled ?? false,
+        nativeWebSearchEnabled: nativeWebSearchEnabled ?? false,
       });
 
       return {
@@ -116,6 +120,15 @@ export function WithOpenAIResponsesInputConverter<
                   role: "system",
                   type: "text",
                   content: { value: TOOL_SEARCH_INSTRUCTION },
+                },
+              ])
+            : []),
+          ...(includesOpenAIWebSearchTool(openAITools)
+            ? this.systemMessagesToInputItems([
+                {
+                  role: "system",
+                  type: "text",
+                  content: { value: NATIVE_WEB_SEARCH_INSTRUCTION },
                 },
               ])
             : []),

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/native_web_search.test.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/native_web_search.test.ts
@@ -1,0 +1,73 @@
+import {
+  includesOpenAIWebSearchTool,
+  OPENAI_WEB_SEARCH_TOOL,
+} from "@app/lib/model_constructors/sdk/openai_responses/converters/input/native_web_search";
+import { OPENAI_TOOL_SEARCH_TOOL } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/tool_search";
+import { toolSpecsToOpenAITools } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/utils";
+import type { ToolSpecification } from "@app/lib/model_constructors/types/input/configuration";
+import { describe, expect, it } from "vitest";
+
+const eagerTool: ToolSpecification = {
+  name: "eager",
+  description: "An eager tool.",
+  inputSchema: { type: "object", properties: {} },
+  eager: true,
+};
+
+const deferrableTool: ToolSpecification = {
+  name: "deferrable",
+  description: "A deferrable tool.",
+  inputSchema: { type: "object", properties: {} },
+};
+
+describe("toolSpecsToOpenAITools with native web search", () => {
+  it("prepends the web search tool when enabled", () => {
+    const tools = toolSpecsToOpenAITools([eagerTool], {
+      forceTool: undefined,
+      toolSearchEnabled: false,
+      nativeWebSearchEnabled: true,
+    });
+
+    expect(tools[0]).toEqual(OPENAI_WEB_SEARCH_TOOL);
+    expect(includesOpenAIWebSearchTool(tools)).toBe(true);
+  });
+
+  it("omits the web search tool when disabled", () => {
+    const tools = toolSpecsToOpenAITools([eagerTool], {
+      forceTool: undefined,
+      toolSearchEnabled: false,
+      nativeWebSearchEnabled: false,
+    });
+
+    expect(includesOpenAIWebSearchTool(tools)).toBe(false);
+  });
+
+  it("omits the web search tool when a tool is force-called", () => {
+    const tools = toolSpecsToOpenAITools([eagerTool], {
+      forceTool: "eager",
+      toolSearchEnabled: false,
+      nativeWebSearchEnabled: true,
+    });
+
+    expect(includesOpenAIWebSearchTool(tools)).toBe(false);
+  });
+
+  it("orders tool search before web search before function tools", () => {
+    const tools = toolSpecsToOpenAITools([deferrableTool], {
+      forceTool: undefined,
+      toolSearchEnabled: true,
+      nativeWebSearchEnabled: true,
+    });
+
+    expect(tools).toHaveLength(3);
+    expect(tools[0]).toEqual(OPENAI_TOOL_SEARCH_TOOL);
+    expect(tools[1]).toEqual(OPENAI_WEB_SEARCH_TOOL);
+    expect(tools[2]).toMatchObject({ name: "deferrable" });
+  });
+});
+
+describe("includesOpenAIWebSearchTool", () => {
+  it("is false for an unrelated tool", () => {
+    expect(includesOpenAIWebSearchTool([{ type: "function" }])).toBe(false);
+  });
+});

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/native_web_search.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/native_web_search.ts
@@ -1,0 +1,15 @@
+import type { WebSearchTool } from "openai/resources/responses/responses";
+
+// `web_search` is the rolling alias; `web_search_2025_08_26` pins a dated
+// snapshot. The optional fields (`filters`, `search_context_size`,
+// `user_location`) are deliberately omitted so the serialized tool stays
+// byte-stable for prompt caching.
+export const OPENAI_WEB_SEARCH_TOOL = {
+  type: "web_search",
+} as const satisfies WebSearchTool;
+
+export function includesOpenAIWebSearchTool(
+  tools: ReadonlyArray<{ type?: string | null }>
+): boolean {
+  return tools.some((tool) => tool.type === OPENAI_WEB_SEARCH_TOOL.type);
+}

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/native_web_search_passthrough.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/native_web_search_passthrough.ts
@@ -1,0 +1,44 @@
+import type {
+  ResponseFunctionWebSearch,
+  ResponseInputItem,
+} from "openai/resources/responses/responses";
+import { z } from "zod";
+
+// The Responses input is rebuilt in full on every request, so a `web_search_call`
+// item the model produced has to be replayed: the API rejects a reasoning item
+// whose following item was dropped, and a search call routinely sits between a
+// reasoning item and the message. We persist it opaquely in the generic content
+// layer (as provider passthrough) and parse it back here.
+//
+// Following the tool-search convention in this directory: validate only the
+// stable fields Dust relies on, and `.passthrough()` the rest so new OpenAI
+// replay fields need no plumbing through shared Dust types.
+
+// OpenAI exposes no runtime schema for the action union. Validate the stable
+// discriminator so Zod can return the SDK type without duplicating the union.
+const webSearchActionSchema = z.custom<ResponseFunctionWebSearch["action"]>(
+  (value) =>
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    typeof value.type === "string"
+);
+
+const webSearchCallSchema: z.ZodType<ResponseFunctionWebSearch> = z
+  .object({
+    type: z.literal("web_search_call"),
+    id: z.string(),
+    action: webSearchActionSchema,
+    status: z.enum(["in_progress", "searching", "completed", "failed"]),
+  })
+  .passthrough();
+
+// Returns null silently when the item is not a web-search call:
+// `parseOpenAIServerToolItem` tries every server-tool family and owns the
+// "unparseable" warning.
+export function parseOpenAIWebSearchItem(
+  block: unknown
+): ResponseInputItem | null {
+  const result = webSearchCallSchema.safeParse(block);
+  return result.success ? result.data : null;
+}

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/server_tool_passthrough.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/server_tool_passthrough.ts
@@ -1,0 +1,34 @@
+import { parseOpenAIWebSearchItem } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/native_web_search_passthrough";
+import { parseOpenAIToolSearchItem } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/tool_search_passthrough";
+import logger from "@app/logger/logger";
+import type { ResponseInputItem } from "openai/resources/responses/responses";
+
+// Dispatch across the OpenAI Responses server-tool families whose items Dust
+// persists as opaque provider passthrough, so callers do not have to know which
+// server tool produced a stored item.
+
+function hasItemType(value: unknown): value is { type: unknown } {
+  return typeof value === "object" && value !== null && "type" in value;
+}
+
+export function parseOpenAIServerToolItem(
+  block: unknown
+): ResponseInputItem | null {
+  const toolSearchItem = parseOpenAIToolSearchItem(block);
+  if (toolSearchItem) {
+    return toolSearchItem;
+  }
+
+  const webSearchItem = parseOpenAIWebSearchItem(block);
+  if (webSearchItem) {
+    return webSearchItem;
+  }
+
+  // We only ever store items we captured ourselves, so a parse failure means
+  // storage drift or a newly enabled server tool no schema knows.
+  logger.warn(
+    { itemType: hasItemType(block) ? block.type : undefined },
+    "[server-tool] Dropping unparseable OpenAI passthrough item"
+  );
+  return null;
+}

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/tool_search_passthrough.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/tool_search_passthrough.ts
@@ -1,4 +1,3 @@
-import logger from "@app/logger/logger";
 import type {
   ResponseInputItem,
   ResponseToolSearchOutputItemParam,
@@ -53,17 +52,12 @@ const openAIToolSearchItemSchema: z.ZodType<OpenAIToolSearchItem> = z.union([
   toolSearchOutputSchema,
 ]);
 
+// Returns null silently when the item is not a tool-search item:
+// `parseOpenAIServerToolItem` tries every server-tool family and owns the
+// "unparseable" warning.
 export function parseOpenAIToolSearchItem(
   block: unknown
 ): ResponseInputItem | null {
   const result = openAIToolSearchItemSchema.safeParse(block);
-  if (result.success) {
-    return result.data;
-  }
-
-  logger.warn(
-    { validationIssues: result.error.issues },
-    "[tool-search] Dropping unparseable OpenAI tool-search item"
-  );
-  return null;
+  return result.success ? result.data : null;
 }

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.test.ts
@@ -444,6 +444,7 @@ describe("toolSpecsToOpenAITools", () => {
       toolSpecsToOpenAITools([eagerTool, deferredTool], {
         forceTool: undefined,
         toolSearchEnabled: true,
+        nativeWebSearchEnabled: false,
       })
     ).toEqual([
       { type: "tool_search" },
@@ -459,6 +460,7 @@ describe("toolSpecsToOpenAITools", () => {
     const tools = toolSpecsToOpenAITools([deferredTool], {
       forceTool: deferredTool.name,
       toolSearchEnabled: true,
+      nativeWebSearchEnabled: false,
     });
 
     expect(tools).toEqual([expect.objectContaining({ name: "get_weather" })]);

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
@@ -1,5 +1,6 @@
+import { OPENAI_WEB_SEARCH_TOOL } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/native_web_search";
+import { parseOpenAIServerToolItem } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/server_tool_passthrough";
 import { OPENAI_TOOL_SEARCH_TOOL } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/tool_search";
-import { parseOpenAIToolSearchItem } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/tool_search_passthrough";
 import type {
   OutputFormat,
   Reasoning,
@@ -240,7 +241,7 @@ export function assistantProviderPassthroughMessageToInputItems(
     return [];
   }
 
-  const item = parseOpenAIToolSearchItem(message.content.block);
+  const item = parseOpenAIServerToolItem(message.content.block);
   return item ? [item] : [];
 }
 
@@ -329,7 +330,12 @@ export function toolSpecsToOpenAITools(
   {
     forceTool,
     toolSearchEnabled,
-  }: { forceTool: string | undefined; toolSearchEnabled: boolean }
+    nativeWebSearchEnabled,
+  }: {
+    forceTool: string | undefined;
+    toolSearchEnabled: boolean;
+    nativeWebSearchEnabled: boolean;
+  }
 ): Tool[] {
   const converted = tools.map((tool) =>
     toFunctionTool(tool, {
@@ -337,9 +343,20 @@ export function toolSpecsToOpenAITools(
     })
   );
 
-  return converted.some((tool) => tool.defer_loading)
-    ? [OPENAI_TOOL_SEARCH_TOOL, ...converted]
-    : converted;
+  // Server tools go first, in a fixed order, so the serialized tools prefix
+  // stays byte-stable across steps for prompt caching.
+  return [
+    ...(converted.some((tool) => tool.defer_loading)
+      ? [OPENAI_TOOL_SEARCH_TOOL]
+      : []),
+    // A forced tool_choice targets a function tool, so keep force-called
+    // requests (auxiliary calls only) free of server tools. `disableToolUse`
+    // deliberately does NOT drop it: tool_choice "none" already forbids every
+    // tool, and removing it would invalidate the cached tools prefix on the last
+    // step of every turn.
+    ...(nativeWebSearchEnabled && !forceTool ? [OPENAI_WEB_SEARCH_TOOL] : []),
+    ...converted,
+  ];
 }
 
 export function forceToolToToolChoice(

--- a/front/lib/model_constructors/sdk/openai_responses/converters/output/index.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/output/index.ts
@@ -12,6 +12,7 @@ import {
   textDeltaToTextDeltaEvent,
   toolSearchItemToProviderPassthroughEvent,
   usageToTokenUsageEvent,
+  webSearchItemToProviderPassthroughEvent,
 } from "@app/lib/model_constructors/sdk/openai_responses/converters/output/utils";
 
 type AbstractConstructor<T> = abstract new (...args: any[]) => T;
@@ -37,6 +38,8 @@ export function WithOpenAIResponsesOutputConverter<
     functionCallToToolCallEvent = functionCallToToolCallEvent;
     toolSearchItemToProviderPassthroughEvent =
       toolSearchItemToProviderPassthroughEvent;
+    webSearchItemToProviderPassthroughEvent =
+      webSearchItemToProviderPassthroughEvent;
     usageToTokenUsageEvent = usageToTokenUsageEvent;
     streamErrorToErrorEvent = streamErrorToErrorEvent;
   }

--- a/front/lib/model_constructors/sdk/openai_responses/converters/output/native_web_search.test.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/output/native_web_search.test.ts
@@ -1,0 +1,175 @@
+import { createAsyncGenerator } from "@app/lib/api/llm/utils";
+import * as converters from "@app/lib/model_constructors/sdk/openai_responses/converters/output/utils";
+import {
+  outputItemToEvents,
+  rawOutputToEvents,
+} from "@app/lib/model_constructors/sdk/openai_responses/converters/output/utils";
+import type {
+  ResponseOutputItem,
+  ResponseStreamEvent,
+} from "openai/resources/responses/responses";
+import { describe, expect, it } from "vitest";
+
+const metadata = {
+  lab: "openai",
+  host: "openai-responses",
+  model: "gpt-5.4",
+  region: "global",
+} as const;
+
+describe("outputItemToEvents for native web search", () => {
+  // Replayed verbatim: the API rejects a reasoning item whose following item was
+  // dropped, and a search call routinely sits between a reasoning item and the
+  // message.
+  it("passes a web_search_call through for verbatim replay", () => {
+    const item = {
+      type: "web_search_call",
+      id: "ws_1",
+      status: "completed",
+      action: { type: "search", queries: ["who won the last world cup"] },
+    } satisfies ResponseOutputItem;
+
+    expect(outputItemToEvents(item, metadata, converters)).toEqual([
+      {
+        type: "provider_passthrough",
+        content: { provider: "openai", block: item },
+        metadata,
+      },
+    ]);
+  });
+
+  it("splices url_citation annotations into the message text", () => {
+    const item = {
+      type: "message",
+      id: "msg_1",
+      role: "assistant",
+      status: "completed",
+      content: [
+        {
+          type: "output_text",
+          text: "Argentina won.",
+          annotations: [
+            {
+              type: "url_citation",
+              url: "https://example.com/wc",
+              title: "World Cup",
+              start_index: 0,
+              end_index: 14,
+            },
+          ],
+        },
+      ],
+    } satisfies ResponseOutputItem;
+
+    expect(outputItemToEvents(item, metadata, converters)).toMatchObject([
+      {
+        type: "text",
+        content: {
+          value: "Argentina won. ([World Cup](https://example.com/wc))",
+        },
+      },
+    ]);
+  });
+
+  it("leaves text with no url_citation annotations untouched", () => {
+    const item = {
+      type: "message",
+      id: "msg_1",
+      role: "assistant",
+      status: "completed",
+      content: [{ type: "output_text", text: "plain", annotations: [] }],
+    } satisfies ResponseOutputItem;
+
+    expect(outputItemToEvents(item, metadata, converters)).toMatchObject([
+      { type: "text", content: { value: "plain" } },
+    ]);
+  });
+});
+
+describe("rawOutputToEvents for native web search", () => {
+  async function collect(events: ResponseStreamEvent[]) {
+    const out = [];
+    for await (const event of rawOutputToEvents(
+      createAsyncGenerator(events),
+      metadata,
+      converters
+    )) {
+      out.push(event);
+    }
+    return out;
+  }
+
+  // Keeps the live view in step with the authoritative text assembled at
+  // `response.output_item.done`, which splices the same links in by offset.
+  it("emits an annotation as a text delta carrying the markdown link", async () => {
+    const events = await collect([
+      {
+        type: "response.output_text.annotation.added",
+        annotation: {
+          type: "url_citation",
+          url: "https://example.com/wc",
+          title: "World Cup",
+          start_index: 0,
+          end_index: 14,
+        },
+        annotation_index: 0,
+        content_index: 0,
+        item_id: "msg_1",
+        output_index: 0,
+        sequence_number: 1,
+      } as ResponseStreamEvent,
+    ]);
+
+    expect(events.filter((event) => event.type === "text_delta")).toEqual([
+      {
+        type: "text_delta",
+        content: { value: " ([World Cup](https://example.com/wc))" },
+        metadata,
+      },
+    ]);
+  });
+
+  it("ignores a non-url_citation annotation", async () => {
+    const events = await collect([
+      {
+        type: "response.output_text.annotation.added",
+        annotation: { type: "file_path", file_id: "f_1", index: 0 },
+        annotation_index: 0,
+        content_index: 0,
+        item_id: "msg_1",
+        output_index: 0,
+        sequence_number: 1,
+      } as ResponseStreamEvent,
+    ]);
+
+    expect(events.filter((event) => event.type === "text_delta")).toEqual([]);
+  });
+
+  // These arrive alongside the call item, which is where the logging and
+  // passthrough happen, so the progress signals stay unsurfaced.
+  it("surfaces nothing for the web_search_call progress events", async () => {
+    const events = await collect(
+      (
+        [
+          "response.web_search_call.in_progress",
+          "response.web_search_call.searching",
+          "response.web_search_call.completed",
+        ] as const
+      ).map(
+        (type, index) =>
+          ({
+            type,
+            item_id: "ws_1",
+            output_index: 0,
+            sequence_number: index,
+          }) as ResponseStreamEvent
+      )
+    );
+
+    expect(
+      events.filter(
+        (event) => event.type !== "success" && event.type !== "token_usage"
+      )
+    ).toEqual([]);
+  });
+});

--- a/front/lib/model_constructors/sdk/openai_responses/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/output/utils.ts
@@ -19,6 +19,15 @@ import type {
 } from "@app/lib/model_constructors/types/output/events";
 import type { Phase } from "@app/lib/model_constructors/types/phases";
 import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
+import {
+  logNativeWebSearchError,
+  logNativeWebSearchRequest,
+} from "@app/lib/model_constructors/utils/native_web_search_logging";
+import type { WebSearchCitationAnnotation } from "@app/lib/model_constructors/utils/web_search_citation";
+import {
+  formatWebSearchCitationLink,
+  insertWebSearchCitationLinks,
+} from "@app/lib/model_constructors/utils/web_search_citation";
 import { OPENAI_PROVIDER_ID } from "@app/types/assistant/models/providers";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { isRecord } from "@app/types/shared/utils/general";
@@ -27,10 +36,13 @@ import type {
   Response as OpenAIResponse,
   ResponseCreatedEvent,
   ResponseError,
+  ResponseFunctionWebSearch,
   ResponseOutputItem,
+  ResponseOutputText,
   ResponseStreamEvent,
   ResponseUsage,
 } from "openai/resources/responses/responses";
+import { z } from "zod";
 
 type ToolSearchOutputItem = Extract<
   ResponseOutputItem,
@@ -94,6 +106,10 @@ export interface OutputEventConverters {
   toolSearchItemToProviderPassthroughEvent(
     metadata: EndpointMetadata,
     item: ToolSearchOutputItem
+  ): ProviderPassthroughEvent;
+  webSearchItemToProviderPassthroughEvent(
+    metadata: EndpointMetadata,
+    item: ResponseFunctionWebSearch
   ): ProviderPassthroughEvent;
   usageToTokenUsageEvent(
     metadata: EndpointMetadata,
@@ -226,6 +242,22 @@ export function toolSearchItemToProviderPassthroughEvent(
       modelId: metadata.model,
     },
   });
+
+  return {
+    type: "provider_passthrough",
+    content: { provider: OPENAI_PROVIDER_ID, block: item },
+    metadata,
+  };
+}
+
+export function webSearchItemToProviderPassthroughEvent(
+  metadata: EndpointMetadata,
+  item: ResponseFunctionWebSearch
+): ProviderPassthroughEvent {
+  // Replayed verbatim: the API rejects a reasoning item whose following item was
+  // dropped, and a search call routinely sits between a reasoning item and the
+  // message.
+  logOpenAIWebSearchCall(item, metadata);
 
   return {
     type: "provider_passthrough",
@@ -370,6 +402,94 @@ export function makeStreamErrorToErrorEvent(
 
 export const streamErrorToErrorEvent = makeStreamErrorToErrorEvent("OpenAI");
 
+// The url_citation annotations native web search attaches to its text. Other
+// annotation kinds (file citations, file paths) are unrelated to web search and
+// are left alone.
+function toWebSearchCitationAnnotations(
+  annotations: ResponseOutputText["annotations"]
+): WebSearchCitationAnnotation[] {
+  return annotations.flatMap((annotation) =>
+    annotation.type === "url_citation"
+      ? [
+          {
+            title: annotation.title,
+            url: annotation.url,
+            endIndex: annotation.end_index,
+          },
+        ]
+      : []
+  );
+}
+
+// The streaming annotation event types its payload as `unknown`, so validate the
+// shape Dust reads. Returns null for any other annotation kind.
+function toWebSearchCitationAnnotation(
+  annotation: unknown
+): WebSearchCitationAnnotation | null {
+  const parsed = urlCitationAnnotationSchema.safeParse(annotation);
+  if (!parsed.success) {
+    return null;
+  }
+
+  return {
+    title: parsed.data.title,
+    url: parsed.data.url,
+    endIndex: parsed.data.end_index,
+  };
+}
+
+const urlCitationAnnotationSchema = z.object({
+  type: z.literal("url_citation"),
+  url: z.string(),
+  title: z.string().nullish(),
+  end_index: z.number(),
+});
+
+// Native web search produces no `AgentMCPAction` row, so logs are the only
+// visibility into query volume and provider-side failures.
+function logOpenAIWebSearchCall(
+  item: ResponseFunctionWebSearch,
+  metadata: EndpointMetadata
+): void {
+  const logFields = {
+    providerId: metadata.lab,
+    api: metadata.host,
+    modelId: metadata.model,
+  };
+  const details = {
+    queries: webSearchQueries(item.action),
+    status: item.status,
+  };
+  const tags = [
+    `provider_id:${metadata.lab}`,
+    `api:${metadata.host}`,
+    `model_id:${metadata.model}`,
+  ];
+
+  logNativeWebSearchRequest({
+    providerName: "OpenAI",
+    details,
+    tags,
+    logFields,
+  });
+
+  if (item.status === "failed") {
+    logNativeWebSearchError({ providerName: "OpenAI", details, logFields });
+  }
+}
+
+// `queries` is the current field; `query` is its deprecated singular form. Only
+// the search action carries either.
+function webSearchQueries(
+  action: ResponseFunctionWebSearch["action"]
+): string[] {
+  if (action.type !== "search") {
+    return [];
+  }
+
+  return action.queries ?? (action.query ? [action.query] : []);
+}
+
 // -- Composite: a completed output item → unified events --
 
 // Returns the events to emit for a finished output item; the caller decides
@@ -387,7 +507,16 @@ export function outputItemToEvents(
             return [
               converters.accumulatedTextToTextEvent(
                 metadata,
-                part.text,
+                // Native web search reports its sources as offsets into the
+                // finished text rather than inline. Dust's `:cite[REF]` scheme
+                // cannot carry them (refs are keyed on a persisted MCP action
+                // row, and a server-side search produces none), so splice them
+                // in as markdown links. This is the authoritative text event, so
+                // it is also what gets persisted.
+                insertWebSearchCitationLinks(
+                  part.text,
+                  toWebSearchCitationAnnotations(part.annotations)
+                ),
                 item.id,
                 item.phase ?? undefined
               ),
@@ -435,11 +564,14 @@ export function outputItemToEvents(
       return [
         converters.toolSearchItemToProviderPassthroughEvent(metadata, item),
       ];
+    case "web_search_call":
+      return [
+        converters.webSearchItemToProviderPassthroughEvent(metadata, item),
+      ];
     // Output item types we don't surface (server tools, image gen, etc.).
     // Listed explicitly so a new Responses output item type breaks the build.
     case "file_search_call":
     case "function_call_output":
-    case "web_search_call":
     case "computer_call":
     case "computer_call_output":
     case "compaction":
@@ -577,6 +709,20 @@ export async function* rawOutputToEvents(
           originalError: event,
         });
         return;
+      case "response.output_text.annotation.added": {
+        // Keeps the live view in step with the authoritative text assembled at
+        // `response.output_item.done`, which splices the same links in by offset.
+        const citation = toWebSearchCitationAnnotation(event.annotation);
+        outputEvents = citation
+          ? [
+              converters.textDeltaToTextDeltaEvent(
+                metadata,
+                formatWebSearchCitationLink(citation)
+              ),
+            ]
+          : [];
+        break;
+      }
       // Other Responses stream signals (audio, web search, mcp, etc.) are not
       // surfaced. Listed explicitly so a new stream event type breaks the build.
       case "response.audio.delta":
@@ -617,7 +763,6 @@ export async function* rawOutputToEvents(
       case "response.mcp_list_tools.completed":
       case "response.mcp_list_tools.failed":
       case "response.mcp_list_tools.in_progress":
-      case "response.output_text.annotation.added":
       case "response.queued":
       case "response.custom_tool_call_input.delta":
       case "response.custom_tool_call_input.done":

--- a/front/lib/model_constructors/types/input/configuration.ts
+++ b/front/lib/model_constructors/types/input/configuration.ts
@@ -60,6 +60,10 @@ export const inputConfigSchema = z.object({
   // When true, supporting provider clients defer non-eager tools behind tool
   // search.
   toolSearchEnabled: z.boolean().optional(),
+  // When true, supporting provider clients add the provider's own server-side
+  // web search tool to the request. The agent loop drops Dust's `websearch`
+  // tool from the specs in the same breath, so the two never coexist.
+  nativeWebSearchEnabled: z.boolean().optional(),
   outputFormat: outputFormatSchema.optional(),
   cacheKey: z.string().optional(),
   serviceTier: serviceTierSchema.optional(),

--- a/front/lib/model_constructors/types/native_web_search.test.ts
+++ b/front/lib/model_constructors/types/native_web_search.test.ts
@@ -1,0 +1,49 @@
+import {
+  AGENT_PLATFORM_HOST,
+  ANTHROPIC_HOST,
+  FIREWORKS_HOST,
+  GOOGLE_AI_STUDIO_HOST,
+  MISTRAL_HOST,
+  NOOP_HOST,
+  OPENAI_RESPONSES_HOST,
+  XAI_HOST,
+} from "@app/lib/model_constructors/types/hosts";
+import { isNativeWebSearchEnabled } from "@app/lib/model_constructors/types/native_web_search";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import { describe, expect, it } from "vitest";
+
+const enabled: WhitelistableFeature[] = ["provider_native_web_search"];
+
+describe("isNativeWebSearchEnabled", () => {
+  it("is true for the hosts whose API exposes a web search server tool", () => {
+    for (const host of [ANTHROPIC_HOST, OPENAI_RESPONSES_HOST]) {
+      expect(isNativeWebSearchEnabled({ host, featureFlags: enabled })).toBe(
+        true
+      );
+    }
+  });
+
+  // The guarantee that the flag is a no-op everywhere else. Vertex
+  // (agent-platform) is excluded on purpose despite sharing Anthropic's provider
+  // id and input converter.
+  it("is false for every other host even with the flag on", () => {
+    for (const host of [
+      AGENT_PLATFORM_HOST,
+      GOOGLE_AI_STUDIO_HOST,
+      MISTRAL_HOST,
+      FIREWORKS_HOST,
+      XAI_HOST,
+      NOOP_HOST,
+    ]) {
+      expect(isNativeWebSearchEnabled({ host, featureFlags: enabled })).toBe(
+        false
+      );
+    }
+  });
+
+  it("is false without the flag", () => {
+    expect(
+      isNativeWebSearchEnabled({ host: ANTHROPIC_HOST, featureFlags: [] })
+    ).toBe(false);
+  });
+});

--- a/front/lib/model_constructors/types/native_web_search.ts
+++ b/front/lib/model_constructors/types/native_web_search.ts
@@ -1,0 +1,51 @@
+import type { Host } from "@app/lib/model_constructors/types/hosts";
+import {
+  ANTHROPIC_HOST,
+  OPENAI_RESPONSES_HOST,
+} from "@app/lib/model_constructors/types/hosts";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+
+const PROVIDER_NATIVE_WEB_SEARCH =
+  "provider_native_web_search" as const satisfies WhitelistableFeature;
+
+// Hosts whose API exposes a server-side web search tool we drive. Gating on the
+// host rather than the provider id deliberately excludes AGENT_PLATFORM_HOST
+// (Vertex), which shares Anthropic's provider id and input converter: server
+// tool support there is unverified, and the regional endpoints exist for
+// workspaces that do not want queries leaving the region. Adding a host here is
+// the single switch to flip once verified.
+const NATIVE_WEB_SEARCH_HOSTS: ReadonlySet<Host> = new Set<Host>([
+  ANTHROPIC_HOST,
+  OPENAI_RESPONSES_HOST,
+]);
+
+/**
+ * Whether the provider's own web search replaces Dust's `websearch` tool for
+ * this request. False for every other host by construction.
+ */
+export function isNativeWebSearchEnabled({
+  host,
+  featureFlags,
+}: {
+  host: Host;
+  featureFlags: WhitelistableFeature[];
+}): boolean {
+  return (
+    featureFlags.includes(PROVIDER_NATIVE_WEB_SEARCH) &&
+    NATIVE_WEB_SEARCH_HOSTS.has(host)
+  );
+}
+
+// Added to the system prompt only when the native tool is in the request, as a
+// trailing block outside the cached system prefix. Two jobs: tell the model
+// search is built in rather than a tool it calls, and neutralize the many
+// prompts that still name a `websearch` tool it no longer has — the deep-dive
+// sub-agent instructions, the `http_client` tool description, and user-authored
+// agent instructions we cannot edit. Citations need no instruction: the provider
+// attaches them to its own results and we render them as markdown links.
+export const NATIVE_WEB_SEARCH_INSTRUCTION =
+  "You can search the web directly: web search is a built-in capability, not a " +
+  "tool you call. Search whenever the request needs current information. " +
+  "Some instructions you were given may refer to a `websearch` tool; that tool " +
+  "is not available to you, so use your built-in web search instead. To read a " +
+  "full page rather than a search snippet, use the web browsing tool.";

--- a/front/lib/model_constructors/utils/native_web_search_logging.ts
+++ b/front/lib/model_constructors/utils/native_web_search_logging.ts
@@ -1,0 +1,61 @@
+import { statsDMetrics } from "@app/lib/utils/statsd";
+import logger from "@app/logger/logger";
+
+// Provider-native web search produces no `AgentMCPAction` row, so none of the
+// usual per-tool surfaces see it: no action card, no message breakdown entry, no
+// cost attribution. Logs and metrics are the only visibility we have into query
+// volume, result counts and provider-side failures, which is what the feature
+// flag is being measured on.
+
+interface NativeWebSearchLogContext {
+  providerName: string;
+  logFields: Record<string, unknown>;
+}
+
+interface NativeWebSearchRequestLog extends NativeWebSearchLogContext {
+  details: Record<string, unknown>;
+  tags: string[];
+}
+
+interface NativeWebSearchResultLog extends NativeWebSearchLogContext {
+  details: Record<string, unknown>;
+}
+
+export function logNativeWebSearchRequest({
+  providerName,
+  details,
+  tags,
+  logFields,
+}: NativeWebSearchRequestLog): void {
+  logger.info(
+    { ...logFields, ...details },
+    `${providerName} native web search query`
+  );
+
+  statsDMetrics.increment("llm_native_web_search.requests", 1, tags);
+}
+
+export function logNativeWebSearchResults({
+  providerName,
+  details,
+  logFields,
+}: NativeWebSearchResultLog): void {
+  logger.info(
+    { ...logFields, ...details },
+    `${providerName} native web search results`
+  );
+}
+
+// The provider returns search failures inside the assistant turn rather than as
+// an API error, so the model degrades on its own. Logged at warn so rate-limit
+// and max-uses exhaustion are visible instead of silent quality loss.
+export function logNativeWebSearchError({
+  providerName,
+  details,
+  logFields,
+}: NativeWebSearchResultLog): void {
+  logger.warn(
+    { ...logFields, ...details },
+    `${providerName} native web search returned an error`
+  );
+}

--- a/front/lib/model_constructors/utils/web_search_citation.test.ts
+++ b/front/lib/model_constructors/utils/web_search_citation.test.ts
@@ -1,0 +1,96 @@
+import {
+  formatWebSearchCitationLink,
+  insertWebSearchCitationLinks,
+} from "@app/lib/model_constructors/utils/web_search_citation";
+import { describe, expect, it } from "vitest";
+
+describe("formatWebSearchCitationLink", () => {
+  it("renders a titled source as a markdown link", () => {
+    expect(
+      formatWebSearchCitationLink({
+        title: "FIFA World Cup",
+        url: "https://example.com/wc",
+      })
+    ).toBe(" ([FIFA World Cup](https://example.com/wc))");
+  });
+
+  it("escapes brackets that would break out of the link label", () => {
+    expect(
+      formatWebSearchCitationLink({
+        title: "A [bracketed] title",
+        url: "https://example.com",
+      })
+    ).toBe(" ([A \\[bracketed\\] title](https://example.com))");
+  });
+
+  it("falls back to the host when the provider reports no title", () => {
+    expect(
+      formatWebSearchCitationLink({
+        title: null,
+        url: "https://news.example.com/a/b",
+      })
+    ).toBe(" ([news.example.com](https://news.example.com/a/b))");
+  });
+
+  it("falls back to the raw value when the url does not parse", () => {
+    expect(formatWebSearchCitationLink({ title: "  ", url: "not a url" })).toBe(
+      " ([not a url](not a url))"
+    );
+  });
+});
+
+describe("insertWebSearchCitationLinks", () => {
+  it("returns the text untouched when there are no annotations", () => {
+    expect(insertWebSearchCitationLinks("hello", [])).toBe("hello");
+  });
+
+  it("splices each link at the end of the span it cites", () => {
+    expect(
+      insertWebSearchCitationLinks("Argentina won. Messi scored.", [
+        { title: "A", url: "https://a.example", endIndex: 14 },
+        { title: "B", url: "https://b.example", endIndex: 28 },
+      ])
+    ).toBe(
+      "Argentina won. ([A](https://a.example)) Messi scored. ([B](https://b.example))"
+    );
+  });
+
+  it("orders by offset regardless of the order annotations arrive in", () => {
+    expect(
+      insertWebSearchCitationLinks("ab", [
+        { title: "second", url: "https://b.example", endIndex: 2 },
+        { title: "first", url: "https://a.example", endIndex: 1 },
+      ])
+    ).toBe("a ([first](https://a.example))b ([second](https://b.example))");
+  });
+
+  it("suppresses a link repeated immediately after itself", () => {
+    expect(
+      insertWebSearchCitationLinks("ab", [
+        { title: "T", url: "https://a.example", endIndex: 1 },
+        { title: "T", url: "https://a.example", endIndex: 2 },
+      ])
+    ).toBe("a ([T](https://a.example))b");
+  });
+
+  it("keeps a source cited again after a different one", () => {
+    expect(
+      insertWebSearchCitationLinks("abc", [
+        { title: "A", url: "https://a.example", endIndex: 1 },
+        { title: "B", url: "https://b.example", endIndex: 2 },
+        { title: "A", url: "https://a.example", endIndex: 3 },
+      ])
+    ).toBe(
+      "a ([A](https://a.example))b ([B](https://b.example))c ([A](https://a.example))"
+    );
+  });
+
+  // A provider offset past the end of the text must not drop the tail.
+  it("clamps out-of-range offsets", () => {
+    expect(
+      insertWebSearchCitationLinks("ab", [
+        { title: "T", url: "https://a.example", endIndex: 99 },
+      ])
+    ).toBe("ab ([T](https://a.example))");
+  });
+});

--- a/front/lib/model_constructors/utils/web_search_citation.ts
+++ b/front/lib/model_constructors/utils/web_search_citation.ts
@@ -1,0 +1,88 @@
+// Provider-native web search returns its citations as structured metadata
+// (Anthropic `web_search_result_location` blocks, OpenAI `url_citation`
+// annotations) rather than as text the model wrote. Dust's own `:cite[REF]`
+// scheme cannot carry them: refs are keyed on a persisted MCP action row, and a
+// server-side search produces none. So we splice the sources into the answer as
+// ordinary markdown links, which the existing markdown pipeline renders with no
+// further plumbing.
+
+// Characters that would break out of a markdown link label.
+const LINK_LABEL_ESCAPE_RE = /([[\]\\])/g;
+
+// Falls back to the bare host when the provider reports no title, so the link
+// still reads as a source rather than as a naked URL.
+function citationLabel(title: string | null | undefined, url: string): string {
+  const trimmed = title?.trim();
+  if (trimmed) {
+    return trimmed.replace(LINK_LABEL_ESCAPE_RE, "\\$1");
+  }
+
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Renders one provider web-search citation as a trailing markdown link, e.g.
+ * ` ([FIFA World Cup](https://example.com))`.
+ */
+export function formatWebSearchCitationLink({
+  title,
+  url,
+}: {
+  title: string | null | undefined;
+  url: string;
+}): string {
+  return ` ([${citationLabel(title, url)}](${url}))`;
+}
+
+export interface WebSearchCitationAnnotation {
+  title: string | null | undefined;
+  url: string;
+  // Index of the character just past the cited span in the finished text.
+  endIndex: number;
+}
+
+/**
+ * Splices markdown links for each annotation into `text` at the end of the span
+ * it cites. Used by providers that report citations as offsets into a completed
+ * message rather than as deltas next to the text they annotate.
+ *
+ * Returns `text` unchanged when there is nothing to insert.
+ */
+export function insertWebSearchCitationLinks(
+  text: string,
+  annotations: readonly WebSearchCitationAnnotation[]
+): string {
+  if (annotations.length === 0) {
+    return text;
+  }
+
+  // Ascending by offset so the segments below are cut in order. Copied first:
+  // the annotations array belongs to the caller.
+  const sorted = [...annotations].sort((a, b) => a.endIndex - b.endIndex);
+
+  const segments: string[] = [];
+  let cursor = 0;
+  let previousLink: string | undefined;
+  for (const annotation of sorted) {
+    const link = formatWebSearchCitationLink(annotation);
+    // Providers repeat a source across adjacent spans; emitting the same link
+    // twice in a row is noise, not a second citation.
+    if (link === previousLink) {
+      continue;
+    }
+
+    // Clamp: a provider offset past the end of the text would otherwise silently
+    // drop the tail of the answer.
+    const at = Math.min(Math.max(annotation.endIndex, cursor), text.length);
+    segments.push(text.slice(cursor, at), link);
+    cursor = at;
+    previousLink = link;
+  }
+  segments.push(text.slice(cursor));
+
+  return segments.join("");
+}

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -286,6 +286,7 @@ export async function getOutputFromLLMStream(
     modelConversationRes,
     conversation,
     toolSearchEnabled,
+    nativeWebSearchEnabled,
     disableToolUse,
     specifications,
     flushParserTokens,
@@ -336,6 +337,7 @@ export async function getOutputFromLLMStream(
     {
       conversation: modelConversationRes.value.modelConversation,
       toolSearchEnabled,
+      nativeWebSearchEnabled,
       disableToolUse,
       prompt,
       specifications,

--- a/front/temporal/agent_loop/lib/run_model.test.ts
+++ b/front/temporal/agent_loop/lib/run_model.test.ts
@@ -2,6 +2,7 @@ import { RETRY_ON_INTERRUPT_MAX_ATTEMPTS } from "@app/lib/actions/constants";
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp_schemas";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { ANTHROPIC_WEB_SEARCH_TOOL } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/native_web_search";
 import { RUN_MODEL_MAX_RETRIES } from "@app/temporal/agent_loop/config";
 import {
   buildBaseSpecifications,
@@ -229,6 +230,30 @@ describe("buildToolDefinitionsForTokenCount", () => {
     expect(tools).toEqual([
       { type: "tool_search_tool_bm25_20251119", name: "tool_search_tool_bm25" },
     ]);
+  });
+
+  // Rough by design: the provider injects the real definition server-side. The
+  // estimate's exact term is the removal of Dust's own websearch spec, which the
+  // agent loop has already filtered out by the time this runs.
+  it("accounts for the native web search tool when it is enabled", () => {
+    const specs = [makeSpecification("eager_tool", { eager: true })];
+
+    const tools = JSON.parse(
+      buildToolDefinitionsForTokenCount(specs, false, true)
+    );
+
+    expect(tools).toEqual([
+      ANTHROPIC_WEB_SEARCH_TOOL,
+      expect.objectContaining({ name: "eager_tool" }),
+    ]);
+  });
+
+  it("omits the native web search tool by default", () => {
+    const specs = [makeSpecification("eager_tool", { eager: true })];
+
+    const tools = JSON.parse(buildToolDefinitionsForTokenCount(specs, false));
+
+    expect(tools).toEqual([expect.objectContaining({ name: "eager_tool" })]);
   });
 });
 

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -11,7 +11,10 @@ import {
   isServerSideMCPServerConfigurationWithName,
   isServerSideMCPToolConfiguration,
 } from "@app/lib/actions/types/guards";
-import { computeStepContexts } from "@app/lib/actions/utils";
+import {
+  computeStepContexts,
+  isDustWebsearchTool,
+} from "@app/lib/actions/utils";
 import { createClientSideMCPServerConfigurations } from "@app/lib/api/actions/mcp_client_side";
 import { categorizeConversationRenderErrorMessage } from "@app/lib/api/assistant/errors";
 import {
@@ -58,11 +61,11 @@ import {
   AgentMessageContentParser,
   getDelimitersConfiguration,
 } from "@app/lib/llms/agent_message_content_parser";
+import { ANTHROPIC_WEB_SEARCH_TOOL } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/native_web_search";
+import { parseAnthropicServerToolBlock } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/server_tool_passthrough";
 import { TOOL_SEARCH_TOOL } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search";
-import {
-  parseAnthropicToolSearchBlock,
-  TOOL_SEARCH_SERVER_TOOL_NAMES,
-} from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search_passthrough";
+import { TOOL_SEARCH_SERVER_TOOL_NAMES } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search_passthrough";
+import { isNativeWebSearchEnabled } from "@app/lib/model_constructors/types/native_web_search";
 import {
   isToolDeferred,
   isToolSearchEnabledForModel,
@@ -148,7 +151,8 @@ export function shouldSurfaceModelError({
 // tool itself, are actually in context up front.
 export function buildToolDefinitionsForTokenCount(
   specifications: AgentActionSpecification[],
-  toolSearchEnabled: boolean
+  toolSearchEnabled: boolean,
+  nativeWebSearchEnabled = false
 ): string {
   const specsInContext = toolSearchEnabled
     ? specifications.filter(
@@ -157,6 +161,10 @@ export function buildToolDefinitionsForTokenCount(
     : specifications;
   return JSON.stringify([
     ...(toolSearchEnabled ? [TOOL_SEARCH_TOOL] : []),
+    // Rough by design: the provider injects the real web search definition
+    // server-side and never exposes its token cost. The estimate's dominant term
+    // is the removal of Dust's `websearch` schema, which is exact.
+    ...(nativeWebSearchEnabled ? [ANTHROPIC_WEB_SEARCH_TOOL] : []),
     ...specsInContext.map((s) => ({
       name: s.name,
       description: s.description,
@@ -210,7 +218,9 @@ function getReplayedToolNames(
           ) {
             // OpenAI keeps loaded definitions in the replayed tool_search_output
             // item. Anthropic requires referenced tools in the current request.
-            const block = parseAnthropicToolSearchBlock(content.value.block);
+            // Other server tools (native web search) parse fine and fall through
+            // the narrowing below: they carry no tool references.
+            const block = parseAnthropicServerToolBlock(content.value.block);
 
             if (
               block?.type === "tool_search_tool_result" &&
@@ -537,6 +547,23 @@ export async function runModel(
     ? mcpActions
     : mcpActions.filter((s) => s.serverName !== "ask_user_question");
 
+  const nativeWebSearchEnabled = isNativeWebSearchEnabled({
+    host: modelInfo.endpoint.host,
+    featureFlags,
+  });
+
+  // The provider's native search replaces Dust's `websearch` entirely. Dropping
+  // it here, before anything derives from the action list, keeps the tools array,
+  // the token-count estimate, the prompt and tool-call resolution in agreement.
+  // Both servers that mount `websearch` also mount `webbrowser`, so neither is
+  // left empty; a server's own instructions are independent of its tools anyway.
+  const mcpActionsForModel = nativeWebSearchEnabled
+    ? filteredMcpActions.map((s) => ({
+        ...s,
+        tools: s.tools.filter((tool) => !isDustWebsearchTool(tool)),
+      }))
+    : filteredMcpActions;
+
   const isLastStep = step === agentConfiguration.maxStepsPerRun;
 
   // On the last step we force the agent to run the generation: the tools are
@@ -545,7 +572,7 @@ export async function runModel(
   // replayed history resolvable), but the model is forbidden from calling them
   // (tool choice "none"). Same treatment after an empty step.
   const disableToolUse = isLastStep || forceDisableToolUse;
-  const availableActions = filteredMcpActions.flatMap((s) => s.tools);
+  const availableActions = mcpActionsForModel.flatMap((s) => s.tools);
 
   let fallbackPrompt = "You are a conversational agent";
   if (agentConfiguration.actions.length || availableActions.length > 0) {
@@ -608,7 +635,7 @@ export async function runModel(
     modelInfo,
     hasAvailableActions: availableActions.length > 0,
     conversation,
-    serverToolsAndInstructions: filteredMcpActions,
+    serverToolsAndInstructions: mcpActionsForModel,
     systemSkills,
     toolsetsContext,
     userContext,
@@ -618,6 +645,7 @@ export async function runModel(
     hasSandboxTools,
     disableFormattingPrompt,
     hasSelectedSpacesOutsideAgentScope,
+    nativeWebSearchEnabled,
   });
   // Only the shared skills message receives the leading skills cache breakpoint.
   const leadingMessages = removeNulls([
@@ -637,7 +665,8 @@ export async function runModel(
   // This is a rough estimate of the number of tokens.
   const tools = buildToolDefinitionsForTokenCount(
     baseSpecifications,
-    toolSearchEnabled
+    toolSearchEnabled,
+    nativeWebSearchEnabled
   );
 
   // Turn the conversation into a digest that can be presented to the model.
@@ -868,6 +897,7 @@ export async function runModel(
     modelConversationRes,
     conversation,
     toolSearchEnabled,
+    nativeWebSearchEnabled,
     disableToolUse,
     userMessage,
     specifications,

--- a/front/temporal/agent_loop/lib/types.ts
+++ b/front/temporal/agent_loop/lib/types.ts
@@ -43,6 +43,9 @@ export type GetOutputRequestParams = {
   // When true, the Anthropic client defers non-eager tools behind tool search.
   // Provider-agnostic signal: clients without tool-search support ignore it.
   toolSearchEnabled: boolean;
+  // When true, the provider's own server-side web search tool is added to the
+  // request and Dust's `websearch` tool is absent from `specifications`.
+  nativeWebSearchEnabled: boolean;
   // When true, the tools are sent but the model is forbidden from calling them
   // (tool choice "none"). Set on the last step to force the final generation.
   disableToolUse: boolean;

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -161,6 +161,12 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "dust_only",
     owner: "fontanierh",
   },
+  provider_native_web_search: {
+    description:
+      "Use the model provider's server-side web search (Anthropic, OpenAI) instead of Dust's own websearch tool. Dust's webbrowser tool is unaffected",
+    stage: "dust_only",
+    owner: "Nils-Fedrigo",
+  },
   salesforce_synced_queries: {
     description: "Salesforce Connection: retrieval on Synchronized queries",
     stage: "ask_owner",


### PR DESCRIPTION
## Description

Adds the `provider_native_web_search` feature flag (`dust_only`). When it is on and the request's host is Anthropic or OpenAI Responses, Dust's own `websearch` tool is dropped from the request and the provider's server-side web search tool is sent instead. The point is to measure the provider path against ours on real traffic — latency, answer quality, cost.

Scope is deliberately narrow:

- **Search only.** `webbrowser` (Firecrawl/Exa) is untouched on both providers. Anthropic has a native `web_fetch` and OpenAI Responses has no fetch equivalent, so swapping browse too would make agent capabilities diverge by provider and would lose screenshots, link extraction, summarization and the tool-output file offload.
- **Gated on host, not provider id.** `isNativeWebSearchEnabled` keys on `ANTHROPIC_HOST` / `OPENAI_RESPONSES_HOST`, which excludes `AGENT_PLATFORM_HOST` (Vertex) even though it shares Anthropic's provider id *and* input converter — server-tool support there is unverified, and the regional endpoints exist for workspaces that don't want queries leaving the region. Adding a host is the single switch to flip once verified.
- No-op for every other provider by construction; no-op everywhere with the flag off.

How it is wired, mirroring the existing tool-search precedent end to end: `run_model.ts` derives the flag and filters the tool out of the action list, then it rides `LLMStreamParameters` → `buildConfig` → `InputConfig.nativeWebSearchEnabled` → the per-SDK input converters, which prepend the server tool.

Two consequences worth calling out for review:

- **Citations become inline markdown links.** Dust's `:cite[REF]` chips can't work here — refs are keyed on a persisted `AgentMCPAction` row and a server-side search produces none. So provider citation metadata is rendered into the answer text as `([title](url))`. On Anthropic the `citations_delta` arrives right after the span it cites, so the link is emitted as a delta *and* appended to the accumulator, keeping the final persisted text byte-identical to what streamed. OpenAI reports offsets into the finished text, so links are spliced by `end_index` at `output_item.done` (the authoritative, persisted event) with matching deltas for the live view. Consecutive repeats of the same source are suppressed. `citationMetaPrompt` stops firing for a web-search-only agent, since it would then have no real refs to cite.
- **No action card.** No MCP action row is created, so there is no "Searching the web" step, no citation chips, no source list, and no message-breakdown entry. Per-workspace search-provider choice (`webSearchProvider` metadata, the `set_web_providers` poke plugin), the `global_disable_firecrawl` kill switch and `getWebsearchNumResults` budgeting also don't apply. Query volume, result counts and provider-side errors are covered by logs plus a `llm_native_web_search.requests` counter instead.

Replay needed real work: Anthropic's `server_tool_use` + `web_search_tool_result` blocks were previously dropped, and the tool-search passthrough parser actively *rejected* a `web_search` block and logged it as unparseable — which would have broken interleaved thinking signatures. Both families now have their own zod schemas and replay rules behind a `parseAnthropicServerToolBlock` dispatcher, with a matching sanitizer that strips a family's blocks when its tool is absent from the request (auxiliary calls such as title generation). OpenAI's `web_search_call` items are replayed for the same reason the tool-search items are: the API rejects a reasoning item whose following item was dropped, and a search call routinely sits between a reasoning item and the message.

Refs 400652.

## Tests

Unit tests only — every surface touched is a pure converter or predicate. `npx tsgo --noEmit` is clean; 438 tests pass with 0 failures.

New coverage: server-tool ordering and the force-call/never-defer rules on both providers; the passthrough schemas and replay sanitation (including that the common path returns its input array *by identity*, so prompt-cache bytes are unchanged); the name-aware `server_tool_use` branch, with an explicit guard against it swallowing tool search; citation splicing on both the streaming and non-streaming paths; `isDustWebsearchTool` across both internal servers that mount `websearch`, and that it leaves `webbrowser` and same-named third-party tools alone; and the host gate's no-op guarantee for every other host.

**Not yet verified, and the one thing to check before this is opened for review:** that `tool_choice: {type:"none"}` actually suppresses the server tool. See Risk.

## Risk

Low with the flag off — the tool array, prompt and token-count estimate are all unchanged, and the two shared passthrough parsers keep their existing behavior (they only stopped owning their own "unparseable" warning, which moved to the dispatcher).

Three things to know before rolling past `dust_only`:

1. **`tool_choice: "none"` is an unverified assumption.** The native tool is deliberately sent on *every* step, including the forced final generation, so the tools prefix stays byte-stable and the prompt cache is never invalidated mid-run. Suppression on the last step therefore rests entirely on `tool_choice` — documented as "the model will not be allowed to use tools" with no server-tool carve-out, and server tools are invoked through the same mechanism (the model emits a `server_tool_use` block). Needs a live check: drive a run to its last step with a search-hungry prompt and confirm no `server_tool_use` block appears. If one does, the fallback is one line — drop the tool when `disableToolUse` is set — because the replay sanitizer is already keyed on whether the tool is in the request. Dropping it unconditionally instead would cost a cache miss on every last step, and a cache breakpoint can't rescue that: the tools array sits ahead of the system prompt and messages in the cached prefix.
2. **Search fees are invisible to cost attribution.** Both providers bill server-side web search on top of tokens. Anthropic reports the count under `usage.server_tool_use` — on the very object the usage converter already receives — but `TokenUsageContent` has no slot for it, so nothing reaches `RunUsageType` or credit attribution. This is a cost *shift* rather than new cost (Dust's `websearch` already pays Firecrawl/Exa and is metered via `toolCostCategory: "basic"`), but it moves from a metered path to an unmetered one. Mitigated for now by `max_uses: 8` on the tool plus per-search logging and a StatsD counter; a `serverToolRequests` field on `TokenUsageContent` should land before broader rollout.
3. **Data egress.** Model-generated queries, derived from conversation content, go to the provider's search infrastructure and its upstream partners rather than to the workspace's configured provider. Fine for `dust_only`; wants an explicit decision before `ask_owner`.

Also: don't flip the flag off mid-conversation. Anthropic is safe (the sanitizer strips the now-unreplayable blocks), but OpenAI replays `web_search_call` items unconditionally, and stripping them would re-expose the dropped-reasoning-item problem.

Rollback is flag-off, with one prompt-cache miss on the first request after the flip.

## Deploy Plan

Nothing special — no migration, no config. Ship, then enable `provider_native_web_search` on a Dust workspace and run the verification in Tests/Risk before enabling anywhere else.
