### PR TITLE
[front] Fix the editor link button doing nothing when clicked

### DIFF
--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -1,6 +1,5 @@
 import type { WorkspaceLimit } from "@app/components/app/ReachedLimitPopup";
 import { DeletedMessage } from "@app/components/assistant/conversation/DeletedMessage";
-import { ToolBarContent } from "@app/components/assistant/conversation/input_bar/toolbar/ToolbarContent";
 import { MessageEmojiPicker } from "@app/components/assistant/conversation/MessageEmojiPicker";
 import { MessageReactions } from "@app/components/assistant/conversation/MessageReactions";
 import type { VirtuosoMessage } from "@app/components/assistant/conversation/types";
@@ -11,7 +10,7 @@ import {
 import { UserHandle } from "@app/components/assistant/conversation/UserHandle";
 import { UserMessageMarkdown } from "@app/components/assistant/UserMessageMarkdown";
 import { ConfirmContext } from "@app/components/Confirm";
-import { EditorSelectionToolbar } from "@app/components/editor/EditorSelectionToolbar";
+import { EditorFormattingToolbar } from "@app/components/editor/EditorFormattingToolbar";
 import type { EditorService } from "@app/components/editor/input_bar/useCustomEditor";
 import useCustomEditor from "@app/components/editor/input_bar/useCustomEditor";
 import { useDeleteMessage } from "@app/hooks/useDeleteMessage";
@@ -49,7 +48,6 @@ import {
   Edit04,
   Icon,
   Link01,
-  Toolbar,
   Tooltip,
   Trash01,
   Zap,
@@ -98,13 +96,7 @@ function UserMessageEditor({
         className="inline-block max-h-[40vh] min-h-14 w-full overflow-y-auto whitespace-pre-wrap scrollbar-hide"
       />
 
-      <EditorSelectionToolbar editor={editor} disabled={isMobile}>
-        {editor && (
-          <Toolbar className="inline-flex">
-            <ToolBarContent editor={editor} />
-          </Toolbar>
-        )}
-      </EditorSelectionToolbar>
+      <EditorFormattingToolbar editor={editor} disabled={isMobile} />
 
       <div className="flex justify-end gap-2">
         <Button

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -12,9 +12,8 @@ import {
   getDisplayNameFromPastedFileId,
   getPastedFileName,
 } from "@app/components/assistant/conversation/input_bar/pasted_utils";
-import { ToolBarContent } from "@app/components/assistant/conversation/input_bar/toolbar/ToolbarContent";
 import { useInputBarOverlayTracker } from "@app/components/assistant/conversation/input_bar/useInputBarOverlayTracker";
-import { EditorSelectionToolbar } from "@app/components/editor/EditorSelectionToolbar";
+import { EditorFormattingToolbar } from "@app/components/editor/EditorFormattingToolbar";
 import type { InputBarSlashCommand } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
 import { getAvailableInputBarSlashCommands } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
 import { SKILL_NODE_TYPE } from "@app/components/editor/extensions/input_bar/SkillNode";
@@ -96,7 +95,6 @@ import {
   FilePlus03,
   Globe01,
   Plus,
-  Toolbar,
   TooltipContent,
   TooltipProvider,
   TooltipRoot,
@@ -1697,13 +1695,9 @@ const InputBarContainer = ({
               )}
             />
           </div>
-          <EditorSelectionToolbar editor={editor} disabled={isMobile}>
-            {editor && (
-              <Toolbar className="inline-flex">
-                <ToolBarContent editor={editor} />
-              </Toolbar>
-            )}
-          </EditorSelectionToolbar>
+          {editor && (
+            <EditorFormattingToolbar editor={editor} disabled={isMobile} />
+          )}
           <div
             className={cn("mt-auto flex w-full flex-col", "pt-2 pb-3")}
             style={{

--- a/front/components/assistant/conversation/input_bar/toolbar/ToolbarContent.tsx
+++ b/front/components/assistant/conversation/input_bar/toolbar/ToolbarContent.tsx
@@ -1,4 +1,3 @@
-import { calculateLinkTextAndPosition } from "@app/components/assistant/conversation/input_bar/toolbar/helpers";
 import { useKeyboardShortcutLabel } from "@app/hooks/useKeyboardShortcutLabel";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import {
@@ -15,18 +14,16 @@ import {
   ToolbarLink,
 } from "@dust-tt/sparkle";
 import type { Editor } from "@tiptap/react";
-import { useEffect, useRef, useState } from "react";
 
 interface ToolBarContentProps {
   editor: Editor;
+  onOpenLinkDialog: () => void;
 }
 
-interface LinkPosition {
-  from: number;
-  to: number;
-}
-
-export function ToolBarContent({ editor }: ToolBarContentProps) {
+export function ToolBarContent({
+  editor,
+  onOpenLinkDialog,
+}: ToolBarContentProps) {
   const isMobile = useIsMobile();
   const buttonSize = isMobile ? "xs" : "sm";
   const headingShortcutLabel = useKeyboardShortcutLabel("Mod+Alt+1");
@@ -38,15 +35,6 @@ export function ToolBarContent({ editor }: ToolBarContentProps) {
   const blockquoteShortcutLabel = useKeyboardShortcutLabel("Mod+Shift+9");
   const inlineCodeShortcutLabel = useKeyboardShortcutLabel("Mod+E");
   const codeBlockShortcutLabel = useKeyboardShortcutLabel("Mod+Alt+C");
-  const [isLinkDialogOpen, setIsLinkDialogOpen] = useState(false);
-  const [linkText, setLinkText] = useState("");
-  const [linkUrl, setLinkUrl] = useState("");
-  const [linkPos, setLinkPos] = useState<LinkPosition>({ from: 0, to: 0 });
-  const editorRef = useRef(editor);
-
-  useEffect(() => {
-    editorRef.current = editor;
-  }, [editor]);
 
   function getTooltipText(label: string, shortcutLabel: string): string {
     if (isMobile) {
@@ -56,76 +44,6 @@ export function ToolBarContent({ editor }: ToolBarContentProps) {
       return `${label} (${shortcutLabel})`;
     }
     return label;
-  }
-
-  function openLinkDialog(editorInstance: Editor): void {
-    const { linkUrl, linkText, linkPos } = calculateLinkTextAndPosition({
-      editor: editorInstance,
-    });
-    setLinkUrl(linkUrl);
-    setLinkText(linkText);
-    setLinkPos(linkPos);
-    setIsLinkDialogOpen(true);
-  }
-
-  function handleLinkDialogOpen(): void {
-    openLinkDialog(editor);
-  }
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
-  useEffect(() => {
-    function handleOpenDialog(event: Event): void {
-      // Prevent other toolbar instances from handling the same event.
-      event.stopImmediatePropagation();
-
-      openLinkDialog(editorRef.current);
-    }
-
-    window.addEventListener("dust:openLinkDialog", handleOpenDialog);
-    return () => {
-      window.removeEventListener("dust:openLinkDialog", handleOpenDialog);
-    };
-  }, []);
-
-  function handleLinkSubmit(): void {
-    let finalText = linkText;
-    const urlWithProtocol =
-      linkUrl.startsWith("http://") || linkUrl.startsWith("https://")
-        ? linkUrl
-        : `https://${linkUrl}`;
-
-    if (!finalText) {
-      finalText = linkUrl;
-    }
-
-    editor
-      .chain()
-      .focus()
-      .deleteRange(linkPos)
-      .insertContent(
-        {
-          type: "text",
-          text: finalText,
-          marks: linkUrl
-            ? [{ type: "link", attrs: { href: urlWithProtocol } }]
-            : [],
-        },
-        { updateSelection: true }
-      )
-      .insertContent(linkUrl ? " " : "")
-      .focus()
-      .run();
-
-    setLinkText("");
-    setLinkUrl("");
-    setIsLinkDialogOpen(false);
-  }
-
-  function handleLinkDialogOpenChange(open: boolean): void {
-    if (!open) {
-      editor.chain().focus().run();
-    }
-    setIsLinkDialogOpen(open);
   }
 
   const groups = [
@@ -165,14 +83,7 @@ export function ToolBarContent({ editor }: ToolBarContentProps) {
       items: [
         <ToolbarLink
           key="link"
-          isOpen={isLinkDialogOpen}
-          onOpenChange={handleLinkDialogOpenChange}
-          onOpenDialog={handleLinkDialogOpen}
-          onSubmit={handleLinkSubmit}
-          linkText={linkText}
-          linkUrl={linkUrl}
-          onLinkTextChange={setLinkText}
-          onLinkUrlChange={setLinkUrl}
+          onClick={onOpenLinkDialog}
           active={editor.isActive("link")}
           tooltip={getTooltipText("Link", linkShortcutLabel)}
           size={buttonSize}

--- a/front/components/editor/EditorFormattingToolbar.test.tsx
+++ b/front/components/editor/EditorFormattingToolbar.test.tsx
@@ -1,0 +1,83 @@
+import { LinkExtension } from "@app/components/editor/input_bar/LinkExtension";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { EditorContent, useEditor } from "@tiptap/react";
+import { StarterKit } from "@tiptap/starter-kit";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { EditorFormattingToolbar } from "./EditorFormattingToolbar";
+
+function TestEditor() {
+  const editor = useEditor({
+    extensions: [StarterKit.configure({ link: false }), LinkExtension],
+    content: "<p>hello world</p>",
+  });
+
+  if (!editor) {
+    return null;
+  }
+
+  return (
+    <div>
+      <EditorContent editor={editor} />
+      <EditorFormattingToolbar editor={editor} />
+    </div>
+  );
+}
+
+class StubDOMRectList extends Array<DOMRect> implements DOMRectList {
+  item(index: number): DOMRect | null {
+    return this[index] ?? null;
+  }
+}
+
+function stubLayout(): void {
+  const rect = new DOMRect(30, 10, 30, 10);
+  const rects = new StubDOMRectList(rect);
+
+  Range.prototype.getClientRects = () => rects;
+  Range.prototype.getBoundingClientRect = () => rect;
+  Element.prototype.getClientRects = () => rects;
+  window.scrollBy = () => {};
+}
+
+describe("EditorFormattingToolbar", () => {
+  beforeAll(() => {
+    stubLayout();
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      value: 1200,
+    });
+  });
+
+  it("keeps the link dialog open once the editor loses focus to it", async () => {
+    const user = userEvent.setup();
+    render(<TestEditor />);
+
+    const editorDom = document.querySelector<HTMLElement>(".tiptap");
+    expect(editorDom).not.toBeNull();
+    editorDom?.focus();
+    await user.keyboard("{Control>}a{/Control}");
+
+    const linkButton = await screen.findByRole("button", { name: /link/i });
+    await user.click(linkButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+    expect(screen.getByPlaceholderText("Text")).toHaveValue("hello world");
+  });
+});

--- a/front/components/editor/EditorFormattingToolbar.tsx
+++ b/front/components/editor/EditorFormattingToolbar.tsx
@@ -15,6 +15,8 @@ interface EditorFormattingToolbarProps {
 /**
  * The formatting toolbar shown above an editor's selection, with the link dialog it opens.
  *
+ */
+/**
  * @cc [owner:rfrenoy,label:react] link-dialog-sibling-of-selection-toolbar
  * The link dialog MUST stay a sibling of `EditorSelectionToolbar`, never a descendant: opening it
  * blurs the editor, which hides the selection toolbar and would unmount the dialog with it.

--- a/front/components/editor/EditorFormattingToolbar.tsx
+++ b/front/components/editor/EditorFormattingToolbar.tsx
@@ -1,0 +1,40 @@
+import { ToolBarContent } from "@app/components/assistant/conversation/input_bar/toolbar/ToolbarContent";
+import { EditorSelectionToolbar } from "@app/components/editor/EditorSelectionToolbar";
+import { useEditorLinkDialog } from "@app/components/editor/useEditorLinkDialog";
+import { Toolbar, ToolbarLinkDialog } from "@dust-tt/sparkle";
+import type { Editor } from "@tiptap/react";
+import type { ReactNode } from "react";
+
+interface EditorFormattingToolbarProps {
+  editor: Editor;
+  disabled?: boolean;
+  /** Extra actions appended to the toolbar, after the formatting ones. */
+  extraActions?: ReactNode;
+}
+
+/**
+ * The formatting toolbar shown above an editor's selection, with the link dialog it opens.
+ *
+ * @cc [owner:rfrenoy,label:react] link-dialog-sibling-of-selection-toolbar
+ * The link dialog MUST stay a sibling of `EditorSelectionToolbar`, never a descendant: opening it
+ * blurs the editor, which hides the selection toolbar and would unmount the dialog with it.
+ */
+export function EditorFormattingToolbar({
+  editor,
+  disabled,
+  extraActions,
+}: EditorFormattingToolbarProps) {
+  const { openLinkDialog, linkDialogProps } = useEditorLinkDialog(editor);
+
+  return (
+    <>
+      <EditorSelectionToolbar editor={editor} disabled={disabled}>
+        <Toolbar className="inline-flex">
+          <ToolBarContent editor={editor} onOpenLinkDialog={openLinkDialog} />
+          {extraActions}
+        </Toolbar>
+      </EditorSelectionToolbar>
+      <ToolbarLinkDialog {...linkDialogProps} />
+    </>
+  );
+}

--- a/front/components/editor/MarkdownEditor.tsx
+++ b/front/components/editor/MarkdownEditor.tsx
@@ -1,9 +1,8 @@
-import { ToolBarContent } from "@app/components/assistant/conversation/input_bar/toolbar/ToolbarContent";
-import { EditorSelectionToolbar } from "@app/components/editor/EditorSelectionToolbar";
+import { EditorFormattingToolbar } from "@app/components/editor/EditorFormattingToolbar";
 import { cleanupPastedHTML } from "@app/components/editor/input_bar/cleanupPastedHTML";
 import { buildMarkdownEditorExtensions } from "@app/lib/editor/build_markdown_editor_extensions";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
-import { cn, Toolbar } from "@dust-tt/sparkle";
+import { cn } from "@dust-tt/sparkle";
 import type { Editor as CoreEditor, Extensions } from "@tiptap/core";
 import type { Editor, EditorOptions } from "@tiptap/react";
 import { EditorContent, useEditor } from "@tiptap/react";
@@ -302,12 +301,11 @@ export function MarkdownEditor({
       <div className="relative">
         <EditorContent editor={editor} />
         {shouldShowFormattingMenu && editor ? (
-          <EditorSelectionToolbar editor={editor} disabled={isMobile}>
-            <Toolbar className="inline-flex">
-              <ToolBarContent editor={editor} />
-              {toolbarExtra}
-            </Toolbar>
-          </EditorSelectionToolbar>
+          <EditorFormattingToolbar
+            editor={editor}
+            disabled={isMobile}
+            extraActions={toolbarExtra}
+          />
         ) : null}
       </div>
       {shouldShowCharacterCount && editor ? (

--- a/front/components/editor/input_bar/LinkExtension.ts
+++ b/front/components/editor/input_bar/LinkExtension.ts
@@ -1,13 +1,38 @@
+import type { Editor } from "@tiptap/core";
 import Link from "@tiptap/extension-link";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
+
+export const OPEN_LINK_DIALOG_EVENT = "dust:openLinkDialog";
+
+export type OpenLinkDialogEvent = CustomEvent<{ editor: Editor }>;
+
+export function isOpenLinkDialogEventFor(
+  event: Event,
+  editor: Editor
+): boolean {
+  if (!(event instanceof CustomEvent)) {
+    return false;
+  }
+  const { detail } = event;
+  return (
+    typeof detail === "object" &&
+    detail !== null &&
+    "editor" in detail &&
+    detail.editor === editor
+  );
+}
 
 export const LinkExtension = Link.extend({
   addKeyboardShortcuts() {
     return {
       ...this.parent?.(),
       "Mod-Shift-u": () => {
-        // This event is caught by the toolbar content to open the link dialog.
-        const event = new CustomEvent("dust:openLinkDialog");
+        // Caught by the editor's link dialog, which carries the editor so that only the one the
+        // shortcut was pressed in reacts.
+        const event: OpenLinkDialogEvent = new CustomEvent(
+          OPEN_LINK_DIALOG_EVENT,
+          { detail: { editor: this.editor } }
+        );
         window.dispatchEvent(event);
         return true;
       },

--- a/front/components/editor/useEditorLinkDialog.ts
+++ b/front/components/editor/useEditorLinkDialog.ts
@@ -1,0 +1,111 @@
+import { calculateLinkTextAndPosition } from "@app/components/assistant/conversation/input_bar/toolbar/helpers";
+import {
+  isOpenLinkDialogEventFor,
+  OPEN_LINK_DIALOG_EVENT,
+} from "@app/components/editor/input_bar/LinkExtension";
+import type { ToolbarLinkDialogProps } from "@dust-tt/sparkle";
+import type { Editor } from "@tiptap/react";
+import { useCallback, useEffect, useState } from "react";
+
+interface LinkPosition {
+  from: number;
+  to: number;
+}
+
+interface EditorLinkDialog {
+  openLinkDialog: () => void;
+  linkDialogProps: ToolbarLinkDialogProps;
+}
+
+function withProtocol(url: string): string {
+  if (url.startsWith("http://") || url.startsWith("https://")) {
+    return url;
+  }
+  return `https://${url}`;
+}
+
+/**
+ * @cc [owner:rfrenoy,label:react] dialog-state-outside-toolbar
+ * The returned `linkDialogProps` MUST be rendered outside the editor's selection toolbar. The
+ * dialog steals focus from the editor when it opens, which hides that toolbar, so state owned by
+ * the toolbar would be discarded before the dialog is painted.
+ */
+export function useEditorLinkDialog(editor: Editor): EditorLinkDialog {
+  const [isOpen, setIsOpen] = useState(false);
+  const [linkText, setLinkText] = useState("");
+  const [linkUrl, setLinkUrl] = useState("");
+  const [linkPos, setLinkPos] = useState<LinkPosition>({ from: 0, to: 0 });
+
+  const openLinkDialog = useCallback(() => {
+    const { linkUrl, linkText, linkPos } = calculateLinkTextAndPosition({
+      editor,
+    });
+    setLinkUrl(linkUrl);
+    setLinkText(linkText);
+    setLinkPos(linkPos);
+    setIsOpen(true);
+  }, [editor]);
+
+  useEffect(() => {
+    function handleOpenDialog(event: Event): void {
+      // Several editors can be mounted at once; only the one the shortcut was pressed in opens
+      // its dialog.
+      if (!isOpenLinkDialogEventFor(event, editor)) {
+        return;
+      }
+      openLinkDialog();
+    }
+
+    window.addEventListener(OPEN_LINK_DIALOG_EVENT, handleOpenDialog);
+    return () => {
+      window.removeEventListener(OPEN_LINK_DIALOG_EVENT, handleOpenDialog);
+    };
+  }, [editor, openLinkDialog]);
+
+  const handleSubmit = useCallback(() => {
+    editor
+      .chain()
+      .focus()
+      .deleteRange(linkPos)
+      .insertContent(
+        {
+          type: "text",
+          text: linkText || linkUrl,
+          marks: linkUrl
+            ? [{ type: "link", attrs: { href: withProtocol(linkUrl) } }]
+            : [],
+        },
+        { updateSelection: true }
+      )
+      .insertContent(linkUrl ? " " : "")
+      .focus()
+      .run();
+
+    setLinkText("");
+    setLinkUrl("");
+    setIsOpen(false);
+  }, [editor, linkPos, linkText, linkUrl]);
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        editor.chain().focus().run();
+      }
+      setIsOpen(open);
+    },
+    [editor]
+  );
+
+  return {
+    openLinkDialog,
+    linkDialogProps: {
+      isOpen,
+      onOpenChange: handleOpenChange,
+      onSubmit: handleSubmit,
+      linkText,
+      linkUrl,
+      onLinkTextChange: setLinkText,
+      onLinkUrlChange: setLinkUrl,
+    },
+  };
+}

--- a/sparkle/src/components/Toolbar.tsx
+++ b/sparkle/src/components/Toolbar.tsx
@@ -84,8 +84,9 @@ export interface ToolbarProps {
  * A formatting toolbar for rich-text editing, typically driving a text editor's commands.
  * Use `variant` "inline" to sit within the editor flow or "overlay" for a floating bubble
  * menu, laying out actions with `ToolbarContent` groups, `ToolbarIcon` buttons, and
- * `ToolbarLink`. Use it to present text-formatting controls (bold, italic, lists, code,
- * links); for general page-level actions, use a `Bar` or `HoveringBar` instead.
+ * `ToolbarLink` (whose `ToolbarLinkDialog` is rendered outside the toolbar). Use it to
+ * present text-formatting controls (bold, italic, lists, code, links); for general
+ * page-level actions, use a `Bar` or `HoveringBar` instead.
  *
  * @summary Rich-text formatting toolbar.
  */
@@ -258,12 +259,36 @@ function ToolbarIcon({
 }
 
 export interface ToolbarLinkProps {
+  onClick: () => void;
+  size: ToolbarButtonSize;
+  active?: boolean;
+  tooltip?: string;
+}
+
+/**
+ * The link button of a toolbar, opening the link-insertion dialog. Render its
+ * `ToolbarLinkDialog` separately: the dialog takes focus away from the editor when it opens, so a
+ * toolbar that hides on blur would unmount the dialog with itself.
+ *
+ * @summary Toolbar link button.
+ */
+function ToolbarLink({ onClick, size, active, tooltip }: ToolbarLinkProps) {
+  return (
+    <ToolbarIcon
+      icon={Link01}
+      onClick={onClick}
+      active={active}
+      tooltip={tooltip}
+      size={size}
+    />
+  );
+}
+
+export interface ToolbarLinkDialogProps {
   /** Controls whether the link-insertion dialog is open. */
   isOpen: boolean;
   /** Called when the dialog requests to open or close. */
   onOpenChange: (open: boolean) => void;
-  /** Called when the link toolbar button is clicked, to open the dialog. */
-  onOpenDialog: () => void;
   /** Called when the dialog's Save button is clicked. */
   onSubmit: () => void;
   linkText: string;
@@ -272,32 +297,28 @@ export interface ToolbarLinkProps {
   onLinkTextChange: (value: string) => void;
   /** Called with the new value when the link URL input changes. */
   onLinkUrlChange: (value: string) => void;
-  size: ToolbarButtonSize;
-  /** Whether a link is applied at the current selection. */
-  active?: boolean;
-  tooltip?: string;
 }
 
 /**
- * A link-insertion control for the toolbar: a link icon button paired with a controlled
- * dialog collecting the link text and URL. Own the dialog state via `isOpen` /
- * `onOpenChange` and apply the link in `onSubmit`.
+ * The dialog collecting the text and URL of the link inserted from a `ToolbarLink`. Own its state
+ * via `isOpen` / `onOpenChange` and apply the link in `onSubmit`.
  *
- * @summary Toolbar link-insertion control.
+ * @cc [owner:rfrenoy,label:react] dialog-outlives-toolbar
+ * The dialog MUST be rendered outside of any toolbar that unmounts when the editor loses focus.
+ * Opening it moves focus into the dialog, so rendering it within such a toolbar unmounts it
+ * before it is painted.
+ *
+ * @summary Toolbar link-insertion dialog.
  */
-function ToolbarLink({
+function ToolbarLinkDialog({
   isOpen,
   onOpenChange,
-  onOpenDialog,
   onSubmit,
   linkText,
   linkUrl,
   onLinkTextChange,
   onLinkUrlChange,
-  size,
-  active,
-  tooltip,
-}: ToolbarLinkProps) {
+}: ToolbarLinkDialogProps) {
   function handleDialogClick(event: React.MouseEvent<HTMLDivElement>): void {
     event.stopPropagation();
   }
@@ -308,13 +329,6 @@ function ToolbarLink({
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <ToolbarIcon
-        icon={Link01}
-        onClick={onOpenDialog}
-        active={active}
-        tooltip={tooltip}
-        size={size}
-      />
       <DialogContent onClick={handleDialogClick}>
         <DialogHeader>
           <DialogTitle>Insert Link</DialogTitle>
@@ -356,4 +370,4 @@ function ToolbarLink({
   );
 }
 
-export { Toolbar, ToolbarContent, ToolbarIcon, ToolbarLink };
+export { Toolbar, ToolbarContent, ToolbarIcon, ToolbarLink, ToolbarLinkDialog };

--- a/sparkle/src/components/Toolbar.tsx
+++ b/sparkle/src/components/Toolbar.tsx
@@ -303,6 +303,8 @@ export interface ToolbarLinkDialogProps {
  * The dialog collecting the text and URL of the link inserted from a `ToolbarLink`. Own its state
  * via `isOpen` / `onOpenChange` and apply the link in `onSubmit`.
  *
+ */
+/**
  * @cc [owner:rfrenoy,label:react] dialog-outlives-toolbar
  * The dialog MUST be rendered outside of any toolbar that unmounts when the editor loses focus.
  * Opening it moves focus into the dialog, so rendering it within such a toolbar unmounts it

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -302,11 +302,18 @@ export type {
   ToolbarContentGroup,
   ToolbarContentProps,
   ToolbarIconProps,
+  ToolbarLinkDialogProps,
   ToolbarLinkProps,
   ToolbarProps,
   ToolbarVariant,
 } from "./Toolbar";
-export { Toolbar, ToolbarContent, ToolbarIcon, ToolbarLink } from "./Toolbar";
+export {
+  Toolbar,
+  ToolbarContent,
+  ToolbarIcon,
+  ToolbarLink,
+  ToolbarLinkDialog,
+} from "./Toolbar";
 export {
   Tooltip,
   TooltipContent,

--- a/sparkle/src/stories/Toolbar.stories.tsx
+++ b/sparkle/src/stories/Toolbar.stories.tsx
@@ -15,6 +15,7 @@ import {
   ToolbarContent,
   ToolbarIcon,
   ToolbarLink,
+  ToolbarLinkDialog,
 } from "../index_with_tw_base";
 
 const TOOLBAR_VARIANTS = ["inline", "overlay"] as const;
@@ -85,14 +86,7 @@ function ToolbarPreview({ variant, scroll, onClose }: ToolbarPreviewProps) {
       items: [
         <ToolbarLink
           key="link"
-          isOpen={isLinkDialogOpen}
-          onOpenChange={handleLinkDialogOpenChange}
-          onOpenDialog={handleLinkDialogOpen}
-          onSubmit={handleLinkSubmit}
-          linkText={linkText}
-          linkUrl={linkUrl}
-          onLinkTextChange={handleLinkTextChange}
-          onLinkUrlChange={handleLinkUrlChange}
+          onClick={handleLinkDialogOpen}
           active={isLinkDialogOpen}
           tooltip="Link"
           size={buttonSize}
@@ -146,6 +140,18 @@ function ToolbarPreview({ variant, scroll, onClose }: ToolbarPreviewProps) {
     },
   ];
 
+  const linkDialog = (
+    <ToolbarLinkDialog
+      isOpen={isLinkDialogOpen}
+      onOpenChange={handleLinkDialogOpenChange}
+      onSubmit={handleLinkSubmit}
+      linkText={linkText}
+      linkUrl={linkUrl}
+      onLinkTextChange={handleLinkTextChange}
+      onLinkUrlChange={handleLinkUrlChange}
+    />
+  );
+
   const toolbar = (
     <Toolbar variant={variant} scroll={scroll} onClose={onClose}>
       <ToolbarContent groups={groups} />
@@ -154,13 +160,21 @@ function ToolbarPreview({ variant, scroll, onClose }: ToolbarPreviewProps) {
 
   if (isOverlay) {
     return (
-      <div className="relative h-14 w-full max-w-[520px] rounded-xl border border-border/70 bg-background p-2">
-        {toolbar}
-      </div>
+      <>
+        <div className="relative h-14 w-full max-w-[520px] rounded-xl border border-border/70 bg-background p-2">
+          {toolbar}
+        </div>
+        {linkDialog}
+      </>
     );
   }
 
-  return toolbar;
+  return (
+    <>
+      {toolbar}
+      {linkDialog}
+    </>
+  );
 }
 
 function renderToolbarStory({ variant, scroll, onClose }: ToolbarProps) {
@@ -178,7 +192,7 @@ const meta = {
   parameters: {
     docs: {
       description: {
-        component: `A formatting toolbar for rich-text editing, typically driving a text editor's commands. Use **variant** \`inline\` to sit within the editor flow or \`overlay\` for a floating bubble menu, with an optional \`onClose\` and a **scroll** flag for horizontally scrollable actions. **ToolbarContent** lays out actions as **groups** with separators; **ToolbarIcon** renders an icon button (with \`active\`, \`tooltip\`, \`size\`) and **ToolbarLink** provides a link-insertion control with its own dialog state.
+        component: `A formatting toolbar for rich-text editing, typically driving a text editor's commands. Use **variant** \`inline\` to sit within the editor flow or \`overlay\` for a floating bubble menu, with an optional \`onClose\` and a **scroll** flag for horizontally scrollable actions. **ToolbarContent** lays out actions as **groups** with separators; **ToolbarIcon** renders an icon button (with \`active\`, \`tooltip\`, \`size\`) and **ToolbarLink** renders the link button that opens a **ToolbarLinkDialog**.
 
 **When to use**
 - To present text-formatting controls (bold, italic, lists, code, links) for an editor.
@@ -186,6 +200,7 @@ const meta = {
 **Guidelines**
 - Group related actions in **ToolbarContent**'s \`groups\` so separators fall in sensible places.
 - Set the \`active\` prop on **ToolbarIcon** to reflect the formatting applied at the current selection.
+- Render **ToolbarLinkDialog** outside the toolbar: opening it moves focus out of the editor, which unmounts a toolbar that only shows while the editor is focused.
 - For general page-level actions rather than text formatting, use a **Bar** or **HoveringBar**.`,
       },
     },


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/10354

The link dialog was rendered inside EditorSelectionToolbar, which returns null unless the editor is focused with a non-empty selection. Opening the dialog moves focus into it, so ProseMirror fired blur, the toolbar hid, and the dialog unmounted before it was painted. The keyboard shortcut faces the same issue: its listener lived in ToolBarContent, so it only existed while the toolbar was visible.

Fix: Split sparkle's ToolbarLink into the button and a separate ToolbarLinkDialog, and render the dialog as a sibling of the selection toolbar instead of a descendant, so its lifetime no longer depends on the editor keeping focus.
## Tests

test file + local env

## Risk

Low

## Deploy Plan

Front