### PR TITLE
Add: dialog to customize before adding a tab.

### DIFF
--- a/front/components/pod/PodNavAddFileTabButton.tsx
+++ b/front/components/pod/PodNavAddFileTabButton.tsx
@@ -1,14 +1,19 @@
 import { listAddablePodTabFiles } from "@app/components/pod/files/addablePodTabFiles";
+import { EditPodFileTabDialog } from "@app/components/pod/files/EditPodFileTabDialog";
 import type { AddablePodTabFile } from "@app/components/pod/settings/AddPodFileMenu";
 import { AddPodFileMenu } from "@app/components/pod/settings/AddPodFileMenu";
-import { usePodFileTabs } from "@app/hooks/usePodFileTabs";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { usePodFiles } from "@app/lib/swr/pods";
 import type { PodFileTab } from "@app/types/pod_file_tab";
-import { MAX_POD_FILE_TABS } from "@app/types/pod_file_tab";
+import {
+  DEFAULT_POD_FILE_TAB_ICON,
+  MAX_POD_FILE_TAB_TITLE_LENGTH,
+  MAX_POD_FILE_TABS,
+  podFileTabBasename,
+} from "@app/types/pod_file_tab";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Button, cn, Plus } from "@dust-tt/sparkle";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 interface PodNavAddFileTabButtonProps {
   owner: LightWorkspaceType;
@@ -29,14 +34,8 @@ export function PodNavAddFileTabButton({
 }: PodNavAddFileTabButtonProps) {
   const { hasFeature } = useFeatureFlags();
   const displayFramePackages = hasFeature("frames_v2");
-
-  const { addFileTab } = usePodFileTabs({
-    owner,
-    podId,
-    fileTabs,
-    tabsOrder,
-    isEditor: true,
-  });
+  const [createFileTabDraft, setCreateFileTabDraft] =
+    useState<PodFileTab | null>(null);
 
   const { files: podFiles } = usePodFiles({
     owner,
@@ -61,9 +60,13 @@ export function PodNavAddFileTabButton({
   const atTabLimit = fileTabs.length >= MAX_POD_FILE_TABS;
 
   const handleAddFile = (file: AddablePodTabFile) => {
-    void addFileTab(file.path, {
-      fileName: file.fileName,
-      skipConfirm: true,
+    setCreateFileTabDraft({
+      path: file.path,
+      title: podFileTabBasename(file.fileName).slice(
+        0,
+        MAX_POD_FILE_TAB_TITLE_LENGTH
+      ),
+      icon: DEFAULT_POD_FILE_TAB_ICON,
     });
   };
 
@@ -93,6 +96,20 @@ export function PodNavAddFileTabButton({
           />
         }
       />
+      {createFileTabDraft && (
+        <EditPodFileTabDialog
+          key={createFileTabDraft.path}
+          owner={owner}
+          podId={podId}
+          fileTabs={fileTabs}
+          tabsOrder={tabsOrder}
+          isEditor
+          tab={createFileTabDraft}
+          mode="create"
+          isOpen
+          onClose={() => setCreateFileTabDraft(null)}
+        />
+      )}
     </div>
   );
 }

--- a/front/components/pod/files/EditPodFileTabDialog.tsx
+++ b/front/components/pod/files/EditPodFileTabDialog.tsx
@@ -3,15 +3,12 @@ import { getIcon } from "@app/components/resources/resources_icons";
 import { usePodFileTabs } from "@app/hooks/usePodFileTabs";
 import type { PodFileTab } from "@app/types/pod_file_tab";
 import {
-  buildPodNavItemsBeforeSettings,
   DEFAULT_POD_FILE_TAB_ICON,
   MAX_POD_FILE_TAB_TITLE_LENGTH,
 } from "@app/types/pod_file_tab";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   ActionIcons,
-  ArrowLeft,
-  ArrowRight,
   Button,
   Dialog,
   DialogContainer,
@@ -25,7 +22,7 @@ import {
   PopoverRoot,
   PopoverTrigger,
 } from "@dust-tt/sparkle";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 
 interface EditPodFileTabDialogProps {
   owner: LightWorkspaceType;
@@ -51,13 +48,7 @@ export function EditPodFileTabDialog({
   onClose,
 }: EditPodFileTabDialogProps) {
   const isCreate = mode === "create";
-  const {
-    addFileTab,
-    updateFileTab,
-    removeFileTab,
-    moveFileTab,
-    tabsOrder: navOrder,
-  } = usePodFileTabs({
+  const { addFileTab, updateFileTab, removeFileTab } = usePodFileTabs({
     owner,
     podId,
     fileTabs,
@@ -69,18 +60,6 @@ export function EditPodFileTabDialog({
   const [icon, setIcon] = useState(tab.icon);
   const [isIconPickerOpen, setIsIconPickerOpen] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
-  const [isMoving, setIsMoving] = useState(false);
-
-  const navItems = useMemo(
-    () => buildPodNavItemsBeforeSettings(fileTabs, navOrder),
-    [fileTabs, navOrder]
-  );
-  const tabIndex = navItems.findIndex(
-    (item) => item.kind === "file" && item.tab.path === tab.path
-  );
-  const canMoveLeft = !isCreate && isEditor && tabIndex > 0;
-  const canMoveRight =
-    !isCreate && isEditor && tabIndex >= 0 && tabIndex < navItems.length - 1;
 
   const selectedIcon = isCustomResourceIconType(icon)
     ? icon
@@ -122,15 +101,6 @@ export function EditPodFileTabDialog({
     if (ok) {
       onClose();
     }
-  };
-
-  const handleMove = async (direction: "left" | "right") => {
-    if (!isEditor || isCreate) {
-      return;
-    }
-    setIsMoving(true);
-    await moveFileTab(tab.path, direction);
-    setIsMoving(false);
   };
 
   return (
@@ -196,24 +166,6 @@ export function EditPodFileTabDialog({
               placeholder="Tab title"
               containerClassName="flex-1"
             />
-            {(canMoveLeft || canMoveRight) && (
-              <div className="flex shrink-0 items-center gap-0.5">
-                <Button
-                  variant="ghost"
-                  icon={ArrowLeft}
-                  tooltip="Move left"
-                  disabled={!canMoveLeft || isMoving || isSaving}
-                  onClick={() => void handleMove("left")}
-                />
-                <Button
-                  variant="ghost"
-                  icon={ArrowRight}
-                  tooltip="Move right"
-                  disabled={!canMoveRight || isMoving || isSaving}
-                  onClick={() => void handleMove("right")}
-                />
-              </div>
-            )}
           </div>
         </DialogContainer>
         <DialogFooter
@@ -224,14 +176,14 @@ export function EditPodFileTabDialog({
                   label: "Remove tab",
                   variant: "warning",
                   onClick: () => void handleRemove(),
-                  disabled: !isEditor || isSaving || isMoving,
+                  disabled: !isEditor || isSaving,
                 }
           }
           rightButtonProps={{
             label: isCreate ? "Add tab" : "Save",
             variant: "primary",
             onClick: () => void handleSave(),
-            disabled: !isEditor || isSaving || isMoving || !title.trim(),
+            disabled: !isEditor || isSaving || !title.trim(),
             isLoading: isSaving,
           }}
         />

--- a/front/components/pod/settings/PodTabsCustomizationSection.tsx
+++ b/front/components/pod/settings/PodTabsCustomizationSection.tsx
@@ -1,5 +1,6 @@
 import { getScopedRelativePath } from "@app/components/file_explorer/utils";
 import { listAddablePodTabFiles } from "@app/components/pod/files/addablePodTabFiles";
+import { EditPodFileTabDialog } from "@app/components/pod/files/EditPodFileTabDialog";
 import type { AddablePodTabFile } from "@app/components/pod/settings/AddPodFileMenu";
 import { AddPodFileMenu } from "@app/components/pod/settings/AddPodFileMenu";
 import { isCustomResourceIconType } from "@app/components/resources/resources_icon_names";
@@ -12,6 +13,7 @@ import {
   DEFAULT_POD_FILE_TAB_ICON,
   MAX_POD_FILE_TAB_TITLE_LENGTH,
   MAX_POD_FILE_TABS,
+  podFileTabBasename,
 } from "@app/types/pod_file_tab";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -59,19 +61,14 @@ export function PodTabsCustomizationSection({
   const { hasFeature } = useFeatureFlags();
   const displayFramePackages = hasFeature("frames_v2");
 
-  const {
-    orderedFileTabs,
-    updateFileTab,
-    removeFileTab,
-    reorderFileTab,
-    addFileTab,
-  } = usePodFileTabs({
-    owner,
-    podId,
-    fileTabs,
-    tabsOrder,
-    isEditor,
-  });
+  const { orderedFileTabs, updateFileTab, removeFileTab, reorderFileTab } =
+    usePodFileTabs({
+      owner,
+      podId,
+      fileTabs,
+      tabsOrder,
+      isEditor,
+    });
 
   const { files: podFiles, isPodFilesLoading } = usePodFiles({
     owner,
@@ -106,6 +103,8 @@ export function PodTabsCustomizationSection({
   const [iconPickerPath, setIconPickerPath] = useState<string | null>(null);
   const [editingTitlePath, setEditingTitlePath] = useState<string | null>(null);
   const [editingTitleValue, setEditingTitleValue] = useState("");
+  const [createFileTabDraft, setCreateFileTabDraft] =
+    useState<PodFileTab | null>(null);
 
   const atTabLimit = orderedFileTabs.length >= MAX_POD_FILE_TABS;
 
@@ -166,9 +165,13 @@ export function PodTabsCustomizationSection({
   };
 
   const handleAddFile = (file: AddablePodTabFile) => {
-    void addFileTab(file.path, {
-      fileName: file.fileName,
-      skipConfirm: true,
+    setCreateFileTabDraft({
+      path: file.path,
+      title: podFileTabBasename(file.fileName).slice(
+        0,
+        MAX_POD_FILE_TAB_TITLE_LENGTH
+      ),
+      icon: DEFAULT_POD_FILE_TAB_ICON,
     });
   };
 
@@ -390,6 +393,20 @@ export function PodTabsCustomizationSection({
           </ListGroup>
         )}
       </div>
+      {createFileTabDraft && (
+        <EditPodFileTabDialog
+          key={createFileTabDraft.path}
+          owner={owner}
+          podId={podId}
+          fileTabs={fileTabs}
+          tabsOrder={tabsOrder}
+          isEditor={isEditor}
+          tab={createFileTabDraft}
+          mode="create"
+          isOpen
+          onClose={() => setCreateFileTabDraft(null)}
+        />
+      )}
     </div>
   );
 }

--- a/front/types/pod_file_tab.ts
+++ b/front/types/pod_file_tab.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 export const MAX_POD_FILE_TABS = 8;
 export const MAX_POD_FILE_TAB_TITLE_LENGTH = 64;
 export const DEFAULT_POD_FILE_TAB_ICON =
-  "ActionDashboardIcon" satisfies CustomResourceIconType;
+  "ActionDocumentIcon" satisfies CustomResourceIconType;
 
 /** System tabs that participate in ordering (Settings is always last and excluded). */
 export const POD_NAV_SYSTEM_TABS_BEFORE_SETTINGS = [


### PR DESCRIPTION
## Description

Adding a file as a Pod tab now opens `EditPodFileTabDialog` in `create` mode from both `PodNavAddFileTabButton` and `PodTabsCustomizationSection`, so users can customize the title and icon before the tab is persisted. New drafts derive a 64-character title from the file basename and use `ActionDocumentIcon`; the edit dialog no longer owns left/right tab reordering

<img width="552" height="239" alt="image" src="https://github.com/user-attachments/assets/de6c5bf0-dd9a-4339-bf6c-fd2ae3df4dfb" />

r? @fabiencelier (easy)

## Tests

Not run; this is a UI-only change.

## Risk

Low. The change is isolated to Pod file-tab creation and customization, with no data migration or API contract change. Existing tabs retain their stored values, and rollback is safe through a front deployment rollback. The main regression risk is create/edit dialog state and the relocated tab-order controls.

## Deploy Plan

Deploy `front`. No SQL migrations, infrastructure changes, or sequencing requirements.