### PR TITLE
[IMAGE_GENERATION] honor exact aspect ratios within the conversation size cap

### DIFF
--- a/front/lib/api/actions/servers/image_generation/clients/openai.test.ts
+++ b/front/lib/api/actions/servers/image_generation/clients/openai.test.ts
@@ -1,0 +1,65 @@
+import { toImageSize } from "@app/lib/api/actions/servers/image_generation/clients/openai";
+import type { ImageGenerationToolInput } from "@app/lib/api/actions/servers/image_generation/metadata";
+import { CONVERSATION_IMG_MAX_SIZE_PIXELS } from "@app/lib/api/files/processing/images";
+import { describe, expect, it } from "vitest";
+
+const ASPECT_RATIOS = [
+  "1:1",
+  "3:2",
+  "2:3",
+  "3:4",
+  "4:3",
+  "4:5",
+  "5:4",
+  "9:16",
+  "16:9",
+  "21:9",
+] as const satisfies readonly ImageGenerationToolInput["aspectRatio"][];
+
+const QUALITIES = [
+  "low",
+  "medium",
+] as const satisfies readonly ImageGenerationToolInput["quality"][];
+
+// Limits gpt-image models enforce on arbitrary WIDTHxHEIGHT sizes.
+const MULTIPLE = 16;
+const MIN_PIXELS = 655_360;
+const MAX_PIXELS = 8_294_400;
+
+describe("toImageSize", () => {
+  for (const aspectRatio of ASPECT_RATIOS) {
+    for (const quality of QUALITIES) {
+      it(`returns an accepted size for ${aspectRatio} at ${quality} quality`, () => {
+        const [width, height] = toImageSize({ aspectRatio, quality })
+          .split("x")
+          .map(Number);
+
+        const [ratioWidth, ratioHeight] = aspectRatio.split(":").map(Number);
+        expect(width * ratioHeight).toBe(height * ratioWidth);
+
+        expect(width % MULTIPLE).toBe(0);
+        expect(height % MULTIPLE).toBe(0);
+
+        // Staying within the conversation cap is what keeps the upload off the imgproxy
+        // resize path; imgproxy is not available in local development.
+        expect(Math.max(width, height)).toBeLessThanOrEqual(
+          CONVERSATION_IMG_MAX_SIZE_PIXELS
+        );
+
+        expect(width * height).toBeGreaterThanOrEqual(MIN_PIXELS);
+        expect(width * height).toBeLessThanOrEqual(MAX_PIXELS);
+      });
+    }
+  }
+
+  it("scales up with quality", () => {
+    const pixels = QUALITIES.map((quality) => {
+      const [width, height] = toImageSize({ aspectRatio: "16:9", quality })
+        .split("x")
+        .map(Number);
+      return width * height;
+    });
+
+    expect(pixels[0]).toBeLessThan(pixels[1]);
+  });
+});

