### PR TITLE
Keep the usage page scroll offset when switching tabs

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -216,7 +216,8 @@ const DEFAULT_PAGE_SIZE = 25;
 
 // Keep every tab panel at least as tall as the scrolling panel so switching to a
 // shorter (or still loading) tab never shrinks the page and clamps the scroll offset.
-const TAB_CONTENT_CLASS = "block min-h-(--panel-height)";
+// Sparkle renders TabsContent as `contents`, so `block` is required for the min-height to apply.
+const TAB_CONTENT_CLASS = "block min-h-panel";
 
 export function UsagePage() {
   const owner = useWorkspace();

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -214,6 +214,10 @@ function CreditPoolProgressBar({
 
 const DEFAULT_PAGE_SIZE = 25;
 
+// Keep every tab panel at least as tall as the scrolling panel so switching to a
+// shorter (or still loading) tab never shrinks the page and clamps the scroll offset.
+const TAB_CONTENT_CLASS = "block min-h-(--panel-height)";
+
 export function UsagePage() {
   const owner = useWorkspace();
   const { subscription } = useAuth();
@@ -1332,7 +1336,7 @@ export function UsagePage() {
               )}
             </TabsList>
 
-            <TabsContent value="members">
+            <TabsContent value="members" className={TAB_CONTENT_CLASS}>
               <Page.Vertical gap="sm" align="stretch">
                 {searchRow}
                 <div className="flex flex-col gap-2">
@@ -1394,7 +1398,7 @@ export function UsagePage() {
                 </div>
               </Page.Vertical>
             </TabsContent>
-            <TabsContent value="groups">
+            <TabsContent value="groups" className={TAB_CONTENT_CLASS}>
               <GroupsUsageTable
                 owner={owner}
                 showSpendLimitColumn={isCreditPriced}
@@ -1403,13 +1407,13 @@ export function UsagePage() {
             </TabsContent>
 
             {isWorkspaceAdmin && isCreditPriced && (
-              <TabsContent value="top-ups">
+              <TabsContent value="top-ups" className={TAB_CONTENT_CLASS}>
                 <TopUpsHistoryTable owner={owner} />
               </TabsContent>
             )}
 
             {isWorkspaceAdmin && (
-              <TabsContent value="settings">
+              <TabsContent value="settings" className={TAB_CONTENT_CLASS}>
                 <div className="flex flex-col gap-10">
                   {isCreditPriced && (
                     <UsageSettingsCard

--- a/front/styles/theme-extras.css
+++ b/front/styles/theme-extras.css
@@ -14,6 +14,9 @@
 @utility h-panel {
   height: var(--panel-height); /* defined in global.css */
 }
+@utility min-h-panel {
+  min-height: var(--panel-height);
+}
 
 /* The expanded input bar paints its own surface color rather than one of the
    shared background tokens (see InputBar.tsx). Defined here, in the one entry


### PR DESCRIPTION
## Description

On `/w/<wId>/usage`, switching tab after scrolling down jumps the page. Radix unmounts the previous tab panel and the new one starts as a spinner (or is just shorter), so the scroll container shrinks and the browser clamps the scroll offset. When the data lands the page grows back but the offset stays clamped.

Each `TabsContent` now gets `min-h-panel` (new utility next to `h-panel`, the height of the scrolling panel), so the content under the tab list is never shorter than the viewport and the offset is never clamped. Sparkle's `TabsContent` renders as `display: contents`, hence the added `block`.

Trade-off: short tabs (Groups with few groups) get up to one screen of empty space below the table, only visible when scrolling past the content.

## Tests

Manual, locally with 41 members: scroll offset stays identical across Members / Groups / Top-ups / Settings, both while loading and after.

## Risk

Low, styling only on the usage page.

## Deploy Plan

Deploy front.
