### PR TITLE
fix: normalize caught errors across result and callback handlers

### DIFF
--- a/connectors/src/connectors/bigquery/lib/bigquery_api.ts
+++ b/connectors/src/connectors/bigquery/lib/bigquery_api.ts
@@ -307,7 +307,7 @@ export const fetchTables = async ({
 
     return new Ok(removeNulls(remoteDBTables));
   } catch (error) {
-    return new Err(error instanceof Error ? error : new Error(String(error)));
+    return new Err(normalizeError(error));
   }
 };
 

--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -31,7 +31,7 @@ import {
   getOAuthConnectionAccessToken,
 } from "@connectors/types";
 import type { Result } from "@dust-tt/client";
-import { Err, Ok } from "@dust-tt/client";
+import { Err, normalizeError, Ok } from "@dust-tt/client";
 import { isLeft } from "fp-ts/lib/Either";
 import { rm } from "fs/promises";
 import * as reporter from "io-ts-reporters";
@@ -598,10 +598,7 @@ export async function getDiscussion(
       }
     );
   } catch (err) {
-    if (err instanceof Error) {
-      return new Err(err);
-    }
-    return new Err(new Error(String(err)));
+    return new Err(normalizeError(err));
   }
 
   const errorPayloadValidation = ErrorPayloadSchema.decode(d);

--- a/connectors/src/types/shared/text_extraction/transform.ts
+++ b/connectors/src/types/shared/text_extraction/transform.ts
@@ -1,3 +1,4 @@
+import { normalizeError } from "@dust-tt/client";
 import { Parser } from "htmlparser2";
 import type { Readable } from "stream";
 import { Transform } from "stream";
@@ -128,17 +129,7 @@ export function transformStream(
         parser.write(chunk.toString());
         callback();
       } catch (error) {
-        if (error instanceof Error) {
-          callback(error);
-        } else {
-          callback(
-            new Error(
-              typeof error === "string"
-                ? error
-                : "Unknown error in htmlParsingTransform.transform()"
-            )
-          );
-        }
+        callback(normalizeError(error));
       }
     },
 
@@ -159,17 +150,7 @@ export function transformStream(
 
         callback();
       } catch (error) {
-        if (error instanceof Error) {
-          callback(error);
-        } else {
-          callback(
-            new Error(
-              typeof error === "string"
-                ? error
-                : "Unknown error in htmlParsingTransform.flush()"
-            )
-          );
-        }
+        callback(normalizeError(error));
       }
     },
   });

--- a/connectors/src/types/shared/text_extraction/transformToCSV.ts
+++ b/connectors/src/types/shared/text_extraction/transformToCSV.ts
@@ -1,3 +1,4 @@
+import { normalizeError } from "@dust-tt/client";
 import { stringify } from "csv-stringify/sync";
 import { Parser } from "htmlparser2";
 import type { Readable } from "stream";
@@ -109,17 +110,7 @@ export function transformStreamToCSV(
         parser.write(chunk.toString());
         callback();
       } catch (error) {
-        if (error instanceof Error) {
-          callback(error);
-        } else {
-          callback(
-            new Error(
-              typeof error === "string"
-                ? error
-                : "Unknown error in htmlParsingTransform.transform()"
-            )
-          );
-        }
+        callback(normalizeError(error));
       }
     },
 
@@ -130,17 +121,7 @@ export function transformStreamToCSV(
 
         callback();
       } catch (error) {
-        if (error instanceof Error) {
-          callback(error);
-        } else {
-          callback(
-            new Error(
-              typeof error === "string"
-                ? error
-                : "Unknown error in htmlParsingTransform.flush()"
-            )
-          );
-        }
+        callback(normalizeError(error));
       }
     },
   });

--- a/front/components/agent_builder/sidekick/useMCPServer.ts
+++ b/front/components/agent_builder/sidekick/useMCPServer.ts
@@ -3,6 +3,7 @@ import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBu
 import { useSidekickSuggestions } from "@app/components/agent_builder/sidekick/SidekickSuggestionsContext";
 import { registerGetAgentConfigTool } from "@app/components/agent_builder/sidekick/tools/getAgentConfig";
 import { BrowserMCPTransport } from "@app/lib/client/BrowserMCPTransport";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useFormContext } from "react-hook-form";
