### PR TITLE
[front] feat: back button in the side panel

### DIFF
--- a/front/components/assistant/AgentMessageMarkdown.integration.test.tsx
+++ b/front/components/assistant/AgentMessageMarkdown.integration.test.tsx
@@ -117,6 +117,8 @@ describe("AgentMessageMarkdown - Integration Tests", () => {
       const { container } = render(
         <ConversationSidePanelContext.Provider
           value={{
+            canGoBack: false,
+            goBack: vi.fn(),
             currentPanel: undefined,
             isPanelClosing: false,
             openPanel,

--- a/front/components/assistant/AgentMessageMarkdown.integration.test.tsx
+++ b/front/components/assistant/AgentMessageMarkdown.integration.test.tsx
@@ -1,8 +1,9 @@
+import { ConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { FilePreviewProvider } from "@app/components/assistant/conversation/FilePreviewContext";
 import { getFilePreviewMarkdownDirective } from "@app/lib/markdown/file_preview";
 import { LightWorkspaceFactory } from "@app/tests/utils/LightWorkspaceFactory";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { AgentMessageMarkdown } from "./AgentMessageMarkdown";
 
@@ -112,15 +113,32 @@ describe("AgentMessageMarkdown - Integration Tests", () => {
     });
 
     it("renders scoped file preview directives as previewable files", async () => {
+      const openPanel = vi.fn();
       const { container } = render(
-        <FilePreviewProvider owner={mockOwner}>
-          <AgentMessageMarkdown
-            owner={mockOwner}
-            content={
-              'Open :preview_file{path="conversation-c1/booklet.pdf" title="booklet.pdf" contentType="application/pdf"} for the details.'
-            }
-          />
-        </FilePreviewProvider>
+        <ConversationSidePanelContext.Provider
+          value={{
+            currentPanel: undefined,
+            isPanelClosing: false,
+            openPanel,
+            togglePanel: vi.fn(),
+            closePanel: vi.fn(),
+            onPanelClosed: vi.fn(),
+            setPanelRef: vi.fn(),
+            panelRef: { current: null },
+            setVirtuosoMsg: vi.fn(),
+            virtuosoMsg: null,
+            data: undefined,
+          }}
+        >
+          <FilePreviewProvider owner={mockOwner}>
+            <AgentMessageMarkdown
+              owner={mockOwner}
+              content={
+                'Open :preview_file{path="conversation-c1/booklet.pdf" title="booklet.pdf" contentType="application/pdf"} for the details.'
+              }
+            />
+          </FilePreviewProvider>
+        </ConversationSidePanelContext.Provider>
       );
 
       const fileLink = screen.getByRole("button", { name: "booklet.pdf" });
@@ -131,10 +149,12 @@ describe("AgentMessageMarkdown - Integration Tests", () => {
 
       fireEvent.click(fileLink);
 
-      expect(await screen.findByRole("dialog")).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: "Download" })
-      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(openPanel).toHaveBeenCalledWith({
+          type: "file_preview",
+          filePath: "conversation-c1/booklet.pdf",
+        });
+      });
     });
 
     it("hides incomplete text directives while content is streaming", async () => {

--- a/front/components/assistant/UserMessageMarkdown.integration.test.tsx
+++ b/front/components/assistant/UserMessageMarkdown.integration.test.tsx
@@ -60,6 +60,8 @@ vi.mock(
   async (importOriginal) => ({
     ...(await importOriginal()),
     useConversationSidePanelContext: () => ({
+      canGoBack: false,
+      goBack: vi.fn(),
       currentPanel: undefined,
       isPanelClosing: false,
       openPanel: vi.fn(),

--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -95,8 +95,8 @@ const ConversationLayoutContent = ({
 
   return (
     <AssistantLayout owner={owner} user={user} conversation={conversation}>
-      <FilePreviewProvider owner={owner}>
-        <ConversationSidePanelProvider>
+      <ConversationSidePanelProvider>
+        <FilePreviewProvider owner={owner}>
           <ConversationInnerLayout
             activeConversationId={activeConversationId}
             conversation={conversation}
@@ -105,8 +105,8 @@ const ConversationLayoutContent = ({
           >
             {children}
           </ConversationInnerLayout>
-        </ConversationSidePanelProvider>
-      </FilePreviewProvider>
+        </FilePreviewProvider>
+      </ConversationSidePanelProvider>
       {shouldDisplayWelcomeTourGuide && (
         <WelcomeTourGuide
           owner={owner}

--- a/front/components/assistant/conversation/ConversationSidePanelContext.test.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.test.tsx
@@ -96,6 +96,80 @@ describe("ConversationSidePanelProvider selection", () => {
   });
 });
 
+describe("ConversationSidePanelProvider history", () => {
+  beforeEach(resetHash);
+
+  it("starts with no history", () => {
+    const probe = renderProvider();
+
+    expect(probe.panel.canGoBack).toBe(false);
+  });
+
+  it("goes back to the previously shown panel", () => {
+    const probe = renderProvider();
+
+    act(() => probe.panel.openPanel({ type: "files" }));
+    expect(probe.panel.canGoBack).toBe(false);
+
+    act(() =>
+      probe.panel.openPanel({ type: "file_preview", filePath: "a.md" })
+    );
+    expect(probe.panel.canGoBack).toBe(true);
+
+    act(() => probe.panel.goBack());
+    expect(probe.panel.currentPanel).toBe("files");
+    expect(probe.panel.data).toBe("files");
+    expect(probe.panel.canGoBack).toBe(false);
+  });
+
+  it("walks back through several panels in order", () => {
+    const probe = renderProvider();
+
+    act(() => probe.panel.openPanel({ type: "files" }));
+    act(() =>
+      probe.panel.openPanel({ type: "file_preview", filePath: "a.md" })
+    );
+    act(() =>
+      probe.panel.openPanel({ type: "file_preview", filePath: "b.md" })
+    );
+
+    act(() => probe.panel.goBack());
+    expect(probe.panel.data).toBe("a.md");
+
+    act(() => probe.panel.goBack());
+    expect(probe.panel.currentPanel).toBe("files");
+    expect(probe.panel.canGoBack).toBe(false);
+  });
+
+  it("does not record a history entry when reselecting the same content", () => {
+    const probe = renderProvider();
+
+    act(() =>
+      probe.panel.openPanel({ type: "file_preview", filePath: "a.md" })
+    );
+    act(() =>
+      probe.panel.openPanel({ type: "file_preview", filePath: "a.md" })
+    );
+
+    expect(probe.panel.canGoBack).toBe(false);
+  });
+
+  it("clears history once the panel has closed", () => {
+    const probe = renderProvider();
+
+    act(() => probe.panel.openPanel({ type: "files" }));
+    act(() =>
+      probe.panel.openPanel({ type: "file_preview", filePath: "a.md" })
+    );
+    expect(probe.panel.canGoBack).toBe(true);
+
+    act(() => probe.panel.closePanel());
+    act(() => probe.panel.onPanelClosed());
+
+    expect(probe.panel.canGoBack).toBe(false);
+  });
+});
+
 describe("ConversationSidePanelProvider toggle", () => {
   beforeEach(resetHash);
 

--- a/front/components/assistant/conversation/ConversationSidePanelContext.test.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.test.tsx
@@ -82,6 +82,18 @@ describe("ConversationSidePanelProvider selection", () => {
     );
     expect(probe.panel.data).toBe("msg_1@act_1");
   });
+
+  it("addresses path-less files by id without colliding with paths", () => {
+    const probe = renderProvider();
+
+    act(() => probe.panel.openPanel({ type: "file_preview", fileId: "fil_1" }));
+    expect(probe.panel.data).toBe("id:fil_1");
+
+    act(() =>
+      probe.panel.openPanel({ type: "file_preview", filePath: "a.md" })
+    );
+    expect(probe.panel.data).toBe("a.md");
+  });
 });
 
 describe("ConversationSidePanelProvider toggle", () => {

--- a/front/components/assistant/conversation/ConversationSidePanelContext.test.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.test.tsx
@@ -1,0 +1,154 @@
+import {
+  ConversationSidePanelProvider,
+  useConversationSidePanelContext,
+} from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import { useHashParam } from "@app/hooks/useHashParams";
+import { FULL_SCREEN_HASH_PARAM } from "@app/types/conversation_side_panel";
+import { act, render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/hooks/useActiveConversationId", () => ({
+  useActiveConversationId: () => "conv-1",
+}));
+
+type Panel = ReturnType<typeof useConversationSidePanelContext>;
+type FullScreen = ReturnType<typeof useHashParam>;
+
+function renderProvider() {
+  const ref: { current: Panel | null } = { current: null };
+  const fullScreenRef: { current: FullScreen | null } = { current: null };
+
+  function Probe() {
+    ref.current = useConversationSidePanelContext();
+    fullScreenRef.current = useHashParam(FULL_SCREEN_HASH_PARAM);
+    return null;
+  }
+
+  render(
+    <ConversationSidePanelProvider>
+      <Probe />
+    </ConversationSidePanelProvider>
+  );
+
+  return {
+    get panel() {
+      if (!ref.current) {
+        throw new Error("provider did not render");
+      }
+      return ref.current;
+    },
+    get fullScreen() {
+      if (!fullScreenRef.current) {
+        throw new Error("provider did not render");
+      }
+      return fullScreenRef.current;
+    },
+  };
+}
+
+function resetHash() {
+  act(() => {
+    window.history.replaceState(null, "", window.location.pathname);
+  });
+}
+
+describe("ConversationSidePanelProvider selection", () => {
+  beforeEach(resetHash);
+
+  it("switches content when a different panel is selected", () => {
+    const probe = renderProvider();
+
+    act(() => probe.panel.openPanel({ type: "files" }));
+    expect(probe.panel.currentPanel).toBe("files");
+    expect(probe.panel.data).toBe("files");
+
+    act(() => probe.panel.openPanel({ type: "credits" }));
+    expect(probe.panel.currentPanel).toBe("credits");
+    expect(probe.panel.data).toBe("credits");
+  });
+
+  it("addresses a single action separately from its message", () => {
+    const probe = renderProvider();
+
+    act(() => probe.panel.openPanel({ type: "actions", messageId: "msg_1" }));
+    expect(probe.panel.data).toBe("msg_1");
+
+    act(() =>
+      probe.panel.openPanel({
+        type: "actions",
+        messageId: "msg_1",
+        actionId: "act_1",
+      })
+    );
+    expect(probe.panel.data).toBe("msg_1@act_1");
+  });
+});
+
+describe("ConversationSidePanelProvider toggle", () => {
+  beforeEach(resetHash);
+
+  it("closes the panel when the shown panel is reselected", () => {
+    const probe = renderProvider();
+
+    act(() => probe.panel.togglePanel({ type: "files" }));
+    expect(probe.panel.currentPanel).toBe("files");
+
+    act(() => probe.panel.togglePanel({ type: "files" }));
+    act(() => probe.panel.onPanelClosed());
+    expect(probe.panel.currentPanel).toBeUndefined();
+  });
+
+  it("switches rather than closing when a different panel is selected", () => {
+    const probe = renderProvider();
+
+    act(() => probe.panel.togglePanel({ type: "files" }));
+    act(() => probe.panel.togglePanel({ type: "credits" }));
+
+    expect(probe.panel.currentPanel).toBe("credits");
+  });
+
+  it("keeps the panel open when openPanel reselects the shown content", () => {
+    const probe = renderProvider();
+
+    act(() => probe.panel.openPanel({ type: "files" }));
+    act(() => probe.panel.openPanel({ type: "files" }));
+
+    expect(probe.panel.currentPanel).toBe("files");
+  });
+});
+
+describe("ConversationSidePanelProvider full screen", () => {
+  beforeEach(resetHash);
+
+  it("leaves full screen when switching to another panel", () => {
+    const probe = renderProvider();
+
+    act(() =>
+      probe.panel.openPanel({ type: "interactive_content", fileId: "fil_1" })
+    );
+    act(() => probe.fullScreen[1]("true"));
+    expect(probe.fullScreen[0]).toBe("true");
+
+    act(() => probe.panel.openPanel({ type: "files" }));
+    expect(probe.fullScreen[0]).toBeUndefined();
+  });
+
+  it("stays full screen when the same panel refreshes its content", () => {
+    const probe = renderProvider();
+
+    act(() =>
+      probe.panel.openPanel({ type: "interactive_content", fileId: "fil_1" })
+    );
+    act(() => probe.fullScreen[1]("true"));
+
+    act(() =>
+      probe.panel.openPanel({
+        type: "interactive_content",
+        fileId: "fil_1",
+        timestamp: "123",
+      })
+    );
+
+    expect(probe.fullScreen[0]).toBe("true");
+  });
+});

--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -66,11 +66,13 @@ const isSupportedPanelType = (
   type === "skill";
 
 interface ConversationSidePanelContextType {
+  canGoBack: boolean;
   currentPanel: ConversationSidePanelType;
   // True between closePanel() and the end of the collapse transition. `currentPanel` keeps the
   // old value meanwhile so the panel content does not flicker; toggles read this to unselect
   // right away.
   isPanelClosing: boolean;
+  goBack: () => void;
   openPanel: (params: OpenPanelParams) => void;
   togglePanel: (params: OpenPanelParams) => void;
   closePanel: () => void;
@@ -163,6 +165,13 @@ function getPanelData(params: OpenPanelParams): string {
   }
 }
 
+interface PanelHistoryEntry {
+  panel: ConversationSidePanelType;
+  data: string;
+}
+
+const MAX_PANEL_HISTORY = 50;
+
 interface ConversationSidePanelProviderProps {
   children: React.ReactNode;
 }
@@ -179,6 +188,9 @@ export function ConversationSidePanelProvider({
   const previousConversationIdRef = React.useRef(activeConversationId);
 
   const panelRef = React.useRef<ImperativePanelHandle | null>(null);
+  const [panelHistory, setPanelHistory] = React.useState<PanelHistoryEntry[]>(
+    []
+  );
   const [isPanelClosing, setIsPanelClosing] = React.useState(false);
   const [virtuosoMsg, setVirtuosoMsg] =
     React.useState<AgentMessageWithStreaming | null>(null);
@@ -196,6 +208,7 @@ export function ConversationSidePanelProvider({
     setIsPanelClosing(false);
     setData(undefined);
     setCurrentPanel(undefined);
+    setPanelHistory([]);
   }, [setData, setCurrentPanel]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
@@ -226,6 +239,17 @@ export function ConversationSidePanelProvider({
         return;
       }
 
+      if (
+        !isSameContent &&
+        !isPanelClosing &&
+        data &&
+        isSupportedPanelType(currentPanel)
+      ) {
+        setPanelHistory((history) =>
+          [...history, { panel: currentPanel, data }].slice(-MAX_PANEL_HISTORY)
+        );
+      }
+
       setIsPanelClosing(false);
       setCurrentPanel(params.type);
       setData(nextData);
@@ -250,6 +274,20 @@ export function ConversationSidePanelProvider({
       setFullScreenHash,
     ]
   );
+
+  const goBack = useCallback(() => {
+    const previous = panelHistory.at(-1);
+    if (!previous) {
+      return;
+    }
+
+    setPanelHistory((history) => history.slice(0, -1));
+    setIsPanelClosing(false);
+    setCurrentPanel(previous.panel);
+    setData(previous.data);
+    setFullScreenHash(undefined);
+    panelRef.current?.expand(getDefaultRightPanelSize(previous.panel));
+  }, [panelHistory, setCurrentPanel, setData, setFullScreenHash]);
 
   // Idempotent open for programmatic callers: a toggle could mis-close during a close→reopen
   // transition where `currentPanel` still reads the old value.
@@ -293,6 +331,8 @@ export function ConversationSidePanelProvider({
 
   const value = useMemo(
     () => ({
+      canGoBack: panelHistory.length > 0,
+      goBack,
       currentPanel: isSupportedPanelType(currentPanel)
         ? currentPanel
         : undefined,
@@ -308,6 +348,8 @@ export function ConversationSidePanelProvider({
       data,
     }),
     [
+      panelHistory,
+      goBack,
       currentPanel,
       isPanelClosing,
       openPanel,

--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -33,6 +33,12 @@ type OpenPanelParams =
   | {
       type: "file_preview";
       filePath: string;
+      fileId?: undefined;
+    }
+  | {
+      type: "file_preview";
+      fileId: string;
+      filePath?: undefined;
     }
   | {
       type: "files";
@@ -91,6 +97,26 @@ export function useConversationSidePanelContext() {
   return context;
 }
 
+const FILE_PREVIEW_FILE_ID_PREFIX = "id:";
+
+export function encodeFilePreviewFileId(fileId: string): string {
+  return `${FILE_PREVIEW_FILE_ID_PREFIX}${fileId}`;
+}
+
+// Content fragments without a sandbox path are addressed by id instead.
+export function parseFilePreviewData(data?: string): {
+  fileId?: string;
+  filePath?: string;
+} {
+  if (!data) {
+    return {};
+  }
+
+  return data.startsWith(FILE_PREVIEW_FILE_ID_PREFIX)
+    ? { fileId: data.slice(FILE_PREVIEW_FILE_ID_PREFIX.length) }
+    : { filePath: data };
+}
+
 export function parseDataAsMessageIdAndActionId(data?: string): {
   messageId?: string;
   actionId?: string;
@@ -118,7 +144,7 @@ function getPanelData(params: OpenPanelParams): string {
         : params.fileId;
 
     case FILE_PREVIEW_SIDE_PANEL_TYPE:
-      return params.filePath;
+      return params.filePath ?? encodeFilePreviewFileId(params.fileId);
 
     case FILES_SIDE_PANEL_TYPE:
       return "files";

--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -105,6 +105,38 @@ export function parseDataAsMessageIdAndActionId(data?: string): {
   return { messageId, actionId };
 }
 
+function getPanelData(params: OpenPanelParams): string {
+  switch (params.type) {
+    case AGENT_ACTIONS_SIDE_PANEL_TYPE:
+      return params.actionId
+        ? `${params.messageId}@${params.actionId}`
+        : params.messageId;
+
+    case INTERACTIVE_CONTENT_SIDE_PANEL_TYPE:
+      return params.timestamp
+        ? `${params.fileId}@${params.timestamp}`
+        : params.fileId;
+
+    case FILE_PREVIEW_SIDE_PANEL_TYPE:
+      return params.filePath;
+
+    case FILES_SIDE_PANEL_TYPE:
+      return "files";
+
+    case CREDITS_SIDE_PANEL_TYPE:
+      return "credits";
+
+    case PLAN_SIDE_PANEL_TYPE:
+      return "plan";
+
+    case SKILL_SIDE_PANEL_TYPE:
+      return params.skillId;
+
+    default:
+      assertNever(params);
+  }
+}
+
 interface ConversationSidePanelProviderProps {
   children: React.ReactNode;
 }
@@ -159,79 +191,38 @@ export function ConversationSidePanelProvider({
   // that is already closing reads as unselected, so re-selecting it reopens instead.
   const applyPanel = useCallback(
     (params: OpenPanelParams, { toggle }: { toggle: boolean }) => {
-      const closeOnReselect = toggle && !isPanelClosing;
+      const nextData = getPanelData(params);
+      const isSamePanel = currentPanel === params.type;
+      const isSameContent = isSamePanel && nextData === data;
+
+      if (toggle && !isPanelClosing && isSameContent) {
+        closePanel();
+        return;
+      }
+
       setIsPanelClosing(false);
       setCurrentPanel(params.type);
-
-      switch (params.type) {
-        case AGENT_ACTIONS_SIDE_PANEL_TYPE: {
-          const newData = params.actionId
-            ? `${params.messageId}@${params.actionId}`
-            : params.messageId;
-
-          // A different message/action switches content; only the same data toggles closed.
-          if (closeOnReselect && newData === data) {
-            closePanel();
-            return;
-          }
-
-          setData(newData);
-          break;
-        }
-
-        case INTERACTIVE_CONTENT_SIDE_PANEL_TYPE:
-          // eslint-disable-next-line no-unused-expressions
-          params.timestamp
-            ? setData(`${params.fileId}@${params.timestamp}`)
-            : setData(params.fileId);
-          break;
-
-        case FILE_PREVIEW_SIDE_PANEL_TYPE:
-          setData(params.filePath);
-          break;
-
-        case FILES_SIDE_PANEL_TYPE:
-          if (closeOnReselect && currentPanel === FILES_SIDE_PANEL_TYPE) {
-            closePanel();
-            return;
-          }
-          setData("files");
-          break;
-
-        case CREDITS_SIDE_PANEL_TYPE:
-          if (closeOnReselect && currentPanel === CREDITS_SIDE_PANEL_TYPE) {
-            closePanel();
-            return;
-          }
-          setData("credits");
-          break;
-
-        case PLAN_SIDE_PANEL_TYPE:
-          if (closeOnReselect && currentPanel === PLAN_SIDE_PANEL_TYPE) {
-            closePanel();
-            return;
-          }
-          setData("plan");
-          break;
-
-        case SKILL_SIDE_PANEL_TYPE:
-          // A different skill switches content; only the same skill toggles closed.
-          if (closeOnReselect && params.skillId === data) {
-            closePanel();
-            return;
-          }
-          setData(params.skillId);
-          break;
-
-        default:
-          assertNever(params);
+      setData(nextData);
+      if (!isSamePanel) {
+        // Only FrameRenderer can leave full screen, so switching away from it would
+        // otherwise strand the next panel at 100% with the nav bar hidden. Staying on
+        // the same panel keeps it, so a refreshing frame does not drop out.
+        setFullScreenHash(undefined);
       }
 
       // Re-expand imperatively: the container's expand effect only fires when `currentPanel`
       // changes, so a close→reopen race (same value) wouldn't re-run it. No-op on mobile.
       panelRef.current?.expand(getDefaultRightPanelSize(params.type));
     },
-    [setCurrentPanel, setData, data, closePanel, currentPanel, isPanelClosing]
+    [
+      setCurrentPanel,
+      setData,
+      data,
+      closePanel,
+      currentPanel,
+      isPanelClosing,
+      setFullScreenHash,
+    ]
   );
 
   // Idempotent open for programmatic callers: a toggle could mis-close during a close→reopen

--- a/front/components/assistant/conversation/ConversationSidePanelHeader.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelHeader.tsx
@@ -1,5 +1,6 @@
+import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
-import { Button, XClose } from "@dust-tt/sparkle";
+import { ArrowLeft, Button, XClose } from "@dust-tt/sparkle";
 import type React from "react";
 
 interface ConversationSidePanelHeaderProps {
@@ -11,9 +12,20 @@ export function ConversationSidePanelHeader({
   children,
   onClose,
 }: ConversationSidePanelHeaderProps) {
+  const { canGoBack, goBack } = useConversationSidePanelContext();
+
   return (
     <AppLayoutTitle className="bg-panel-background @container">
       <div className="flex h-full items-center">
+        {canGoBack && (
+          <Button
+            variant="ghost"
+            onClick={goBack}
+            icon={ArrowLeft}
+            tooltip="Back"
+            className="text-element-600 hover:text-element-900 mr-1 shrink-0"
+          />
+        )}
         {children}
         {onClose && (
           <Button

--- a/front/components/assistant/conversation/FilePreviewContext.tsx
+++ b/front/components/assistant/conversation/FilePreviewContext.tsx
@@ -1,21 +1,21 @@
-import { FilePreviewDialog } from "@app/components/file_explorer/FilePreviewDialog";
-import type { FileEntry } from "@app/components/file_explorer/types";
+import { ConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { isFilePreviewableContentType } from "@app/components/file_explorer/utils";
+import { useSendNotification } from "@app/hooks/useNotification";
 import {
   fetchFileIdFromPath,
   getFileDownloadUrl,
   getFilePathDownloadUrl,
-  getFilePathViewUrl,
-  getFileViewUrl,
 } from "@app/lib/swr/files";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { ReactNode } from "react";
 import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
-  useState,
+  useRef,
 } from "react";
 
 interface PreviewableFile {
@@ -25,14 +25,21 @@ interface PreviewableFile {
   contentType: string;
 }
 
+interface FrameFile {
+  fileId?: string | null;
+  filePath?: string;
+}
+
 type FilePreviewContextType = {
+  canPreview: boolean;
   openFilePreview: (file: PreviewableFile) => void;
-  resolveFileIdFromPath: (filePath: string) => Promise<string | null>;
+  openFramePreview: (frame: FrameFile) => Promise<void>;
 };
 
 const FilePreviewContext = createContext<FilePreviewContextType>({
+  canPreview: false,
   openFilePreview: () => {},
-  resolveFileIdFromPath: () => Promise.resolve(null),
+  openFramePreview: () => Promise.resolve(),
 });
 
 interface FilePreviewProviderProps {
@@ -44,19 +51,32 @@ export function FilePreviewProvider({
   owner,
   children,
 }: FilePreviewProviderProps) {
-  const [previewState, setPreviewState] = useState<{
-    entry: FileEntry;
-    fileUrl: string;
-    downloadUrl: string;
-  } | null>(null);
+  const sidePanel = useContext(ConversationSidePanelContext);
+  const sendNotification = useSendNotification();
+  const canPreview = sidePanel != null;
+
+  // The side panel context value changes on every panel navigation. Reading it
+  // through a ref keeps the callbacks below stable, so citations do not all
+  // re-render each time the panel switches.
+  const sidePanelRef = useRef(sidePanel);
+  useEffect(() => {
+    sidePanelRef.current = sidePanel;
+  });
 
   const openFilePreview = useCallback(
     (file: PreviewableFile) => {
-      const fileUrl = file.filePath
-        ? getFilePathViewUrl(owner, file.filePath)
-        : file.fileId
-          ? getFileViewUrl(owner, file.fileId)
-          : null;
+      const panel = sidePanelRef.current;
+
+      if (isFilePreviewableContentType(file.contentType) && panel) {
+        if (file.filePath) {
+          panel.openPanel({ type: "file_preview", filePath: file.filePath });
+          return;
+        }
+        if (file.fileId) {
+          panel.openPanel({ type: "file_preview", fileId: file.fileId });
+          return;
+        }
+      }
 
       const downloadUrl = file.filePath
         ? getFilePathDownloadUrl(owner, file.filePath)
@@ -64,67 +84,47 @@ export function FilePreviewProvider({
           ? getFileDownloadUrl(owner, file.fileId)
           : null;
 
-      if (!fileUrl || !downloadUrl) {
-        return;
-      }
-
-      if (!isFilePreviewableContentType(file.contentType)) {
+      if (downloadUrl) {
         window.open(downloadUrl, "_blank");
-        return;
       }
-
-      setPreviewState({
-        entry: {
-          kind: "file",
-          isDirectory: false,
-          fileName: file.title,
-          path: file.filePath ?? file.title,
-          contentType: file.contentType,
-          fileId: file.fileId ?? null,
-          thumbnailUrl: null,
-          sizeBytes: 0,
-          // No mtime here: stands in to cache-bust the per-URL cached PDF
-          // conversion, so an edited file stops rendering its stale one.
-          lastModifiedMs: Date.now(),
-        },
-        fileUrl,
-        downloadUrl,
-      });
     },
     [owner]
   );
 
-  const resolveFileIdFromPath = useCallback(
-    (filePath: string) => fetchFileIdFromPath({ owner, filePath }),
-    [owner]
+  const openFramePreview = useCallback(
+    async ({ fileId, filePath }: FrameFile) => {
+      try {
+        const resolvedFileId =
+          fileId ??
+          (filePath ? await fetchFileIdFromPath({ owner, filePath }) : null);
+
+        if (!resolvedFileId) {
+          throw new Error("No linked file was found for this Frame.");
+        }
+
+        sidePanelRef.current?.openPanel({
+          type: "interactive_content",
+          fileId: resolvedFileId,
+        });
+      } catch (error) {
+        sendNotification({
+          type: "error",
+          title: "Failed to open Frame",
+          description: normalizeError(error).message,
+        });
+      }
+    },
+    [owner, sendNotification]
   );
 
-  const handleDownload = useCallback(async () => {
-    if (previewState?.downloadUrl) {
-      window.open(previewState.downloadUrl, "_blank");
-    }
-  }, [previewState?.downloadUrl]);
-
   const contextValue = useMemo(
-    () => ({ openFilePreview, resolveFileIdFromPath }),
-    [openFilePreview, resolveFileIdFromPath]
+    () => ({ canPreview, openFilePreview, openFramePreview }),
+    [canPreview, openFilePreview, openFramePreview]
   );
 
   return (
     <FilePreviewContext.Provider value={contextValue}>
       {children}
-      <FilePreviewDialog
-        entry={previewState?.entry ?? null}
-        fileUrl={previewState?.fileUrl ?? null}
-        isOpen={!!previewState}
-        onOpenChange={(open) => {
-          if (!open) {
-            setPreviewState(null);
-          }
-        }}
-        onDownload={handleDownload}
-        owner={owner}
-      />
     </FilePreviewContext.Provider>
   );
 }

--- a/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
@@ -3,10 +3,9 @@ import { FileCitationCard } from "@app/components/assistant/conversation/attachm
 import { PreviewableCitation } from "@app/components/assistant/conversation/attachment/PreviewableCitation";
 import type { AttachmentCitation } from "@app/components/assistant/conversation/attachment/types";
 import { isAudioContentType } from "@app/components/assistant/conversation/attachment/utils";
-import { ConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
-import { isFrameContentType, opensInSidePanel } from "@app/types/files";
+import { useFilePreviewContext } from "@app/components/assistant/conversation/FilePreviewContext";
+import { isFrameContentType } from "@app/types/files";
 import { Icon, useTranscribingProgress } from "@dust-tt/sparkle";
-import { useContext } from "react";
 
 interface AttachmentCitationProps {
   attachmentCitation: AttachmentCitation;
@@ -17,7 +16,7 @@ export function AttachmentCitation({
   attachmentCitation,
   size = "md",
 }: AttachmentCitationProps) {
-  const sidePanel = useContext(ConversationSidePanelContext);
+  const { canPreview, openFramePreview } = useFilePreviewContext();
 
   const isLoading =
     attachmentCitation.type === "file" && attachmentCitation.isUploading;
@@ -75,43 +74,14 @@ export function AttachmentCitation({
 
   // Interactive content (spreadsheets etc.): open side panel instead of preview dialog.
   // Path-backed interactive citations are handled by PreviewableCitation below.
-  if (
-    fileId &&
-    !isLoading &&
-    isFrameContentType(contentType) &&
-    sidePanel != null
-  ) {
+  if (fileId && !isLoading && isFrameContentType(contentType) && canPreview) {
     return (
       <FileCitationCard
         icon={attachmentCitation.visual}
         title={title}
         description={attachmentCitation.description}
         size={size}
-        onClick={() =>
-          sidePanel.openPanel({ type: "interactive_content", fileId })
-        }
-        onRemove={attachmentCitation.onRemove}
-        tooltipLabel={title}
-      />
-    );
-  }
-
-  // Some formats (e.g. presentations) open the resizable side panel instead of
-  // the center preview dialog. Requires a file path (the preview conversion is
-  // only served on the path-based route) and the side panel provider.
-  if (
-    filePath &&
-    !isLoading &&
-    opensInSidePanel(contentType) &&
-    sidePanel != null
-  ) {
-    return (
-      <FileCitationCard
-        icon={attachmentCitation.visual}
-        title={title}
-        description={attachmentCitation.description}
-        size={size}
-        onClick={() => sidePanel.openPanel({ type: "file_preview", filePath })}
+        onClick={() => openFramePreview({ fileId })}
         onRemove={attachmentCitation.onRemove}
         tooltipLabel={title}
       />

--- a/front/components/assistant/conversation/attachment/PreviewableCitation.tsx
+++ b/front/components/assistant/conversation/attachment/PreviewableCitation.tsx
@@ -3,15 +3,12 @@ import type {
   FileCitationCardSize,
 } from "@app/components/assistant/conversation/attachment/FileCitationCard";
 import { FileCitationCard } from "@app/components/assistant/conversation/attachment/FileCitationCard";
-import { ConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { useFilePreviewContext } from "@app/components/assistant/conversation/FilePreviewContext";
-import { useSendNotification } from "@app/hooks/useNotification";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import {
   isFrameContentType,
   isSupportedImageContentType,
 } from "@app/types/files";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 import {
   Citation,
   CitationImage,
@@ -20,7 +17,6 @@ import {
   Tooltip,
 } from "@dust-tt/sparkle";
 import type React from "react";
-import { useContext } from "react";
 
 interface PreviewableCitationProps {
   containerClassName?: string;
@@ -59,31 +55,11 @@ export function PreviewableCitation({
   tooltipLabel,
   variant = "card",
 }: PreviewableCitationProps) {
-  const { openFilePreview, resolveFileIdFromPath } = useFilePreviewContext();
-  const sendNotification = useSendNotification();
-  const sidePanel = useContext(ConversationSidePanelContext);
+  const { openFilePreview, openFramePreview } = useFilePreviewContext();
 
   const handleClick = async () => {
-    if (isFrameContentType(contentType) && sidePanel) {
-      try {
-        const resolvedFileId =
-          fileId ?? (filePath ? await resolveFileIdFromPath(filePath) : null);
-
-        if (!resolvedFileId) {
-          throw new Error("No linked file was found for this Frame.");
-        }
-
-        sidePanel.openPanel({
-          type: "interactive_content",
-          fileId: resolvedFileId,
-        });
-      } catch (error) {
-        sendNotification({
-          type: "error",
-          title: "Failed to open Frame",
-          description: normalizeError(error).message,
-        });
-      }
+    if (isFrameContentType(contentType)) {
+      await openFramePreview({ fileId, filePath });
       return;
     }
 

--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -9,7 +9,10 @@ import type {
   FileExplorerVirtualScopeRoot,
 } from "@app/components/file_explorer/types";
 import { useFileExplorerDownload } from "@app/components/file_explorer/useFileExplorerDownload";
-import { withVirtualExplorerPath } from "@app/components/file_explorer/utils";
+import {
+  isFilePreviewableContentType,
+  withVirtualExplorerPath,
+} from "@app/components/file_explorer/utils";
 import { EditPodFileTabDialog } from "@app/components/pod/files/EditPodFileTabDialog";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
@@ -26,7 +29,6 @@ import { usePodFiles } from "@app/lib/swr/pods";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { isPodConversation } from "@app/types/assistant/conversation";
-import { opensInSidePanel } from "@app/types/files";
 import type { PodFileTab } from "@app/types/pod_file_tab";
 import {
   DEFAULT_POD_FILE_TAB_ICON,
@@ -208,7 +210,7 @@ export function ConversationFileExplorer({
 
   const onOpenInPanel = useCallback(
     (entry: FileEntry): boolean => {
-      if (opensInSidePanel(entry.contentType)) {
+      if (isFilePreviewableContentType(entry.contentType)) {
         openPanel({ type: "file_preview", filePath: entry.path });
         return true;
       }

--- a/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
@@ -14,7 +14,7 @@ import { isFileAttachmentType } from "@app/lib/api/assistant/conversation/attach
 import { downloadFile } from "@app/lib/swr/files";
 import type { FileSystemFileEntry } from "@app/types/api/file_system/types";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
-import { isFrameContentType, opensInSidePanel } from "@app/types/files";
+import { isFrameContentType } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -71,11 +71,6 @@ export function ConversationFilesPanel({
     }) => {
       if (isFrameContentType(contentType)) {
         openPanel({ type: "interactive_content", fileId });
-      } else if (opensInSidePanel(contentType) && filePath) {
-        // Some formats (e.g. presentations) open in the resizable right panel
-        // like frames, rather than the cramped file preview modal. Preview
-        // relies on the path-based conversion route, so a file path is required.
-        openPanel({ type: "file_preview", filePath });
       } else {
         openFilePreview({
           fileId,

--- a/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
@@ -1,19 +1,31 @@
-import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import {
+  parseFilePreviewData,
+  useConversationSidePanelContext,
+} from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { ConversationSidePanelHeader } from "@app/components/assistant/conversation/ConversationSidePanelHeader";
 import { CenteredState } from "@app/components/assistant/conversation/interactive_content/CenteredState";
 import {
   FilePreviewContent,
+  MAX_CSV_ROWS,
   useFilePreviewContent,
 } from "@app/components/file_explorer/FilePreviewContent";
+import { MarkdownFilePreviewViewModeSwitch } from "@app/components/file_explorer/MarkdownFilePreview";
 import type { FileEntry } from "@app/components/file_explorer/types";
+import { useMarkdownFileEditor } from "@app/components/file_explorer/useMarkdownFileEditor";
 import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
-import { getFilePathDownloadUrl, getFilePathViewUrl } from "@app/lib/swr/files";
+import {
+  getFileDownloadUrl,
+  getFilePathDownloadUrl,
+  getFilePathViewUrl,
+  getFileViewUrl,
+  useFileMetadata,
+} from "@app/lib/swr/files";
 import type { FileSystemFileEntry } from "@app/types/api/file_system/types";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { contentTypeFromFileName } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Button, Download01, Icon } from "@dust-tt/sparkle";
+import { Button, cn, Download01, Icon } from "@dust-tt/sparkle";
 
 interface FilePreviewPanelProps {
   conversation: ConversationWithoutContentType;
@@ -24,7 +36,8 @@ export function FilePreviewPanel({
   conversation,
   owner,
 }: FilePreviewPanelProps) {
-  const { data: filePath, closePanel } = useConversationSidePanelContext();
+  const { data, closePanel } = useConversationSidePanelContext();
+  const { fileId, filePath } = parseFilePreviewData(data);
 
   // The conversion preview is cached (Cache-Control: max-age) per URL, so we
   // bust it with the file's lastModifiedMs. SWR revalidates this list on mount
@@ -37,8 +50,26 @@ export function FilePreviewPanel({
     options: { disabled: !filePath },
   });
 
-  const fileName = filePath ? (filePath.split("/").pop() ?? filePath) : "";
-  const baseUrl = filePath ? getFilePathViewUrl(owner, filePath) : null;
+  // Files opened by id are absent from the sandbox listing.
+  const { fileMetadata } = useFileMetadata({
+    fileId: fileId ?? null,
+    owner,
+    disabled: !fileId,
+  });
+
+  const fileName = filePath
+    ? (filePath.split("/").pop() ?? filePath)
+    : (fileMetadata?.fileName ?? "");
+  const baseUrl = filePath
+    ? getFilePathViewUrl(owner, filePath)
+    : fileId
+      ? getFileViewUrl(owner, fileId)
+      : null;
+  const downloadUrl = filePath
+    ? getFilePathDownloadUrl(owner, filePath)
+    : fileId
+      ? getFileDownloadUrl(owner, fileId)
+      : null;
 
   // Reuse the file-explorer entry when the sandbox listing has loaded so we get
   // the real content type, fileId, and version. Before it loads (or for files
@@ -51,37 +82,51 @@ export function FilePreviewPanel({
       )
     : undefined;
   const contentType =
-    sandboxFile?.contentType ?? contentTypeFromFileName(fileName) ?? "";
+    sandboxFile?.contentType ??
+    fileMetadata?.contentType ??
+    contentTypeFromFileName(fileName) ??
+    "";
 
-  const entry: FileEntry | null = !filePath
-    ? null
-    : sandboxFile
-      ? { ...sandboxFile, kind: "file" }
-      : {
+  const entry: FileEntry | null = sandboxFile
+    ? { ...sandboxFile, kind: "file" }
+    : filePath || fileMetadata
+      ? {
           kind: "file",
           isDirectory: false,
           fileName,
-          path: filePath,
+          path: filePath ?? fileName,
           contentType,
-          fileId: null,
+          fileId: fileId ?? null,
           thumbnailUrl: null,
           sizeBytes: 0,
           lastModifiedMs: 0,
-        };
+        }
+      : null;
 
   const {
     category,
     truncatedContent,
     processedContent,
+    recordCounts,
     hasError,
     isContentLoading,
   } = useFilePreviewContent({
     entry,
     fileUrl: baseUrl,
-    enabled: !!filePath,
+    enabled: !!entry,
   });
 
-  if (!filePath || !entry || !baseUrl) {
+  const markdown = useMarkdownFileEditor({
+    category,
+    entryPath: filePath,
+    fileUrl: baseUrl,
+    isActive: !!entry,
+    isContentLoading,
+    owner,
+    processedContent,
+  });
+
+  if (!entry || !baseUrl || !downloadUrl) {
     return null;
   }
 
@@ -95,18 +140,52 @@ export function FilePreviewPanel({
           <span className="line-clamp-1 text-sm font-medium">{fileName}</span>
         </div>
         <div className="ml-2 flex items-center gap-1">
+          {markdown.canEdit && (
+            <>
+              <MarkdownFilePreviewViewModeSwitch
+                viewMode={markdown.viewMode}
+                onViewModeChange={markdown.setViewMode}
+              />
+              {markdown.isDirty && (
+                <>
+                  <Button
+                    label="Save"
+                    variant="highlight"
+                    size="xs"
+                    isLoading={markdown.isSaving}
+                    disabled={markdown.isSaving}
+                    onClick={() => void markdown.save()}
+                  />
+                  <Button
+                    label="Revert"
+                    variant="outline"
+                    size="xs"
+                    disabled={markdown.isSaving}
+                    onClick={markdown.revert}
+                  />
+                </>
+              )}
+            </>
+          )}
           <Button
             variant="ghost"
             size="sm"
             icon={Download01}
             tooltip="Download"
-            href={getFilePathDownloadUrl(owner, filePath)}
+            href={downloadUrl}
             target="_blank"
             rel="noopener noreferrer"
           />
         </div>
       </ConversationSidePanelHeader>
-      <div className="min-h-0 flex-1 overflow-y-auto bg-muted-background p-4">
+      <div
+        className={cn(
+          "min-h-0 flex-1 bg-muted-background p-4",
+          category === "markdown"
+            ? "flex flex-col overflow-hidden"
+            : "overflow-y-auto"
+        )}
+      >
         {hasError ? (
           <CenteredState>
             <p className="text-sm text-muted-foreground">
@@ -114,18 +193,30 @@ export function FilePreviewPanel({
             </p>
           </CenteredState>
         ) : (
-          <FilePreviewContent
-            category={category}
-            entry={entry}
-            fileContent={truncatedContent}
-            fileUrl={baseUrl}
-            isContentLoading={isContentLoading}
-            isFullWidth
-            markdownContent={processedContent?.text}
-            markdownViewMode="preview"
-            owner={owner}
-            processedContent={processedContent}
-          />
+          <>
+            {recordCounts && (
+              <div className="pb-2 text-xs text-muted-foreground">
+                Showing {recordCounts.displayed} of {recordCounts.total} records
+                {recordCounts.total > MAX_CSV_ROWS && " (truncated)"}
+              </div>
+            )}
+            <FilePreviewContent
+              category={category}
+              entry={entry}
+              fileContent={truncatedContent}
+              fileUrl={baseUrl}
+              isContentLoading={isContentLoading}
+              isFullWidth
+              markdownCanEdit={markdown.canEdit}
+              markdownContent={markdown.content}
+              markdownViewMode={markdown.viewMode}
+              onMarkdownContentChange={
+                markdown.canEdit ? markdown.setDraft : undefined
+              }
+              owner={owner}
+              processedContent={processedContent}
+            />
+          </>
         )}
       </div>
     </div>

--- a/front/components/file_explorer/FilePreviewDialog.tsx
+++ b/front/components/file_explorer/FilePreviewDialog.tsx
@@ -3,13 +3,10 @@ import {
   MAX_CSV_ROWS,
   useFilePreviewContent,
 } from "@app/components/file_explorer/FilePreviewContent";
-import type { MarkdownFilePreviewViewMode } from "@app/components/file_explorer/MarkdownFilePreview";
 import { MarkdownFilePreviewViewModeSwitch } from "@app/components/file_explorer/MarkdownFilePreview";
 import type { FileEntry } from "@app/components/file_explorer/types";
-import { useSendNotification } from "@app/hooks/useNotification";
+import { useMarkdownFileEditor } from "@app/components/file_explorer/useMarkdownFileEditor";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
-import { writeFileContentByPath } from "@app/lib/swr/files";
-import { parseCanonicalScopedPath } from "@app/types/mount_path";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -24,8 +21,7 @@ import {
   Download01,
   Icon,
 } from "@dust-tt/sparkle";
-import { useEffect, useRef, useState } from "react";
-import { useSWRConfig } from "swr";
+import { useEffect, useState } from "react";
 
 interface FilePreviewDialogProps {
   entry: FileEntry | null;
@@ -49,22 +45,6 @@ export function FilePreviewDialog({
   owner,
 }: FilePreviewDialogProps) {
   const [isDownloading, setIsDownloading] = useState(false);
-  const [markdownViewMode, setMarkdownViewMode] =
-    useState<MarkdownFilePreviewViewMode>("preview");
-  const [markdownDraft, setMarkdownDraft] = useState("");
-  const [markdownSavedContent, setMarkdownSavedContent] = useState("");
-  const [markdownSourcePath, setMarkdownSourcePath] = useState<string | null>(
-    null
-  );
-  const [isMarkdownSaving, setIsMarkdownSaving] = useState(false);
-  const [markdownDialogKey, setMarkdownDialogKey] = useState({
-    isOpen,
-    path: entry?.path,
-  });
-  const markdownInitKeyRef = useRef<string | null>(null);
-
-  const sendNotification = useSendNotification();
-  const { mutate } = useSWRConfig();
 
   const handleDownload = async () => {
     if (!entry) {
@@ -116,103 +96,15 @@ export function FilePreviewDialog({
     ? getFileTypeIcon(entry.contentType, entry.fileName)
     : null;
 
-  const editableMarkdownFilePath =
-    entry && owner && parseCanonicalScopedPath(entry.path) ? entry.path : null;
-  const canEditMarkdown = category === "markdown" && !!editableMarkdownFilePath;
-
-  if (
-    isOpen !== markdownDialogKey.isOpen ||
-    entry?.path !== markdownDialogKey.path
-  ) {
-    setMarkdownDialogKey({ isOpen, path: entry?.path });
-    setMarkdownViewMode("preview");
-    setMarkdownSourcePath(null);
-    setMarkdownDraft("");
-    setMarkdownSavedContent("");
-    markdownInitKeyRef.current = null;
-  }
-
-  const isMarkdownDirty = markdownDraft !== markdownSavedContent;
-
-  useEffect(() => {
-    if (
-      !isOpen ||
-      !canEditMarkdown ||
-      !entry?.path ||
-      isContentLoading ||
-      !processedContent
-    ) {
-      return;
-    }
-
-    const initKey = `${entry.path}:${processedContent.text}`;
-    if (markdownInitKeyRef.current === initKey) {
-      return;
-    }
-
-    const hadInitializedForPath = markdownInitKeyRef.current?.startsWith(
-      `${entry.path}:`
-    );
-    if (hadInitializedForPath && isMarkdownDirty) {
-      return;
-    }
-
-    setMarkdownSourcePath(entry.path);
-    setMarkdownDraft(processedContent.text);
-    setMarkdownSavedContent(processedContent.text);
-    markdownInitKeyRef.current = initKey;
-  }, [
-    canEditMarkdown,
-    entry?.path,
+  const markdown = useMarkdownFileEditor({
+    category,
+    entryPath: entry?.path,
+    fileUrl,
+    isActive: isOpen,
     isContentLoading,
-    isMarkdownDirty,
-    isOpen,
-    processedContent?.text,
+    owner,
     processedContent,
-  ]);
-
-  const handleMarkdownSave = async () => {
-    if (
-      !owner ||
-      !editableMarkdownFilePath ||
-      !isMarkdownDirty ||
-      isMarkdownSaving
-    ) {
-      return;
-    }
-
-    setIsMarkdownSaving(true);
-    try {
-      await writeFileContentByPath({
-        owner,
-        canonicalPath: editableMarkdownFilePath,
-        content: markdownDraft,
-        contentType: "text/markdown",
-      });
-      await mutate(
-        fileUrl,
-        { kind: "loaded", content: markdownDraft },
-        { revalidate: false }
-      );
-      setMarkdownSavedContent(markdownDraft);
-      if (entry?.path) {
-        markdownInitKeyRef.current = `${entry.path}:${markdownDraft}`;
-      }
-      sendNotification({ type: "success", title: "File saved" });
-    } catch (e) {
-      sendNotification({
-        type: "error",
-        title: "Failed to save file",
-        description: e instanceof Error ? e.message : "Unknown error",
-      });
-    } finally {
-      setIsMarkdownSaving(false);
-    }
-  };
-
-  const handleMarkdownRevert = () => {
-    setMarkdownDraft(markdownSavedContent);
-  };
+  });
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
@@ -246,12 +138,12 @@ export function FilePreviewDialog({
             )}
           </div>
         </DialogHeader>
-        {canEditMarkdown && (
+        {markdown.canEdit && (
           <div className="flex shrink-0 justify-end px-4">
             <MarkdownFilePreviewViewModeSwitch
               key={`${entry?.path ?? "none"}:${isOpen}`}
-              viewMode={markdownViewMode}
-              onViewModeChange={setMarkdownViewMode}
+              viewMode={markdown.viewMode}
+              onViewModeChange={markdown.setViewMode}
             />
           </div>
         )}
@@ -270,22 +162,14 @@ export function FilePreviewDialog({
                 fileContent={truncatedContent}
                 fileUrl={fileUrl ?? ""}
                 isContentLoading={isContentLoading}
-                markdownCanEdit={canEditMarkdown}
-                markdownContent={
-                  canEditMarkdown
-                    ? markdownSourcePath === entry.path
-                      ? markdownDraft
-                      : processedContent?.text
-                    : processedContent?.text
-                }
-                markdownViewMode={
-                  canEditMarkdown ? markdownViewMode : "preview"
-                }
+                markdownCanEdit={markdown.canEdit}
+                markdownContent={markdown.content}
+                markdownViewMode={markdown.viewMode}
                 onMarkdownContentChange={
-                  canEditMarkdown ? setMarkdownDraft : undefined
+                  markdown.canEdit ? markdown.setDraft : undefined
                 }
                 onMarkdownViewModeChange={
-                  canEditMarkdown ? setMarkdownViewMode : undefined
+                  markdown.canEdit ? markdown.setViewMode : undefined
                 }
                 owner={owner}
                 processedContent={processedContent}
@@ -308,22 +192,14 @@ export function FilePreviewDialog({
                 fileContent={truncatedContent}
                 fileUrl={fileUrl ?? ""}
                 isContentLoading={isContentLoading}
-                markdownCanEdit={canEditMarkdown}
-                markdownContent={
-                  canEditMarkdown
-                    ? markdownSourcePath === entry.path
-                      ? markdownDraft
-                      : processedContent?.text
-                    : processedContent?.text
-                }
-                markdownViewMode={
-                  canEditMarkdown ? markdownViewMode : "preview"
-                }
+                markdownCanEdit={markdown.canEdit}
+                markdownContent={markdown.content}
+                markdownViewMode={markdown.viewMode}
                 onMarkdownContentChange={
-                  canEditMarkdown ? setMarkdownDraft : undefined
+                  markdown.canEdit ? markdown.setDraft : undefined
                 }
                 onMarkdownViewModeChange={
-                  canEditMarkdown ? setMarkdownViewMode : undefined
+                  markdown.canEdit ? markdown.setViewMode : undefined
                 }
                 owner={owner}
                 processedContent={processedContent}
@@ -351,22 +227,22 @@ export function FilePreviewDialog({
                 tooltip="Next"
               />
             </div>
-            {canEditMarkdown ? (
+            {markdown.canEdit ? (
               <div className="flex items-center gap-2">
                 <Button
                   label="Save"
                   variant="highlight"
                   size="sm"
-                  isLoading={isMarkdownSaving}
-                  disabled={!isMarkdownDirty || isMarkdownSaving}
-                  onClick={() => void handleMarkdownSave()}
+                  isLoading={markdown.isSaving}
+                  disabled={!markdown.isDirty || markdown.isSaving}
+                  onClick={() => void markdown.save()}
                 />
                 <Button
                   label="Revert"
                   variant="outline"
                   size="sm"
-                  disabled={!isMarkdownDirty || isMarkdownSaving}
-                  onClick={handleMarkdownRevert}
+                  disabled={!markdown.isDirty || markdown.isSaving}
+                  onClick={markdown.revert}
                 />
                 <Button
                   variant="outline"
@@ -374,7 +250,7 @@ export function FilePreviewDialog({
                   icon={Download01}
                   label={isDownloading ? "Downloading…" : "Download"}
                   onClick={handleDownload}
-                  disabled={!entry || isDownloading || isMarkdownDirty}
+                  disabled={!entry || isDownloading || markdown.isDirty}
                 />
               </div>
             ) : (

--- a/front/components/file_explorer/useMarkdownFileEditor.ts
+++ b/front/components/file_explorer/useMarkdownFileEditor.ts
@@ -1,0 +1,154 @@
+import type { MarkdownFilePreviewViewMode } from "@app/components/file_explorer/MarkdownFilePreview";
+import type { FilePreviewCategory } from "@app/components/file_explorer/utils";
+import { useSendNotification } from "@app/hooks/useNotification";
+import type { ProcessedContent } from "@app/lib/file_content_utils";
+import { writeFileContentByPath } from "@app/lib/swr/files";
+import { parseCanonicalScopedPath } from "@app/types/mount_path";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useEffect, useRef, useState } from "react";
+import { useSWRConfig } from "swr";
+
+interface UseMarkdownFileEditorParams {
+  category: FilePreviewCategory;
+  entryPath: string | undefined;
+  fileUrl: string | null;
+  isActive: boolean;
+  isContentLoading: boolean;
+  owner: LightWorkspaceType | undefined;
+  processedContent: ProcessedContent | null;
+}
+
+interface MarkdownFileEditor {
+  canEdit: boolean;
+  content: string | undefined;
+  isDirty: boolean;
+  isSaving: boolean;
+  revert: () => void;
+  save: () => Promise<void>;
+  setDraft: (content: string) => void;
+  setViewMode: (mode: MarkdownFilePreviewViewMode) => void;
+  viewMode: MarkdownFilePreviewViewMode;
+}
+
+export function useMarkdownFileEditor({
+  category,
+  entryPath,
+  fileUrl,
+  isActive,
+  isContentLoading,
+  owner,
+  processedContent,
+}: UseMarkdownFileEditorParams): MarkdownFileEditor {
+  const [viewMode, setViewMode] =
+    useState<MarkdownFilePreviewViewMode>("preview");
+  const [draft, setDraft] = useState("");
+  const [savedContent, setSavedContent] = useState("");
+  const [sourcePath, setSourcePath] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [resetKey, setResetKey] = useState({ isActive, path: entryPath });
+  const initKeyRef = useRef<string | null>(null);
+
+  const sendNotification = useSendNotification();
+  const { mutate } = useSWRConfig();
+
+  const editablePath =
+    entryPath && owner && parseCanonicalScopedPath(entryPath)
+      ? entryPath
+      : null;
+  const canEdit = category === "markdown" && !!editablePath;
+
+  if (isActive !== resetKey.isActive || entryPath !== resetKey.path) {
+    setResetKey({ isActive, path: entryPath });
+    setViewMode("preview");
+    setSourcePath(null);
+    setDraft("");
+    setSavedContent("");
+    initKeyRef.current = null;
+  }
+
+  const isDirty = draft !== savedContent;
+
+  useEffect(() => {
+    if (
+      !isActive ||
+      !canEdit ||
+      !entryPath ||
+      isContentLoading ||
+      !processedContent
+    ) {
+      return;
+    }
+
+    const initKey = `${entryPath}:${processedContent.text}`;
+    if (initKeyRef.current === initKey) {
+      return;
+    }
+
+    const hadInitializedForPath = initKeyRef.current?.startsWith(
+      `${entryPath}:`
+    );
+    if (hadInitializedForPath && isDirty) {
+      return;
+    }
+
+    setSourcePath(entryPath);
+    setDraft(processedContent.text);
+    setSavedContent(processedContent.text);
+    initKeyRef.current = initKey;
+  }, [
+    canEdit,
+    entryPath,
+    isActive,
+    isContentLoading,
+    isDirty,
+    processedContent,
+  ]);
+
+  const save = async () => {
+    if (!owner || !editablePath || !isDirty || isSaving) {
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await writeFileContentByPath({
+        owner,
+        canonicalPath: editablePath,
+        content: draft,
+        contentType: "text/markdown",
+      });
+      await mutate(
+        fileUrl,
+        { kind: "loaded", content: draft },
+        {
+          revalidate: false,
+        }
+      );
+      setSavedContent(draft);
+      initKeyRef.current = `${entryPath}:${draft}`;
+      sendNotification({ type: "success", title: "File saved" });
+    } catch (e) {
+      sendNotification({
+        type: "error",
+        title: "Failed to save file",
+        description: normalizeError(e).message,
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return {
+    canEdit,
+    content:
+      canEdit && sourcePath === entryPath ? draft : processedContent?.text,
+    isDirty,
+    isSaving,
+    revert: () => setDraft(savedContent),
+    save,
+    setDraft,
+    setViewMode,
+    viewMode: canEdit ? viewMode : "preview",
+  };
+}

--- a/front/components/markdown/FilePreviewBlock.test.tsx
+++ b/front/components/markdown/FilePreviewBlock.test.tsx
@@ -135,6 +135,8 @@ function renderWithSidePanel(
     ...render(
       <ConversationSidePanelContext.Provider
         value={{
+          canGoBack: false,
+          goBack: vi.fn(),
           currentPanel: undefined,
           isPanelClosing: false,
           openPanel,
@@ -215,6 +217,8 @@ describe("getFilePreviewPlugin", () => {
     render(
       <ConversationSidePanelContext.Provider
         value={{
+          canGoBack: false,
+          goBack: vi.fn(),
           currentPanel: undefined,
           isPanelClosing: false,
           openPanel,

--- a/front/components/markdown/FilePreviewBlock.test.tsx
+++ b/front/components/markdown/FilePreviewBlock.test.tsx
@@ -126,18 +126,44 @@ describe("getFilePreviewDirectivePaths", () => {
   });
 });
 
+function renderWithSidePanel(
+  ui: React.ReactNode
+): { openPanel: ReturnType<typeof vi.fn> } & ReturnType<typeof render> {
+  const openPanel = vi.fn();
+  return {
+    openPanel,
+    ...render(
+      <ConversationSidePanelContext.Provider
+        value={{
+          currentPanel: undefined,
+          isPanelClosing: false,
+          openPanel,
+          togglePanel: vi.fn(),
+          closePanel: vi.fn(),
+          onPanelClosed: vi.fn(),
+          setPanelRef: vi.fn(),
+          panelRef: { current: null },
+          setVirtuosoMsg: vi.fn(),
+          virtuosoMsg: null,
+          data: undefined,
+        }}
+      >
+        <FilePreviewProvider owner={mockOwner}>{ui}</FilePreviewProvider>
+      </ConversationSidePanelContext.Provider>
+    ),
+  };
+}
+
 describe("getFilePreviewPlugin", () => {
-  it("renders a previewable file with the file name", async () => {
+  it("opens a previewable file in the side panel", async () => {
     const FilePreview = getFilePreviewPlugin();
 
-    const { container } = render(
-      <FilePreviewProvider owner={mockOwner}>
-        <FilePreview
-          path="conversation-c1/reports/report final.pdf"
-          title="report final.pdf"
-          contentType="application/pdf"
-        />
-      </FilePreviewProvider>
+    const { container, openPanel } = renderWithSidePanel(
+      <FilePreview
+        path="conversation-c1/reports/report final.pdf"
+        title="report final.pdf"
+        contentType="application/pdf"
+      />
     );
 
     expect(screen.getByText("report final.pdf")).toBeInTheDocument();
@@ -146,25 +172,24 @@ describe("getFilePreviewPlugin", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "report final.pdf" }));
 
-    expect(
-      await screen.findByRole("dialog", { name: "report final.pdf" })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Download" })
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(openPanel).toHaveBeenCalledWith({
+        type: "file_preview",
+        filePath: "conversation-c1/reports/report final.pdf",
+      });
+    });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   it("downloads binary files without opening a preview", () => {
     const FilePreview = getFilePreviewPlugin();
 
-    render(
-      <FilePreviewProvider owner={mockOwner}>
-        <FilePreview
-          path="conversation-c1/archive.zip"
-          title="archive.zip"
-          contentType="application/zip"
-        />
-      </FilePreviewProvider>
+    renderWithSidePanel(
+      <FilePreview
+        path="conversation-c1/archive.zip"
+        title="archive.zip"
+        contentType="application/zip"
+      />
     );
 
     fireEvent.click(screen.getByRole("button", { name: "archive.zip" }));

--- a/front/components/workspace/analytics/AnalyticsConversationPanel.tsx
+++ b/front/components/workspace/analytics/AnalyticsConversationPanel.tsx
@@ -223,8 +223,8 @@ export function AnalyticsConversationPanel({
         <AnalyticsConversationPanelHeader onClose={onClose} />
       </div>
       <div className="min-h-0 flex-1 overflow-hidden">
-        <FilePreviewProvider owner={owner}>
-          <ConversationSidePanelProvider>
+        <ConversationSidePanelProvider>
+          <FilePreviewProvider owner={owner}>
             <BlockedActionsProvider
               owner={owner}
               conversation={conversation ?? undefined}
@@ -240,8 +240,8 @@ export function AnalyticsConversationPanel({
                 />
               </GenerationContextProvider>
             </BlockedActionsProvider>
-          </ConversationSidePanelProvider>
-        </FilePreviewProvider>
+          </FilePreviewProvider>
+        </ConversationSidePanelProvider>
       </div>
     </div>
   );

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -455,14 +455,6 @@ type FileFormat = {
    * - Any file type that could contain executable code
    */
   isSafeToDisplay: boolean;
-  /**
-   * When true, this format opens in the resizable conversation side panel
-   * (like frames) rather than the cramped file preview modal. This is the
-   * source of truth for the open-in-side-panel behavior per content type.
-   * Note: the side panel preview relies on the path-based conversion route, so
-   * a file path is still required at the call site.
-   */
-  opensInSidePanel?: boolean;
   // When set, restricts which upload use cases expose this format in their file picker.
   // Possible values: conversation, avatar, tool_output, skill_attachment, upsert_document,
   // folders_document, upsert_table, project_context. Omit to allow in all contexts.
@@ -563,13 +555,11 @@ export const FILE_FORMATS = {
     cat: "data",
     exts: [".ppt", ".pptx"],
     isSafeToDisplay: true,
-    opensInSidePanel: true,
   },
   "application/vnd.openxmlformats-officedocument.presentationml.presentation": {
     cat: "data",
     exts: [".ppt", ".pptx"],
     isSafeToDisplay: true,
-    opensInSidePanel: true,
   },
   "application/pdf": { cat: "data", exts: [".pdf"], isSafeToDisplay: true },
   "application/vnd.google-apps.document": {
@@ -1110,10 +1100,6 @@ export function isPdfContentType(contentType: string): boolean {
 
 export function isMarkdownContentType(contentType: string): boolean {
   return contentType === "text/markdown";
-}
-
-export function opensInSidePanel(contentType: string): boolean {
-  return getFileFormat(contentType)?.opensInSidePanel ?? false;
 }
 
 /**


### PR DESCRIPTION
## Description

Going from the files list into a preview, or from one preview to another, left no way back. The panel now keeps an in-memory stack of what it showed and renders a back arrow in the shared header. Browser history can't serve here: panel state lives in hash params written with `replaceState`, so no entries are pushed. The stack is capped at 50 entries and cleared when the panel closes.

## Tests

Provider tests cover the stack, walking back through several panels, no entry on reselect, and clearing on close.

## Risk

Low. The arrow only shows when there is something to go back to.

## Deploy Plan

Deploy front.