--- a/front/lib/api/actions/servers/image_generation/clients/openai.ts
+++ b/front/lib/api/actions/servers/image_generation/clients/openai.ts
@@ -1,4 +1,3 @@
-import type { GenerateImageInputType } from "@app/lib/actions/mcp_internal_actions/types";
 import type { Base64ImageData } from "@app/lib/api/actions/servers/image_generation/helpers";
 import { ImageGenerationError } from "@app/lib/api/actions/servers/image_generation/helpers";
 import type {
@@ -8,6 +7,7 @@ import type {
   TokenCountDetails,
 } from "@app/lib/api/actions/servers/image_generation/imageGeneration";
 import { ImageGenerationLLM } from "@app/lib/api/actions/servers/image_generation/imageGeneration";
+import { CONVERSATION_IMG_MAX_SIZE_PIXELS } from "@app/lib/api/files/processing/images";
 import type { Authenticator } from "@app/lib/auth";
 import { trustedFetch } from "@app/lib/egress/server";
 import { concurrentExecutor } from "@app/temporal/workflow_utils";
@@ -23,35 +23,45 @@ import { Err, Ok } from "@app/types/shared/result";
 import { isString } from "@app/types/shared/utils/general";
 import assert from "assert";
 import { OpenAI, toFile } from "openai";
-import type {
-  ImageGenerateParamsBase,
-  ImagesResponse,
-} from "openai/resources/images";
+import type { ImagesResponse } from "openai/resources/images";
 
-const SQUARE = "1024x1024";
-const LANDSCAPE = "1536x1024";
-const PORTRAIT = "1024x1536";
+// GPT image models accept arbitrary `WIDTHxHEIGHT` sizes, not only the three documented presets.
+// See https://developers.openai.com/api/docs/guides/image-generation.
+const SIZE_MULTIPLE = 16;
 
-type SupportedImageSize = Extract<
-  ImageGenerateParamsBase["size"],
-  typeof SQUARE | typeof LANDSCAPE | typeof PORTRAIT
->;
+const MAX_EDGE = CONVERSATION_IMG_MAX_SIZE_PIXELS;
 
-const ASPECT_RATIO_TO_IMAGE_SIZE: Record<
-  GenerateImageInputType["aspectRatio"],
-  SupportedImageSize
-> = {
-  "1:1": SQUARE,
-  "3:2": LANDSCAPE,
-  "4:3": LANDSCAPE,
-  "5:4": LANDSCAPE,
-  "16:9": LANDSCAPE,
-  "21:9": LANDSCAPE,
-  "2:3": PORTRAIT,
-  "3:4": PORTRAIT,
-  "4:5": PORTRAIT,
-  "9:16": PORTRAIT,
-};
+const QUALITY_TO_PIXEL_BUDGET: Record<ImageGenerationInput["quality"], number> =
+  {
+    low: 1024 * 1024,
+    medium: 2048 * 2048,
+  };
+
+/**
+ * @cc [owner:pmilliotte,label:product] openai-image-size-limits
+ * The returned size MUST have the exact requested aspect ratio, both edges multiples of 16, and a
+ * total pixel count within [655360, 8294400] — the limits gpt-image models enforce on arbitrary
+ * sizes. Sizes outside those limits are rejected by the API.
+ */
+export function toImageSize({
+  aspectRatio,
+  quality,
+}: Pick<ImageGenerationInput, "aspectRatio" | "quality">): string {
+  const [width, height] = aspectRatio.split(":").map(Number);
+
+  // Scale the ratio by the largest factor `k` that keeps both edges multiples of 16 and within the
+  // quality's pixel budget and the model's max edge, so the ratio is honored exactly.
+  const k = Math.min(
+    Math.floor(
+      Math.sqrt(
+        QUALITY_TO_PIXEL_BUDGET[quality] / (SIZE_MULTIPLE ** 2 * width * height)
+      )
+    ),
+    Math.floor(MAX_EDGE / (SIZE_MULTIPLE * Math.max(width, height)))
+  );
+
+  return `${SIZE_MULTIPLE * width * k}x${SIZE_MULTIPLE * height * k}`;
+}
 
 function isSafetyBlockError(
   error: unknown
@@ -95,7 +105,7 @@ export class ImageGenerationOpenAILLM extends ImageGenerationLLM {
   ): Promise<Result<ImageGenerationOutput, ImageGenerationError>> {
     const { prompt, aspectRatio, referenceFiles, quality } = params;
 
-    const size = ASPECT_RATIO_TO_IMAGE_SIZE[aspectRatio];
+    const size = toImageSize({ aspectRatio, quality });
 
     let response: ImagesResponse;
     try {
@@ -206,7 +216,7 @@ export class ImageGenerationOpenAILLM extends ImageGenerationLLM {
   }: ImageGenerationInput): Record<string, string | number> {
     return {
       aspectRatio,
-      imageSize: ASPECT_RATIO_TO_IMAGE_SIZE[aspectRatio],
+      imageSize: toImageSize({ aspectRatio, quality }),
       quality,
     };
   }

--- a/front/lib/api/files/processing/images.ts
+++ b/front/lib/api/files/processing/images.ts
@@ -10,7 +10,8 @@ import imageSize from "image-size";
 import sharp from "sharp";
 import { pipeline } from "stream/promises";
 
-const CONVERSATION_IMG_MAX_SIZE_PIXELS = 1538;
+// Exported so generators can stay within it and skip the resize path entirely.
+export const CONVERSATION_IMG_MAX_SIZE_PIXELS = 1538;
 const AVATAR_IMG_MAX_SIZE_PIXELS = 256;
 const BRANDING_LOGO_MAX_SIZE_PIXELS = 512;
 const BRANDING_FAVICON_MAX_SIZE_PIXELS = 256;


### PR DESCRIPTION
## Description

Replace the three fixed OpenAI image size presets with a computed `WIDTHxHEIGHT` that honors the requested aspect ratio exactly, capped at the conversation image size limit so generated images never go through imgproxy resizing on upload.

## Tests

Added unit tests covering every aspect ratio × quality combination: exact ratio preserved, both edges multiples of 16, within the conversation cap and the API's pixel bounds.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`