@@ -128,7 +129,7 @@ export function useSidekickMCPServer({
       } catch (err) {
         console.error("[useSidekickMCPServer] Failed to initialize:", err);
         if (isMounted) {
-          setError(err instanceof Error ? err : new Error(String(err)));
+          setError(normalizeError(err));
           setIsConnecting(false);
         }
       }

--- a/front/lib/api/billing/info.ts
+++ b/front/lib/api/billing/info.ts
@@ -11,7 +11,7 @@ import type {
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { errorToString } from "@app/types/shared/utils/error_utils";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type Stripe from "stripe";
 
 function serializeAddress(
@@ -188,6 +188,6 @@ export async function getWorkspaceBillingInfo(
       }),
     });
   } catch (error) {
-    return new Err(new Error(errorToString(error)));
+    return new Err(normalizeError(error));
   }
 }

--- a/front/lib/api/billing/invoices.ts
+++ b/front/lib/api/billing/invoices.ts
@@ -7,7 +7,7 @@ import type { BillingInvoice } from "@app/types/api/billing/invoices";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { errorToString } from "@app/types/shared/utils/error_utils";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import type Stripe from "stripe";
 
@@ -107,6 +107,6 @@ export async function listRecentBillingInvoices(
         .map(serializeInvoice)
     );
   } catch (error) {
-    return new Err(new Error(errorToString(error)));
+    return new Err(normalizeError(error));
   }
 }

--- a/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
+++ b/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
@@ -3,6 +3,7 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 export const applyGroupRoles = createPlugin({
   manifest: {
@@ -38,7 +39,7 @@ export const applyGroupRoles = createPlugin({
     try {
       await GroupResource.recomputeAndSyncWorkspaceRolesForUsers(auth, users);
     } catch (error) {
-      return new Err(error instanceof Error ? error : new Error(String(error)));
+      return new Err(normalizeError(error));
     }
 
     const groupSummary = roleGrantingGroups

--- a/front/lib/api/projects/connector.ts
+++ b/front/lib/api/projects/connector.ts
@@ -397,7 +397,7 @@ export async function createDataSourceAndConnectorForProject(
         { error },
         "Failed to create dust_project connector for project"
       );
-      return new Err(error instanceof Error ? error : new Error(String(error)));
+      return new Err(normalizeError(error));
     }
   });
 }

--- a/front/lib/client/BrowserMCPTransport.ts
+++ b/front/lib/client/BrowserMCPTransport.ts
@@ -1,4 +1,5 @@
 import { clientEventSource, clientFetch } from "@app/lib/egress/client";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 import type { EventSourcePolyfill } from "event-source-polyfill";
@@ -229,7 +230,7 @@ export class BrowserMCPTransport implements Transport {
         "[BrowserMCPTransport] Failed to start MCP transport:",
         error
       );
-      this.onerror?.(error instanceof Error ? error : new Error(String(error)));
+      this.onerror?.(normalizeError(error));
       throw error;
     }
   }

--- a/front/lib/resources/activation_recommendation_resource.ts
+++ b/front/lib/resources/activation_recommendation_resource.ts
@@ -9,6 +9,7 @@ import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type {
   Attributes,
   CreationAttributes,
@@ -296,7 +297,7 @@ export class ActivationRecommendationResource extends BaseResource<ActivationRec
       });
       return new Ok(undefined);
     } catch (err) {
-      return new Err(err instanceof Error ? err : new Error(String(err)));
+      return new Err(normalizeError(err));
     }
   }
 

--- a/front/lib/resources/activation_work_area_resource.ts
+++ b/front/lib/resources/activation_work_area_resource.ts
@@ -13,6 +13,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
 import { Op } from "sequelize";
 
@@ -210,7 +211,7 @@ export class ActivationWorkAreaResource extends BaseResource<ActivationWorkAreaM
       });
       return new Ok(undefined);
     } catch (err) {
-      return new Err(err instanceof Error ? err : new Error(String(err)));
+      return new Err(normalizeError(err));
     }
   }
 

--- a/front/types/shared/text_extraction/transform.ts
+++ b/front/types/shared/text_extraction/transform.ts
@@ -1,3 +1,4 @@
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { Parser } from "htmlparser2";
 import type { Readable } from "stream";
 import { Transform } from "stream";
@@ -128,17 +129,7 @@ export function transformStream(
         parser.write(chunk.toString());
         callback();
       } catch (error) {
-        if (error instanceof Error) {
-          callback(error);
-        } else {
-          callback(
-            new Error(
-              typeof error === "string"
-                ? error
-                : "Unknown error in htmlParsingTransform.transform()"
-            )
-          );
-        }
+        callback(normalizeError(error));
       }
     },
 
