### PR TITLE
Only reveal cycles with consumption in the usage cycle history and add a show less control

### DIFF
--- a/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.test.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.test.ts
@@ -137,8 +137,10 @@ describe("GET /api/w/[wId]/credits/awu-pool-cycle-history", () => {
     expect(await response.json()).toEqual({
       cycleBreakdown: [],
       excessCycleBreakdown: [],
-      hasMoreCycleBreakdown: false,
-      hasMoreExcessCycleBreakdown: false,
+      hasMoreCycleHistory: {
+        cycleBreakdown: false,
+        excessCycleBreakdown: false,
+      },
     });
     expect(metronomeClient.listMetronomeFinalizedInvoices).toHaveBeenCalled();
   });
@@ -169,10 +171,10 @@ describe("GET /api/w/[wId]/credits/awu-pool-cycle-history", () => {
 
     expect(response.status).toBe(200);
     expect(cycleIds(body.excessCycleBreakdown)).toEqual(["inv-0", "inv-3"]);
-    expect(body.hasMoreExcessCycleBreakdown).toBe(true);
+    expect(body.hasMoreCycleHistory.excessCycleBreakdown).toBe(true);
     // No pool ledger data was mocked, so the pool breakdown stays empty and must not
     // borrow "more" from the unrelated excess breakdown.
-    expect(body.hasMoreCycleBreakdown).toBe(false);
+    expect(body.hasMoreCycleHistory.cycleBreakdown).toBe(false);
   });
 
   it("reports no more history when the remaining invoices have no consumption", async () => {
@@ -189,7 +191,7 @@ describe("GET /api/w/[wId]/credits/awu-pool-cycle-history", () => {
     const body = await response.json();
 
     expect(cycleIds(body.excessCycleBreakdown)).toEqual(["inv-0", "inv-1"]);
-    expect(body.hasMoreExcessCycleBreakdown).toBe(false);
+    expect(body.hasMoreCycleHistory.excessCycleBreakdown).toBe(false);
   });
 
   it("reports no more history at the 24 cycle cap even when more exist", async () => {
@@ -202,7 +204,7 @@ describe("GET /api/w/[wId]/credits/awu-pool-cycle-history", () => {
 
     expect(response.status).toBe(200);
     expect(body.excessCycleBreakdown).toHaveLength(24);
-    expect(body.hasMoreExcessCycleBreakdown).toBe(false);
+    expect(body.hasMoreCycleHistory.excessCycleBreakdown).toBe(false);
   });
 
   it("falls back to the default limit when the requested one is out of range", async () => {
@@ -215,7 +217,7 @@ describe("GET /api/w/[wId]/credits/awu-pool-cycle-history", () => {
 
     expect(response.status).toBe(200);
     expect(body.excessCycleBreakdown).toHaveLength(5);
-    expect(body.hasMoreExcessCycleBreakdown).toBe(true);
+    expect(body.hasMoreCycleHistory.excessCycleBreakdown).toBe(true);
   });
 
   it("does not borrow 'more history' from the excess breakdown for the pool breakdown", async () => {
@@ -237,7 +239,7 @@ describe("GET /api/w/[wId]/credits/awu-pool-cycle-history", () => {
     expect(response.status).toBe(200);
     expect(cycleIds(body.cycleBreakdown)).toEqual(["inv-0"]);
     expect(body.excessCycleBreakdown).toEqual([]);
-    expect(body.hasMoreCycleBreakdown).toBe(true);
-    expect(body.hasMoreExcessCycleBreakdown).toBe(false);
+    expect(body.hasMoreCycleHistory.cycleBreakdown).toBe(true);
+    expect(body.hasMoreCycleHistory.excessCycleBreakdown).toBe(false);
   });
 });

--- a/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.test.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.test.ts
@@ -1,4 +1,5 @@
 import * as metronomeClient from "@app/lib/metronome/client";
+import type { MetronomeBalance } from "@app/lib/metronome/types";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { Ok } from "@app/types/shared/result";
@@ -61,6 +62,25 @@ function cycleIds(cycles: { cycleEndMs: number | null }[]): string[] {
   );
 }
 
+// A pool commit whose ledger deducts `consumedCredits` against `invoiceId`, making that invoice
+// a cycle with consumption in the pool (non-excess) breakdown.
+function poolBalanceWithDeduction(
+  invoiceId: string,
+  consumedCredits: number
+): MetronomeBalance {
+  return {
+    id: `commit-${invoiceId}`,
+    ledger: [
+      {
+        type: "PREPAID_COMMIT_AUTOMATED_INVOICE_DEDUCTION",
+        amount: -consumedCredits,
+        invoice_id: invoiceId,
+        timestamp: new Date().toISOString(),
+      },
+    ],
+  } as unknown as MetronomeBalance;
+}
+
 async function requestAsManager(query = "") {
   const workspace = await WorkspaceFactory.creditPriced();
   await createPrivateApiMockRequest({
@@ -117,7 +137,8 @@ describe("GET /api/w/[wId]/credits/awu-pool-cycle-history", () => {
     expect(await response.json()).toEqual({
       cycleBreakdown: [],
       excessCycleBreakdown: [],
-      hasMoreCycleHistory: false,
+      hasMoreCycleBreakdown: false,
+      hasMoreExcessCycleBreakdown: false,
     });
     expect(metronomeClient.listMetronomeFinalizedInvoices).toHaveBeenCalled();
   });
@@ -148,7 +169,10 @@ describe("GET /api/w/[wId]/credits/awu-pool-cycle-history", () => {
 
     expect(response.status).toBe(200);
     expect(cycleIds(body.excessCycleBreakdown)).toEqual(["inv-0", "inv-3"]);
-    expect(body.hasMoreCycleHistory).toBe(true);
+    expect(body.hasMoreExcessCycleBreakdown).toBe(true);
+    // No pool ledger data was mocked, so the pool breakdown stays empty and must not
+    // borrow "more" from the unrelated excess breakdown.
+    expect(body.hasMoreCycleBreakdown).toBe(false);
   });
 
   it("reports no more history when the remaining invoices have no consumption", async () => {
@@ -165,7 +189,7 @@ describe("GET /api/w/[wId]/credits/awu-pool-cycle-history", () => {
     const body = await response.json();
 
     expect(cycleIds(body.excessCycleBreakdown)).toEqual(["inv-0", "inv-1"]);
-    expect(body.hasMoreCycleHistory).toBe(false);
+    expect(body.hasMoreExcessCycleBreakdown).toBe(false);
   });
 
   it("reports no more history at the 24 cycle cap even when more exist", async () => {
@@ -178,7 +202,7 @@ describe("GET /api/w/[wId]/credits/awu-pool-cycle-history", () => {
 
     expect(response.status).toBe(200);
     expect(body.excessCycleBreakdown).toHaveLength(24);
-    expect(body.hasMoreCycleHistory).toBe(false);
+    expect(body.hasMoreExcessCycleBreakdown).toBe(false);
   });
 
   it("falls back to the default limit when the requested one is out of range", async () => {
@@ -191,6 +215,29 @@ describe("GET /api/w/[wId]/credits/awu-pool-cycle-history", () => {
 
     expect(response.status).toBe(200);
     expect(body.excessCycleBreakdown).toHaveLength(5);
-    expect(body.hasMoreCycleHistory).toBe(true);
+    expect(body.hasMoreExcessCycleBreakdown).toBe(true);
+  });
+
+  it("does not borrow 'more history' from the excess breakdown for the pool breakdown", async () => {
+    // Invoices 0 and 1 have pool consumption (via the ledger deduction below) and no overage,
+    // so the excess breakdown stays empty while the pool breakdown overflows the limit.
+    vi.mocked(metronomeClient.listMetronomeFinalizedInvoices).mockResolvedValue(
+      new Ok([finalizedInvoice(0), finalizedInvoice(1)])
+    );
+    vi.mocked(metronomeClient.listMetronomeBalances).mockResolvedValue(
+      new Ok([
+        poolBalanceWithDeduction("inv-0", 5),
+        poolBalanceWithDeduction("inv-1", 5),
+      ])
+    );
+
+    const response = await requestAsManager("?cycleHistoryLimit=1");
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(cycleIds(body.cycleBreakdown)).toEqual(["inv-0"]);
+    expect(body.excessCycleBreakdown).toEqual([]);
+    expect(body.hasMoreCycleBreakdown).toBe(true);
+    expect(body.hasMoreExcessCycleBreakdown).toBe(false);
   });
 });

--- a/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.test.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.test.ts
@@ -22,19 +22,43 @@ function awuPoolCycleHistoryUrl(wId: string, query = "") {
   return `/api/w/${wId}/credits/awu-pool-cycle-history${query}`;
 }
 
-function finalizedInvoice(index: number): Invoice {
+const USD_CREDIT_TYPE = {
+  id: "2714e483-4ff1-48e4-9e25-ac732e8f24f2",
+  name: "USD",
+};
+
+// `overageCredits` makes the invoice a cycle with consumption in the excess breakdown.
+function finalizedInvoice(index: number, overageCredits = 0): Invoice {
   const end = Date.UTC(2026, 0, 1) - index * 31 * 24 * 60 * 60 * 1000;
   return {
     id: `inv-${index}`,
     customer_id: "m-customer",
     status: "FINALIZED",
     type: "USAGE",
-    total: 0,
+    total: overageCredits,
     start_timestamp: new Date(end - 31 * 24 * 60 * 60 * 1000).toISOString(),
     end_timestamp: new Date(end).toISOString(),
-    credit_type: { id: "2714e483-4ff1-48e4-9e25-ac732e8f24f2", name: "USD" },
-    line_items: [],
+    credit_type: USD_CREDIT_TYPE,
+    line_items:
+      overageCredits > 0
+        ? [
+            {
+              type: "cpu_conversion",
+              name: "Overage",
+              quantity: overageCredits,
+              total: overageCredits,
+              credit_type: USD_CREDIT_TYPE,
+            },
+          ]
+        : [],
   };
+}
+
+function cycleIds(cycles: { cycleEndMs: number | null }[]): string[] {
+  return cycles.map(
+    (cycle) =>
+      `inv-${Math.round((Date.UTC(2026, 0, 1) - (cycle.cycleEndMs ?? 0)) / (31 * 24 * 60 * 60 * 1000))}`
+  );
 }
 
 async function requestAsManager(query = "") {
@@ -98,48 +122,75 @@ describe("GET /api/w/[wId]/credits/awu-pool-cycle-history", () => {
     expect(metronomeClient.listMetronomeFinalizedInvoices).toHaveBeenCalled();
   });
 
-  it("fetches one invoice past the limit to detect older cycles", async () => {
-    vi.mocked(metronomeClient.listMetronomeFinalizedInvoices).mockResolvedValue(
-      new Ok([finalizedInvoice(0), finalizedInvoice(1), finalizedInvoice(2)])
-    );
-
+  it("scans a fixed window of invoices regardless of the limit", async () => {
     const response = await requestAsManager("?cycleHistoryLimit=2");
 
     expect(response.status).toBe(200);
-    expect((await response.json()).hasMoreCycleHistory).toBe(true);
     expect(metronomeClient.listMetronomeFinalizedInvoices).toHaveBeenCalledWith(
       expect.any(String),
-      { limit: 3 }
+      { limit: 48 }
     );
   });
 
-  it("reports no more history when the invoices run out", async () => {
+  it("skips invoices without consumption when filling the limit", async () => {
     vi.mocked(metronomeClient.listMetronomeFinalizedInvoices).mockResolvedValue(
-      new Ok([finalizedInvoice(0), finalizedInvoice(1)])
+      new Ok([
+        finalizedInvoice(0, 10),
+        finalizedInvoice(1),
+        finalizedInvoice(2),
+        finalizedInvoice(3, 20),
+        finalizedInvoice(4, 30),
+      ])
     );
 
     const response = await requestAsManager("?cycleHistoryLimit=2");
+    const body = await response.json();
 
-    expect((await response.json()).hasMoreCycleHistory).toBe(false);
+    expect(response.status).toBe(200);
+    expect(cycleIds(body.excessCycleBreakdown)).toEqual(["inv-0", "inv-3"]);
+    expect(body.hasMoreCycleHistory).toBe(true);
   });
 
-  it("caps the limit at 24 cycles", async () => {
+  it("reports no more history when the remaining invoices have no consumption", async () => {
+    vi.mocked(metronomeClient.listMetronomeFinalizedInvoices).mockResolvedValue(
+      new Ok([
+        finalizedInvoice(0, 10),
+        finalizedInvoice(1, 20),
+        finalizedInvoice(2),
+        finalizedInvoice(3),
+      ])
+    );
+
+    const response = await requestAsManager("?cycleHistoryLimit=2");
+    const body = await response.json();
+
+    expect(cycleIds(body.excessCycleBreakdown)).toEqual(["inv-0", "inv-1"]);
+    expect(body.hasMoreCycleHistory).toBe(false);
+  });
+
+  it("reports no more history at the 24 cycle cap even when more exist", async () => {
+    vi.mocked(metronomeClient.listMetronomeFinalizedInvoices).mockResolvedValue(
+      new Ok(Array.from({ length: 30 }, (_, i) => finalizedInvoice(i, 10)))
+    );
+
     const response = await requestAsManager("?cycleHistoryLimit=24");
+    const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(metronomeClient.listMetronomeFinalizedInvoices).toHaveBeenCalledWith(
-      expect.any(String),
-      { limit: 25 }
-    );
+    expect(body.excessCycleBreakdown).toHaveLength(24);
+    expect(body.hasMoreCycleHistory).toBe(false);
   });
 
   it("falls back to the default limit when the requested one is out of range", async () => {
+    vi.mocked(metronomeClient.listMetronomeFinalizedInvoices).mockResolvedValue(
+      new Ok(Array.from({ length: 8 }, (_, i) => finalizedInvoice(i, 10)))
+    );
+
     const response = await requestAsManager("?cycleHistoryLimit=25");
+    const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(metronomeClient.listMetronomeFinalizedInvoices).toHaveBeenCalledWith(
-      expect.any(String),
-      { limit: 6 }
-    );
+    expect(body.excessCycleBreakdown).toHaveLength(5);
+    expect(body.hasMoreCycleHistory).toBe(true);
   });
 });

--- a/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.test.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-cycle-history.test.ts
@@ -70,15 +70,19 @@ function poolBalanceWithDeduction(
 ): MetronomeBalance {
   return {
     id: `commit-${invoiceId}`,
+    created_at: new Date().toISOString(),
+    product: { id: "product-pool", name: "Pool" },
+    type: "PREPAID",
     ledger: [
       {
         type: "PREPAID_COMMIT_AUTOMATED_INVOICE_DEDUCTION",
         amount: -consumedCredits,
         invoice_id: invoiceId,
+        segment_id: `segment-${invoiceId}`,
         timestamp: new Date().toISOString(),
       },
     ],
-  } as unknown as MetronomeBalance;
+  };
 }
 
 async function requestAsManager(query = "") {
@@ -137,7 +141,8 @@ describe("GET /api/w/[wId]/credits/awu-pool-cycle-history", () => {
     expect(await response.json()).toEqual({
       cycleBreakdown: [],
       excessCycleBreakdown: [],
-      hasMoreCycleHistory: {
+      hasMoreCycleHistory: false,
+      hasMoreCycleHistoryByBreakdown: {
         cycleBreakdown: false,
         excessCycleBreakdown: false,
       },
@@ -171,10 +176,10 @@ describe("GET /api/w/[wId]/credits/awu-pool-cycle-history", () => {
 
     expect(response.status).toBe(200);
     expect(cycleIds(body.excessCycleBreakdown)).toEqual(["inv-0", "inv-3"]);
-    expect(body.hasMoreCycleHistory.excessCycleBreakdown).toBe(true);
+    expect(body.hasMoreCycleHistoryByBreakdown.excessCycleBreakdown).toBe(true);
     // No pool ledger data was mocked, so the pool breakdown stays empty and must not
     // borrow "more" from the unrelated excess breakdown.
-    expect(body.hasMoreCycleHistory.cycleBreakdown).toBe(false);
+    expect(body.hasMoreCycleHistoryByBreakdown.cycleBreakdown).toBe(false);
   });
 
   it("reports no more history when the remaining invoices have no consumption", async () => {
@@ -191,7 +196,9 @@ describe("GET /api/w/[wId]/credits/awu-pool-cycle-history", () => {
     const body = await response.json();
 
     expect(cycleIds(body.excessCycleBreakdown)).toEqual(["inv-0", "inv-1"]);
-    expect(body.hasMoreCycleHistory.excessCycleBreakdown).toBe(false);
+    expect(body.hasMoreCycleHistoryByBreakdown.excessCycleBreakdown).toBe(
+      false
+    );
   });
 
   it("reports no more history at the 24 cycle cap even when more exist", async () => {
@@ -204,7 +211,9 @@ describe("GET /api/w/[wId]/credits/awu-pool-cycle-history", () => {
 
     expect(response.status).toBe(200);
     expect(body.excessCycleBreakdown).toHaveLength(24);
-    expect(body.hasMoreCycleHistory.excessCycleBreakdown).toBe(false);
+    expect(body.hasMoreCycleHistoryByBreakdown.excessCycleBreakdown).toBe(
+      false
+    );
   });
 
   it("falls back to the default limit when the requested one is out of range", async () => {
@@ -217,7 +226,7 @@ describe("GET /api/w/[wId]/credits/awu-pool-cycle-history", () => {
 
     expect(response.status).toBe(200);
     expect(body.excessCycleBreakdown).toHaveLength(5);
-    expect(body.hasMoreCycleHistory.excessCycleBreakdown).toBe(true);
+    expect(body.hasMoreCycleHistoryByBreakdown.excessCycleBreakdown).toBe(true);
   });
 
   it("does not borrow 'more history' from the excess breakdown for the pool breakdown", async () => {
@@ -239,7 +248,9 @@ describe("GET /api/w/[wId]/credits/awu-pool-cycle-history", () => {
     expect(response.status).toBe(200);
     expect(cycleIds(body.cycleBreakdown)).toEqual(["inv-0"]);
     expect(body.excessCycleBreakdown).toEqual([]);
-    expect(body.hasMoreCycleHistory.cycleBreakdown).toBe(true);
-    expect(body.hasMoreCycleHistory.excessCycleBreakdown).toBe(false);
+    expect(body.hasMoreCycleHistoryByBreakdown.cycleBreakdown).toBe(true);
+    expect(body.hasMoreCycleHistoryByBreakdown.excessCycleBreakdown).toBe(
+      false
+    );
   });
 });

--- a/front-api/routes/w/[wId]/credits/awu-pool-summary.test.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-summary.test.ts
@@ -33,8 +33,7 @@ const EMPTY_POOL_SUMMARY = {
   cycleBreakdown: [],
   excessConsumedCredits: null,
   excessCycleBreakdown: [],
-  hasMoreCycleBreakdown: false,
-  hasMoreExcessCycleBreakdown: false,
+  hasMoreCycleHistory: { cycleBreakdown: false, excessCycleBreakdown: false },
   programmaticConsumedCredits: null,
 };
 

--- a/front-api/routes/w/[wId]/credits/awu-pool-summary.test.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-summary.test.ts
@@ -33,7 +33,11 @@ const EMPTY_POOL_SUMMARY = {
   cycleBreakdown: [],
   excessConsumedCredits: null,
   excessCycleBreakdown: [],
-  hasMoreCycleHistory: { cycleBreakdown: false, excessCycleBreakdown: false },
+  hasMoreCycleHistory: false,
+  hasMoreCycleHistoryByBreakdown: {
+    cycleBreakdown: false,
+    excessCycleBreakdown: false,
+  },
   programmaticConsumedCredits: null,
 };
 

--- a/front-api/routes/w/[wId]/credits/awu-pool-summary.test.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-summary.test.ts
@@ -33,7 +33,8 @@ const EMPTY_POOL_SUMMARY = {
   cycleBreakdown: [],
   excessConsumedCredits: null,
   excessCycleBreakdown: [],
-  hasMoreCycleHistory: false,
+  hasMoreCycleBreakdown: false,
+  hasMoreExcessCycleBreakdown: false,
   programmaticConsumedCredits: null,
 };
 

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -246,9 +246,6 @@ export function UsagePage() {
     pageIndex: 0,
     pageSize: DEFAULT_PAGE_SIZE,
   });
-  // Under the new usage page, defer to the same empty-sorting + fallback
-  // pattern as Poke's PoolUsagePage so the initial sort (pool usage,
-  // descending) matches until the user picks a column explicitly.
   const [sorting, setSorting] = useState<SortingState>(
     isNewUsagePage ? [] : [{ id: "name", desc: false }]
   );

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -246,9 +246,12 @@ export function UsagePage() {
     pageIndex: 0,
     pageSize: DEFAULT_PAGE_SIZE,
   });
-  const [sorting, setSorting] = useState<SortingState>([
-    { id: "name", desc: false },
-  ]);
+  // Under the new usage page, defer to the same empty-sorting + fallback
+  // pattern as Poke's PoolUsagePage so the initial sort (pool usage,
+  // descending) matches until the user picks a column explicitly.
+  const [sorting, setSorting] = useState<SortingState>(
+    isNewUsagePage ? [] : [{ id: "name", desc: false }]
+  );
 
   // Members are sorted server-side; reset to the first page when the sort
   // changes so the user lands on the start of the new ordering.
@@ -279,7 +282,11 @@ export function UsagePage() {
     setPagination((prev) => ({ ...prev, pageIndex: 0 }));
   }, []);
 
-  const sort = sorting[0];
+  const effectiveSorting: SortingState =
+    isNewUsagePage && sorting.length === 0
+      ? [{ id: "consumedFromPoolAwuCredits", desc: true }]
+      : sorting;
+  const sort = effectiveSorting[0];
   // The legacy table's pool-usage cell displays total consumption
   // (consumedAwuCredits), not the pool-only amount, so its "column" of the
   // same id must sort by the total. Only the compact/Poke variant, which
@@ -290,7 +297,9 @@ export function UsagePage() {
     sort?.id === "email" || sort?.id === "seatUsage"
       ? sort.id
       : sort?.id === "consumedFromPoolAwuCredits"
-        ? "consumedAwuCredits"
+        ? isNewUsagePage
+          ? "consumedFromPoolAwuCredits"
+          : "consumedAwuCredits"
         : "name";
   const membersOrderDirection = sort?.desc ? "desc" : "asc";
 
@@ -1041,7 +1050,7 @@ export function UsagePage() {
       pagination={pagination}
       setPagination={setPagination}
       totalRowCount={totalMembersUsage}
-      sorting={sorting}
+      sorting={effectiveSorting}
       setSorting={handleSetSorting}
       showGroupsColumn={groups.length > 0}
       enableSelection={isCreditPriced}

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -79,7 +79,8 @@ interface PoolCreditCardProps {
 }
 
 function PoolCreditCard({ owner }: PoolCreditCardProps) {
-  const { cycleHistoryLimit, onLoadMoreCycleHistory } = useCycleHistoryLimit();
+  const { cycleHistoryLimit, onLoadMoreCycleHistory, onShowLessCycleHistory } =
+    useCycleHistoryLimit();
   const {
     awuPoolCurrentCycle,
     isAwuPoolCurrentCycleLoading,
@@ -112,6 +113,7 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
         isLoading:
           isAwuPoolCycleHistoryValidating && !isAwuPoolCycleHistoryLoading,
         onLoadMore: onLoadMoreCycleHistory,
+        onShowLess: onShowLessCycleHistory,
       }}
     />
   );

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -89,7 +89,7 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
   const {
     cycleBreakdown: poolCycleBreakdown,
     excessCycleBreakdown,
-    hasMoreCycleHistory,
+    hasMoreCycleHistoryByBreakdown: hasMoreCycleHistory,
     isAwuPoolCycleHistoryLoading,
     isAwuPoolCycleHistoryError,
     isAwuPoolCycleHistoryValidating,

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -89,8 +89,7 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
   const {
     cycleBreakdown: poolCycleBreakdown,
     excessCycleBreakdown,
-    hasMoreCycleBreakdown,
-    hasMoreExcessCycleBreakdown,
+    hasMoreCycleHistory,
     isAwuPoolCycleHistoryLoading,
     isAwuPoolCycleHistoryError,
     isAwuPoolCycleHistoryValidating,
@@ -110,8 +109,7 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
         !!isAwuPoolCycleHistoryError
       )}
       cycleHistoryLoadMore={{
-        hasMoreCycleBreakdown,
-        hasMoreExcessCycleBreakdown,
+        hasMoreCycleHistory,
         isLoading:
           isAwuPoolCycleHistoryValidating && !isAwuPoolCycleHistoryLoading,
         onLoadMore: onLoadMoreCycleHistory,

--- a/front/components/poke/pages/PoolUsagePage.tsx
+++ b/front/components/poke/pages/PoolUsagePage.tsx
@@ -89,7 +89,8 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
   const {
     cycleBreakdown: poolCycleBreakdown,
     excessCycleBreakdown,
-    hasMoreCycleHistory,
+    hasMoreCycleBreakdown,
+    hasMoreExcessCycleBreakdown,
     isAwuPoolCycleHistoryLoading,
     isAwuPoolCycleHistoryError,
     isAwuPoolCycleHistoryValidating,
@@ -109,7 +110,8 @@ function PoolCreditCard({ owner }: PoolCreditCardProps) {
         !!isAwuPoolCycleHistoryError
       )}
       cycleHistoryLoadMore={{
-        hasMore: hasMoreCycleHistory,
+        hasMoreCycleBreakdown,
+        hasMoreExcessCycleBreakdown,
         isLoading:
           isAwuPoolCycleHistoryValidating && !isAwuPoolCycleHistoryLoading,
         onLoadMore: onLoadMoreCycleHistory,

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -9,6 +9,7 @@ import {
 import type {
   AwuPoolCurrentCycleResponseBody,
   AwuPoolCycleBreakdown,
+  AwuPoolCycleHistoryOverflow,
 } from "@app/types/api/credits/awu_pool_summary";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { ONE_DAY_MS } from "@app/types/shared/utils/date_utils";
@@ -365,8 +366,7 @@ export type CycleHistoryLoadMoreByBreakdown = Omit<
   CycleHistoryLoadMore,
   "hasMore"
 > & {
-  hasMoreCycleBreakdown: boolean;
-  hasMoreExcessCycleBreakdown: boolean;
+  hasMoreCycleHistory: AwuPoolCycleHistoryOverflow;
 };
 
 interface CreditPoolCardsFromCycleDataProps {
@@ -409,11 +409,8 @@ export function CreditPoolCardsFromCycleData({
   const hasExcessData =
     excessConsumedCredits !== null || excessCycleBreakdown.length > 0;
 
-  const {
-    hasMoreCycleBreakdown,
-    hasMoreExcessCycleBreakdown,
-    ...restCycleHistoryLoadMore
-  } = cycleHistoryLoadMore;
+  const { hasMoreCycleHistory, ...restCycleHistoryLoadMore } =
+    cycleHistoryLoadMore;
 
   return (
     <WorkspaceCreditPoolSection
@@ -432,7 +429,9 @@ export function CreditPoolCardsFromCycleData({
       programmaticConsumedCredits={programmaticConsumedCredits}
       cycleHistoryLoadMore={{
         ...restCycleHistoryLoadMore,
-        hasMore: hasPool ? hasMoreCycleBreakdown : hasMoreExcessCycleBreakdown,
+        hasMore: hasPool
+          ? hasMoreCycleHistory.cycleBreakdown
+          : hasMoreCycleHistory.excessCycleBreakdown,
       }}
     />
   );
@@ -454,8 +453,7 @@ export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
   const {
     cycleBreakdown: poolCycleBreakdown,
     excessCycleBreakdown,
-    hasMoreCycleBreakdown,
-    hasMoreExcessCycleBreakdown,
+    hasMoreCycleHistory,
     isAwuPoolCycleHistoryLoading,
     isAwuPoolCycleHistoryError,
     isAwuPoolCycleHistoryValidating,
@@ -482,8 +480,7 @@ export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
         !!isAwuPoolCycleHistoryError
       )}
       cycleHistoryLoadMore={{
-        hasMoreCycleBreakdown,
-        hasMoreExcessCycleBreakdown,
+        hasMoreCycleHistory,
         isLoading:
           isAwuPoolCycleHistoryValidating && !isAwuPoolCycleHistoryLoading,
         onLoadMore: onLoadMoreCycleHistory,

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -140,6 +140,8 @@ export interface CycleHistoryLoadMore {
   hasMore: boolean;
   isLoading: boolean;
   onLoadMore: () => void;
+  // Absent while only the initial rows are shown.
+  onShowLess?: () => void;
 }
 
 interface WorkspaceCreditPoolCycleHistoryTableProps {
@@ -205,6 +207,7 @@ export function WorkspaceCreditPoolCycleHistoryTable({
           cycleHistoryLoadMore.hasMore ? undefined : cycleBreakdown.length
         }
         onLoadMore={cycleHistoryLoadMore.onLoadMore}
+        onShowLess={cycleHistoryLoadMore.onShowLess}
         isLoadingMore={cycleHistoryLoadMore.isLoading}
       />
     </>
@@ -327,7 +330,8 @@ export function WorkspaceCreditPoolSection({
 // Reveals cycle history a page at a time, re-fetching a growing
 // `cycleHistoryLimit` from the backend rather than paginating client-side,
 // since the backend itself caps how many cycles it will ever return
-// (`MAX_CYCLE_HISTORY_LIMIT`).
+// (`MAX_CYCLE_HISTORY_LIMIT`). The limit counts cycles with consumption, so
+// each step reveals a full page of rows whenever that many exist.
 export function useCycleHistoryLimit() {
   const [cycleHistoryLimit, setCycleHistoryLimit] = useState(
     INITIAL_CYCLE_HISTORY_ROW_COUNT
@@ -339,7 +343,19 @@ export function useCycleHistoryLimit() {
     );
   }, []);
 
-  return { cycleHistoryLimit, onLoadMoreCycleHistory };
+  const onShowLessCycleHistory = useCallback(() => {
+    setCycleHistoryLimit(INITIAL_CYCLE_HISTORY_ROW_COUNT);
+  }, []);
+
+  return {
+    cycleHistoryLimit,
+    onLoadMoreCycleHistory,
+    // Collapsing back is only offered once extra rows have been revealed.
+    onShowLessCycleHistory:
+      cycleHistoryLimit > INITIAL_CYCLE_HISTORY_ROW_COUNT
+        ? onShowLessCycleHistory
+        : undefined,
+  };
 }
 
 interface CreditPoolCardsFromCycleDataProps {
@@ -407,7 +423,8 @@ interface CreditPoolCardsProps {
   disabled: boolean;
 }
 export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
-  const { cycleHistoryLimit, onLoadMoreCycleHistory } = useCycleHistoryLimit();
+  const { cycleHistoryLimit, onLoadMoreCycleHistory, onShowLessCycleHistory } =
+    useCycleHistoryLimit();
   const {
     awuPoolCurrentCycle,
     isAwuPoolCurrentCycleLoading,
@@ -448,6 +465,7 @@ export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
         isLoading:
           isAwuPoolCycleHistoryValidating && !isAwuPoolCycleHistoryLoading,
         onLoadMore: onLoadMoreCycleHistory,
+        onShowLess: onShowLessCycleHistory,
       }}
     />
   );

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -453,7 +453,7 @@ export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
   const {
     cycleBreakdown: poolCycleBreakdown,
     excessCycleBreakdown,
-    hasMoreCycleHistory,
+    hasMoreCycleHistoryByBreakdown: hasMoreCycleHistory,
     isAwuPoolCycleHistoryLoading,
     isAwuPoolCycleHistoryError,
     isAwuPoolCycleHistoryValidating,

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -358,6 +358,17 @@ export function useCycleHistoryLimit() {
   };
 }
 
+// The backend tracks "more history" separately per breakdown since only one of the two is ever
+// rendered for a given workspace (see `hasPool` below); resolving `hasMore` happens here, once
+// that choice is made, rather than upstream where it isn't known yet.
+export type CycleHistoryLoadMoreByBreakdown = Omit<
+  CycleHistoryLoadMore,
+  "hasMore"
+> & {
+  hasMoreCycleBreakdown: boolean;
+  hasMoreExcessCycleBreakdown: boolean;
+};
+
 interface CreditPoolCardsFromCycleDataProps {
   awuPoolCurrentCycle: AwuPoolCurrentCycleResponseBody | null;
   cardsStatus: CreditPoolFetchStatus;
@@ -365,7 +376,7 @@ interface CreditPoolCardsFromCycleDataProps {
   poolCycleBreakdown: AwuPoolCycleBreakdown[];
   excessCycleBreakdown: AwuPoolCycleBreakdown[];
   tableStatus: CreditPoolFetchStatus;
-  cycleHistoryLoadMore: CycleHistoryLoadMore;
+  cycleHistoryLoadMore: CycleHistoryLoadMoreByBreakdown;
 }
 export function CreditPoolCardsFromCycleData({
   awuPoolCurrentCycle,
@@ -398,6 +409,12 @@ export function CreditPoolCardsFromCycleData({
   const hasExcessData =
     excessConsumedCredits !== null || excessCycleBreakdown.length > 0;
 
+  const {
+    hasMoreCycleBreakdown,
+    hasMoreExcessCycleBreakdown,
+    ...restCycleHistoryLoadMore
+  } = cycleHistoryLoadMore;
+
   return (
     <WorkspaceCreditPoolSection
       cardsStatus={cardsStatus}
@@ -413,7 +430,10 @@ export function CreditPoolCardsFromCycleData({
       currentCycleEndMs={currentCycleEndMs}
       cycleBreakdown={hasPool ? poolCycleBreakdown : excessCycleBreakdown}
       programmaticConsumedCredits={programmaticConsumedCredits}
-      cycleHistoryLoadMore={cycleHistoryLoadMore}
+      cycleHistoryLoadMore={{
+        ...restCycleHistoryLoadMore,
+        hasMore: hasPool ? hasMoreCycleBreakdown : hasMoreExcessCycleBreakdown,
+      }}
     />
   );
 }
@@ -434,7 +454,8 @@ export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
   const {
     cycleBreakdown: poolCycleBreakdown,
     excessCycleBreakdown,
-    hasMoreCycleHistory,
+    hasMoreCycleBreakdown,
+    hasMoreExcessCycleBreakdown,
     isAwuPoolCycleHistoryLoading,
     isAwuPoolCycleHistoryError,
     isAwuPoolCycleHistoryValidating,
@@ -461,7 +482,8 @@ export function CreditPoolCards({ owner, disabled }: CreditPoolCardsProps) {
         !!isAwuPoolCycleHistoryError
       )}
       cycleHistoryLoadMore={{
-        hasMore: hasMoreCycleHistory,
+        hasMoreCycleBreakdown,
+        hasMoreExcessCycleBreakdown,
         isLoading:
           isAwuPoolCycleHistoryValidating && !isAwuPoolCycleHistoryLoading,
         onLoadMore: onLoadMoreCycleHistory,

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -439,11 +439,11 @@ export async function getAwuPoolCycleHistory(
  */
 /**
  * @cc [owner:avervaet,label:product] has-more-is-per-breakdown
- * `hasMoreCycleBreakdown` and `hasMoreExcessCycleBreakdown` MUST each be `true` only when
- * `cycleHistoryLimit` is below `MAX_CYCLE_HISTORY_LIMIT` and at least one more cycle with
- * consumption was found beyond the returned ones in that specific breakdown. Neither MUST be
- * `true` merely because older invoices exist, or because the *other* breakdown has more —
- * callers only ever render one of the two breakdowns for a given workspace.
+ * Each field of `hasMoreCycleHistory` MUST be `true` only when `cycleHistoryLimit` is below
+ * `MAX_CYCLE_HISTORY_LIMIT` and at least one more cycle with consumption was found beyond the
+ * returned ones in that specific breakdown. Neither field MUST be `true` merely because older
+ * invoices exist, or because the *other* breakdown has more — callers only ever render one of
+ * the two breakdowns for a given workspace.
  */
 async function getAwuPoolCycleHistoryUncached(
   auth: Authenticator,
@@ -482,8 +482,10 @@ async function getAwuPoolCycleHistoryUncached(
     return new Ok({
       cycleBreakdown: [],
       excessCycleBreakdown: [],
-      hasMoreCycleBreakdown: false,
-      hasMoreExcessCycleBreakdown: false,
+      hasMoreCycleHistory: {
+        cycleBreakdown: false,
+        excessCycleBreakdown: false,
+      },
     });
   }
 
@@ -502,10 +504,12 @@ async function getAwuPoolCycleHistoryUncached(
   return new Ok({
     cycleBreakdown: consumedCycles.slice(0, cycleHistoryLimit),
     excessCycleBreakdown: excessCycles.slice(0, cycleHistoryLimit),
-    hasMoreCycleBreakdown:
-      belowMaxLimit && consumedCycles.length > cycleHistoryLimit,
-    hasMoreExcessCycleBreakdown:
-      belowMaxLimit && excessCycles.length > cycleHistoryLimit,
+    hasMoreCycleHistory: {
+      cycleBreakdown:
+        belowMaxLimit && consumedCycles.length > cycleHistoryLimit,
+      excessCycleBreakdown:
+        belowMaxLimit && excessCycles.length > cycleHistoryLimit,
+    },
   });
 }
 

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -429,22 +429,6 @@ export async function getAwuPoolCycleHistory(
   return new Ok(outcome.body);
 }
 
-/**
- * @cc [owner:avervaet,label:product] cycle-history-limit-counts-consumed-cycles
- * `cycleHistoryLimit` bounds the number of returned cycles that have consumption, not the
- * number of invoices inspected: an invoice without consumption MUST NOT count toward the limit
- * nor appear in either breakdown. Inspection MUST stop after
- * `CYCLE_HISTORY_INVOICE_SCAN_LIMIT` invoices, so a returned breakdown may hold fewer than
- * `cycleHistoryLimit` cycles even when older invoices exist.
- */
-/**
- * @cc [owner:avervaet,label:product] has-more-is-per-breakdown
- * Each field of `hasMoreCycleHistory` MUST be `true` only when `cycleHistoryLimit` is below
- * `MAX_CYCLE_HISTORY_LIMIT` and at least one more cycle with consumption was found beyond the
- * returned ones in that specific breakdown. Neither field MUST be `true` merely because older
- * invoices exist, or because the *other* breakdown has more — callers only ever render one of
- * the two breakdowns for a given workspace.
- */
 async function getAwuPoolCycleHistoryUncached(
   auth: Authenticator,
   { cycleHistoryLimit }: { cycleHistoryLimit: number }

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -30,6 +30,7 @@ import logger from "@app/logger/logger";
 import type {
   AwuPoolCurrentCycleResponseBody,
   AwuPoolCycleBreakdown,
+  AwuPoolCycleHistoryOverflow,
   AwuPoolCycleHistoryResponseBody,
   AwuPoolSummaryResponseBody,
 } from "@app/types/api/credits/awu_pool_summary";
@@ -367,7 +368,7 @@ function cacheResolverKeyWithHistoryLimit(
   return `${workspaceId}-${cycleHistoryLimit}`;
 }
 
-const AWU_POOL_CYCLE_HISTORY_CACHE_ID = "awuPoolCycleHistoryV2";
+const AWU_POOL_CYCLE_HISTORY_CACHE_ID = "awuPoolCycleHistoryV3";
 const AWU_POOL_CYCLE_HISTORY_CACHE_TTL_MS = 60 * 1000;
 
 const getCachedAwuPoolCycleHistoryOutcome = cacheWithRedis(
@@ -466,7 +467,8 @@ async function getAwuPoolCycleHistoryUncached(
     return new Ok({
       cycleBreakdown: [],
       excessCycleBreakdown: [],
-      hasMoreCycleHistory: {
+      hasMoreCycleHistory: false,
+      hasMoreCycleHistoryByBreakdown: {
         cycleBreakdown: false,
         excessCycleBreakdown: false,
       },
@@ -485,15 +487,19 @@ async function getAwuPoolCycleHistoryUncached(
   );
   const belowMaxLimit = cycleHistoryLimit < MAX_CYCLE_HISTORY_LIMIT;
 
+  const hasMoreCycleHistoryByBreakdown: AwuPoolCycleHistoryOverflow = {
+    cycleBreakdown: belowMaxLimit && consumedCycles.length > cycleHistoryLimit,
+    excessCycleBreakdown:
+      belowMaxLimit && excessCycles.length > cycleHistoryLimit,
+  };
+
   return new Ok({
     cycleBreakdown: consumedCycles.slice(0, cycleHistoryLimit),
     excessCycleBreakdown: excessCycles.slice(0, cycleHistoryLimit),
-    hasMoreCycleHistory: {
-      cycleBreakdown:
-        belowMaxLimit && consumedCycles.length > cycleHistoryLimit,
-      excessCycleBreakdown:
-        belowMaxLimit && excessCycles.length > cycleHistoryLimit,
-    },
+    hasMoreCycleHistory:
+      hasMoreCycleHistoryByBreakdown.cycleBreakdown ||
+      hasMoreCycleHistoryByBreakdown.excessCycleBreakdown,
+    hasMoreCycleHistoryByBreakdown,
   });
 }
 

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -44,6 +44,10 @@ import { z } from "zod";
 
 export const DEFAULT_CYCLE_HISTORY_LIMIT = 5;
 
+// Upper bound on finalized invoices inspected per request while looking for
+// cycles with consumption. Sized for a few years of monthly invoices.
+export const CYCLE_HISTORY_INVOICE_SCAN_LIMIT = 48;
+
 /**
  * @cc [owner:arthurvervaet,label:api] cycle-history-limit-bounds
  * A missing, non-integer, or out-of-range `cycleHistoryLimit` (below 1 or above
@@ -79,16 +83,16 @@ type PoolLedgerData = {
 
 const APPROX_CYCLE_LENGTH_DAYS = 31;
 
-// Balance listing bounded to the history the caller can actually surface
+// Balance listing bounded to the cycles the caller will actually inspect
 async function getPoolLedgerData({
   metronomeCustomerId,
-  cycleHistoryLimit,
+  lookbackCycles,
 }: {
   metronomeCustomerId: string;
-  cycleHistoryLimit: number;
+  lookbackCycles: number;
 }): Promise<Result<PoolLedgerData, Error>> {
   const startingAt = new Date(
-    Date.now() - cycleHistoryLimit * APPROX_CYCLE_LENGTH_DAYS * ONE_DAY_MS
+    Date.now() - lookbackCycles * APPROX_CYCLE_LENGTH_DAYS * ONE_DAY_MS
   );
   const balancesResult = await listMetronomeBalances(metronomeCustomerId, {
     coveringDate: null,
@@ -132,14 +136,13 @@ function sumPoolLedgerEntriesForInvoice(
     .reduce((sum, entry) => sum + Math.abs(entry.amountCredits), 0);
 }
 
+// Cycles with no pool consumption are dropped rather than surfaced as zero rows
 function computeCycleBreakdown({
   finalizedInvoices,
   ledgerEntries,
-  cycleHistoryLimit,
 }: {
   finalizedInvoices: Invoice[];
   ledgerEntries: PoolLedgerEntry[];
-  cycleHistoryLimit: number;
 }): AwuPoolCycleBreakdown[] {
   return finalizedInvoices
     .map((invoice) => ({
@@ -154,8 +157,7 @@ function computeCycleBreakdown({
         invoice.id
       ),
     }))
-    .filter((cycle) => cycle.consumedCredits > 0)
-    .slice(0, cycleHistoryLimit);
+    .filter((cycle) => cycle.consumedCredits > 0);
 }
 
 type MetronomeContext = {
@@ -230,8 +232,7 @@ function extractOverageFromInvoice(invoice: Invoice): {
 
 // Fallback cycle history for workspaces with no credit pool
 function computeExcessCycleBreakdown(
-  finalizedInvoices: Invoice[],
-  cycleHistoryLimit: number
+  finalizedInvoices: Invoice[]
 ): AwuPoolCycleBreakdown[] {
   return finalizedInvoices
     .map((invoice) => ({
@@ -243,8 +244,7 @@ function computeExcessCycleBreakdown(
         : null,
       consumedCredits: extractOverageFromInvoice(invoice).overageCredits ?? 0,
     }))
-    .filter((cycle) => cycle.consumedCredits > 0)
-    .slice(0, cycleHistoryLimit);
+    .filter((cycle) => cycle.consumedCredits > 0);
 }
 
 // Programmatic AWU spend against the pool, read straight from the current
@@ -429,6 +429,20 @@ export async function getAwuPoolCycleHistory(
   return new Ok(outcome.body);
 }
 
+/**
+ * @cc [owner:avervaet,label:product] cycle-history-limit-counts-consumed-cycles
+ * `cycleHistoryLimit` bounds the number of returned cycles that have consumption, not the
+ * number of invoices inspected: an invoice without consumption MUST NOT count toward the limit
+ * nor appear in either breakdown. Inspection MUST stop after
+ * `CYCLE_HISTORY_INVOICE_SCAN_LIMIT` invoices, so a returned breakdown may hold fewer than
+ * `cycleHistoryLimit` cycles even when older invoices exist.
+ */
+/**
+ * @cc [owner:avervaet,label:product] has-more-means-another-consumed-cycle
+ * `hasMoreCycleHistory` MUST be `true` only when `cycleHistoryLimit` is below
+ * `MAX_CYCLE_HISTORY_LIMIT` and at least one more cycle with consumption, in either breakdown,
+ * was found beyond the returned ones. It MUST NOT be `true` merely because older invoices exist.
+ */
 async function getAwuPoolCycleHistoryUncached(
   auth: Authenticator,
   { cycleHistoryLimit }: { cycleHistoryLimit: number }
@@ -440,9 +454,12 @@ async function getAwuPoolCycleHistoryUncached(
   const { metronomeCustomerId, metronomeContractId } = contextResult.value;
 
   const [poolLedgerDataResult, finalizedInvoicesResult] = await Promise.all([
-    getPoolLedgerData({ metronomeCustomerId, cycleHistoryLimit }),
+    getPoolLedgerData({
+      metronomeCustomerId,
+      lookbackCycles: CYCLE_HISTORY_INVOICE_SCAN_LIMIT,
+    }),
     listMetronomeFinalizedInvoices(metronomeCustomerId, {
-      limit: cycleHistoryLimit + 1,
+      limit: CYCLE_HISTORY_INVOICE_SCAN_LIMIT,
     }),
   ]);
 
@@ -467,28 +484,26 @@ async function getAwuPoolCycleHistoryUncached(
     });
   }
 
-  // One invoice past the limit is fetched only to learn whether older cycles
-  // exist; it is never surfaced. Row counts cannot answer this because cycles
-  // without consumption are filtered out of the breakdowns.
-  const finalizedInvoices = finalizedInvoicesResult.value.slice(
-    0,
-    cycleHistoryLimit
+  // Every scanned invoice is reduced before slicing so that "load more" always
+  // reveals cycles with consumption, and the footer only offers it when at
+  // least one such cycle is left.
+  const consumedCycles = computeCycleBreakdown({
+    finalizedInvoices: finalizedInvoicesResult.value,
+    ledgerEntries: poolLedgerDataResult.value.ledgerEntries,
+  });
+  const excessCycles = computeExcessCycleBreakdown(
+    finalizedInvoicesResult.value
   );
   const hasMoreCycleHistory =
-    finalizedInvoicesResult.value.length > cycleHistoryLimit &&
-    cycleHistoryLimit < MAX_CYCLE_HISTORY_LIMIT;
+    cycleHistoryLimit < MAX_CYCLE_HISTORY_LIMIT &&
+    (consumedCycles.length > cycleHistoryLimit ||
+      excessCycles.length > cycleHistoryLimit);
 
-  const cycleBreakdown = computeCycleBreakdown({
-    finalizedInvoices,
-    ledgerEntries: poolLedgerDataResult.value.ledgerEntries,
-    cycleHistoryLimit,
+  return new Ok({
+    cycleBreakdown: consumedCycles.slice(0, cycleHistoryLimit),
+    excessCycleBreakdown: excessCycles.slice(0, cycleHistoryLimit),
+    hasMoreCycleHistory,
   });
-  const excessCycleBreakdown = computeExcessCycleBreakdown(
-    finalizedInvoices,
-    cycleHistoryLimit
-  );
-
-  return new Ok({ cycleBreakdown, excessCycleBreakdown, hasMoreCycleHistory });
 }
 
 export async function getAwuPoolSummary(
@@ -530,7 +545,7 @@ async function getAwuPoolCurrentCycleUncached(
     await Promise.all([
       listMetronomeBalances(metronomeCustomerId),
       listMetronomeDraftInvoices(metronomeCustomerId),
-      getPoolLedgerData({ metronomeCustomerId, cycleHistoryLimit: 1 }),
+      getPoolLedgerData({ metronomeCustomerId, lookbackCycles: 1 }),
     ]);
 
   if (balancesResult.isErr()) {

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -438,10 +438,12 @@ export async function getAwuPoolCycleHistory(
  * `cycleHistoryLimit` cycles even when older invoices exist.
  */
 /**
- * @cc [owner:avervaet,label:product] has-more-means-another-consumed-cycle
- * `hasMoreCycleHistory` MUST be `true` only when `cycleHistoryLimit` is below
- * `MAX_CYCLE_HISTORY_LIMIT` and at least one more cycle with consumption, in either breakdown,
- * was found beyond the returned ones. It MUST NOT be `true` merely because older invoices exist.
+ * @cc [owner:avervaet,label:product] has-more-is-per-breakdown
+ * `hasMoreCycleBreakdown` and `hasMoreExcessCycleBreakdown` MUST each be `true` only when
+ * `cycleHistoryLimit` is below `MAX_CYCLE_HISTORY_LIMIT` and at least one more cycle with
+ * consumption was found beyond the returned ones in that specific breakdown. Neither MUST be
+ * `true` merely because older invoices exist, or because the *other* breakdown has more —
+ * callers only ever render one of the two breakdowns for a given workspace.
  */
 async function getAwuPoolCycleHistoryUncached(
   auth: Authenticator,
@@ -480,7 +482,8 @@ async function getAwuPoolCycleHistoryUncached(
     return new Ok({
       cycleBreakdown: [],
       excessCycleBreakdown: [],
-      hasMoreCycleHistory: false,
+      hasMoreCycleBreakdown: false,
+      hasMoreExcessCycleBreakdown: false,
     });
   }
 
@@ -494,15 +497,15 @@ async function getAwuPoolCycleHistoryUncached(
   const excessCycles = computeExcessCycleBreakdown(
     finalizedInvoicesResult.value
   );
-  const hasMoreCycleHistory =
-    cycleHistoryLimit < MAX_CYCLE_HISTORY_LIMIT &&
-    (consumedCycles.length > cycleHistoryLimit ||
-      excessCycles.length > cycleHistoryLimit);
+  const belowMaxLimit = cycleHistoryLimit < MAX_CYCLE_HISTORY_LIMIT;
 
   return new Ok({
     cycleBreakdown: consumedCycles.slice(0, cycleHistoryLimit),
     excessCycleBreakdown: excessCycles.slice(0, cycleHistoryLimit),
-    hasMoreCycleHistory,
+    hasMoreCycleBreakdown:
+      belowMaxLimit && consumedCycles.length > cycleHistoryLimit,
+    hasMoreExcessCycleBreakdown:
+      belowMaxLimit && excessCycles.length > cycleHistoryLimit,
   });
 }
 

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -328,8 +328,8 @@ export function useAwuPoolCycleHistory({
     excessCycleBreakdown: isUsable
       ? (data?.excessCycleBreakdown ?? emptyArray<AwuPoolCycleBreakdown>())
       : emptyArray<AwuPoolCycleBreakdown>(),
-    hasMoreCycleHistory: isUsable
-      ? (data?.hasMoreCycleHistory ?? EMPTY_HAS_MORE_CYCLE_HISTORY)
+    hasMoreCycleHistoryByBreakdown: isUsable
+      ? (data?.hasMoreCycleHistoryByBreakdown ?? EMPTY_HAS_MORE_CYCLE_HISTORY)
       : EMPTY_HAS_MORE_CYCLE_HISTORY,
     isAwuPoolCycleHistoryLoading: !error && !data && !disabled,
     isAwuPoolCycleHistoryError: error,

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -323,8 +323,11 @@ export function useAwuPoolCycleHistory({
     excessCycleBreakdown: isUsable
       ? (data?.excessCycleBreakdown ?? emptyArray<AwuPoolCycleBreakdown>())
       : emptyArray<AwuPoolCycleBreakdown>(),
-    hasMoreCycleHistory: isUsable
-      ? (data?.hasMoreCycleHistory ?? false)
+    hasMoreCycleBreakdown: isUsable
+      ? (data?.hasMoreCycleBreakdown ?? false)
+      : false,
+    hasMoreExcessCycleBreakdown: isUsable
+      ? (data?.hasMoreExcessCycleBreakdown ?? false)
       : false,
     isAwuPoolCycleHistoryLoading: !error && !data && !disabled,
     isAwuPoolCycleHistoryError: error,

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -8,6 +8,7 @@ import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
   AwuPoolCurrentCycleResponseBody,
   AwuPoolCycleBreakdown,
+  AwuPoolCycleHistoryOverflow,
   AwuPoolCycleHistoryResponseBody,
   AwuPoolSummaryResponseBody,
 } from "@app/types/api/credits/awu_pool_summary";
@@ -23,6 +24,10 @@ import type { Fetcher } from "swr";
 
 // Global state for tracking purchase loading status per workspace
 const purchaseLoadingState = new Map<string, boolean>();
+
+const EMPTY_HAS_MORE_CYCLE_HISTORY: AwuPoolCycleHistoryOverflow = Object.freeze(
+  { cycleBreakdown: false, excessCycleBreakdown: false }
+);
 const purchaseLoadingListeners = new Set<() => void>();
 
 function setPurchaseLoading(workspaceId: string, loading: boolean) {
@@ -323,12 +328,9 @@ export function useAwuPoolCycleHistory({
     excessCycleBreakdown: isUsable
       ? (data?.excessCycleBreakdown ?? emptyArray<AwuPoolCycleBreakdown>())
       : emptyArray<AwuPoolCycleBreakdown>(),
-    hasMoreCycleBreakdown: isUsable
-      ? (data?.hasMoreCycleBreakdown ?? false)
-      : false,
-    hasMoreExcessCycleBreakdown: isUsable
-      ? (data?.hasMoreExcessCycleBreakdown ?? false)
-      : false,
+    hasMoreCycleHistory: isUsable
+      ? (data?.hasMoreCycleHistory ?? EMPTY_HAS_MORE_CYCLE_HISTORY)
+      : EMPTY_HAS_MORE_CYCLE_HISTORY,
     isAwuPoolCycleHistoryLoading: !error && !data && !disabled,
     isAwuPoolCycleHistoryError: error,
     isAwuPoolCycleHistoryValidating: isValidating,

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -222,8 +222,11 @@ export function usePokeAwuPoolCycleHistory({
     excessCycleBreakdown: isUsable
       ? (data?.excessCycleBreakdown ?? emptyArray<AwuPoolCycleBreakdown>())
       : emptyArray<AwuPoolCycleBreakdown>(),
-    hasMoreCycleHistory: isUsable
-      ? (data?.hasMoreCycleHistory ?? false)
+    hasMoreCycleBreakdown: isUsable
+      ? (data?.hasMoreCycleBreakdown ?? false)
+      : false,
+    hasMoreExcessCycleBreakdown: isUsable
+      ? (data?.hasMoreExcessCycleBreakdown ?? false)
       : false,
     isAwuPoolCycleHistoryLoading: !error && !data && !disabled,
     isAwuPoolCycleHistoryError: error,

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -227,8 +227,8 @@ export function usePokeAwuPoolCycleHistory({
     excessCycleBreakdown: isUsable
       ? (data?.excessCycleBreakdown ?? emptyArray<AwuPoolCycleBreakdown>())
       : emptyArray<AwuPoolCycleBreakdown>(),
-    hasMoreCycleHistory: isUsable
-      ? (data?.hasMoreCycleHistory ?? EMPTY_HAS_MORE_CYCLE_HISTORY)
+    hasMoreCycleHistoryByBreakdown: isUsable
+      ? (data?.hasMoreCycleHistoryByBreakdown ?? EMPTY_HAS_MORE_CYCLE_HISTORY)
       : EMPTY_HAS_MORE_CYCLE_HISTORY,
     isAwuPoolCycleHistoryLoading: !error && !data && !disabled,
     isAwuPoolCycleHistoryError: error,

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -14,6 +14,7 @@ import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type {
   AwuPoolCurrentCycleResponseBody,
   AwuPoolCycleBreakdown,
+  AwuPoolCycleHistoryOverflow,
   AwuPoolCycleHistoryResponseBody,
   AwuPoolSummaryResponseBody,
 } from "@app/types/api/credits/awu_pool_summary";
@@ -29,6 +30,10 @@ export type PokeCreditsData = {
   rows: PokeListCreditsResponseBody["rows"];
   excessCreditsLast30DaysMicroUsd: number;
 };
+
+const EMPTY_HAS_MORE_CYCLE_HISTORY: AwuPoolCycleHistoryOverflow = Object.freeze(
+  { cycleBreakdown: false, excessCycleBreakdown: false }
+);
 
 export function usePokeCredits({ disabled, owner }: PokeConditionalFetchProps) {
   const { fetcher } = useFetcher();
@@ -222,12 +227,9 @@ export function usePokeAwuPoolCycleHistory({
     excessCycleBreakdown: isUsable
       ? (data?.excessCycleBreakdown ?? emptyArray<AwuPoolCycleBreakdown>())
       : emptyArray<AwuPoolCycleBreakdown>(),
-    hasMoreCycleBreakdown: isUsable
-      ? (data?.hasMoreCycleBreakdown ?? false)
-      : false,
-    hasMoreExcessCycleBreakdown: isUsable
-      ? (data?.hasMoreExcessCycleBreakdown ?? false)
-      : false,
+    hasMoreCycleHistory: isUsable
+      ? (data?.hasMoreCycleHistory ?? EMPTY_HAS_MORE_CYCLE_HISTORY)
+      : EMPTY_HAS_MORE_CYCLE_HISTORY,
     isAwuPoolCycleHistoryLoading: !error && !data && !disabled,
     isAwuPoolCycleHistoryError: error,
     isAwuPoolCycleHistoryValidating: isValidating,

--- a/front/types/api/credits/awu_pool_summary.ts
+++ b/front/types/api/credits/awu_pool_summary.ts
@@ -33,8 +33,11 @@ export type AwuPoolCycleHistoryResponseBody = {
   // Per-cycle pool consumption, most recent first
   cycleBreakdown: AwuPoolCycleBreakdown[];
   excessCycleBreakdown: AwuPoolCycleBreakdown[];
-  // Whether older cycles exist beyond the requested limit
-  hasMoreCycleHistory: boolean;
+  // Whether older cycles with consumption exist beyond the returned ones, per breakdown — only
+  // one of the two breakdowns is ever rendered for a given workspace, so callers must check the
+  // flag matching the breakdown they display rather than OR-ing the two together.
+  hasMoreCycleBreakdown: boolean;
+  hasMoreExcessCycleBreakdown: boolean;
 };
 
 export type AwuPoolSummaryResponseBody = AwuPoolCurrentCycleResponseBody &

--- a/front/types/api/credits/awu_pool_summary.ts
+++ b/front/types/api/credits/awu_pool_summary.ts
@@ -29,15 +29,19 @@ export type AwuPoolCurrentCycleResponseBody = {
   programmaticConsumedCredits: number | null;
 };
 
+// Whether older cycles with consumption exist beyond the returned ones, per breakdown — only
+// one of the two breakdowns is ever rendered for a given workspace, so callers must check the
+// flag matching the breakdown they display rather than OR-ing the two together.
+export type AwuPoolCycleHistoryOverflow = {
+  cycleBreakdown: boolean;
+  excessCycleBreakdown: boolean;
+};
+
 export type AwuPoolCycleHistoryResponseBody = {
   // Per-cycle pool consumption, most recent first
   cycleBreakdown: AwuPoolCycleBreakdown[];
   excessCycleBreakdown: AwuPoolCycleBreakdown[];
-  // Whether older cycles with consumption exist beyond the returned ones, per breakdown — only
-  // one of the two breakdowns is ever rendered for a given workspace, so callers must check the
-  // flag matching the breakdown they display rather than OR-ing the two together.
-  hasMoreCycleBreakdown: boolean;
-  hasMoreExcessCycleBreakdown: boolean;
+  hasMoreCycleHistory: AwuPoolCycleHistoryOverflow;
 };
 
 export type AwuPoolSummaryResponseBody = AwuPoolCurrentCycleResponseBody &

--- a/front/types/api/credits/awu_pool_summary.ts
+++ b/front/types/api/credits/awu_pool_summary.ts
@@ -37,11 +37,22 @@ export type AwuPoolCycleHistoryOverflow = {
   excessCycleBreakdown: boolean;
 };
 
+/**
+ * @cc [owner:avervaet,label:api] hasMoreCycleHistory-stays-boolean
+ * `hasMoreCycleHistory` MUST remain a plain `boolean` (true if either breakdown has more), never
+ * an object, so that a client bundle predating `hasMoreCycleHistoryByBreakdown` keeps reading a
+ * boolean rather than a truthy object that would leave its "Load more" control always enabled.
+ * Per-breakdown detail belongs in `hasMoreCycleHistoryByBreakdown` instead. Remove this contract
+ * and `hasMoreCycleHistory` together once old clients are confirmed cycled out.
+ */
 export type AwuPoolCycleHistoryResponseBody = {
   // Per-cycle pool consumption, most recent first
   cycleBreakdown: AwuPoolCycleBreakdown[];
   excessCycleBreakdown: AwuPoolCycleBreakdown[];
-  hasMoreCycleHistory: AwuPoolCycleHistoryOverflow;
+  // Deprecated: true if either breakdown has more. Kept for backward compatibility with clients
+  // predating `hasMoreCycleHistoryByBreakdown`.
+  hasMoreCycleHistory: boolean;
+  hasMoreCycleHistoryByBreakdown: AwuPoolCycleHistoryOverflow;
 };
 
 export type AwuPoolSummaryResponseBody = AwuPoolCurrentCycleResponseBody &

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -116,6 +116,8 @@ interface DataTableProps<TData extends TBaseData> {
   onLoadMore?: () => void;
   /** Swaps the "Load more" label for an animated "Loading" and disables it. */
   isLoadingMore?: boolean;
+  /** Adds a "Show less" control next to "Load more"; pass it only once extra rows are revealed. */
+  onShowLess?: () => void;
   /** Minimum breakpoint per column id below which the column is hidden. */
   columnsBreakpoints?: ColumnBreakpoint;
   /** Controlled sorting state. */
@@ -256,6 +258,7 @@ export function DataTable<TData extends TBaseData>({
   setPagination,
   onLoadMore,
   isLoadingMore = false,
+  onShowLess,
   sorting,
   setSorting,
   isServerSideSorting = false,
@@ -482,6 +485,7 @@ export function DataTable<TData extends TBaseData>({
         <div className="p-1">
           <LoadMore
             onLoadMore={onLoadMore}
+            onShowLess={onShowLess}
             isLoading={isLoadingMore}
             rowCount={data.length}
             totalRowCount={totalRowCount}

--- a/sparkle/src/components/LoadMore.tsx
+++ b/sparkle/src/components/LoadMore.tsx
@@ -3,6 +3,12 @@ import React from "react";
 
 const LOADING_DOT_DELAYS = ["0ms", "250ms", "500ms"];
 
+const CONTROL_CLASS_NAME = cn(
+  "text-xs font-medium",
+  "transition-colors duration-200",
+  "text-primary-400 hover:text-foreground disabled:hover:text-primary-400"
+);
+
 interface LoadMoreProps {
   showDetails?: boolean;
   /** Number of rows currently loaded. */
@@ -12,8 +18,11 @@ interface LoadMoreProps {
   totalRowCountIsCapped?: boolean;
   isLoading?: boolean;
   onLoadMore: () => void;
+  /** Renders a "Show less" control; pass it only once extra rows are revealed. */
+  onShowLess?: () => void;
   label?: string;
   loadingLabel?: string;
+  showLessLabel?: string;
 }
 
 export function LoadMore({
@@ -23,51 +32,55 @@ export function LoadMore({
   totalRowCountIsCapped = false,
   isLoading = false,
   onLoadMore,
+  onShowLess,
   label = "Load more",
   loadingLabel = "Loading",
+  showLessLabel = "Show less",
 }: LoadMoreProps) {
   // When the total is known and everything is loaded, there is nothing left to
   // fetch: keep the details, hide the control (same behavior as Pagination).
-  const controlIsHidden =
+  const loadMoreIsHidden =
     totalRowCount !== undefined &&
     !totalRowCountIsCapped &&
     rowCount >= totalRowCount;
 
   return (
-    <div
-      className={cn(
-        "flex w-full items-center",
-        controlIsHidden ? "justify-end" : "justify-between"
-      )}
-    >
-      <button
-        type="button"
-        className={cn(
-          "text-xs font-medium",
-          "transition-colors duration-200",
-          "text-primary-400 hover:text-foreground disabled:hover:text-primary-400",
-          controlIsHidden ? "invisible" : "visible"
+    <div className="flex w-full items-center justify-between">
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          className={cn(CONTROL_CLASS_NAME, loadMoreIsHidden && "hidden")}
+          onClick={onLoadMore}
+          disabled={isLoading || loadMoreIsHidden}
+        >
+          {isLoading ? (
+            <span>
+              {loadingLabel}
+              {LOADING_DOT_DELAYS.map((delay) => (
+                <span
+                  key={delay}
+                  className="animate-loading-dot opacity-100 motion-reduce:animate-none"
+                  style={{ animationDelay: delay }}
+                >
+                  .
+                </span>
+              ))}
+            </span>
+          ) : (
+            label
+          )}
+        </button>
+        {onShowLess && (
+          <button
+            type="button"
+            className={CONTROL_CLASS_NAME}
+            onClick={onShowLess}
+            disabled={isLoading}
+          >
+            {showLessLabel}
+          </button>
         )}
-        onClick={onLoadMore}
-        disabled={isLoading || controlIsHidden}
-      >
-        {isLoading ? (
-          <span>
-            {loadingLabel}
-            {LOADING_DOT_DELAYS.map((delay) => (
-              <span
-                key={delay}
-                className="animate-loading-dot opacity-100 motion-reduce:animate-none"
-                style={{ animationDelay: delay }}
-              >
-                .
-              </span>
-            ))}
-          </span>
-        ) : (
-          label
-        )}
-      </button>
+      </div>
 
       <span
         className={cn(

--- a/sparkle/src/components/LoadMore.tsx
+++ b/sparkle/src/components/LoadMore.tsx
@@ -1,7 +1,11 @@
 import { cn } from "@sparkle/lib/utils";
 import React from "react";
 
-const LOADING_DOT_DELAYS = ["0ms", "250ms", "500ms"];
+const LOADING_DOT_DELAY_CLASS_NAMES = [
+  "[animation-delay:0ms]",
+  "[animation-delay:250ms]",
+  "[animation-delay:500ms]",
+];
 
 const CONTROL_CLASS_NAME = cn(
   "text-xs font-medium",
@@ -56,11 +60,13 @@ export function LoadMore({
           {isLoading ? (
             <span>
               {loadingLabel}
-              {LOADING_DOT_DELAYS.map((delay) => (
+              {LOADING_DOT_DELAY_CLASS_NAMES.map((delayClassName) => (
                 <span
-                  key={delay}
-                  className="animate-loading-dot opacity-100 motion-reduce:animate-none"
-                  style={{ animationDelay: delay }}
+                  key={delayClassName}
+                  className={cn(
+                    "animate-loading-dot opacity-100 motion-reduce:animate-none",
+                    delayClassName
+                  )}
                 >
                   .
                 </span>

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -614,8 +614,18 @@ export const ServerSidePagination = () => {
   );
 };
 
+const INITIAL_LOAD_MORE_ROW_COUNT = 2;
+
+/**
+ * "Load more" footer as an alternative to pagination: each click appends a
+ * page after a simulated delay. Once extra rows are revealed, `onShowLess`
+ * adds a "Show less" control that collapses back to the initial rows.
+ * @summary Load more footer with show less.
+ */
 export const DataTableLoadMoreExample = () => {
-  const [visibleCount, setVisibleCount] = React.useState(2);
+  const [visibleCount, setVisibleCount] = React.useState(
+    INITIAL_LOAD_MORE_ROW_COUNT
+  );
   const [isLoadingMore, setIsLoadingMore] = React.useState(false);
   const [filter, setFilter] = React.useState<string>("");
 
@@ -628,6 +638,10 @@ export const DataTableLoadMoreExample = () => {
       setVisibleCount((count) => Math.min(count + 2, data.length));
       setIsLoadingMore(false);
     }, 600);
+  };
+
+  const handleShowLess = () => {
+    setVisibleCount(INITIAL_LOAD_MORE_ROW_COUNT);
   };
 
   return (
@@ -645,6 +659,11 @@ export const DataTableLoadMoreExample = () => {
         filter={filter}
         filterColumn="name"
         onLoadMore={handleLoadMore}
+        onShowLess={
+          visibleCount > INITIAL_LOAD_MORE_ROW_COUNT
+            ? handleShowLess
+            : undefined
+        }
         isLoadingMore={isLoadingMore}
         columns={columns}
         columnsBreakpoints={{ lastUpdated: "sm" }}


### PR DESCRIPTION
## Description

On the usage page and the poke pool usage page, the previous cycles table fetched N invoices then dropped the ones without consumption. "Load more" could therefore append fewer than a page of rows, or none at all, and the footer offered "load more" whenever older invoices existed even if none of them would render.

The backend now scans a fixed window of finalized invoices and counts only cycles with consumption toward the requested limit. A workspace only ever renders one of the two breakdowns (pool vs. excess), so `hasMoreCycleHistory` is returned as `{ cycleBreakdown, excessCycleBreakdown }` instead of a single flag — the frontend checks the one it actually displays. Otherwise "load more" could show up when only the *other*, unrendered breakdown had more, reproducing the same bug for that case.

Also add a show less property to the Sparkle loading table component.

## Tests

- tested locally and on front-edge
- added a regression test asserting the pool and excess "more history" flags stay independent of each other

## Risk

Low. Each cycle history request now lists up to 48 invoices instead of `limit + 1` (one or two Metronome pages), cached per workspace and limit for a minute as before. `hasMoreCycleHistory` changes shape from a boolean to `{ cycleBreakdown, excessCycleBreakdown }` — consumed only by this PR's own frontend changes.

## Deploy

front, sparkle
