### PR TITLE
[connectors] fix: skip BigQuery enumeration when nothing is selected

### DIFF
--- a/connectors/src/connectors/bigquery/temporal/activities.ts
+++ b/connectors/src/connectors/bigquery/temporal/activities.ts
@@ -3,7 +3,11 @@ import {
   isConnectionReadonly,
 } from "@connectors/connectors/bigquery/lib/bigquery_api";
 import { BigQueryConfigurationModel } from "@connectors/lib/models/bigquery";
-import { sync } from "@connectors/lib/remote_databases/activities";
+import {
+  hasSelectedRemoteDatabasePermissions,
+  sync,
+} from "@connectors/lib/remote_databases/activities";
+import type { RemoteDBTree } from "@connectors/lib/remote_databases/utils";
 import { getConnectorAndCredentials } from "@connectors/lib/remote_databases/utils";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import logger, { getActivityLogger } from "@connectors/logger/logger";
@@ -49,15 +53,27 @@ export async function syncBigQueryConnection(connectorId: ModelId) {
 
   const activityLogger = getActivityLogger(connector);
 
-  const treeRes = await fetchTree({
-    credentials,
-    fetchTablesDescription: useMetadataForDBML,
-    logger: activityLogger,
-  });
-  if (treeRes.isErr()) {
-    throw treeRes.error;
+  // Enumerating a BigQuery project's datasets and tables can take hours on large warehouses
+  // (observed 14h on a 100k+ table project). When nothing is selected there is nothing to sync,
+  // so skip the enumeration entirely and let `sync` run its cleanup with an empty tree. See the
+  // `remote-databases-skip-enumeration-when-nothing-selected` contract in remote_databases.
+  let tree: RemoteDBTree | undefined;
+  if (await hasSelectedRemoteDatabasePermissions(connector.id)) {
+    const treeRes = await fetchTree({
+      credentials,
+      fetchTablesDescription: useMetadataForDBML,
+      logger: activityLogger,
+    });
+    if (treeRes.isErr()) {
+      throw treeRes.error;
+    }
+    tree = treeRes.value;
+  } else {
+    activityLogger.info(
+      { connectorId },
+      "[BigQuery] No selected permissions, skipping remote tree enumeration."
+    );
   }
-  const tree = treeRes.value;
 
   await sync({
     remoteDBTree: tree,

--- a/connectors/src/connectors/bigquery/temporal/activities.ts
+++ b/connectors/src/connectors/bigquery/temporal/activities.ts
@@ -54,11 +54,13 @@ export async function syncBigQueryConnection(connectorId: ModelId) {
   const activityLogger = getActivityLogger(connector);
 
   // Enumerating a BigQuery project's datasets and tables can take hours on large warehouses
-  // (observed 14h on a 100k+ table project). When nothing is selected there is nothing to sync,
-  // so skip the enumeration entirely and let `sync` run its cleanup with an empty tree. See the
+  // (observed 14h on a 100k+ table project). When nothing is selected there is nothing to sync, so
+  // skip the enumeration entirely and let `sync` run its cleanup with an empty tree. See the
   // `remote-databases-skip-enumeration-when-nothing-selected` contract in remote_databases.
+  const hasSelection = await hasSelectedRemoteDatabasePermissions(connector.id);
+
   let tree: RemoteDBTree | undefined;
-  if (await hasSelectedRemoteDatabasePermissions(connector.id)) {
+  if (hasSelection) {
     const treeRes = await fetchTree({
       credentials,
       fetchTablesDescription: useMetadataForDBML,
@@ -80,6 +82,10 @@ export async function syncBigQueryConnection(connectorId: ModelId) {
     mimeTypes: INTERNAL_MIME_TYPES.BIGQUERY,
     connector,
     tags: useMetadataForDBML ? [USE_METADATA_FOR_DBML_TAG] : [],
+    // On the skip path a selection may have been saved between the precheck and `sync`'s read;
+    // preserve it instead of deleting it so the resync it signaled can recover it. Required by the
+    // `remote-databases-skip-enumeration-when-nothing-selected` contract.
+    preserveSelectedPermissions: !hasSelection,
   });
 
   await syncSucceeded(connectorId);

--- a/connectors/src/lib/remote_databases/activities.test.ts
+++ b/connectors/src/lib/remote_databases/activities.test.ts
@@ -763,3 +763,78 @@ describe("hasSelectedRemoteDatabasePermissions", async () => {
     );
   });
 });
+
+// Guards the race in the `remote-databases-skip-enumeration-when-nothing-selected` contract: a
+// selection saved between the precheck and `sync`'s read must survive the empty-tree cleanup.
+describe("sync empty tree with preserveSelectedPermissions", async () => {
+  const makeConnector = (suffix = "") =>
+    ConnectorResource.makeNew(
+      "bigquery",
+      {
+        connectionId: `test-connection-id${suffix}`,
+        workspaceId: `test-workspace-id${suffix}`,
+        dataSourceId: `test-data-source-id${suffix}`,
+        workspaceAPIKey: "test-workspace-api-key",
+      },
+      {
+        useMetadataForDBML: false,
+      }
+    );
+
+  it("preserves a concurrently-selected table (skip path)", async () => {
+    const connector = await makeConnector("-preserve");
+
+    await RemoteTableModel.create({
+      internalId: "db.schema.table",
+      name: "table",
+      databaseName: "db",
+      schemaName: "schema",
+      permission: "selected",
+      lastUpsertedAt: new Date(),
+      connectorId: connector.id,
+    });
+
+    await sync({
+      remoteDBTree: undefined,
+      connector,
+      mimeTypes: INTERNAL_MIME_TYPES.BIGQUERY,
+      preserveSelectedPermissions: true,
+      tags: [],
+    });
+
+    const table = await RemoteTableModel.findOne({
+      where: { internalId: "db.schema.table" },
+    });
+
+    expect(table).not.toBeNull();
+    expect(table?.permission).toBe("selected");
+    expect(table?.lastUpsertedAt).toBeNull();
+  });
+
+  it("deletes a selected table when not preserving (default cleanup)", async () => {
+    const connector = await makeConnector("-delete");
+
+    await RemoteTableModel.create({
+      internalId: "db.schema.table",
+      name: "table",
+      databaseName: "db",
+      schemaName: "schema",
+      permission: "selected",
+      lastUpsertedAt: new Date(),
+      connectorId: connector.id,
+    });
+
+    await sync({
+      remoteDBTree: undefined,
+      connector,
+      mimeTypes: INTERNAL_MIME_TYPES.BIGQUERY,
+      tags: [],
+    });
+
+    const table = await RemoteTableModel.findOne({
+      where: { internalId: "db.schema.table" },
+    });
+
+    expect(table).toBeNull();
+  });
+});

--- a/connectors/src/lib/remote_databases/activities.test.ts
+++ b/connectors/src/lib/remote_databases/activities.test.ts
@@ -14,7 +14,7 @@ import type { DataSourceConfig } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
 import { describe, expect, it, vi } from "vitest";
 
-import { sync } from "./activities";
+import { hasSelectedRemoteDatabasePermissions, sync } from "./activities";
 
 // Mock the data_sources module to spy on upsertTable
 vi.mock(import("@connectors/lib/data_sources"), async (importOriginal) => {
@@ -671,5 +671,95 @@ describe("sync remote databases", async () => {
       mimeType: INTERNAL_MIME_TYPES.BIGQUERY.TABLE,
       tags: ["my-test-tag"],
     });
+  });
+});
+
+describe("hasSelectedRemoteDatabasePermissions", async () => {
+  const makeConnector = (suffix = "") =>
+    ConnectorResource.makeNew(
+      "bigquery",
+      {
+        connectionId: `test-connection-id${suffix}`,
+        workspaceId: `test-workspace-id${suffix}`,
+        dataSourceId: `test-data-source-id${suffix}`,
+        workspaceAPIKey: "test-workspace-api-key",
+      },
+      {
+        useMetadataForDBML: false,
+      }
+    );
+
+  it("returns false when the connector has no rows", async () => {
+    const connector = await makeConnector();
+
+    expect(await hasSelectedRemoteDatabasePermissions(connector.id)).toBe(
+      false
+    );
+  });
+
+  it("returns false when no row is selected", async () => {
+    const connector = await makeConnector();
+
+    await RemoteDatabaseModel.create({
+      internalId: "db",
+      name: "db",
+      permission: "inherited",
+      connectorId: connector.id,
+    });
+    await RemoteSchemaModel.create({
+      internalId: "db.schema",
+      name: "schema",
+      databaseName: "db",
+      permission: "unselected",
+      connectorId: connector.id,
+    });
+
+    expect(await hasSelectedRemoteDatabasePermissions(connector.id)).toBe(
+      false
+    );
+  });
+
+  it("returns true when a database is selected", async () => {
+    const connector = await makeConnector();
+
+    await RemoteDatabaseModel.create({
+      internalId: "db",
+      name: "db",
+      permission: "selected",
+      connectorId: connector.id,
+    });
+
+    expect(await hasSelectedRemoteDatabasePermissions(connector.id)).toBe(true);
+  });
+
+  it("returns true when a table is selected", async () => {
+    const connector = await makeConnector();
+
+    await RemoteTableModel.create({
+      internalId: "db.schema.table",
+      name: "table",
+      databaseName: "db",
+      schemaName: "schema",
+      permission: "selected",
+      connectorId: connector.id,
+    });
+
+    expect(await hasSelectedRemoteDatabasePermissions(connector.id)).toBe(true);
+  });
+
+  it("scopes the check to the given connector", async () => {
+    const connectorA = await makeConnector("-a");
+    const connectorB = await makeConnector("-b");
+
+    await RemoteDatabaseModel.create({
+      internalId: "db",
+      name: "db",
+      permission: "selected",
+      connectorId: connectorA.id,
+    });
+
+    expect(await hasSelectedRemoteDatabasePermissions(connectorB.id)).toBe(
+      false
+    );
   });
 });

--- a/connectors/src/lib/remote_databases/activities.ts
+++ b/connectors/src/lib/remote_databases/activities.ts
@@ -374,14 +374,23 @@ async function cleanupUnusedRemoteDatabaseHierarchyModel({
   }
 }
 
-// @cc [label:performance] remote-databases-skip-enumeration-when-nothing-selected
-// A read-granted internal id is a database/schema/table row with permission "selected".
-// `sync` only creates read-granted nodes and then removes every existing row that was not
-// (re)used, so when nothing is selected the remote tree is irrelevant: sync creates nothing and
-// cleans everything up regardless of the tree passed in. Callers MUST check this before running
-// the (potentially multi-hour) remote enumeration and skip it — passing an empty tree to `sync`
-// still performs the correct cleanup. Keep the "selected" filter identical to the one `sync` uses
-// to build `readGrantedInternalIds` below.
+/**
+ * @cc [owner:frankaloia,label:performance] remote-databases-skip-enumeration-when-nothing-selected
+ * Returns whether the connector has any read-granted node, i.e. a database/schema/table row with
+ * permission "selected" — the same set `sync` derives into `readGrantedInternalIds`. Keep this
+ * "selected" filter identical to the one `sync` uses.
+ *
+ * `sync` only creates read-granted nodes and removes every existing row it did not (re)use, so when
+ * nothing is selected the remote tree is irrelevant: `sync` creates nothing and cleans everything up
+ * regardless of the tree. Callers MUST use this to skip the (potentially multi-hour) remote
+ * enumeration when it returns false, passing an empty `remoteDBTree` to `sync`.
+ *
+ * `sync` re-reads selections via its own `findAll` AFTER this precheck, so a selection saved in that
+ * window would be left unused and destroyed by cleanup. Callers taking the skip path MUST therefore
+ * call `sync` with `preserveSelectedPermissions: true`, so a concurrently-saved selection is
+ * preserved (its `lastUpsertedAt` reset rather than the row deleted) and recovered by the resync
+ * that selection signals.
+ */
 export async function hasSelectedRemoteDatabasePermissions(
   connectorId: ModelId
 ): Promise<boolean> {

--- a/connectors/src/lib/remote_databases/activities.ts
+++ b/connectors/src/lib/remote_databases/activities.ts
@@ -19,7 +19,11 @@ import { buildInternalId } from "@connectors/lib/remote_databases/utils";
 import { heartbeat } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
-import type { DataSourceConfig, INTERNAL_MIME_TYPES } from "@connectors/types";
+import type {
+  DataSourceConfig,
+  INTERNAL_MIME_TYPES,
+  ModelId,
+} from "@connectors/types";
 
 type RemoteDatabaseHierarchyModel =
   | RemoteDatabaseModel
@@ -368,6 +372,33 @@ async function cleanupUnusedRemoteDatabaseHierarchyModel({
   } else {
     await model.destroy();
   }
+}
+
+// @cc [label:performance] remote-databases-skip-enumeration-when-nothing-selected
+// A read-granted internal id is a database/schema/table row with permission "selected".
+// `sync` only creates read-granted nodes and then removes every existing row that was not
+// (re)used, so when nothing is selected the remote tree is irrelevant: sync creates nothing and
+// cleans everything up regardless of the tree passed in. Callers MUST check this before running
+// the (potentially multi-hour) remote enumeration and skip it — passing an empty tree to `sync`
+// still performs the correct cleanup. Keep the "selected" filter identical to the one `sync` uses
+// to build `readGrantedInternalIds` below.
+export async function hasSelectedRemoteDatabasePermissions(
+  connectorId: ModelId
+): Promise<boolean> {
+  const [selectedDatabases, selectedSchemas, selectedTables] =
+    await Promise.all([
+      RemoteDatabaseModel.count({
+        where: { connectorId, permission: "selected" },
+      }),
+      RemoteSchemaModel.count({
+        where: { connectorId, permission: "selected" },
+      }),
+      RemoteTableModel.count({
+        where: { connectorId, permission: "selected" },
+      }),
+    ]);
+
+  return selectedDatabases + selectedSchemas + selectedTables > 0;
 }
 
 export async function sync({


### PR DESCRIPTION
## Summary

Fixes [dust-tt/tasks#10362](https://github.com/dust-tt/tasks/issues/10362).

The BigQuery connector sync (`fetchTree`) enumerates **every dataset and table** of the customer's project on each run, even when nothing is selected (`readGrantedInternalIds = 0`).

`sync()` only creates read-granted (`permission: "selected"`) nodes and then removes every existing row that was not re-used. So when nothing is selected, the enumerated tree is irrelevant — sync creates nothing and cleans everything up regardless of the tree passed in.

This PR:
This addresses the first requested item in the issue (short-circuit when no permissions granted). The broader asks — scoping enumeration to selected datasets and checkpointing/heartbeat-resumable enumeration so deploys don't restart hours of work — are larger and intentionally out of scope here.

## Testing
- `npx tsgo --noEmit` (connectors): clean.
- `biome check` on changed files: clean.
- New unit tests for `hasSelectedRemoteDatabasePermissions` (no rows, non-selected rows, selected database, selected table, connector scoping). Full `remote_databases/activities.test.ts` suite: 13/13 pass against a local test DB.

## Risk

Low. Behavior is unchanged when anything is selected. When nothing is selected the outcome is identical to before (0 created, stale rows cleaned up) minus the multi-hour enumeration. No schema or API changes.

## Deploy Plan
1. Deploy Connector

## Review
r? @Fraggle Eng runner ticket