@@ -159,17 +150,7 @@ export function transformStream(
 
         callback();
       } catch (error) {
-        if (error instanceof Error) {
-          callback(error);
-        } else {
-          callback(
-            new Error(
-              typeof error === "string"
-                ? error
-                : "Unknown error in htmlParsingTransform.flush()"
-            )
-          );
-        }
+        callback(normalizeError(error));
       }
     },
   });

--- a/front/types/shared/text_extraction/transformToCSV.ts
+++ b/front/types/shared/text_extraction/transformToCSV.ts
@@ -1,3 +1,4 @@
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { stringify } from "csv-stringify/sync";
 import { Parser } from "htmlparser2";
 import type { Readable } from "stream";
@@ -108,17 +109,7 @@ export function transformStreamToCSV(
         parser.write(chunk.toString());
         callback();
       } catch (error) {
-        if (error instanceof Error) {
-          callback(error);
-        } else {
-          callback(
-            new Error(
-              typeof error === "string"
-                ? error
-                : "Unknown error in htmlParsingTransform.transform()"
-            )
-          );
-        }
+        callback(normalizeError(error));
       }
     },
 
@@ -129,17 +120,7 @@ export function transformStreamToCSV(
 
         callback();
       } catch (error) {
-        if (error instanceof Error) {
-          callback(error);
-        } else {
-          callback(
-            new Error(
-              typeof error === "string"
-                ? error
-                : "Unknown error in htmlParsingTransform.flush()"
-            )
-          );
-        }
+        callback(normalizeError(error));
       }
     },
   });

--- a/front/types/shared/utils/error_utils.ts
+++ b/front/types/shared/utils/error_utils.ts
@@ -10,6 +10,11 @@ export function errorToString(error: unknown): string {
   return JSON.stringify(error);
 }
 
+/**
+ * @cc [owner:spolu,label:error-handling] normalized-error-identity
+ * Error inputs MUST be returned unchanged, preserving their subtype, stack, cause, and custom fields.
+ * Other inputs MUST be wrapped using errorToString; serialization failures MUST propagate.
+ */
 export function normalizeError(error: unknown): Error {
   if (error instanceof Error) {
     return error;

--- a/sdks/js/src/error_utils.ts
+++ b/sdks/js/src/error_utils.ts
@@ -8,6 +8,11 @@ export function errorToString(error: unknown): string {
   return JSON.stringify(error);
 }
 
+/**
+ * @cc [owner:spolu,label:error-handling] normalized-error-identity
+ * Error inputs MUST be returned unchanged, preserving their subtype, stack, cause, and custom fields.
+ * Other inputs MUST be wrapped using errorToString; serialization failures MUST propagate.
+ */
 export function normalizeError(error: unknown): Error {
   if (error instanceof Error) {
     return error;

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -1754,9 +1754,7 @@ export class DustAPI {
       const responseData = await response.json();
       return new Ok(responseData.file);
     } catch (err) {
-      return new Err(
-        new Error(err instanceof Error ? err.message : "Unknown error")
-      );
+      return new Err(normalizeError(err));
     }
   }
 

--- a/sdks/js/src/mcp_transport.ts
+++ b/sdks/js/src/mcp_transport.ts
@@ -3,6 +3,7 @@ import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types";
 import { EventSourcePolyfill } from "event-source-polyfill";
 
 import type { DustAPI } from ".";
+import { normalizeError } from "./error_utils";
 
 const logger = console;
 
@@ -110,7 +111,7 @@ export class DustMcpServerTransport implements Transport {
       this.logInfo("MCP transport started successfully");
     } catch (error) {
       this.logError("Failed to start MCP transport:", error);
-      this.onerror?.(error instanceof Error ? error : new Error(String(error)));
+      this.onerror?.(normalizeError(error));
       throw error;
     }
   }


### PR DESCRIPTION
## Description

Replace ad hoc caught-error conversions with `normalizeError` at 20 result, MCP/sidekick, and text-extraction callback sites. Existing errors retain their original stack, cause, subtype, and fields; structured non-Error failures retain their details instead of becoming `[object Object]` or a generic message. Document the helper's identity-preservation contract.

## Tests

- Four existing SDK tests passed.
- Sixteen local stream checks passed across the front and connectors text/CSV transforms, covering transform and flush failures with Error and structured-object rejections.
- Billing endpoint suites could not start because the local `@novu/framework` dependency is missing.

## Risk

Low. Uses existing normalization helpers. Non-Error diagnostic messages become more descriptive. Local front validation is limited by missing or outdated dependencies.

## Deploy Plan

Deploy affected front services and connectors. Include SDK changes in the next SDK release.
