### PR TITLE
Add: right click menu to edit / remove a file Tab in pod.git status

### DIFF
--- a/front/components/pages/pod/PodPage.tsx
+++ b/front/components/pages/pod/PodPage.tsx
@@ -1,7 +1,7 @@
+import { PodFileTabNavTrigger } from "@app/components/pod/PodFileTabNavTrigger";
 import { PodHeaderActions } from "@app/components/pod/PodHeaderActions";
 import { PodNavAddFileTabButton } from "@app/components/pod/PodNavAddFileTabButton";
 import { PodPageContent } from "@app/components/pod/PodPageContent";
-import { getIcon } from "@app/components/resources/resources_icons";
 import { useActivePodId } from "@app/hooks/useActivePodId";
 import { useScopedPodUiPreferences } from "@app/hooks/useScopedUIPreferences";
 import {
@@ -21,7 +21,6 @@ import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { classNames } from "@app/lib/utils";
 import {
   buildPodNavItemsBeforeSettings,
-  makePodFileTabValue,
   normalizeTabsOrder,
   parsePodFileTabPath,
   sortPodFileTabs,
@@ -201,18 +200,20 @@ export function PodPage() {
                   const isFileMissing =
                     !isPodFilesLoading && !podFilePaths.has(item.tab.path);
                   return (
-                    <NavTabPillTrigger
+                    <PodFileTabNavTrigger
                       key={item.tab.path}
-                      value={makePodFileTabValue(item.tab.path)}
-                      icon={getIcon(item.tab.icon)}
+                      owner={owner}
+                      podId={podInfo.sId}
+                      fileTabs={fileTabs}
+                      tabsOrder={tabsOrder}
+                      isEditor={podInfo.isEditor}
+                      tab={item.tab}
                       className={
                         isFileMissing
                           ? MISSING_FILE_TAB_TRIGGER_CLASSNAME
                           : undefined
                       }
-                    >
-                      {item.tab.title}
-                    </NavTabPillTrigger>
+                    />
                   );
                 }
                 default: {

--- a/front/components/pod/PodFileTabNavTrigger.tsx
+++ b/front/components/pod/PodFileTabNavTrigger.tsx
@@ -1,0 +1,118 @@
+import { EditPodFileTabDialog } from "@app/components/pod/files/EditPodFileTabDialog";
+import { usePodMenu } from "@app/components/pod/PodMenu";
+import { getIcon } from "@app/components/resources/resources_icons";
+import { usePodFileTabs } from "@app/hooks/usePodFileTabs";
+import type { PodFileTab } from "@app/types/pod_file_tab";
+import { makePodFileTabValue } from "@app/types/pod_file_tab";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Edit04,
+  NavTabPillTrigger,
+  XClose,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+interface PodFileTabNavTriggerProps {
+  owner: LightWorkspaceType;
+  podId: string;
+  fileTabs: PodFileTab[];
+  tabsOrder?: string[];
+  isEditor: boolean;
+  tab: PodFileTab;
+  className?: string;
+}
+
+export function PodFileTabNavTrigger({
+  owner,
+  podId,
+  fileTabs,
+  tabsOrder,
+  isEditor,
+  tab,
+  className,
+}: PodFileTabNavTriggerProps) {
+  const { removeFileTab } = usePodFileTabs({
+    owner,
+    podId,
+    fileTabs,
+    tabsOrder,
+    isEditor,
+  });
+  const {
+    isMenuOpen,
+    menuTriggerPosition,
+    handleRightClick,
+    handleMenuPhaseChange,
+  } = usePodMenu();
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+
+  return (
+    <>
+      <NavTabPillTrigger
+        value={makePodFileTabValue(tab.path)}
+        icon={getIcon(tab.icon)}
+        className={className}
+        onContextMenu={isEditor ? handleRightClick : undefined}
+      >
+        {tab.title}
+      </NavTabPillTrigger>
+      {isEditor && menuTriggerPosition && (
+        <DropdownMenu
+          modal={false}
+          open={isMenuOpen}
+          onOpenChange={(open) =>
+            handleMenuPhaseChange(open ? "open" : "closing")
+          }
+        >
+          <DropdownMenuTrigger asChild>
+            <div
+              style={{
+                position: "fixed",
+                left: menuTriggerPosition.x,
+                top: menuTriggerPosition.y,
+                width: 0,
+                height: 0,
+                pointerEvents: "none",
+              }}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            onCloseAutoFocus={() => handleMenuPhaseChange("closed")}
+            onFocusOutside={(e) => e.preventDefault()}
+          >
+            <DropdownMenuItem
+              label="Edit"
+              icon={Edit04}
+              onClick={() => setIsEditDialogOpen(true)}
+            />
+            <DropdownMenuItem
+              label="Remove"
+              icon={XClose}
+              onClick={() =>
+                void removeFileTab(tab.path, { fileName: tab.title })
+              }
+            />
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+      {isEditDialogOpen && (
+        <EditPodFileTabDialog
+          key={tab.path}
+          owner={owner}
+          podId={podId}
+          fileTabs={fileTabs}
+          tabsOrder={tabsOrder}
+          isEditor={isEditor}
+          tab={tab}
+          mode="edit"
+          isOpen
+          onClose={() => setIsEditDialogOpen(false)}
+        />
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Description

Pod file tabs now expose an editor-only context menu with `Edit` and `Remove` actions. `Edit` opens `EditPodFileTabDialog` in edit mode, while `Remove` reuses `usePodFileTabs.removeFileTab`; existing tab navigation and missing-file styling remain unchanged.

<img width="230" height="129" alt="image" src="https://github.com/user-attachments/assets/c1f757c7-7dba-41d8-8a5b-2cfd432109a4" />

r? @fabiencelier easy

## Tests

No new automated tests were added. Repository lint, React Doctor, CodeQL, and security checks pass; TypeScript checks and test shards were still running when this description was generated.

## Risk

Low risk. The change is front-only and editor-gated, and it reuses the existing tab edit and removal flows. Rollback is safe by reverting the front-end commit.

## Deploy Plan

Deploy `front`. No migrations, infrastructure changes, or feature-flag sequencing required.