### PR TITLE
feat(triggers): notify admins when a trigger is blocked by the programmatic cap

### DIFF
--- a/front/lib/api/credits/access_control.ts
+++ b/front/lib/api/credits/access_control.ts
@@ -31,6 +31,11 @@ import type { ModelId } from "@app/types/shared/model_id";
 export const PROGRAMMATIC_CAP_REACHED_MESSAGE =
   "Your workspace has reached its programmatic monthly spending cap. An admin can raise the cap in the workspace's usage settings.";
 
+// Structured reason attached to logs and analytics when a run is blocked by the
+// programmatic monthly cap, as opposed to pool depletion or a generic rate limit.
+export const PROGRAMMATIC_MONTHLY_CAP_BLOCK_REASON =
+  "programmatic_monthly_cap" as const;
+
 /**
  * Whether the workspace is on a credit-priced (Metronome) plan, i.e. whether
  * the pool and programmatic-cap readers below apply to it.

--- a/front/lib/api/credits/programmatic_cap_trigger_alert.test.ts
+++ b/front/lib/api/credits/programmatic_cap_trigger_alert.test.ts
@@ -5,6 +5,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
 import * as capNotification from "@app/lib/notifications/workflows/programmatic-cap-reached";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
@@ -161,6 +162,24 @@ describe("notifyAdminsTriggerBlockedByProgrammaticCap", () => {
     expect(notify().mock.calls[1][1].idempotencyKey).not.toBe(
       notify().mock.calls[0][1].idempotencyKey
     );
+  });
+
+  it("does not re-arm on an unrelated usage-configuration change", async () => {
+    const { auth, trigger } = await setup();
+    await syncProgrammaticUsageLimit({ auth, monthlyCapCredits: 0 });
+
+    await notifyAdminsTriggerBlockedByProgrammaticCap(auth, { trigger });
+    expect(notify()).toHaveBeenCalledTimes(1);
+
+    const configuration =
+      await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+    await configuration?.updateConfiguration(auth, {
+      defaultDiscountPercent: 10,
+    });
+    advanceClockPastThrottleWindow();
+    await notifyAdminsTriggerBlockedByProgrammaticCap(auth, { trigger });
+
+    expect(notify()).toHaveBeenCalledTimes(1);
   });
 
   it("keys a positive cap on the billing cycle", async () => {

--- a/front/lib/api/credits/programmatic_cap_trigger_alert.test.ts
+++ b/front/lib/api/credits/programmatic_cap_trigger_alert.test.ts
@@ -1,0 +1,233 @@
+import * as workosAudit from "@app/lib/api/audit/workos_audit";
+import { notifyAdminsTriggerBlockedByProgrammaticCap } from "@app/lib/api/credits/programmatic_cap_trigger_alert";
+import { syncProgrammaticUsageLimit } from "@app/lib/api/credits/programmatic_usage_limit";
+import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
+import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
+import * as capNotification from "@app/lib/notifications/workflows/programmatic-cap-reached";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
+import type {
+  TriggerExecutionMode,
+  TriggerStatus,
+  TriggerType,
+} from "@app/types/assistant/triggers";
+import { Err, Ok } from "@app/types/shared/result";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(
+  "@app/lib/notifications/workflows/programmatic-cap-reached",
+  async () => {
+    const actual = await vi.importActual<typeof capNotification>(
+      "@app/lib/notifications/workflows/programmatic-cap-reached"
+    );
+    return { ...actual, triggerProgrammaticCapReachedNotifications: vi.fn() };
+  }
+);
+
+vi.mock("@app/lib/metronome/contracts", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/metronome/contracts")>();
+  return { ...actual, getCachedMetronomeCurrentBillingPeriod: vi.fn() };
+});
+
+vi.mock("@app/lib/api/audit/workos_audit", async () => {
+  const actual = await vi.importActual<typeof workosAudit>(
+    "@app/lib/api/audit/workos_audit"
+  );
+  return { ...actual, emitAuditLogEvent: vi.fn() };
+});
+
+const CYCLE_START = new Date("2026-09-01T00:00:00.000Z");
+const CYCLE_END = new Date("2026-10-01T00:00:00.000Z");
+
+// The service throttles its check per workspace; tests that need a second
+// check to run move the clock past the window.
+const PAST_THROTTLE_WINDOW_MS = 61 * 1000;
+
+function advanceClockPastThrottleWindow() {
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(Date.now() + PAST_THROTTLE_WINDOW_MS);
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(workosAudit.emitAuditLogEvent).mockResolvedValue(undefined);
+  vi.mocked(
+    capNotification.triggerProgrammaticCapReachedNotifications
+  ).mockResolvedValue(new Ok(undefined));
+  vi.mocked(getCachedMetronomeCurrentBillingPeriod).mockResolvedValue(
+    new Ok({ cycleStart: CYCLE_START, cycleEnd: CYCLE_END })
+  );
+});
+
+// The trigger is created disabled (the factory default, which keeps Temporal
+// out of the test) and reported to the service in the state under test.
+async function setup({
+  plan = "creditPriced",
+  status = "enabled",
+  executionMode = "workspace_pool",
+}: {
+  plan?: "basic" | "creditPriced";
+  status?: TriggerStatus;
+  executionMode?: TriggerExecutionMode;
+} = {}): Promise<{
+  auth: Authenticator;
+  adminSId: string;
+  workspaceSId: string;
+  trigger: TriggerType;
+}> {
+  const { authenticator, user, workspace } = await createResourceTest({
+    role: "admin",
+    plan,
+  });
+  const agent = await AgentConfigurationFactory.createTestAgent(authenticator, {
+    name: "Schedule Agent",
+  });
+  const triggerResource = await TriggerFactory.schedule(authenticator, {
+    agentConfigurationId: agent.sId,
+    configuration: { cron: "0 9 * * *", timezone: "UTC" },
+    executionMode,
+  });
+
+  return {
+    auth: authenticator,
+    adminSId: user.sId,
+    workspaceSId: workspace.sId,
+    trigger: { ...triggerResource.toJSON(), status },
+  };
+}
+
+const notify = () =>
+  vi.mocked(capNotification.triggerProgrammaticCapReachedNotifications);
+
+describe("notifyAdminsTriggerBlockedByProgrammaticCap", () => {
+  it("sends one admin notification when the cap is 0", async () => {
+    const { auth, adminSId, workspaceSId, trigger } = await setup();
+
+    const res = await notifyAdminsTriggerBlockedByProgrammaticCap(auth, {
+      trigger,
+    });
+
+    expect(res.isOk()).toBe(true);
+    expect(notify()).toHaveBeenCalledTimes(1);
+    const [calledAuth, args] = notify().mock.calls[0];
+    expect(calledAuth.getNonNullableWorkspace().sId).toBe(workspaceSId);
+    expect(args).toEqual(
+      expect.objectContaining({
+        monthlyCapCredits: 0,
+        reason: "programmatic_cap_disabled",
+        admins: [expect.objectContaining({ sId: adminSId })],
+      })
+    );
+  });
+
+  it("does not send duplicates on repeated blocked runs", async () => {
+    const { auth, trigger } = await setup();
+
+    // Back-to-back runs (a burst) and runs spaced past the throttle window
+    // (later scheduled fires) both stay silent.
+    await notifyAdminsTriggerBlockedByProgrammaticCap(auth, { trigger });
+    await notifyAdminsTriggerBlockedByProgrammaticCap(auth, { trigger });
+    advanceClockPastThrottleWindow();
+    await notifyAdminsTriggerBlockedByProgrammaticCap(auth, { trigger });
+
+    expect(notify()).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends a new notification when the cap configuration changes state", async () => {
+    const { auth, trigger } = await setup();
+
+    await notifyAdminsTriggerBlockedByProgrammaticCap(auth, { trigger });
+    expect(notify()).toHaveBeenCalledTimes(1);
+    expect(notify().mock.calls[0][1].reason).toBe("programmatic_cap_disabled");
+
+    await syncProgrammaticUsageLimit({ auth, monthlyCapCredits: 100 });
+    advanceClockPastThrottleWindow();
+    await notifyAdminsTriggerBlockedByProgrammaticCap(auth, { trigger });
+
+    expect(notify()).toHaveBeenCalledTimes(2);
+    expect(notify().mock.calls[1][1]).toEqual(
+      expect.objectContaining({
+        monthlyCapCredits: 100,
+        reason: "programmatic_cap_exhausted",
+      })
+    );
+    expect(notify().mock.calls[1][1].idempotencyKey).not.toBe(
+      notify().mock.calls[0][1].idempotencyKey
+    );
+  });
+
+  it("keys a positive cap on the billing cycle", async () => {
+    const { auth, trigger } = await setup();
+    await syncProgrammaticUsageLimit({ auth, monthlyCapCredits: 100 });
+
+    await notifyAdminsTriggerBlockedByProgrammaticCap(auth, { trigger });
+
+    expect(notify()).toHaveBeenCalledTimes(1);
+    const { reason, idempotencyKey } = notify().mock.calls[0][1];
+    expect(reason).toBe("programmatic_cap_exhausted");
+    expect(idempotencyKey).toContain(`cycle-${CYCLE_START.getTime()}`);
+  });
+
+  it("stays silent for a positive cap without a resolvable billing cycle", async () => {
+    vi.mocked(getCachedMetronomeCurrentBillingPeriod).mockResolvedValue(
+      new Ok(null)
+    );
+    const { auth, trigger } = await setup();
+    await syncProgrammaticUsageLimit({ auth, monthlyCapCredits: 100 });
+
+    await notifyAdminsTriggerBlockedByProgrammaticCap(auth, { trigger });
+
+    expect(notify()).not.toHaveBeenCalled();
+  });
+
+  it("retries on the next run when the send failed", async () => {
+    notify().mockResolvedValueOnce(
+      new Err(new DustError("internal_error", "novu down"))
+    );
+    const { auth, trigger } = await setup();
+
+    const first = await notifyAdminsTriggerBlockedByProgrammaticCap(auth, {
+      trigger,
+    });
+    expect(first.isErr()).toBe(true);
+
+    advanceClockPastThrottleWindow();
+    await notifyAdminsTriggerBlockedByProgrammaticCap(auth, { trigger });
+    advanceClockPastThrottleWindow();
+    await notifyAdminsTriggerBlockedByProgrammaticCap(auth, { trigger });
+
+    // The failed attempt left no sent marker; the next run sends, then dedupes.
+    expect(notify()).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not notify for disabled triggers", async () => {
+    const { auth, trigger } = await setup({ status: "disabled" });
+
+    await notifyAdminsTriggerBlockedByProgrammaticCap(auth, { trigger });
+
+    expect(notify()).not.toHaveBeenCalled();
+  });
+
+  it("does not notify for triggers charged to the user pool", async () => {
+    const { auth, trigger } = await setup({ executionMode: "user_pool" });
+
+    await notifyAdminsTriggerBlockedByProgrammaticCap(auth, { trigger });
+
+    expect(notify()).not.toHaveBeenCalled();
+  });
+
+  it("does not notify workspaces that are not credit-priced", async () => {
+    const { auth, trigger } = await setup({ plan: "basic" });
+
+    await notifyAdminsTriggerBlockedByProgrammaticCap(auth, { trigger });
+
+    expect(notify()).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/credits/programmatic_cap_trigger_alert.ts
+++ b/front/lib/api/credits/programmatic_cap_trigger_alert.ts
@@ -1,0 +1,174 @@
+import {
+  isCreditPricedWorkspace,
+  PROGRAMMATIC_MONTHLY_CAP_BLOCK_REASON,
+} from "@app/lib/api/credits/access_control";
+import { runOnRedis } from "@app/lib/api/redis";
+import { getMembers } from "@app/lib/api/workspace";
+import type { Authenticator } from "@app/lib/auth";
+import type { DustError } from "@app/lib/error";
+import type { ProgrammaticCapNotificationReason } from "@app/lib/notifications/workflows/programmatic-cap-reached";
+import { triggerProgrammaticCapReachedNotifications } from "@app/lib/notifications/workflows/programmatic-cap-reached";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
+import { resolveSpendLimitCycleBounds } from "@app/lib/spend_limits/cycle";
+import logger from "@app/logger/logger";
+import type { TriggerType } from "@app/types/assistant/triggers";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+
+const ALERT_REDIS_ORIGIN = "programmatic_cap_trigger_alert" as const;
+
+// Blocked webhook requests can arrive in bursts; before reading anything from
+// the database, one cheap Redis claim per workspace throttles the check itself.
+const ALERT_CHECK_THROTTLE_SECONDS = 60;
+
+// The sent marker is keyed on the cap state (configuration row version, billing
+// cycle), so a state change always allows a new email. When a marker expires
+// while the workspace is still blocked, the next run sends one reminder.
+// A 0 cap has no cycle to roll over on: one reminder per quarter at most.
+const DISABLED_CAP_ALERT_TTL_SECONDS = 90 * 24 * 60 * 60; // 90 days.
+// An exhausted positive cap is keyed on the billing cycle, which is monthly, so
+// the marker normally goes stale before it expires.
+const EXHAUSTED_CAP_ALERT_TTL_SECONDS = 45 * 24 * 60 * 60; // 45 days.
+
+type ProgrammaticCapBlockReason = Extract<
+  ProgrammaticCapNotificationReason,
+  "programmatic_cap_disabled" | "programmatic_cap_exhausted"
+>;
+
+function makeAlertSentKey(idempotencyKey: string): string {
+  return `programmatic_cap_trigger_alert:${idempotencyKey}`;
+}
+
+// `true` when this run gets to check the cap state for the workspace; `false`
+// when another run did so within the throttle window.
+async function tryClaimAlertCheck(workspaceId: string): Promise<boolean> {
+  const res = await runOnRedis({ origin: ALERT_REDIS_ORIGIN }, (redis) =>
+    redis.set(`programmatic_cap_trigger_alert:check:${workspaceId}`, "1", {
+      NX: true,
+      EX: ALERT_CHECK_THROTTLE_SECONDS,
+    })
+  );
+  return res === "OK";
+}
+
+async function wasAlertSent(idempotencyKey: string): Promise<boolean> {
+  const value = await runOnRedis({ origin: ALERT_REDIS_ORIGIN }, (redis) =>
+    redis.get(makeAlertSentKey(idempotencyKey))
+  );
+  return value !== null;
+}
+
+async function markAlertSent(
+  idempotencyKey: string,
+  { ttlSeconds }: { ttlSeconds: number }
+): Promise<void> {
+  await runOnRedis({ origin: ALERT_REDIS_ORIGIN }, (redis) =>
+    redis.set(makeAlertSentKey(idempotencyKey), "1", { EX: ttlSeconds })
+  );
+}
+
+/**
+ * Email workspace admins once when an enabled workspace-pool trigger is blocked
+ * by the programmatic monthly cap. Called from the trigger gates, after
+ * `isTriggerProgrammaticCapReached` reported the block, through
+ * `fireAndForgetNotification` so a failure is logged and never fails the run.
+ *
+ * The reason distinguishes a cap set to 0 (`programmatic_cap_disabled`, nothing
+ * was consumed) from a positive cap that was used up
+ * (`programmatic_cap_exhausted`). The idempotency key covers workspace, reason,
+ * the usage-configuration row version (any write to that row, not only the cap,
+ * re-arms the email) and, for a positive cap, the billing cycle. A sent marker
+ * in Redis keeps repeated runs from calling Novu again; it is only written after
+ * a successful send, and the Novu `transactionId` on the same key absorbs the
+ * race between two concurrent runs.
+ */
+export async function notifyAdminsTriggerBlockedByProgrammaticCap(
+  auth: Authenticator,
+  { trigger }: { trigger: TriggerType }
+): Promise<Result<void, DustError<"internal_error">>> {
+  if (
+    trigger.status !== "enabled" ||
+    trigger.executionMode !== "workspace_pool" ||
+    !isCreditPricedWorkspace(auth)
+  ) {
+    return new Ok(undefined);
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  if (!(await tryClaimAlertCheck(workspace.sId))) {
+    return new Ok(undefined);
+  }
+
+  const configuration =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+  const monthlyCapCredits =
+    configuration?.programmaticMonthlyCapAwuCredits ?? 0;
+  const configurationVersion = configuration
+    ? `config-${configuration.updatedAt.getTime()}`
+    : "config-none";
+
+  let reason: ProgrammaticCapBlockReason;
+  let idempotencyKey: string;
+  let ttlSeconds: number;
+  if (monthlyCapCredits <= 0) {
+    reason = "programmatic_cap_disabled";
+    idempotencyKey = `${workspace.sId}-${reason}-${configurationVersion}`;
+    ttlSeconds = DISABLED_CAP_ALERT_TTL_SECONDS;
+  } else {
+    // A positive cap can only be reached over a resolved billing cycle; without
+    // one the block came from elsewhere (or a race), so stay quiet.
+    const bounds = await resolveSpendLimitCycleBounds(workspace);
+    if (!bounds) {
+      return new Ok(undefined);
+    }
+    reason = "programmatic_cap_exhausted";
+    idempotencyKey = `${workspace.sId}-${reason}-${bounds.label}-${configurationVersion}`;
+    ttlSeconds = EXHAUSTED_CAP_ALERT_TTL_SECONDS;
+  }
+
+  if (await wasAlertSent(idempotencyKey)) {
+    return new Ok(undefined);
+  }
+
+  const { members: admins } = await getMembers(auth, {
+    roles: ["admin"],
+    activeOnly: true,
+  });
+  if (admins.length === 0) {
+    logger.warn(
+      { workspaceId: workspace.sId, triggerId: trigger.sId, reason },
+      "[ProgrammaticCapTriggerAlert] No active admins to notify"
+    );
+    return new Ok(undefined);
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      triggerId: trigger.sId,
+      blockReason: PROGRAMMATIC_MONTHLY_CAP_BLOCK_REASON,
+      reason,
+      idempotencyKey,
+    },
+    "[ProgrammaticCapTriggerAlert] Notifying admins of blocked trigger"
+  );
+
+  const res = await triggerProgrammaticCapReachedNotifications(auth, {
+    admins: admins.map((admin) => ({
+      sId: admin.sId,
+      email: admin.email,
+      firstName: admin.firstName,
+      lastName: admin.lastName,
+    })),
+    monthlyCapCredits,
+    reason,
+    idempotencyKey,
+  });
+  if (res.isErr()) {
+    return res;
+  }
+
+  await markAlertSent(idempotencyKey, { ttlSeconds });
+
+  return new Ok(undefined);
+}

