### PR TITLE
[front] Preserve Gemini function response boundaries

### DIFF
--- a/front/lib/model_constructors/sdk/google_genai/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/sdk/google_genai/converters/input/utils.test.ts
@@ -43,9 +43,57 @@ describe("conversationToContents — provider_passthrough", () => {
     const contents = await conversationToContents(conversation, converters);
 
     // The two text turns merge into one model Content; the passthrough produces
-    // no part (no empty `{ text: "" }` slips in).
+    // no part (no empty `{ text: "" }` slips in). The trailing model turn is
+    // closed by the synthetic user turn.
     expect(contents).toEqual([
       { role: "model", parts: [{ text: "before" }, { text: "after" }] },
+      { role: "user", parts: [{ text: "." }] },
     ]);
+  });
+});
+
+describe("conversationToContents — trailing model turn", () => {
+  it("appends a user turn when the conversation ends on an assistant turn", async () => {
+    const conversation: BaseConversation = {
+      system: [],
+      messages: [
+        { role: "user", type: "text", content: { value: "hello" } },
+        { role: "assistant", type: "text", content: { value: "hi" } },
+      ],
+    };
+
+    const contents = await conversationToContents(conversation, converters);
+
+    expect(contents).toEqual([
+      { role: "user", parts: [{ text: "hello" }] },
+      { role: "model", parts: [{ text: "hi" }] },
+      { role: "user", parts: [{ text: "." }] },
+    ]);
+  });
+
+  it("leaves a conversation already ending on a user turn untouched", async () => {
+    const conversation: BaseConversation = {
+      system: [],
+      messages: [
+        { role: "assistant", type: "text", content: { value: "hi" } },
+        { role: "user", type: "text", content: { value: "hello" } },
+      ],
+    };
+
+    const contents = await conversationToContents(conversation, converters);
+
+    expect(contents).toEqual([
+      { role: "model", parts: [{ text: "hi" }] },
+      { role: "user", parts: [{ text: "hello" }] },
+    ]);
+  });
+
+  it("returns no contents for an empty conversation", async () => {
+    const contents = await conversationToContents(
+      { system: [], messages: [] },
+      converters
+    );
+
+    expect(contents).toEqual([]);
   });
 });

--- a/front/lib/model_constructors/sdk/google_genai/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/sdk/google_genai/converters/input/utils.test.ts
@@ -43,73 +43,109 @@ describe("conversationToContents — provider_passthrough", () => {
     const contents = await conversationToContents(conversation, converters);
 
     // The two text turns merge into one model Content; the passthrough produces
-    // no part (no empty `{ text: "" }` slips in). The trailing model turn is
-    // closed by the synthetic user turn.
+    // no part (no empty `{ text: "" }` slips in).
     expect(contents).toEqual([
       { role: "model", parts: [{ text: "before" }, { text: "after" }] },
-      { role: "user", parts: [{ text: "." }] },
     ]);
   });
 });
 
