### PR TITLE
Auth: correctly attribute child agent run to the parent key

### DIFF
--- a/front-api/middlewares/public_api_auth.test.ts
+++ b/front-api/middlewares/public_api_auth.test.ts
@@ -1,0 +1,183 @@
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { KeyFactory } from "@app/tests/utils/KeyFactory";
+import { createHono } from "@front-api/lib/hono";
+import type { PublicApiCtx } from "@front-api/middlewares/ctx";
+import { describe, expect, it } from "vitest";
+
+import { publicApiAuth } from "./public_api_auth";
+
+// Mounts publicApiAuth on a throwaway route that reports what the resolved
+// Authenticator carries, so the header handling can be asserted directly
+// instead of through a downstream endpoint.
+function appReportingAuth() {
+  const app = createHono<PublicApiCtx>();
+  app.use("/:wId", publicApiAuth);
+  app.get("/:wId", (ctx) => {
+    const auth = ctx.get("auth");
+    return ctx.json({
+      attributionKeyName: auth.attributionKey()?.name ?? null,
+      attributionKeyModelId: auth.attributionKeyModelId(),
+      keyModelId: auth.key()?.id ?? null,
+      keyName: auth.key()?.name ?? null,
+      keyIsSystem: auth.key()?.isSystem ?? null,
+      role: auth.role(),
+    });
+  });
+  return app;
+}
+
+function get(
+  app: ReturnType<typeof appReportingAuth>,
+  { wId, secret, keyName }: { wId: string; secret: string; keyName?: string }
+) {
+  return app.request(`/${wId}`, {
+    headers: {
+      authorization: `Bearer ${secret}`,
+      ...(keyName ? { "x-dust-api-key-name": keyName } : {}),
+    },
+  });
+}
+
+describe("publicApiAuth — x-dust-api-key-name attribution", () => {
+  it("attributes a system-key request to the forwarded key without touching auth.key()", async () => {
+    const {
+      workspace,
+      globalGroup,
+      key: systemKey,
+    } = await createPublicApiMockRequest({ systemKey: true });
+    const originatingKey = await KeyFactory.regular(globalGroup);
+
+    const response = await get(appReportingAuth(), {
+      wId: workspace.sId,
+      secret: systemKey.secret,
+      keyName: originatingKey.name,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        attributionKeyName: originatingKey.name,
+        attributionKeyModelId: originatingKey.id,
+        // Attribution only: authorization keeps operating on the system key.
+        keyModelId: systemKey.id,
+        keyName: systemKey.name,
+        keyIsSystem: true,
+        role: "admin",
+      })
+    );
+  });
+
+  it("ignores the header when the request is not authenticated with a system key", async () => {
+    const {
+      workspace,
+      globalGroup,
+      key: regularKey,
+    } = await createPublicApiMockRequest();
+    const otherKey = await KeyFactory.admin(globalGroup);
+
+    const response = await get(appReportingAuth(), {
+      wId: workspace.sId,
+      secret: regularKey.secret,
+      keyName: otherKey.name,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        attributionKeyName: null,
+        attributionKeyModelId: null,
+        keyModelId: regularKey.id,
+        keyIsSystem: false,
+        // The header must not grant the other key's role.
+        role: "builder",
+      })
+    );
+  });
+
+  it("ignores a name that resolves to a system key", async () => {
+    const {
+      workspace,
+      globalGroup,
+      key: systemKey,
+    } = await createPublicApiMockRequest({ systemKey: true });
+    const otherSystemKey = await KeyFactory.system(globalGroup);
+
+    const response = await get(appReportingAuth(), {
+      wId: workspace.sId,
+      secret: systemKey.secret,
+      keyName: otherSystemKey.name,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        attributionKeyName: null,
+        attributionKeyModelId: null,
+      })
+    );
+  });
+
+  it("ignores a name that resolves to a disabled key", async () => {
+    const {
+      workspace,
+      globalGroup,
+      key: systemKey,
+    } = await createPublicApiMockRequest({ systemKey: true });
+    const disabledKey = await KeyFactory.disabled(globalGroup);
+
+    const response = await get(appReportingAuth(), {
+      wId: workspace.sId,
+      secret: systemKey.secret,
+      keyName: disabledKey.name,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        attributionKeyName: null,
+        attributionKeyModelId: null,
+      })
+    );
+  });
+
+  it("ignores a key name from another workspace", async () => {
+    const { workspace, key: systemKey } = await createPublicApiMockRequest({
+      systemKey: true,
+    });
+    const other = await createPublicApiMockRequest();
+
+    const response = await get(appReportingAuth(), {
+      wId: workspace.sId,
+      secret: systemKey.secret,
+      keyName: other.key.name,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        attributionKeyName: null,
+        attributionKeyModelId: null,
+      })
+    );
+  });
+
+  it("ignores an unknown key name", async () => {
+    const { workspace, key: systemKey } = await createPublicApiMockRequest({
+      systemKey: true,
+    });
+
+    const response = await get(appReportingAuth(), {
+      wId: workspace.sId,
+      secret: systemKey.secret,
+      keyName: "no-such-key",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        attributionKeyName: null,
+        attributionKeyModelId: null,
+      })
+    );
+  });
+});