--- a/front/lib/api/credits/programmatic_cap_trigger_alert.ts
+++ b/front/lib/api/credits/programmatic_cap_trigger_alert.ts
@@ -21,8 +21,8 @@ const ALERT_REDIS_ORIGIN = "programmatic_cap_trigger_alert" as const;
 // the database, one cheap Redis claim per workspace throttles the check itself.
 const ALERT_CHECK_THROTTLE_SECONDS = 60;
 
-// The sent marker is keyed on the cap state (configuration row version, billing
-// cycle), so a state change always allows a new email. When a marker expires
+// The sent marker is keyed on the cap state (cap value, billing cycle), so a
+// cap change always allows a new email. When a marker expires
 // while the workspace is still blocked, the next run sends one reminder.
 // A 0 cap has no cycle to roll over on: one reminder per quarter at most.
 const DISABLED_CAP_ALERT_TTL_SECONDS = 90 * 24 * 60 * 60; // 90 days.
@@ -76,8 +76,8 @@ async function markAlertSent(
  * The reason distinguishes a cap set to 0 (`programmatic_cap_disabled`, nothing
  * was consumed) from a positive cap that was used up
  * (`programmatic_cap_exhausted`). The idempotency key covers workspace, reason,
- * the usage-configuration row version (any write to that row, not only the cap,
- * re-arms the email) and, for a positive cap, the billing cycle. A sent marker
+ * the cap value and, for a positive cap, the billing cycle, so unrelated
+ * usage-configuration edits never re-arm the email. A sent marker
  * in Redis keeps repeated runs from calling Novu again; it is only written after
  * a successful send, and the Novu `transactionId` on the same key absorbs the
  * race between two concurrent runs.
@@ -103,16 +103,14 @@ export async function notifyAdminsTriggerBlockedByProgrammaticCap(
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
   const monthlyCapCredits =
     configuration?.programmaticMonthlyCapAwuCredits ?? 0;
-  const configurationVersion = configuration
-    ? `config-${configuration.updatedAt.getTime()}`
-    : "config-none";
+  const capVersion = `cap-${monthlyCapCredits}`;
 
   let reason: ProgrammaticCapBlockReason;
   let idempotencyKey: string;
   let ttlSeconds: number;
   if (monthlyCapCredits <= 0) {
     reason = "programmatic_cap_disabled";
-    idempotencyKey = `${workspace.sId}-${reason}-${configurationVersion}`;
+    idempotencyKey = `${workspace.sId}-${reason}-${capVersion}`;
     ttlSeconds = DISABLED_CAP_ALERT_TTL_SECONDS;
   } else {
     // A positive cap can only be reached over a resolved billing cycle; without
@@ -122,7 +120,7 @@ export async function notifyAdminsTriggerBlockedByProgrammaticCap(
       return new Ok(undefined);
     }
     reason = "programmatic_cap_exhausted";
-    idempotencyKey = `${workspace.sId}-${reason}-${bounds.label}-${configurationVersion}`;
+    idempotencyKey = `${workspace.sId}-${reason}-${bounds.label}-${capVersion}`;
     ttlSeconds = EXHAUSTED_CAP_ALERT_TTL_SECONDS;
   }
 

--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -62,6 +62,7 @@ export type RedisUsageTagsType =
   | "email_context"
   | "otp_challenge"
   | "force_reload_commits"
+  | "programmatic_cap_trigger_alert"
   | "programmatic_usage_tracking"
   | "group_permissions_cache"
   | "key_usage_tracking"

--- a/front/lib/notifications/workflows/programmatic-cap-reached.test.ts
+++ b/front/lib/notifications/workflows/programmatic-cap-reached.test.ts
@@ -1,0 +1,196 @@
+import * as novuClientModule from "@app/lib/notifications/novu-client";
+import {
+  buildProgrammaticCapReachedEmailCopy,
+  triggerProgrammaticCapReachedNotifications,
+} from "@app/lib/notifications/workflows/programmatic-cap-reached";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { PROGRAMMATIC_CAP_REACHED_TRIGGER_ID } from "@app/types/notification_preferences";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockTriggerBulk = vi.fn();
+
+vi.mock(import("@app/lib/notifications/novu-client"), async (orig) => {
+  const mod = await orig();
+  return { ...mod, getNovuClient: vi.fn() };
+});
+
+beforeEach(() => {
+  mockTriggerBulk.mockReset();
+  mockTriggerBulk.mockResolvedValue({ result: [{}] });
+  vi.mocked(novuClientModule.getNovuClient).mockResolvedValue({
+    triggerBulk: mockTriggerBulk,
+  } as unknown as Awaited<ReturnType<typeof novuClientModule.getNovuClient>>);
+});
+
+const ADMIN = {
+  sId: "usr_admin",
+  email: "admin@example.com",
+  firstName: "Ada",
+  lastName: null,
+};
+
+describe("buildProgrammaticCapReachedEmailCopy", () => {
+  it("describes a 0 cap as paused triggers, not consumed credits", () => {
+    const { subject, content } = buildProgrammaticCapReachedEmailCopy({
+      workspaceName: "Acme",
+      monthlyCapCredits: 0,
+      reason: "programmatic_cap_disabled",
+    });
+
+    expect(subject).toBe(
+      "[Dust] Your programmatic triggers are paused in Acme"
+    );
+    expect(content).toContain(
+      'A scheduled trigger in your Dust workspace "Acme" could not run because the workspace\'s monthly programmatic usage limit is set to 0 credits.'
+    );
+    expect(content).toContain(
+      "Programmatic triggers will remain blocked until an admin sets a positive limit in workspace usage settings."
+    );
+    expect(content).not.toMatch(/exhausted|consumed/);
+  });
+
+  it("keeps the exhausted-cap copy for a positive cap", () => {
+    const { subject, content } = buildProgrammaticCapReachedEmailCopy({
+      workspaceName: "Acme",
+      monthlyCapCredits: 500,
+      reason: "programmatic_cap_exhausted",
+    });
+
+    expect(subject).toBe(
+      "[Dust] Your workspace has reached its programmatic API credit cap in Acme"
+    );
+    expect(content).toContain(
+      'Your workspace "Acme" has exhausted its monthly programmatic API credit cap of 500 credits.'
+    );
+    expect(content).toContain(
+      "blocked until the billing cycle resets or the cap is raised"
+    );
+  });
+
+  it("keeps the 80% warning copy", () => {
+    const { subject } = buildProgrammaticCapReachedEmailCopy({
+      workspaceName: "Acme",
+      monthlyCapCredits: 500,
+      reason: "programmatic_cap_warning",
+    });
+
+    expect(subject).toBe(
+      "[Dust] Your workspace has used 80% of its programmatic API credit cap in Acme"
+    );
+  });
+});
+
+describe("triggerProgrammaticCapReachedNotifications", () => {
+  it("sends the reason in the payload and dedupes on the idempotency key", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+      plan: "creditPriced",
+    });
+
+    const res = await triggerProgrammaticCapReachedNotifications(
+      authenticator,
+      {
+        admins: [ADMIN],
+        monthlyCapCredits: 0,
+        reason: "programmatic_cap_disabled",
+        idempotencyKey: "k-disabled-config-none",
+      }
+    );
+
+    expect(res.isOk()).toBe(true);
+    expect(mockTriggerBulk).toHaveBeenCalledTimes(1);
+    const [event] = mockTriggerBulk.mock.calls[0][0].events;
+    expect(event.workflowId).toBe(PROGRAMMATIC_CAP_REACHED_TRIGGER_ID);
+    expect(event.to.subscriberId).toBe(ADMIN.sId);
+    expect(event.payload).toEqual({
+      workspaceId: workspace.sId,
+      workspaceName: workspace.name,
+      monthlyCapCredits: 0,
+      reason: "programmatic_cap_disabled",
+    });
+    expect(event.transactionId).toContain("k-disabled-config-none");
+    expect(event.transactionId).toContain(ADMIN.sId);
+
+    // Same cap state → same transactionId, so Novu drops the duplicate.
+    await triggerProgrammaticCapReachedNotifications(authenticator, {
+      admins: [ADMIN],
+      monthlyCapCredits: 0,
+      reason: "programmatic_cap_disabled",
+      idempotencyKey: "k-disabled-config-none",
+    });
+    expect(mockTriggerBulk.mock.calls[1][0].events[0].transactionId).toBe(
+      event.transactionId
+    );
+
+    // A new cap state → a new transactionId.
+    await triggerProgrammaticCapReachedNotifications(authenticator, {
+      admins: [ADMIN],
+      monthlyCapCredits: 100,
+      reason: "programmatic_cap_exhausted",
+      idempotencyKey: "k-exhausted-cycle-1-config-2",
+    });
+    expect(mockTriggerBulk.mock.calls[2][0].events[0].transactionId).not.toBe(
+      event.transactionId
+    );
+  });
+
+  it("does nothing without admins", async () => {
+    const { authenticator } = await createResourceTest({
+      role: "admin",
+      plan: "creditPriced",
+    });
+
+    const res = await triggerProgrammaticCapReachedNotifications(
+      authenticator,
+      {
+        admins: [],
+        monthlyCapCredits: 0,
+        reason: "programmatic_cap_disabled",
+        idempotencyKey: "k",
+      }
+    );
+
+    expect(res.isOk()).toBe(true);
+    expect(mockTriggerBulk).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when Novu reports a per-event error", async () => {
+    mockTriggerBulk.mockResolvedValue({ result: [{ error: ["boom"] }] });
+    const { authenticator } = await createResourceTest({
+      role: "admin",
+      plan: "creditPriced",
+    });
+
+    const res = await triggerProgrammaticCapReachedNotifications(
+      authenticator,
+      {
+        admins: [ADMIN],
+        monthlyCapCredits: 0,
+        reason: "programmatic_cap_disabled",
+        idempotencyKey: "k",
+      }
+    );
+
+    expect(res.isErr()).toBe(true);
+  });
+
+  it("returns an error when the Novu call rejects", async () => {
+    mockTriggerBulk.mockRejectedValue(new Error("network error"));
+    const { authenticator } = await createResourceTest({
+      role: "admin",
+      plan: "creditPriced",
+    });
+
+    const res = await triggerProgrammaticCapReachedNotifications(
+      authenticator,
+      {
+        admins: [ADMIN],
+        monthlyCapCredits: 0,
+        reason: "programmatic_cap_disabled",
+        idempotencyKey: "k",
+      }
+    );
+
+    expect(res.isErr()).toBe(true);
+  });
+});