-describe("conversationToContents — trailing model turn", () => {
-  it("appends a user turn when the conversation ends on an assistant turn", async () => {
-    const conversation: BaseConversation = {
-      system: [],
-      messages: [
-        { role: "user", type: "text", content: { value: "hello" } },
-        { role: "assistant", type: "text", content: { value: "hi" } },
-      ],
-    };
-
-    const contents = await conversationToContents(conversation, converters);
-
-    expect(contents).toEqual([
-      { role: "user", parts: [{ text: "hello" }] },
-      { role: "model", parts: [{ text: "hi" }] },
-      { role: "user", parts: [{ text: "." }] },
-    ]);
-  });
-
-  it("leaves a conversation already ending on a user turn untouched", async () => {
-    const conversation: BaseConversation = {
-      system: [],
-      messages: [
-        { role: "assistant", type: "text", content: { value: "hi" } },
-        { role: "user", type: "text", content: { value: "hello" } },
-      ],
-    };
-
-    const contents = await conversationToContents(conversation, converters);
-
-    expect(contents).toEqual([
-      { role: "model", parts: [{ text: "hi" }] },
-      { role: "user", parts: [{ text: "hello" }] },
-    ]);
-  });
-
-  it("returns no contents for an empty conversation", async () => {
-    const contents = await conversationToContents(
-      { system: [], messages: [] },
-      converters
-    );
-
-    expect(contents).toEqual([]);
-  });
-
-  it("appends nothing when every message converts to nothing", async () => {
-    // A passthrough-only conversation converts to no Contents at all. There is
-    // no trailing model turn to close, so the guard stays out of it rather than
-    // inventing a user turn for a request that has nothing to answer.
+describe("conversationToContents — function responses", () => {
+  it("keeps a function response separate from following user text", async () => {
     const conversation: BaseConversation = {
       system: [],
       messages: [
         {
           role: "assistant",
-          type: "provider_passthrough",
+          type: "reasoning",
+          content: { value: "I should enable the skill." },
+        },
+        {
+          role: "assistant",
+          type: "tool_call_request",
           content: {
-            provider: "anthropic",
-            block: { type: "server_tool_use", id: "x", name: "y", input: {} },
+            callId: "call-1",
+            toolName: "skill_management__enable_skill",
+            arguments: '{"skill_id":"skill-1"}',
+          },
+          signature: "thought-signature",
+        },
+        {
+          role: "user",
+          type: "tool_call_result",
+          content: {
+            callId: "call-1",
+            toolName: "skill_management__enable_skill",
+            parts: [{ type: "text", text: "Skill enabled." }],
+            isError: false,
+          },
+        },
+        {
+          role: "user",
+          type: "text",
+          content: { value: "<dust_system>Skill instructions.</dust_system>" },
+        },
+      ],
+    };
+
+    const contents = await conversationToContents(conversation, converters);
+
+    expect(contents).toEqual([
+      {
+        role: "model",
+        parts: [
+          { text: "I should enable the skill.", thought: true },
+          {
+            functionCall: {
+              id: "call-1",
+              name: "skill_management__enable_skill",
+              args: { skill_id: "skill-1" },
+            },
+            thoughtSignature: "thought-signature",
+          },
+        ],
+      },
+      {
+        role: "user",
+        parts: [
+          {
+            functionResponse: {
+              id: "call-1",
+              name: "skill_management__enable_skill",
+              response: { output: "Skill enabled." },
+            },
+          },
+        ],
+      },
+      {
+        role: "user",
+        parts: [{ text: "<dust_system>Skill instructions.</dust_system>" }],
+      },
+    ]);
+  });
+
+  it("still merges adjacent function responses into one user turn", async () => {
+    const conversation: BaseConversation = {
+      system: [],
+      messages: [
+        {
+          role: "user",
+          type: "tool_call_result",
+          content: {
+            callId: "call-1",
+            toolName: "tool-1",
+            parts: [{ type: "text", text: "result-1" }],
+            isError: false,
+          },
+        },
+        {
+          role: "user",
+          type: "tool_call_result",
+          content: {
+            callId: "call-2",
+            toolName: "tool-2",
+            parts: [{ type: "text", text: "result-2" }],
+            isError: false,
           },
         },
       ],
@@ -117,6 +153,50 @@ describe("conversationToContents — trailing model turn", () => {
 
     const contents = await conversationToContents(conversation, converters);
 
-    expect(contents).toEqual([]);
+    expect(contents).toEqual([
+      {
+        role: "user",
+        parts: [
+          {
+            functionResponse: {
+              id: "call-1",
+              name: "tool-1",
+              response: { output: "result-1" },
+            },
+          },
+          {
+            functionResponse: {
+              id: "call-2",
+              name: "tool-2",
+              response: { output: "result-2" },
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("still merges adjacent plain user messages", async () => {
+    const conversation: BaseConversation = {
+      system: [],
+      messages: [
+        {
+          role: "user",
+          type: "text",
+          content: { value: "first" },
+        },
+        {
+          role: "user",
+          type: "text",
+          content: { value: "second" },
+        },
+      ],
+    };
+
+    const contents = await conversationToContents(conversation, converters);
+
+    expect(contents).toEqual([
+      { role: "user", parts: [{ text: "first" }, { text: "second" }] },
+    ]);
   });
 });

--- a/front/lib/model_constructors/sdk/google_genai/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/sdk/google_genai/converters/input/utils.test.ts
@@ -96,4 +96,27 @@ describe("conversationToContents — trailing model turn", () => {
 
     expect(contents).toEqual([]);
   });
+
+  it("appends nothing when every message converts to nothing", async () => {
+    // A passthrough-only conversation converts to no Contents at all. There is
+    // no trailing model turn to close, so the guard stays out of it rather than
+    // inventing a user turn for a request that has nothing to answer.
+    const conversation: BaseConversation = {
+      system: [],
+      messages: [
+        {
+          role: "assistant",
+          type: "provider_passthrough",
+          content: {
+            provider: "anthropic",
+            block: { type: "server_tool_use", id: "x", name: "y", input: {} },
+          },
+        },
+      ],
+    };
+
+    const contents = await conversationToContents(conversation, converters);
+
+    expect(contents).toEqual([]);
+  });
 });

--- a/front/lib/model_constructors/sdk/google_genai/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/google_genai/converters/input/utils.ts
@@ -17,6 +17,7 @@ import type {
   SystemTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isRecord, removeNulls } from "@app/types/shared/utils/general";
 import { trustedFetchImageBase64 } from "@app/types/shared/utils/image_utils";
@@ -45,6 +46,11 @@ const UNSUPPORTED_MIME_TYPE_MESSAGE = "Image mime type is not supported.";
 
 // Conversion fans out to external image fetches; bound the concurrency.
 const MESSAGE_CONVERSION_CONCURRENCY = 10;
+
+// Closes a conversation that would otherwise end on a model turn. Kept to a
+// single character to steer the next generation as little as possible; an empty
+// text part is rejected too.
+const MODEL_TURN_CLOSER = ".";
 
 // Fetches an image URL and returns a Gemini inline-data part, degrading to a
 // text note when the image cannot be fetched or its MIME type is unsupported
@@ -259,6 +265,18 @@ function assistantMessageToContent(
   }
 }
 
+// Part kinds only ("text", "functionCall", ...) — never the values, which carry
+// conversation content ([no-sensitive-data-logging]).
+function partKinds(content: Content): string[] {
+  return (content.parts ?? []).flatMap((part) => Object.keys(part));
+}
+
+/**
+ * @cc [owner:frankaloia,label:backend] no-trailing-model-turn
+ * The returned contents MUST NOT end with a `model` Content. When the conversation ends on an
+ * assistant turn, a non-empty synthetic `user` Content is appended; Gemini rejects both a
+ * trailing model turn and an empty text part.
+ */
 export async function conversationToContents(
   conversation: BaseConversation,
   converters: ContentBlockConverters
@@ -296,7 +314,7 @@ export async function conversationToContents(
   //   rejected as corrupted.
   // Consecutive same-role Contents only arise from one logical turn being split:
   // distinct assistant turns are always separated by a tool-result/user turn.
-  return contents.reduce<Content[]>((merged, content) => {
+  const mergedContents = contents.reduce<Content[]>((merged, content) => {
     const previous = merged[merged.length - 1];
     if (previous && previous.role === content.role) {
       return [
@@ -309,6 +327,32 @@ export async function conversationToContents(
     }
     return [...merged, content];
   }, []);
+
+  // Gemini rejects a request whose last Content is a model turn (verified
+  // against gemini-3.8-flash: HTTP 400 "Requests ending with a model turn are
+  // not supported."). The agent loop is supposed to always end its payload on a
+  // user or tool-result turn, so reaching this branch means an upstream
+  // invariant broke; close the conversation rather than fail the whole request,
+  // and log enough to identify the producer.
+  const lastContent = mergedContents[mergedContents.length - 1];
+  if (lastContent?.role === "model") {
+    logger.warn(
+      {
+        contentCount: mergedContents.length,
+        lastContentPartKinds: partKinds(lastContent),
+        // `removeNulls` above only drops provider_passthrough messages, so any
+        // shortfall is the count of blocks owned by another provider.
+        droppedPassthroughCount: conversation.messages.length - contents.length,
+      },
+      "Gemini conversation ends on a model turn; appending a synthetic user turn."
+    );
+    return [
+      ...mergedContents,
+      { role: "user", parts: [{ text: MODEL_TURN_CLOSER }] },
+    ];
+  }
+
+  return mergedContents;
 }
 
 export function systemMessagesToSystemInstruction(

--- a/front/lib/model_constructors/sdk/google_genai/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/google_genai/converters/input/utils.ts
@@ -17,7 +17,6 @@ import type {
   SystemTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isRecord, removeNulls } from "@app/types/shared/utils/general";
 import { trustedFetchImageBase64 } from "@app/types/shared/utils/image_utils";
@@ -46,11 +45,6 @@ const UNSUPPORTED_MIME_TYPE_MESSAGE = "Image mime type is not supported.";
 
 // Conversion fans out to external image fetches; bound the concurrency.
 const MESSAGE_CONVERSION_CONCURRENCY = 10;
-
-// Closes a conversation that would otherwise end on a model turn. Kept to a
-// single character to steer the next generation as little as possible; an empty
-// text part is rejected too.
-const MODEL_TURN_CLOSER = ".";
 
 // Fetches an image URL and returns a Gemini inline-data part, degrading to a
 // text note when the image cannot be fetched or its MIME type is unsupported
@@ -265,19 +259,33 @@ function assistantMessageToContent(
   }
 }
 
-// Part kinds only ("text", "functionCall", ...) — never the values, which carry
-// conversation content ([no-sensitive-data-logging]).
-function partKinds(content: Content): string[] {
-  return (content.parts ?? []).flatMap((part) => Object.keys(part));
+function hasFunctionResponse(content: Content): boolean {
+  return (
+    content.parts?.some((part) => part.functionResponse !== undefined) ?? false
+  );
+}
+
+function canMergeContents(previous: Content, content: Content): boolean {
+  if (previous.role !== content.role) {
+    return false;
+  }
+
+  if (previous.role === "model") {
+    return true;
+  }
+
+  // A function-response turn must remain distinct from a following user
+  // message. This matters for enable_skill: its result is immediately followed
+  // by a user message containing the enabled skill's instructions.
+  return hasFunctionResponse(previous) === hasFunctionResponse(content);
 }
 
 /**
- * @cc [owner:frankaloia,label:backend] no-trailing-model-turn
- * The returned contents MUST NOT end with a `model` Content: when the converted contents would,
- * a `user` Content with a non-empty text part is appended, since Gemini rejects a trailing model
- * turn and an empty text part alike. The requirement is about the returned contents, not the
- * input: a conversation whose messages all convert to nothing yields an empty array, and nothing
- * is appended to it.
+ * @cc [owner:frankaloia,label:backend] preserve-function-response-boundary
+ * A Gemini `user` Content containing a functionResponse MUST NOT be merged with an adjacent user
+ * Content that does not contain one. Adjacent functionResponse Contents still merge so their count
+ * matches the preceding functionCall count, and adjacent model Contents still merge so replayed
+ * thought signatures remain attached to their logical model turn.
  */
 export async function conversationToContents(
   conversation: BaseConversation,
@@ -304,8 +312,7 @@ export async function conversationToContents(
     )
   );
 
-  // Merge consecutive same-role turns into a single Content. This serves two
-  // purposes:
+  // Merge compatible consecutive same-role Contents. This serves two purposes:
   // - Function-response turns: Gemini requires the functionResponse part count
   //   to match the functionCall count of the preceding model turn.
   // - Model turns: a single assistant turn is split into one BaseMessage per
@@ -314,11 +321,13 @@ export async function conversationToContents(
   //   over the whole turn (e.g. reasoning followed by the functionCall), so the
   //   parts must be replayed together in one Content or the signature is
   //   rejected as corrupted.
-  // Consecutive same-role Contents only arise from one logical turn being split:
-  // distinct assistant turns are always separated by a tool-result/user turn.
-  const mergedContents = contents.reduce<Content[]>((merged, content) => {
+  // Keep a function-response Content separate from adjacent ordinary user
+  // content. In particular, enable_skill emits its result followed by a user
+  // message carrying the skill instructions; mixing those parts makes the
+  // function-response boundary ambiguous to Gemini.
+  return contents.reduce<Content[]>((merged, content) => {
     const previous = merged[merged.length - 1];
-    if (previous && previous.role === content.role) {
+    if (previous && canMergeContents(previous, content)) {
       return [
         ...merged.slice(0, -1),
         {
@@ -329,32 +338,6 @@ export async function conversationToContents(
     }
     return [...merged, content];
   }, []);
-
-  // Gemini rejects a request whose last Content is a model turn (verified
-  // against gemini-3.8-flash: HTTP 400 "Requests ending with a model turn are
-  // not supported."). The agent loop is supposed to always end its payload on a
-  // user or tool-result turn, so reaching this branch means an upstream
-  // invariant broke; close the conversation rather than fail the whole request,
-  // and log enough to identify the producer.
-  const lastContent = mergedContents[mergedContents.length - 1];
-  if (lastContent?.role === "model") {
-    logger.warn(
-      {
-        contentCount: mergedContents.length,
-        lastContentPartKinds: partKinds(lastContent),
-        // `removeNulls` above only drops provider_passthrough messages, so any
-        // shortfall is the count of blocks owned by another provider.
-        droppedPassthroughCount: conversation.messages.length - contents.length,
-      },
-      "Gemini conversation ends on a model turn; appending a synthetic user turn."
-    );
-    return [
-      ...mergedContents,
-      { role: "user", parts: [{ text: MODEL_TURN_CLOSER }] },
-    ];
-  }
-
-  return mergedContents;
 }
 
 export function systemMessagesToSystemInstruction(

--- a/front/lib/model_constructors/sdk/google_genai/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/google_genai/converters/input/utils.ts
@@ -273,9 +273,11 @@ function partKinds(content: Content): string[] {
 
 /**
  * @cc [owner:frankaloia,label:backend] no-trailing-model-turn
- * The returned contents MUST NOT end with a `model` Content. When the conversation ends on an
- * assistant turn, a non-empty synthetic `user` Content is appended; Gemini rejects both a
- * trailing model turn and an empty text part.
+ * The returned contents MUST NOT end with a `model` Content: when the converted contents would,
+ * a `user` Content with a non-empty text part is appended, since Gemini rejects a trailing model
+ * turn and an empty text part alike. The requirement is about the returned contents, not the
+ * input: a conversation whose messages all convert to nothing yields an empty array, and nothing
+ * is appended to it.
  */
 export async function conversationToContents(
   conversation: BaseConversation,


### PR DESCRIPTION
## Summary

Fix Gemini request construction after `skill_management__enable_skill` without adding synthetic conversation content.

- Keep a `functionResponse` user Content separate from an adjacent ordinary user Content, such as the enabled skill instructions.
- Continue merging adjacent function responses so they match the preceding function-call count.
- Continue merging adjacent model parts so thought signatures stay attached to their logical turn.
- Remove the previous synthetic `\".\"` user-turn closer entirely.

No messages or parts are dropped; this only changes the boundary between two adjacent user Contents.

## Production evidence

Conversation `1ttRJZ6zHe` failed three times on `gemini-3.8-flash` with Google returning `Requests ending with a model turn are not supported.` In every version:

1. Gemini produced reasoning plus a signed `skill_management__enable_skill` call.
2. The MCP action succeeded and persisted one output item.
3. The next inference started after that output was committed and immediately returned the Google 400.
4. Rendering selected the full conversation (`prunedContext: false`), including the tool result and the following enabled-skill instruction message.

The Gemini converter then merged those adjacent user messages into one Content containing both `functionResponse` and plain text. The repeated failure shape and timing point to that lost function-response boundary, rather than a genuinely missing tool result or context pruning.

Direct A/B verification against the production agent-platform/Vertex route was not available. Google AI Studio accepted both hand-built shapes, so the provider error text alone is not treated as proof. This change instead preserves the semantic tool boundary represented in the source conversation and common to both production failures investigated.

## Test plan

- [x] Reproduction test for `enable_skill`: signed model tool call, function result, then skill-instruction user message remain three logical Contents.
- [x] Adjacent function responses still merge.
- [x] Adjacent plain user messages still merge.
- [x] Existing provider-passthrough coverage still passes.
- [x] Focused converter suite: 4/4 passed.
- [x] Biome check with warnings as errors on both changed files: clean.
- [x] Code-contract format check: clean.
- [x] PR diff whitespace check: clean.
- [ ] Full local typecheck is currently blocked by unrelated workspace dependency errors (`archiver` declaration in the active hive; stale Sparkle types in the isolated worktree). Neither reports an error in the changed files.

## Risk

Low. All converted parts remain present and in order; only incompatible user Contents are prevented from merging. Remaining uncertainty is end-to-end validation on the production Vertex-backed route.

## Deploy Plan

1. Deploy front.
2. Verify new `enable_skill` turns no longer produce the Google 400.

## Review

r? @davidebbo

Solving eng runner ticket: https://github.com/dust-tt/tasks/issues/10341