### PR TITLE
poke: stop double-fetching the credit pool summary

### DIFF
--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -16,7 +16,7 @@ import type {
 import { formatCredits, formatCreditsPrecise } from "@app/lib/client/credits";
 import type { DefaultMetronomeAlerts } from "@app/lib/metronome/alerts/default_alerts";
 import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
-import { usePokeAwuPoolSummary } from "@app/poke/swr/credits";
+import { usePokeAwuPoolCurrentCycle } from "@app/poke/swr/credits";
 import type {
   WorkspacePoolCreditState,
   WorkspaceProgrammaticCreditState,
@@ -301,10 +301,13 @@ interface PokeCreditPoolCardProps {
 }
 
 function PokeCreditPoolCard({ owner }: PokeCreditPoolCardProps) {
-  const { awuPoolSummary, isAwuPoolSummaryLoading, isAwuPoolSummaryError } =
-    usePokeAwuPoolSummary({ owner });
+  const {
+    awuPoolCurrentCycle,
+    isAwuPoolCurrentCycleLoading,
+    isAwuPoolCurrentCycleError,
+  } = usePokeAwuPoolCurrentCycle({ owner });
 
-  if (isAwuPoolSummaryLoading) {
+  if (isAwuPoolCurrentCycleLoading) {
     return (
       <div className="flex justify-center py-8">
         <Spinner />
@@ -312,7 +315,7 @@ function PokeCreditPoolCard({ owner }: PokeCreditPoolCardProps) {
     );
   }
 
-  if (isAwuPoolSummaryError || !awuPoolSummary) {
+  if (isAwuPoolCurrentCycleError || !awuPoolCurrentCycle) {
     return (
       <ContentMessage
         title="Failed to load Workspace Credits Pool"
@@ -325,7 +328,7 @@ function PokeCreditPoolCard({ owner }: PokeCreditPoolCardProps) {
   }
 
   const { totalActiveCredits, totalRemainingCredits, overageCredits } =
-    awuPoolSummary;
+    awuPoolCurrentCycle;
   const consumed = Math.max(0, totalActiveCredits - totalRemainingCredits);
   const consumedPct =
     totalActiveCredits > 0

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -16,7 +16,6 @@ import type {
   AwuPoolCycleBreakdown,
   AwuPoolCycleHistoryOverflow,
   AwuPoolCycleHistoryResponseBody,
-  AwuPoolSummaryResponseBody,
 } from "@app/types/api/credits/awu_pool_summary";
 import type { GetAwuTopUpsHistoryResponseBody } from "@app/types/api/credits/top_ups_history";
 import type { PokeListCreditsResponseBody } from "@app/types/api/poke/credits";
@@ -153,28 +152,6 @@ export function usePokeAwuUsageFromAnalytics({
     isAwuUsageLoading: !error && !data && !disabled,
     isAwuUsageError: error,
     isAwuUsageValidating: isValidating,
-  };
-}
-
-export function usePokeAwuPoolSummary({
-  owner,
-  disabled,
-}: PokeConditionalFetchProps) {
-  const { fetcher } = useFetcher();
-  const fetcherFn: Fetcher<AwuPoolSummaryResponseBody> = fetcher;
-
-  const { data, error, isValidating, mutate } = useSWRWithDefaults(
-    `/api/poke/workspaces/${owner.sId}/credits/awu-pool-summary`,
-    fetcherFn,
-    { disabled }
-  );
-
-  return {
-    awuPoolSummary: data ?? null,
-    isAwuPoolSummaryLoading: !error && !data && !disabled,
-    isAwuPoolSummaryError: error,
-    isAwuPoolSummaryValidating: isValidating,
-    mutateAwuPoolSummary: mutate,
   };
 }
 


### PR DESCRIPTION
PokeCreditPoolCard fetched the heavier awu-pool-summary endpoint
(current-cycle + full cycle history) just to read fields already
returned by the lighter awu-pool-current-cycle endpoint the pool
cards elsewhere already use. Same pattern fixed for the customer-
facing usage page in #32258.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://app.notion.com/p/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
