### PR TITLE
[Admin Governance] Fix agent permission mismatches from Poke MCP

### DIFF
--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.test.ts
@@ -208,6 +208,7 @@ describe("GET /api/v1/w/[wId]/assistant/agent_configurations/[sId]", () => {
     const data = await response.json();
 
     expect(response.status).toBe(200);
+    expect(data.agentConfiguration.canRead).toBe(false);
     expect(data.agentConfiguration.canEdit).toBe(role === "admin");
 
     const patchResponse = await patchAgentConfiguration(

--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -84,6 +84,32 @@ describe("getAgentConfigurations", () => {
     }
   });
 
+  it.each([true, false])(
+    "internal admins report edit access from their grants (all groups: %s)",
+    async (dangerouslyRequestAllGroups) => {
+      const { authenticator, workspace } = await createResourceTest({
+        role: "admin",
+      });
+      const agent = await AgentConfigurationFactory.createTestAgent(
+        authenticator,
+        { scope: "hidden" }
+      );
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId, {
+        dangerouslyRequestAllGroups,
+      });
+
+      const configuration = await getAgentConfiguration(auth, {
+        agentId: agent.sId,
+        variant: "light",
+      });
+
+      expect(configuration).toMatchObject({
+        canRead: dangerouslyRequestAllGroups,
+        canEdit: dangerouslyRequestAllGroups,
+      });
+    }
+  );
+
   it("respects the agent grants of a scoped system key", async () => {
     const { authenticator, workspace, systemGroup } = await createResourceTest({
       role: "admin",

--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -84,31 +84,31 @@ describe("getAgentConfigurations", () => {
     }
   });
 
-  it.each([true, false])(
-    "internal admins report edit access from their grants (all groups: %s)",
-    async (dangerouslyRequestAllGroups) => {
-      const { authenticator, workspace } = await createResourceTest({
-        role: "admin",
-      });
-      const agent = await AgentConfigurationFactory.createTestAgent(
-        authenticator,
-        { scope: "hidden" }
-      );
-      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId, {
-        dangerouslyRequestAllGroups,
-      });
+  it.each([
+    true,
+    false,
+  ])("internal admins report edit access from their grants (all groups: %s)", async (dangerouslyRequestAllGroups) => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { scope: "hidden" }
+    );
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId, {
+      dangerouslyRequestAllGroups,
+    });
 
-      const configuration = await getAgentConfiguration(auth, {
-        agentId: agent.sId,
-        variant: "light",
-      });
+    const configuration = await getAgentConfiguration(auth, {
+      agentId: agent.sId,
+      variant: "light",
+    });
 
-      expect(configuration).toMatchObject({
-        canRead: dangerouslyRequestAllGroups,
-        canEdit: dangerouslyRequestAllGroups,
-      });
-    }
-  );
+    expect(configuration).toMatchObject({
+      canRead: dangerouslyRequestAllGroups,
+      canEdit: dangerouslyRequestAllGroups,
+    });
+  });
 
   it("respects the agent grants of a scoped system key", async () => {
     const { authenticator, workspace, systemGroup } = await createResourceTest({

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -179,7 +179,7 @@ async function shadowAgentPermissions(
  */
 /**
  * @cc [owner:philipperolet,label:security] agent-editability
- * Outside regular API keys, `canEdit` allows legacy authors/editors or user-less system-key/Poke
+ * Outside regular API keys, `canEdit` allows legacy authors/editors or user-less
  * callers with agent write permission; workspace admin role alone does not grant it.
  */
 export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
@@ -245,7 +245,7 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
     const isMember = editorIds.includes(agent.id);
     const canEditWithoutUser =
       !user &&
-      (auth.isSystemKey() || auth.isDustSuperUser()) &&
+      !isRegularApiKey &&
       auth.can("write", AgentResource.fromAgentConfigurationModel(agent));
 
     const canRead =


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/32146.

Poke MCP reads conversations using an internal admin identity with no user attached. Its groups grant agent edit access, but the old permission check only recognizes system keys and Poke web sessions in this case. It therefore reports that agents cannot be edited while the new check says they can. A large batch of Poke reads produced over 27,000 mismatch logs on September 9.

Use the existing agent write-permission check for internal callers without a user too. Callers without editor grants still cannot edit; human permissions and regular API-key behavior stay unchanged. No new grants or backfill are needed.

## Risks

Blast radius: Agent read/edit permission reporting for internal callers without a user.
Risk: low

## Deploy Plan

- Deploy front-api and front workers.

## Tests

- [x] Internal admins with and without editor grants; existing agent configuration, ACL and shadow tests (50 tests).
- [x] Public API agent list and details tests, including unchanged hidden-agent read reporting for regular keys (19 tests).