--- a/front/lib/notifications/workflows/programmatic-cap-reached.test.ts
+++ b/front/lib/notifications/workflows/programmatic-cap-reached.test.ts
@@ -44,7 +44,7 @@ describe("buildProgrammaticCapReachedEmailCopy", () => {
       'A scheduled trigger in your Dust workspace "Acme" could not run because the workspace\'s monthly programmatic usage limit is set to 0 credits.'
     );
     expect(content).toContain(
-      "Programmatic triggers will remain blocked until an admin sets a positive limit in workspace usage settings."
+      "Programmatic triggers will remain blocked until you set a positive limit in workspace usage settings."
     );
     expect(content).not.toMatch(/exhausted|consumed/);
   });

--- a/front/lib/notifications/workflows/programmatic-cap-reached.test.ts
+++ b/front/lib/notifications/workflows/programmatic-cap-reached.test.ts
@@ -41,7 +41,7 @@ describe("buildProgrammaticCapReachedEmailCopy", () => {
       "[Dust] Your programmatic triggers are paused in Acme"
     );
     expect(content).toContain(
-      'A scheduled trigger in your Dust workspace "Acme" could not run because the workspace\'s monthly programmatic usage limit is set to 0 credits.'
+      'A programmatic trigger in your Dust workspace "Acme" could not run because the workspace\'s monthly programmatic usage limit is set to 0 credits.'
     );
     expect(content).toContain(
       "Programmatic triggers will remain blocked until you set a positive limit in workspace usage settings."

--- a/front/lib/notifications/workflows/programmatic-cap-reached.ts
+++ b/front/lib/notifications/workflows/programmatic-cap-reached.ts
@@ -71,7 +71,7 @@ export function buildProgrammaticCapReachedEmailCopy({
     case "programmatic_cap_disabled":
       return {
         subject: `[Dust] Your programmatic triggers are paused in ${workspaceName}`,
-        content: `A scheduled trigger in your Dust workspace "${workspaceName}" could not run because the workspace's monthly programmatic usage limit is set to 0 credits.\nProgrammatic triggers will remain blocked until an admin sets a positive limit in workspace usage settings.`,
+        content: `A scheduled trigger in your Dust workspace "${workspaceName}" could not run because the workspace's monthly programmatic usage limit is set to 0 credits.\nProgrammatic triggers will remain blocked until you set a positive limit in workspace usage settings.`,
       };
     default:
       return assertNever(reason);

--- a/front/lib/notifications/workflows/programmatic-cap-reached.ts
+++ b/front/lib/notifications/workflows/programmatic-cap-reached.ts
@@ -1,21 +1,39 @@
 import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
 import { renderEmail } from "@app/lib/notifications/email-templates/default";
 import { getNovuClient } from "@app/lib/notifications/novu-client";
-import logger from "@app/logger/logger";
 import {
   PROGRAMMATIC_CAP_REACHED_TAG,
   PROGRAMMATIC_CAP_REACHED_TRIGGER_ID,
 } from "@app/types/notification_preferences";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { workflow } from "@novu/framework";
 import z from "zod";
+
+// Why admins are being told about the programmatic cap:
+// - `programmatic_cap_warning`: 80% of a positive cap consumed.
+// - `programmatic_cap_exhausted`: a positive cap fully consumed, calls blocked.
+// - `programmatic_cap_disabled`: the cap is set to 0, so programmatic runs are
+//   blocked without any credits having been consumed.
+export const PROGRAMMATIC_CAP_NOTIFICATION_REASONS = [
+  "programmatic_cap_warning",
+  "programmatic_cap_exhausted",
+  "programmatic_cap_disabled",
+] as const;
+
+export type ProgrammaticCapNotificationReason =
+  (typeof PROGRAMMATIC_CAP_NOTIFICATION_REASONS)[number];
 
 const ProgrammaticCapReachedPayloadSchema = z.object({
   workspaceId: z.string(),
   workspaceName: z.string(),
   // The monthly programmatic credit cap in credits, if known.
   monthlyCapCredits: z.number().nullable(),
-  // true → cap fully depleted and API calls are blocked; false → 80% warning.
-  isBlocked: z.boolean(),
+  reason: z.enum(PROGRAMMATIC_CAP_NOTIFICATION_REASONS),
 });
 
 type ProgrammaticCapReachedPayloadType = z.infer<
@@ -26,24 +44,48 @@ function formatCredits(credits: number): string {
   return credits.toLocaleString("en-US");
 }
 
+export function buildProgrammaticCapReachedEmailCopy({
+  workspaceName,
+  monthlyCapCredits,
+  reason,
+}: Pick<
+  ProgrammaticCapReachedPayloadType,
+  "workspaceName" | "monthlyCapCredits" | "reason"
+>): { subject: string; content: string } {
+  const capLine =
+    monthlyCapCredits !== null
+      ? ` of ${formatCredits(monthlyCapCredits)} credits`
+      : "";
+
+  switch (reason) {
+    case "programmatic_cap_warning":
+      return {
+        subject: `[Dust] Your workspace has used 80% of its programmatic API credit cap in ${workspaceName}`,
+        content: `Your workspace "${workspaceName}" has used 80% of its monthly programmatic API credit cap${capLine}.\nOnce the cap is fully reached, programmatic API calls will be blocked. Consider raising the cap before that happens.`,
+      };
+    case "programmatic_cap_exhausted":
+      return {
+        subject: `[Dust] Your workspace has reached its programmatic API credit cap in ${workspaceName}`,
+        content: `Your workspace "${workspaceName}" has exhausted its monthly programmatic API credit cap${capLine}.\nProgrammatic API calls are now blocked until the billing cycle resets or the cap is raised.`,
+      };
+    case "programmatic_cap_disabled":
+      return {
+        subject: `[Dust] Your programmatic triggers are paused in ${workspaceName}`,
+        content: `A scheduled trigger in your Dust workspace "${workspaceName}" could not run because the workspace's monthly programmatic usage limit is set to 0 credits.\nProgrammatic triggers will remain blocked until an admin sets a positive limit in workspace usage settings.`,
+      };
+    default:
+      return assertNever(reason);
+  }
+}
+
 // Email-only (no in-app): these notifications target workspace admins who
 // manage programmatic API usage, not individual end-users.
 export const programmaticCapReachedWorkflow = workflow(
   PROGRAMMATIC_CAP_REACHED_TRIGGER_ID,
   async ({ step, payload, subscriber }) => {
     await step.email("programmatic-cap-reached-email", async () => {
-      const capLine =
-        payload.monthlyCapCredits !== null
-          ? ` of ${formatCredits(payload.monthlyCapCredits)} credits`
-          : "";
-
-      const subject = payload.isBlocked
-        ? `[Dust] Your workspace has reached its programmatic API credit cap in ${payload.workspaceName}`
-        : `[Dust] Your workspace has used 80% of its programmatic API credit cap in ${payload.workspaceName}`;
-
-      const content = payload.isBlocked
-        ? `Your workspace "${payload.workspaceName}" has exhausted its monthly programmatic API credit cap${capLine}.\nProgrammatic API calls are now blocked until the billing cycle resets or the cap is raised.`
-        : `Your workspace "${payload.workspaceName}" has used 80% of its monthly programmatic API credit cap${capLine}.\nOnce the cap is fully reached, programmatic API calls will be blocked. Consider raising the cap before that happens.`;
+      const { subject, content } =
+        buildProgrammaticCapReachedEmailCopy(payload);
 
       const body = await renderEmail({
         name: subscriber.firstName ?? "there",
@@ -67,70 +109,77 @@ export const programmaticCapReachedWorkflow = workflow(
 );
 
 /**
- * Email workspace admins about programmatic API credit cap status.
- * isBlocked=true → cap depleted, API calls blocked.
- * isBlocked=false → 80% warning.
- * Fire-and-forget — errors are logged but don't block the caller.
+ * Trigger the programmatic cap email for the given workspace admins.
+ * `idempotencyKey` identifies the cap state being reported (billing cycle, cap
+ * configuration version); Novu drops repeats of the same `transactionId`.
  */
-export function notifyAdminsProgrammaticCapReached({
-  admins,
-  workspaceId,
-  workspaceName,
-  monthlyCapCredits,
-  isBlocked,
-  eventId,
-}: {
-  admins: Array<{
-    sId: string;
-    email: string;
-    firstName: string | null;
-    lastName: string | null;
-  }>;
-  workspaceId: string;
-  workspaceName: string;
-  monthlyCapCredits: number | null;
-  isBlocked: boolean;
-  eventId: string;
-}): void {
+export async function triggerProgrammaticCapReachedNotifications(
+  auth: Authenticator,
+  {
+    admins,
+    monthlyCapCredits,
+    reason,
+    idempotencyKey,
+  }: {
+    admins: Array<{
+      sId: string;
+      email: string;
+      firstName: string | null;
+      lastName: string | null;
+    }>;
+    monthlyCapCredits: number | null;
+    reason: ProgrammaticCapNotificationReason;
+    idempotencyKey: string;
+  }
+): Promise<Result<void, DustError<"internal_error">>> {
   if (admins.length === 0) {
-    return;
+    return new Ok(undefined);
   }
 
+  const workspace = auth.getNonNullableWorkspace();
   const payload: ProgrammaticCapReachedPayloadType = {
-    workspaceId,
-    workspaceName,
+    workspaceId: workspace.sId,
+    workspaceName: workspace.name,
     monthlyCapCredits,
-    isBlocked,
+    reason,
   };
 
-  void getNovuClient()
-    .then((novuClient) =>
-      novuClient.triggerBulk({
-        events: admins.map((admin) => ({
-          workflowId: PROGRAMMATIC_CAP_REACHED_TRIGGER_ID,
-          to: {
-            subscriberId: admin.sId,
-            email: admin.email,
-            firstName: admin.firstName ?? undefined,
-            lastName: admin.lastName ?? undefined,
-          },
-          payload,
-          transactionId: `${PROGRAMMATIC_CAP_REACHED_TRIGGER_ID}-${eventId}-${admin.sId}-${isBlocked ? "blocked" : "warned"}`,
-        })),
-      })
-    )
-    .then((r) => {
-      if (r.result.some((res) => !!res.error?.length)) {
-        logger.error(
-          { workspaceId, isBlocked },
-          "Failed to trigger programmatic cap reached notification"
-        );
-      }
-    })
-    .catch((err) => {
-      logger.error(
-        { err, workspaceId, isBlocked },
-        "Failed to trigger programmatic cap reached notification"
-      );
+  try {
+    const novuClient = await getNovuClient();
+    const r = await novuClient.triggerBulk({
+      events: admins.map((admin) => ({
+        workflowId: PROGRAMMATIC_CAP_REACHED_TRIGGER_ID,
+        to: {
+          subscriberId: admin.sId,
+          email: admin.email,
+          firstName: admin.firstName ?? undefined,
+          lastName: admin.lastName ?? undefined,
+        },
+        payload,
+        transactionId: `${PROGRAMMATIC_CAP_REACHED_TRIGGER_ID}-${idempotencyKey}-${admin.sId}-${reason}`,
+      })),
     });
+
+    if (r.result.some((res) => !!res.error?.length)) {
+      const eventErrors = r.result
+        .filter((res) => !!res.error?.length)
+        .map(({ error }) => error?.join("; "))
+        .join("; ");
+      return new Err(
+        new DustError(
+          "internal_error",
+          `Failed to trigger programmatic cap reached notification: ${eventErrors}`
+        )
+      );
+    }
+  } catch (err) {
+    return new Err(
+      new DustError(
+        "internal_error",
+        `Failed to trigger programmatic cap reached notification: ${normalizeError(err).message}`
+      )
+    );
+  }
+
+  return new Ok(undefined);
 }

--- a/front/lib/notifications/workflows/programmatic-cap-reached.ts
+++ b/front/lib/notifications/workflows/programmatic-cap-reached.ts
@@ -71,7 +71,7 @@ export function buildProgrammaticCapReachedEmailCopy({
     case "programmatic_cap_disabled":
       return {
         subject: `[Dust] Your programmatic triggers are paused in ${workspaceName}`,
-        content: `A scheduled trigger in your Dust workspace "${workspaceName}" could not run because the workspace's monthly programmatic usage limit is set to 0 credits.\nProgrammatic triggers will remain blocked until you set a positive limit in workspace usage settings.`,
+        content: `A programmatic trigger in your Dust workspace "${workspaceName}" could not run because the workspace's monthly programmatic usage limit is set to 0 credits.\nProgrammatic triggers will remain blocked until you set a positive limit in workspace usage settings.`,
       };
     default:
       return assertNever(reason);

--- a/front/lib/triggers/webhook.test.ts
+++ b/front/lib/triggers/webhook.test.ts
@@ -1,3 +1,4 @@
+import * as capTriggerAlert from "@app/lib/api/credits/programmatic_cap_trigger_alert";
 import { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { TriggerResource } from "@app/lib/resources/trigger_resource";
@@ -14,22 +15,37 @@ import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WebhookSourceViewFactory } from "@app/tests/utils/WebhookSourceViewFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockIsApiBlocked, mockCheckWebhookRequestForRateLimit } = vi.hoisted(
-  () => ({
-    mockIsApiBlocked: vi.fn(),
-    mockCheckWebhookRequestForRateLimit: vi.fn(),
-  })
-);
+const {
+  mockIsApiBlocked,
+  mockIsProgrammaticApiBlocked,
+  mockCheckWebhookRequestForRateLimit,
+} = vi.hoisted(() => ({
+  mockIsApiBlocked: vi.fn(),
+  mockIsProgrammaticApiBlocked: vi.fn(),
+  mockCheckWebhookRequestForRateLimit: vi.fn(),
+}));
 
 vi.mock("@app/lib/api/credits/access_control", async (importOriginal) => ({
   ...(await importOriginal<
     typeof import("@app/lib/api/credits/access_control")
   >()),
   isPoolDepleted: mockIsApiBlocked,
+  isProgrammaticApiBlocked: mockIsProgrammaticApiBlocked,
 }));
+
+vi.mock(
+  "@app/lib/api/credits/programmatic_cap_trigger_alert",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@app/lib/api/credits/programmatic_cap_trigger_alert")
+    >()),
+    notifyAdminsTriggerBlockedByProgrammaticCap: vi.fn(),
+  })
+);
 
 vi.mock("@app/lib/triggers/rate_limits", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@app/lib/triggers/rate_limits")>()),
@@ -60,10 +76,17 @@ describe("processWebhookRequest", () => {
   let workspace: WorkspaceType;
   let auth: Authenticator;
   let webhookSource: WebhookSourceResource;
+  let webhookSourceViewId: number;
+  let agentId: string;
   let trigger: TriggerResource;
 
   beforeEach(async () => {
+    vi.clearAllMocks();
     mockIsApiBlocked.mockResolvedValue(false);
+    mockIsProgrammaticApiBlocked.mockResolvedValue(false);
+    vi.mocked(
+      capTriggerAlert.notifyAdminsTriggerBlockedByProgrammaticCap
+    ).mockResolvedValue(new Ok(undefined));
     mockCheckWebhookRequestForRateLimit.mockResolvedValue({
       rateLimited: false,
     });
@@ -95,6 +118,8 @@ describe("processWebhookRequest", () => {
       workspace
     ).create(globalSpace);
     webhookSource = webhookSourceView.webhookSource;
+    webhookSourceViewId = webhookSourceView.id;
+    agentId = agent.sId;
 
     trigger = await TriggerFactory.webhook(auth, {
       agentConfigurationId: agent.sId,
@@ -123,9 +148,9 @@ describe("processWebhookRequest", () => {
     });
   }
 
-  async function fetchTriggerRequests() {
+  async function fetchTriggerRequests(forTrigger: TriggerResource = trigger) {
     return fetchRecentWebhookRequestTriggersWithPayload(auth, {
-      trigger: trigger.toJSON(),
+      trigger: forTrigger.toJSON(),
     });
   }
 
@@ -139,6 +164,39 @@ describe("processWebhookRequest", () => {
     expect(requests).toHaveLength(1);
     expect(requests[0].status).toBe("credits_exhausted");
     expect(requests[0].errorMessage).toContain("run out of credits");
+  });
+
+  it("blocks workspace_pool triggers on the programmatic cap and notifies admins", async () => {
+    mockIsProgrammaticApiBlocked.mockResolvedValue(true);
+    const poolTrigger = await TriggerFactory.webhook(auth, {
+      agentConfigurationId: agentId,
+      name: "Pool Webhook Trigger",
+      status: "enabled",
+      webhookSourceViewId,
+      configuration: { includePayload: false },
+      executionMode: "workspace_pool",
+    });
+
+    const result = await postWebhookRequest();
+    expect(result.isOk()).toBe(true);
+
+    const poolRequests = await fetchTriggerRequests(poolTrigger);
+    expect(poolRequests).toHaveLength(1);
+    expect(poolRequests[0].status).toBe("credits_exhausted");
+    expect(poolRequests[0].errorMessage).toContain(
+      "programmatic monthly spending cap"
+    );
+    expect(
+      capTriggerAlert.notifyAdminsTriggerBlockedByProgrammaticCap
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      capTriggerAlert.notifyAdminsTriggerBlockedByProgrammaticCap
+    ).toHaveBeenCalledWith(expect.anything(), {
+      trigger: expect.objectContaining({
+        sId: poolTrigger.sId,
+        kind: "webhook",
+      }),
+    });
   });
 
   it("marks the request as rate_limited when the workspace fair-use limit is reached", async () => {

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -2,6 +2,7 @@ import {
   isPoolDepleted,
   PROGRAMMATIC_CAP_REACHED_MESSAGE,
 } from "@app/lib/api/credits/access_control";
+import { notifyAdminsTriggerBlockedByProgrammaticCap } from "@app/lib/api/credits/programmatic_cap_trigger_alert";
 import { checkProgrammaticUsageLimits } from "@app/lib/api/programmatic_usage/tracking";
 import { FathomClient } from "@app/lib/api/triggers/built-in-webhooks/fathom/fathom_client";
 import type { Authenticator } from "@app/lib/auth";
@@ -9,6 +10,7 @@ import type { DustError } from "@app/lib/error";
 import { getWebhookRequestsBucket } from "@app/lib/file_storage";
 import { isGCSPreconditionFailedError } from "@app/lib/file_storage/types";
 import { matchPayload, parseMatcherExpression } from "@app/lib/matcher";
+import { fireAndForgetNotification } from "@app/lib/notifications/fire_and_forget";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
 import type { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
@@ -310,6 +312,14 @@ async function checkWorkspaceRateLimit({
       status: "credits_exhausted",
       message: PROGRAMMATIC_CAP_REACHED_MESSAGE,
     };
+    fireAndForgetNotification(
+      notifyAdminsTriggerBlockedByProgrammaticCap(auth, { trigger }),
+      {
+        message:
+          "[ProgrammaticCapTriggerAlert] Failed to notify admins of blocked trigger",
+        context: { workspaceId, webhookRequestId, triggerId: trigger.sId },
+      }
+    );
   }
 
   /**

--- a/front/temporal/triggers/activities.test.ts
+++ b/front/temporal/triggers/activities.test.ts
@@ -1,4 +1,6 @@
 import { createConversation } from "@app/lib/api/assistant/conversation";
+import * as capTriggerAlert from "@app/lib/api/credits/programmatic_cap_trigger_alert";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { WakeUpModel } from "@app/lib/resources/storage/models/wakeup";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
@@ -10,7 +12,7 @@ import {
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockIsProgrammaticApiBlocked, mockPostUserMessage } = vi.hoisted(
@@ -47,6 +49,16 @@ vi.mock("@app/lib/temporal", async (importOriginal) => ({
   }),
 }));
 
+vi.mock(
+  "@app/lib/api/credits/programmatic_cap_trigger_alert",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@app/lib/api/credits/programmatic_cap_trigger_alert")
+    >()),
+    notifyAdminsTriggerBlockedByProgrammaticCap: vi.fn(),
+  })
+);
+
 const MISSING_WAKE_UP_MODEL_ID = 9_000_000_000;
 const MISSING_TRIGGER_MODEL_ID = 9_000_000_000;
 
@@ -67,7 +79,7 @@ async function createProgrammaticScheduleTrigger() {
     executionMode: "workspace_pool",
   });
 
-  return { user, workspace, trigger };
+  return { authenticator, user, workspace, trigger };
 }
 
 describe("runTriggeredAgentsActivity", () => {
@@ -75,6 +87,9 @@ describe("runTriggeredAgentsActivity", () => {
     vi.clearAllMocks();
     mockIsProgrammaticApiBlocked.mockResolvedValue(false);
     mockPostUserMessage.mockResolvedValue(new Ok(undefined));
+    vi.mocked(
+      capTriggerAlert.notifyAdminsTriggerBlockedByProgrammaticCap
+    ).mockResolvedValue(new Ok(undefined));
   });
 
   it("skips missing triggers without failing the activity", async () => {
@@ -111,7 +126,7 @@ describe("runTriggeredAgentsActivity", () => {
 
   it("stops workspace_pool runs without retrying when the programmatic monthly cap is reached", async () => {
     mockIsProgrammaticApiBlocked.mockResolvedValue(true);
-    const { user, workspace, trigger } =
+    const { authenticator, user, workspace, trigger } =
       await createProgrammaticScheduleTrigger();
 
     await expect(
@@ -122,6 +137,40 @@ describe("runTriggeredAgentsActivity", () => {
       })
     ).resolves.toBeUndefined();
     expect(mockPostUserMessage).not.toHaveBeenCalled();
+    expect(await ConversationResource.listAll(authenticator)).toHaveLength(0);
+    expect(
+      capTriggerAlert.notifyAdminsTriggerBlockedByProgrammaticCap
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      capTriggerAlert.notifyAdminsTriggerBlockedByProgrammaticCap
+    ).toHaveBeenCalledWith(expect.anything(), {
+      trigger: expect.objectContaining({ sId: trigger.sId }),
+    });
+  });
+
+  it("does not use the programmatic-cap notification when the workspace pool is depleted", async () => {
+    mockPostUserMessage.mockResolvedValue(
+      new Err({
+        status_code: 403,
+        api_error: {
+          type: "credits_exhausted",
+          message: "Your workspace has run out of credits.",
+        },
+      })
+    );
+    const { user, workspace, trigger } =
+      await createProgrammaticScheduleTrigger();
+
+    await expect(
+      runTriggeredAgentsActivity({
+        userId: user.sId,
+        workspaceId: workspace.sId,
+        triggerId: trigger.sId,
+      })
+    ).resolves.toBeUndefined();
+    expect(
+      capTriggerAlert.notifyAdminsTriggerBlockedByProgrammaticCap
+    ).not.toHaveBeenCalled();
   });
 
   it("posts the triggered message when the programmatic monthly cap is not reached", async () => {

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -10,10 +10,15 @@ import {
   buildAuditLogTarget,
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
-import { PROGRAMMATIC_CAP_REACHED_MESSAGE } from "@app/lib/api/credits/access_control";
+import {
+  PROGRAMMATIC_CAP_REACHED_MESSAGE,
+  PROGRAMMATIC_MONTHLY_CAP_BLOCK_REASON,
+} from "@app/lib/api/credits/access_control";
+import { notifyAdminsTriggerBlockedByProgrammaticCap } from "@app/lib/api/credits/programmatic_cap_trigger_alert";
 import { PostHogServerSideTracking } from "@app/lib/api/posthog";
 import { Authenticator } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
+import { fireAndForgetNotification } from "@app/lib/notifications/fire_and_forget";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
@@ -333,6 +338,7 @@ export async function runTriggeredAgentsActivity({
         triggerId: trigger.sId,
         agentConfigurationId: trigger.agentConfigurationId,
         workspaceId: auth.getNonNullableWorkspace().sId,
+        blockReason: PROGRAMMATIC_MONTHLY_CAP_BLOCK_REASON,
       },
       "Trigger run skipped: programmatic monthly cap reached."
     );
@@ -343,8 +349,20 @@ export async function runTriggeredAgentsActivity({
       extra: {
         trigger_id: trigger.sId,
         error_type: "credits_exhausted",
+        block_reason: PROGRAMMATIC_MONTHLY_CAP_BLOCK_REASON,
       },
     });
+    fireAndForgetNotification(
+      notifyAdminsTriggerBlockedByProgrammaticCap(auth, { trigger }),
+      {
+        message:
+          "[ProgrammaticCapTriggerAlert] Failed to notify admins of blocked trigger",
+        context: {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          triggerId: trigger.sId,
+        },
+      }
+    );
     if (webhookRequest) {
       await webhookRequest.markRelatedTrigger({
         trigger,


### PR DESCRIPTION
## Description

Follow up of `#32179`. Scheduled `workspace_pool` triggers now stop cleanly when the workspace programmatic monthly cap blocks them, but nobody is told. This emails workspace admins once per cap state through the existing `programmatic-cap-reached` Novu workflow, which had no live producer since `#31914`.

The payload's `isBlocked` flag becomes a `reason`. A cap of 0 gets new copy ("Your programmatic triggers are paused", addressed to the admin reading it, generic across schedule and webhook triggers, no mention of consumed credits); a positive cap that was used up keeps the existing exhausted copy, and the 80% warning keeps its own. A new `notifyAdminsTriggerBlockedByProgrammaticCap` in `lib/api/credits/` runs from the trigger activity gate and the webhook ingest gate via `fireAndForgetNotification`, so a failure is logged and never fails the run. It only acts for enabled `workspace_pool` triggers on credit-priced workspaces.

Deduplication keys on workspace, reason, the cap value and, for a positive cap, the billing cycle. That key is the Novu `transactionId` and a Redis sent marker written only after a successful send, so a failed send retries on the next run, a cap change re-arms the email, and unrelated usage-configuration edits do not. A 60 second per-workspace claim throttles the check itself, so a burst of blocked webhook requests costs one Redis call per event. Logs and the `trigger_blocked` PostHog event carry `block_reason=programmatic_monthly_cap`; the webhook request status stays `credits_exhausted`.

## Tests

28 tests across 4 files: copy per reason, `transactionId` stability, one email per cap state with retries and repeated runs staying silent, re-arm on cap change but not on unrelated configuration edits, the webhook ingest path notifying for a blocked `workspace_pool` trigger, and no email for disabled, `user_pool`, non-credit-priced or pool-depleted cases. A blocked schedule run still creates no conversation and completes without retry.

## Risk

Low. Worst case an admin gets one reminder per quarter while a workspace stays at a 0 cap. Safe to roll back.

## Deploy Plan

Deploy `front`. The Novu bridge picks up the new payload schema on its next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