--- a/front-api/middlewares/public_api_auth.ts
+++ b/front-api/middlewares/public_api_auth.ts
@@ -212,15 +212,10 @@ export const publicApiAuth = createMiddleware<PublicApiCtx>(
         )) ?? workspaceAuth;
     }
 
-    // x-dust-api-key-name: system-key-only usage attribution. Internal flows that
-    // re-authenticate with the workspace system key (run_agent sub-agents,
-    // agent_router, run_dust_app) forward the originating key's name so usage
-    // analytics and Metronome events stay attributed to it instead of collapsing
-    // into "Not API". Attribution only: `auth.key()` keeps pointing at the system
-    // key, so role, caps and system-key checks are unaffected.
-    //
-    // Must stay after the x-api-user-email exchange above: that exchange rebuilds
-    // the Authenticator and does not carry the attribution key over.
+    // x-dust-api-key-name: system-key-only usage attribution, see
+    // `Authenticator.keyForUsageAttribution`. Must stay after the
+    // x-api-user-email exchange above, which rebuilds the Authenticator without
+    // carrying the attribution key over.
     const apiKeyNameFromHeader = getApiKeyNameFromHeaders(headers);
     const key = workspaceAuth.key();
     if (apiKeyNameFromHeader && key && key.isSystem) {

--- a/front-api/middlewares/public_api_auth.ts
+++ b/front-api/middlewares/public_api_auth.ts
@@ -4,6 +4,7 @@ import {
   getApiKeyNameFromHeaders,
   getSessionFromBearerToken,
 } from "@app/lib/auth";
+import { KeyResource } from "@app/lib/resources/key_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getClientIp } from "@app/lib/utils/request";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
@@ -95,8 +96,7 @@ function applyClientIp(auth: Authenticator, headers: HeaderRecord): void {
 /**
  * Authenticates a public-API request (Authorization header required:
  * sandbox token, OAuth bearer, or API key) and stashes the resolved
- * `Authenticator` on the Hono context under `auth`. Mirrors
- * `withPublicAPIAuthentication` in `front/lib/api/auth_wrappers.ts`.
+ * `Authenticator` on the Hono context under `auth`.
  */
 export const publicApiAuth = createMiddleware<PublicApiCtx>(
   async (ctx, next) => {
@@ -212,18 +212,28 @@ export const publicApiAuth = createMiddleware<PublicApiCtx>(
         )) ?? workspaceAuth;
     }
 
-    // x-api-key-name: system-key-only key name override (for analytics).
+    // x-dust-api-key-name: system-key-only usage attribution. Internal flows that
+    // re-authenticate with the workspace system key (run_agent sub-agents,
+    // agent_router, run_dust_app) forward the originating key's name so usage
+    // analytics and Metronome events stay attributed to it instead of collapsing
+    // into "Not API". Attribution only: `auth.key()` keeps pointing at the system
+    // key, so role, caps and system-key checks are unaffected.
+    //
+    // Must stay after the x-api-user-email exchange above: that exchange rebuilds
+    // the Authenticator and does not carry the attribution key over.
     const apiKeyNameFromHeader = getApiKeyNameFromHeaders(headers);
     const key = workspaceAuth.key();
     if (apiKeyNameFromHeader && key && key.isSystem) {
-      workspaceAuth = workspaceAuth.exchangeKey({
-        id: key.id,
-        isSystem: key.isSystem,
-        monthlyCapMicroUsd: key.monthlyCapMicroUsd,
+      const attributionKey = await KeyResource.fetchByName(workspaceAuth, {
         name: apiKeyNameFromHeader,
-        role: key.role,
-        userModelId: key.userModelId,
+        onlyActive: true,
       });
+      if (attributionKey && !attributionKey.isSystem) {
+        workspaceAuth = workspaceAuth.withAttributionKey({
+          id: attributionKey.id,
+          name: attributionKey.name,
+        });
+      }
     }
 
     applyClientIp(workspaceAuth, headers);

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
@@ -184,10 +184,9 @@ app.post(
               },
             });
           }
-          // Must resolve the same key as the authoritative gate in
-          // `postUserMessage`, or a capped originating key behind an uncapped
-          // system key would pass here and be rejected there — persisting the
-          // empty conversation this precheck exists to avoid.
+          // Same key as the authoritative gate in `postUserMessage`, or this
+          // precheck would let through a message that gate rejects — persisting
+          // the empty conversation it exists to avoid.
           const key = auth.keyForUsageAttribution();
           if (key && (await isApiKeyBlocked(auth, { keyModelId: key.id }))) {
             return apiError(ctx, {

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
@@ -184,7 +184,11 @@ app.post(
               },
             });
           }
-          const key = auth.key();
+          // Must resolve the same key as the authoritative gate in
+          // `postUserMessage`, or a capped originating key behind an uncapped
+          // system key would pass here and be rejected there — persisting the
+          // empty conversation this precheck exists to avoid.
+          const key = auth.keyForUsageAttribution();
           if (key && (await isApiKeyBlocked(auth, { keyModelId: key.id }))) {
             return apiError(ctx, {
               status_code: 429,

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -563,6 +563,38 @@ describe("retryAgentMessage", () => {
     rateLimiterSpy.mockRestore();
   });
 
+  it("should use the attributed key for rate limiting over the system key", async () => {
+    // A run_agent sub-agent re-authenticates with the system key but carries the
+    // originating key as attribution, so its messages must share that key's
+    // bucket instead of pooling every key's sub-agent traffic under the system
+    // key. No user here: the key branch is only reached when auth has none.
+    const systemKey = await KeyFactory.system(globalGroup);
+    const originatingKey = await KeyFactory.regular(globalGroup);
+    const subAgentAuth = (
+      await Authenticator.fromKey(systemKey, workspace.sId)
+    ).withAttributionKey({
+      id: originatingKey.id,
+      name: originatingKey.name,
+    });
+
+    const rateLimiterSpy = vi
+      .spyOn(rateLimiterModule, "rateLimiter")
+      .mockResolvedValue(0);
+
+    await retryAgentMessage(subAgentAuth, {
+      conversationResource,
+      message: agentMessage,
+    });
+
+    expect(rateLimiterSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: `workspace:${workspace.sId}:api_key:${originatingKey.id}:post_user_message`,
+      })
+    );
+
+    rateLimiterSpy.mockRestore();
+  });
+
   it("should use the actor user key when auth has both user and api key", async () => {
     const systemKey = await KeyFactory.system(globalGroup);
     const mixedAuth = auth.exchangeKey(systemKey.toAuthJSON());

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -875,7 +875,7 @@ export async function postUserMessage(
     // this drives api_key_name in usage analytics without affecting authorization.
     const enrichedContext: UserMessageContext = {
       ...context,
-      apiKeyId: auth.attributionKeyModelId() ?? auth.key()?.id ?? null,
+      apiKeyId: auth.keyForUsageAttribution()?.id ?? null,
       authMethod: auth.authMethod(),
     };
 
@@ -2638,7 +2638,9 @@ export async function checkMessagesLimit(
     if (isProgrammaticUsage(auth, { userMessageOrigin: context.origin })) {
       // Per-API-key credit cap. `isApiKeyBlocked` is flag-aware (rate-limiter
       // counter when the flag is on, Metronome per-key credit state otherwise).
-      const key = auth.key();
+      // Gated on the attributed key so it reads the counter the spend was
+      // charged to (see `keyForUsageAttribution`).
+      const key = auth.keyForUsageAttribution();
       if (key) {
         if (await isApiKeyBlocked(auth, { keyModelId: key.id })) {
           return new Err({
@@ -2912,7 +2914,7 @@ async function checkProgrammaticUsageRateLimit(
   // Prevents close-to-0 cap attacks where many messages are sent simultaneously.
   const remainingCapMicroUsd = await getRemainingKeyCapMicroUsd(auth);
   if (remainingCapMicroUsd !== null) {
-    const keyAuth = auth.key();
+    const keyAuth = auth.keyForUsageAttribution();
     if (keyAuth) {
       const remainingCapDollars = remainingCapMicroUsd / 1_000_000;
       const keyMaxMessagesPerMinute = Math.max(

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2638,8 +2638,6 @@ export async function checkMessagesLimit(
     if (isProgrammaticUsage(auth, { userMessageOrigin: context.origin })) {
       // Per-API-key credit cap. `isApiKeyBlocked` is flag-aware (rate-limiter
       // counter when the flag is on, Metronome per-key credit state otherwise).
-      // Gated on the attributed key so it reads the counter the spend was
-      // charged to (see `keyForUsageAttribution`).
       const key = auth.keyForUsageAttribution();
       if (key) {
         if (await isApiKeyBlocked(auth, { keyModelId: key.id })) {
@@ -2975,7 +2973,7 @@ function getMessageRateLimitActor(auth: Authenticator):
     return { type: "user", id: user.id };
   }
 
-  const apiKey = auth.key();
+  const apiKey = auth.keyForUsageAttribution();
   if (apiKey) {
     return { type: "api_key", id: apiKey.id };
   }

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -280,9 +280,7 @@ export async function computeAndStoreAgentMessageCredits(
       }
     }
 
-    // Per-API-key cap, charged to the attributed key: the originating key for
-    // internal system-key flows (run_agent sub-agents), the request's own key
-    // otherwise.
+    // Per-API-key cap.
     const apiKey = auth.keyForUsageAttribution();
     if (apiKey) {
       await recordApiKeySpendLimitUsage(auth, {

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -280,8 +280,10 @@ export async function computeAndStoreAgentMessageCredits(
       }
     }
 
-    // Per-API-key cap, for calls authenticated with an API key.
-    const apiKey = auth.key();
+    // Per-API-key cap, charged to the attributed key: the originating key for
+    // internal system-key flows (run_agent sub-agents), the request's own key
+    // otherwise.
+    const apiKey = auth.keyForUsageAttribution();
     if (apiKey) {
       await recordApiKeySpendLimitUsage(auth, {
         keyModelId: apiKey.id,

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -277,6 +277,8 @@ export abstract class LLM<
       { asType: "generation" }
     );
 
+    const attributedKey = this.authenticator.keyForUsageAttribution();
+
     this.generation.updateTrace({
       name: startCase(this.context.operationType),
       metadata: {
@@ -288,9 +290,10 @@ export abstract class LLM<
         ...(this.authenticator.user()?.sId && {
           actualUserId: this.authenticator.user()!.sId,
         }),
-        ...(this.authenticator.key() && {
-          apiKeyId: this.authenticator.key()!.id,
-        }),
+        // The attributed key, so a trace joins to the message analytics and
+        // spend counters for the same run rather than naming the system key an
+        // internal flow re-authenticated with (`authMethod` still shows that).
+        ...(attributedKey && { apiKeyId: attributedKey.id }),
         authMethod: this.authenticator.authMethod() ?? "unknown",
         // Include all context fields (except userId and workspaceId).
         ...pickBy(
@@ -729,6 +732,7 @@ export abstract class LLM<
    */
   private async traceBatchResults(results: BatchResult): Promise<void> {
     const workspaceId = this.authenticator.getNonNullableWorkspace().sId;
+    const attributedKey = this.authenticator.keyForUsageAttribution();
 
     for (const [customId, events] of results) {
       const traceId = createLLMTraceId(randomUUID());
@@ -755,9 +759,7 @@ export abstract class LLM<
           ...(this.authenticator.user()?.sId && {
             actualUserId: this.authenticator.user()!.sId,
           }),
-          ...(this.authenticator.key() && {
-            apiKeyId: this.authenticator.key()!.id,
-          }),
+          ...(attributedKey && { apiKeyId: attributedKey.id }),
           authMethod: this.authenticator.authMethod() ?? "unknown",
           ...pickBy(
             this.context!,

--- a/front/lib/api/programmatic_usage/key_cap.ts
+++ b/front/lib/api/programmatic_usage/key_cap.ts
@@ -192,7 +192,7 @@ export async function incrementRedisKeyUsageMicroUsd(
 export async function hasKeyReachedUsageCap(
   auth: Authenticator
 ): Promise<boolean> {
-  const keyAuth = auth.key();
+  const keyAuth = auth.keyForUsageAttribution();
 
   if (!keyAuth) {
     return false;
@@ -251,7 +251,7 @@ export async function hasKeyReachedUsageCap(
 export async function getRemainingKeyCapMicroUsd(
   auth: Authenticator
 ): Promise<number | null> {
-  const keyAuth = auth.key();
+  const keyAuth = auth.keyForUsageAttribution();
 
   if (!keyAuth) {
     return null;

--- a/front/lib/api/programmatic_usage/tracking.ts
+++ b/front/lib/api/programmatic_usage/tracking.ts
@@ -407,7 +407,7 @@ export async function trackProgrammaticCost(
       localLogger
     );
 
-  const keyAuth = auth.key();
+  const keyAuth = auth.keyForUsageAttribution();
   if (keyAuth) {
     await incrementRedisKeyUsageMicroUsd(keyAuth.id, costWithMarkupMicroUsd);
   }

--- a/front/lib/auth.key_for_usage_attribution.test.ts
+++ b/front/lib/auth.key_for_usage_attribution.test.ts
@@ -1,0 +1,51 @@
+import { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { KeyFactory } from "@app/tests/utils/KeyFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { describe, expect, it } from "vitest";
+
+describe("Authenticator.keyForUsageAttribution", () => {
+  it("returns the request's own key when no attribution key is set", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const { globalGroup } =
+      await GroupResource.makeDefaultsForWorkspace(workspace);
+    const key = await KeyFactory.regular(globalGroup);
+
+    const auth = await Authenticator.fromKey(key, workspace.sId);
+
+    expect(auth.keyForUsageAttribution()).toEqual({
+      id: key.id,
+      name: key.name,
+    });
+  });
+
+  it("returns the attribution key over the request's own key", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const { globalGroup } =
+      await GroupResource.makeDefaultsForWorkspace(workspace);
+    const systemKey = await KeyFactory.system(globalGroup);
+    const originatingKey = await KeyFactory.regular(globalGroup);
+
+    const auth = (
+      await Authenticator.fromKey(systemKey, workspace.sId)
+    ).withAttributionKey({ id: originatingKey.id, name: originatingKey.name });
+
+    expect(auth.keyForUsageAttribution()).toEqual({
+      id: originatingKey.id,
+      name: originatingKey.name,
+    });
+    // Authorization still runs on the system key: only usage moved.
+    expect(auth.key()?.id).toBe(systemKey.id);
+    expect(auth.key()?.isSystem).toBe(true);
+  });
+
+  it("returns null when the request carries no key", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    await GroupResource.makeDefaultsForWorkspace(workspace);
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    expect(auth.key()).toBeNull();
+    expect(auth.keyForUsageAttribution()).toBeNull();
+  });
+});

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1733,6 +1733,23 @@ export class Authenticator {
     return this._attributionKey?.id ?? null;
   }
 
+  // The key that usage is charged to: the attribution key when an internal
+  // system-key flow forwarded one (run_agent sub-agents, agent_router,
+  // run_dust_app), the request's own key otherwise. Distinct from
+  // `attributionKey()`, which exposes only the forwarded reference and is null
+  // on a direct call.
+  /**
+   * @cc [owner:fabiencelier,label:product;performance] one-usage-key-identity
+   * Every per-API-key spend-cap read, gate and increment, and every persisted usage attribution,
+   * MUST resolve the key through this method.
+   */
+  keyForUsageAttribution(): { id: ModelId; name: string } | null {
+    if (this._attributionKey) {
+      return this._attributionKey;
+    }
+    return this._key ? { id: this._key.id, name: this._key.name } : null;
+  }
+
   // Returns a copy of this authenticator carrying an attribution-only key
   // reference. Used to attribute usage to the original caller's key when an
   // internal flow re-authenticates with the workspace system key (e.g. run_agent
@@ -2148,6 +2165,12 @@ export function getApiKeyNameFromHeaders(headers: {
   return undefined;
 }
 
+/**
+ * @cc [owner:fabiencelier,label:product] forwarded-key-name-prefers-attribution
+ * When `auth` carries an attribution key, the forwarded `x-dust-api-key-name` MUST be that key's
+ * name rather than `auth.key()`'s, so the originating key's name survives nested internal
+ * system-key calls. With neither an attribution key nor a request key, no header is returned.
+ */
 export function getApiKeyNameHeader(auth: Authenticator) {
   // Prefer the attribution key name over the request's own key so the original
   // caller's key name propagates transitively through nested internal system-key

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1740,8 +1740,9 @@ export class Authenticator {
   // on a direct call.
   /**
    * @cc [owner:fabiencelier,label:product;performance] one-usage-key-identity
-   * Every per-API-key spend-cap read, gate and increment, and every persisted usage attribution,
-   * MUST resolve the key through this method.
+   * Every per-API-key spend-cap read, gate and increment, every persisted usage attribution, and
+   * every api-key field on an observability trace MUST resolve the key through this method.
+   * Authorization checks are the exception and MUST keep using `key()`.
    */
   keyForUsageAttribution(): { id: ModelId; name: string } | null {
     if (this._attributionKey) {


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/9537

run agent calls originating from API calls were not correctly assigned to the api key.
This fixes the issue by correctly attributing the key in the auth + using the attribution key everywhere

Tested locally: before the fix child run where wrongly billed on no key and the rate limiter was not hit.
After the fix, the billing is done on correct key + rate limiter is used.

Note that attribution key was already added in #26888 but removed in #26933

## Tests

- Tested locally: before the fix child run where wrongly billed on no key and the rate limiter was not hit. After the fix, the billing is done on correct key + rate limiter is used.
- Added some small unit tests


## Risk

medium, this impact authentication

## Deploy Plan

deploy front
