### PR TITLE
feat(frames): add an open-in-new-tab button next to the full screen button (#32163)

### DIFF
--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -1,4 +1,7 @@
-import { SummaryCard } from "@app/components/workspace/analytics/SummaryCard";
+import {
+  SummaryCard,
+  SummaryCardSkeleton,
+} from "@app/components/workspace/analytics/SummaryCard";
 import { formatConsumptionDate } from "@app/lib/analytics/consumption_period";
 import { formatCredits } from "@app/lib/client/credits";
 import { MAX_CYCLE_HISTORY_LIMIT } from "@app/lib/credits/awu_purchase_constants";
@@ -18,8 +21,9 @@ import {
   ContentMessage,
   cn,
   DataTable,
+  DataTableLoadingSkeleton,
+  LoadingBlock,
   Page,
-  Spinner,
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useCallback, useState } from "react";
@@ -97,10 +101,27 @@ export function WorkspaceCreditUsageValueCards({
     currentCycleStartMs,
     currentCycleEndMs
   );
+  const gridClassName = cn(
+    "grid gap-4",
+    showPoolCard ? "grid-cols-3" : "grid-cols-2"
+  );
+
+  if (isLoading) {
+    return (
+      <div
+        aria-label="Loading credit consumption"
+        className={gridClassName}
+        role="status"
+      >
+        {showPoolCard && <SummaryCardSkeleton />}
+        <SummaryCardSkeleton />
+        <SummaryCardSkeleton />
+      </div>
+    );
+  }
+
   return (
-    <div
-      className={cn("grid gap-4", showPoolCard ? "grid-cols-3" : "grid-cols-2")}
-    >
+    <div className={gridClassName}>
       {showPoolCard && (
         <SummaryCard
           label="Remaining credits in the pool"
@@ -236,8 +257,16 @@ function WorkspaceCreditPoolHistory({
       );
     case "loading":
       return (
-        <div className="flex justify-center py-4">
-          <Spinner />
+        <div
+          aria-label="Loading previous cycles"
+          className="flex flex-col gap-2"
+          role="status"
+        >
+          <LoadingBlock className="h-5 w-32" />
+          <DataTableLoadingSkeleton
+            rows={INITIAL_CYCLE_HISTORY_ROW_COUNT}
+            showSelectionColumn={false}
+          />
         </div>
       );
     case "ready":
@@ -297,9 +326,17 @@ export function WorkspaceCreditPoolSection({
           An error occurred while loading the workspace&apos;s credit pool data.
         </ContentMessage>
       ) : cardsStatus === "loading" ? (
-        <div className="flex justify-center py-8">
-          <Spinner />
-        </div>
+        // Whether the workspace has a pool is unknown until the data lands, so
+        // the placeholder assumes the fuller layout.
+        <WorkspaceCreditUsageValueCards
+          showPoolCard
+          totalRemainingCredits={0}
+          consumedCredits={null}
+          currentCycleStartMs={null}
+          currentCycleEndMs={null}
+          programmaticConsumedCredits={null}
+          isLoading
+        />
       ) : (
         <>
           <WorkspaceCreditUsageValueCards

--- a/front/components/workspace/analytics/SummaryCard.tsx
+++ b/front/components/workspace/analytics/SummaryCard.tsx
@@ -1,10 +1,32 @@
-import { cn } from "@dust-tt/sparkle";
+import { cn, LoadingBlock } from "@dust-tt/sparkle";
 
 interface SummaryCardProps {
   className?: string;
   label: string;
   value: string;
   hint: string | null;
+}
+
+const CARD_FRAME_CLASSES = cn(
+  "flex flex-1 flex-col justify-center h-24 gap-1 rounded-xl",
+  "border border-border bg-panel-background p-4"
+);
+
+// Same frame as the card so the swap to real content doesn't shift layout.
+interface SummaryCardSkeletonProps {
+  className?: string;
+}
+
+export function SummaryCardSkeleton({ className }: SummaryCardSkeletonProps) {
+  return (
+    <div aria-hidden="true" className={cn(CARD_FRAME_CLASSES, className)}>
+      <LoadingBlock className="h-3 w-32" />
+      <div className="flex flex-col gap-1">
+        <LoadingBlock className="h-5 w-20" />
+        <LoadingBlock className="h-3 w-16" />
+      </div>
+    </div>
+  );
 }
 
 export function SummaryCard({
@@ -14,13 +36,7 @@ export function SummaryCard({
   hint,
 }: SummaryCardProps) {
   return (
-    <div
-      className={cn(
-        "flex flex-1 flex-col justify-center h-24 gap-1 rounded-xl",
-        "border border-border bg-panel-background p-4",
-        className
-      )}
-    >
+    <div className={cn(CARD_FRAME_CLASSES, className)}>
       <span className="text-xs font-semibold text-muted-foreground">
         {label}
       </span>


### PR DESCRIPTION
feat(frames): add an open-in-new-tab button next to the full screen button (#32163)

The button opens the frame's share URL, the same one the share sheet hands
out, so the new tab shows the standalone frame rather than the conversation.

Remove the two Pod functions specific features (#32215)

* dsbx db: take a ready sandbox, drop the pod-only paths

`dsbx_db.ts` had two shapes for the same commands: a `*OnReadySandbox` one the Frame reconcile uses, and a pod-ensuring wrapper behind it. Pods no longer own sandboxes, so the wrapper's owner is going away. This moves every remaining wrapper-only helper onto the ready-sandbox shape and deletes the pod-only rest.

getDatabaseSchemaOnSandbox, queryDatabaseOnSandbox and deleteDatabaseOnSandbox become getDatabaseSchemaOnReadySandbox, queryDatabaseOnReadySandbox and deleteDatabaseOnReadySandbox, taking the sandbox their caller already has. That matches reconcileDatabaseOnReadySandbox and listDatabasesOnReadySandbox, and it is what lets one ensure cover several databases (see database_reconciliation.ts) instead of one per call. Their bodies were already owner-neutral: the databases directory is shared, and FRAME_DATABASE_NAME_REGEX and POD_DATABASE_NAME_REGEX are both SANDBOX_DATABASE_NAME_REGEX, so the name guard needed nothing.

The query spill dir does move. It pointed at the pod files mount, and a Frame-owned sandbox carries no agent-visible files mount, so oversized results now spill to a non-mounted scratch root. `resultsFile` is still a sandbox path, read back off the same sandbox like the regenerated schema file above it -- scratch space that does not outlive the sandbox.

deletePodDatabaseReplica becomes deleteFrameDatabaseReplica, keyed on getFrameDatabaseReplicaBasePath. It comes along because the two are incoherent apart: deleting live files without wiping the replica means the next cold start restores the database, so the live delete alone would look like it deletes a database and quietly not.

Deleted: reconcileDatabaseFromPodPath and the private pod-ensuring reconcile behind it, plus the reconcile-side prefix helpers in db_naming that only they used. None had a caller.

Nothing here has a caller yet, including before this change. The gap the delete pair is waiting for is real though: reconcileFramePublicationDatabases only ever adds or alters, so a publication that drops a database from its manifest leaves the live file and its replica behind. Wiring that up means publish starts destroying data, which wants its own decision.

* Poke: drop the pod sandbox surfaces

Three Poke views existed only to inspect or wake a pod-owned sandbox, which is about to stop being a thing.

The pod-databases table on the project page goes with its route, SWR hook and columns. It had no database-backed source: it ran `dsbx db list` against the pod, waking or cold-starting the sandbox to answer, which is exactly the reason it cannot survive the owner kind. That was also the last caller of listDatabasesOnSandbox, so the pod-ensuring list wrapper goes with it -- the ready-sandbox variant the Frame view uses stays.

The Sandbox Status and Sandbox Connect rows go from the space Overview, along with the `sandbox` field on the space-details response that fed them. Only pods ever populated it.

The wake-sandbox plugin goes: there is no pod sandbox left to wake.

Frame sandboxes keep their own Poke surfaces, which are unaffected.

* Remove the two features whose subject was Pod functions

Both of these can only ever have Pod functions as their subject, and Pod functions are unpublishable and uninvocable: nothing calls SandboxFunctionResource.makeNew, and every .invoke() entry point resolves through resolveSandboxFunctionWithCapability, which is Frames-v2-only.

Publish-time validation of Frame-to-Pod-function references goes: validate_frame_pod_functions.ts, a TypeScript-compiler pass that type-checked callFunction() arguments against the pod's published contracts, plus its four PublishFrameErrorCode entries. pod_function_reference.ts goes with it, so a legacy Frame's bare callFunction name no longer resolves against a Pod app folder -- FrameFunctionReferenceScope keeps its v2 arm and its legacy arm now refuses. normalizeAppPrefix moves to slug.ts, its only remaining consumer.

The Pod restriction-impact warning goes: the dialog that told an editor how many Pod function calls would break if they restricted the Pod. It counted invocations of functions returned by listBySpace, which only ever finds Pod functions, so it would report zero forever. countByUserSince existed for it alone and goes too.

Frames keep their own callFunction resolution and their publish validation, which run on the frameId form.

Add workspace isolation contracts (#32241)

* Add workspace isolation and model contracts

* List existing workspace model inheritance exceptions

* Document remaining workspace isolation bypasses

[front] fix: Select All stuck on "Loading..." forever for empty data source views (#32202)

* [front] fix: Select All stuck on Loading forever for empty data source views

* fix(front): don't let a stale cached SWR error abort an in-flight Select All retry

The error guard added to useLazyLoadAllNodes ran before the in-flight check, so
retrying after a failed fetch saw SWR's cached nodesError from the previous
attempt and immediately aborted, hiding the loading state and dropping the
retry before it could reach onComplete. Check isLoadingMore first so an
active request takes priority over a stale error.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---------

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>

Show skeleton placeholders while the new usage page credit consumption section loads

Replace the spinners in the flag-gated credit consumption section with
skeletons that mirror the final layout: summary-card shaped blocks for the
value cards and a table skeleton for the previous cycles list.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://app.notion.com/p/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
