### PR TITLE
Scope user metadata deletion to its workspace

### DIFF
--- a/front-api/routes/user/index.test.ts
+++ b/front-api/routes/user/index.test.ts
@@ -1,6 +1,8 @@
 import { computeSubscriberHash } from "@app/lib/notifications";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
@@ -15,6 +17,63 @@ function patchUser(body: unknown) {
     body: JSON.stringify(body),
   });
 }
+
+describe("DELETE /api/user/metadata/:key", () => {
+  it("deletes a prefix only in the selected user's workspace", async () => {
+    const { user, workspace } = await createPrivateApiMockRequest();
+    const otherWorkspace = await WorkspaceFactory.basic();
+    const otherUser = await UserFactory.basic();
+    const key = "test-preference:first";
+    const secondKey = "test-preference:second";
+
+    await user.setMetadata(key, "workspace", workspace.id);
+    await user.setMetadata(secondKey, "workspace", workspace.id);
+    await user.setMetadata("keep", "workspace", workspace.id);
+    await user.setMetadata(key, "other-workspace", otherWorkspace.id);
+    await user.setMetadata(key, "global");
+    await otherUser.setMetadata(key, "other-user", workspace.id);
+
+    const response = await honoApp.request(
+      `/api/user/metadata/test-preference%3A?workspaceId=${workspace.sId}`,
+      { method: "DELETE" }
+    );
+
+    expect(response.status).toBe(200);
+    expect(await user.getMetadata(key, workspace.id)).toBeNull();
+    expect(await user.getMetadata(secondKey, workspace.id)).toBeNull();
+    expect((await user.getMetadata("keep", workspace.id))?.value).toBe(
+      "workspace"
+    );
+    expect((await user.getMetadata(key, otherWorkspace.id))?.value).toBe(
+      "other-workspace"
+    );
+    expect((await user.getMetadata(key))?.value).toBe("global");
+    expect((await otherUser.getMetadata(key, workspace.id))?.value).toBe(
+      "other-user"
+    );
+  });
+
+  it("deletes only global metadata when no workspace is selected", async () => {
+    const { user, workspace } = await createPrivateApiMockRequest();
+    const key = "test-preference:first";
+
+    await user.setMetadata(key, "global");
+    await user.setMetadata(key, "workspace", workspace.id);
+
+    const response = await honoApp.request(
+      "/api/user/metadata/test-preference%3A",
+      {
+        method: "DELETE",
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(await user.getMetadata(key)).toBeNull();
+    expect((await user.getMetadata(key, workspace.id))?.value).toBe(
+      "workspace"
+    );
+  });
+});
 
 describe("GET /api/user", () => {
   it("returns 200 when the user is authenticated", async () => {

--- a/front-api/routes/user/metadata/[key]/index.ts
+++ b/front-api/routes/user/metadata/[key]/index.ts
@@ -113,6 +113,7 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
 
   const { key } = ctx.req.valid("param");
   await r.u.deleteMetadata({
+    workspaceId: r.workspaceModelId ?? null,
     key: {
       [Op.like]: `${key}%`,
     },

--- a/front/lib/resources/user_resource.test.ts
+++ b/front/lib/resources/user_resource.test.ts
@@ -611,7 +611,7 @@ describe("UserResource", () => {
         const key = "delete-key";
         await user.setMetadata(key, "value");
 
-        await user.deleteMetadata({ key });
+        await user.deleteMetadata({ key, workspaceId: null });
 
         const metadata = await user.getMetadata(key);
         expect(metadata).toBeNull();
@@ -624,7 +624,7 @@ describe("UserResource", () => {
         await user.setMetadata(key1, "value1");
         await user.setMetadata(key2, "value2");
 
-        await user.deleteMetadata({ key: key1 });
+        await user.deleteMetadata({ key: key1, workspaceId: null });
 
         expect(await user.getMetadata(key1)).toBeNull();
         expect(await user.getMetadata(key2)).not.toBeNull();

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -747,7 +747,14 @@ export class UserResource extends BaseResource<UserModel> {
     );
   }
 
-  async deleteMetadata(where: WhereOptions<UserMetadataModel>) {
+  /**
+   * @cc [owner:spolu,label:security;backend] user-metadata-deletion-scope
+   * Deletion MUST affect only this user's metadata in `where.workspaceId`; `null` selects only
+   * global metadata.
+   */
+  async deleteMetadata(
+    where: WhereOptions<UserMetadataModel> & { workspaceId: ModelId | null }
+  ) {
     return UserMetadataModel.destroy({
       where: {
         ...where,


### PR DESCRIPTION
## Description

Deleting user metadata with `workspaceId=A` previously removed matching keys for that user across every workspace and global metadata. Scope deletion to the selected workspace, or global metadata when no workspace is selected, and require an explicit scope in `UserResource.deleteMetadata` with a local contract.

Fixes the workspace-isolation violation found while verifying #32241.

## Tests

Added endpoint regression tests covering workspace isolation, global-only deletion, other users, and key-prefix matching. Updated existing resource tests to specify global scope. Both focused suites were attempted locally but failed before running tests because the shared dependencies are missing `@novu/framework`.

## Risk

Low. Narrows deletion to one metadata scope; key-prefix matching is unchanged.

## Deploy Plan

Deploy `front-api`.
