### PR TITLE
[front] fix: validate file formats on Folder drag-and-drop

### DIFF
--- a/front/components/data_source/MultipleFilesUpload.tsx
+++ b/front/components/data_source/MultipleFilesUpload.tsx
@@ -5,6 +5,7 @@ import type {
   FileBlobWithFileId,
 } from "@app/hooks/useFileUploaderService";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
+import { useSendNotification } from "@app/hooks/useNotification";
 import { useUpsertFileAsDatasourceEntry } from "@app/lib/swr/files";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { ContentNode } from "@app/types/connectors/connectors_api";
@@ -30,12 +31,25 @@ import {
 } from "@dust-tt/sparkle";
 import type { ChangeEvent } from "react";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 // Helper to check if a file should be treated as a table based on its MIME type
 function isDelimitedFile(file: File): boolean {
   const contentType = file.type || "application/octet-stream";
   return isSupportedDelimitedTextContentType(contentType);
+}
+
+// Returns the lower-cased extension (including the leading dot) of a file name,
+// or "" when the name has no extension.
+function getFileExtension(fileName: string): string {
+  const dotIndex = fileName.lastIndexOf(".");
+  return dotIndex === -1 ? "" : fileName.slice(dotIndex).toLowerCase();
 }
 
 type MultipleFilesUploadProps = {
@@ -64,6 +78,15 @@ export const MultipleFilesUpload = ({
   const [wasOpened, setWasOpened] = useState(isOpen);
   const [pendingFiles, setPendingFiles] = useState<File[] | null>(null);
   const [duplicateFiles, setDuplicateFiles] = useState<string[]>([]);
+  const sendNotification = useSendNotification();
+
+  // The same set of extensions the file picker restricts to via the `accept`
+  // attribute below. The drop path bypasses that filter, so we validate against
+  // it explicitly to keep both entry points consistent.
+  const supportedExtensions = useMemo(
+    () => new Set<string>(getSupportedNonImageFileExtensions()),
+    []
+  );
 
   const close = useCallback(
     (save: boolean) => {
@@ -106,8 +129,38 @@ export const MultipleFilesUpload = ({
   }>(null);
 
   const checkDuplicatesAndUpload = useCallback(
-    async (files: File[], skipDuplicateCheck = false) => {
+    async (inputFiles: File[], skipDuplicateCheck = false) => {
       // Empty file input
+      if (inputFiles.length === 0) {
+        close(false);
+        return;
+      }
+
+      // Reject unsupported formats before uploading. The file picker already
+      // restricts formats via its `accept` attribute, but the drag-and-drop
+      // path does not, so unsupported files (e.g. .xlsm) would otherwise be
+      // sent to the server only to fail downstream with no clear message.
+      const unsupportedFiles = inputFiles.filter(
+        (file) => !supportedExtensions.has(getFileExtension(file.name))
+      );
+      if (unsupportedFiles.length > 0) {
+        const names = unsupportedFiles.map((file) => file.name).join(", ");
+        sendNotification({
+          type: "error",
+          title:
+            unsupportedFiles.length === 1
+              ? "Unsupported file format"
+              : "Unsupported file formats",
+          description:
+            unsupportedFiles.length === 1
+              ? `"${names}" is not a supported format and was skipped.`
+              : `The following files are not a supported format and were skipped: ${names}.`,
+        });
+      }
+
+      const files = inputFiles.filter((file) =>
+        supportedExtensions.has(getFileExtension(file.name))
+      );
       if (files.length === 0) {
         close(false);
         return;
@@ -236,6 +289,8 @@ export const MultipleFilesUpload = ({
       plan.limits.dataSources.documents.count,
       totalNodesCount,
       doUpsertFileAsDataSourceEntry,
+      sendNotification,
+      supportedExtensions,
     ]
   );
 


### PR DESCRIPTION
## Summary

Fixes [dust-tt/tasks#9547](https://github.com/dust-tt/tasks/issues/9547).

Files dragged into a Space Folder were not checked against supported formats before upload. The "Add data" file picker restricts formats via its `accept` attribute, but the **drag-and-drop** (and paste) path in `MultipleFilesUpload` bypassed that filter — so an unsupported file (e.g. `.xlsm`) was sent to the server only to fail downstream with no rejection message.

This PR validates incoming files against the same extension set the picker uses (`getSupportedNonImageFileExtensions()`) in `checkDuplicatesAndUpload`:
- Unsupported files trigger an error notification listing them and are skipped.
- Only supported files continue through the duplicate check / upload.
- If nothing supported remains, the dialog closes cleanly.

Because both the picker path and the drop/paste path go through `checkDuplicatesAndUpload`, the two entry points are now consistent.

Note: the separate Firefox drag-and-drop *freeze* reported in the issue (tracked in #6543) is a distinct, deeper problem and is intentionally out of scope here — this PR addresses the missing format validation / rejection message.

## Testing

- `npx tsgo --noEmit` (front): no new errors (pre-existing unrelated `archiver` declaration error only).
- `biome check` on the changed file: clean.

## Risk

Low. Scoped to the folder bulk-upload component. The picker path already only surfaced supported extensions, so its behavior is unchanged; the change adds the same guard to the drop/paste path and a user-facing notification.

## Testing Plan

- Drag a `.xlsm` (or other unsupported) file into a Space Folder → error notification appears, file is skipped, no indefinite spinner.
- Drag a mix of supported + unsupported files → unsupported are skipped with a notification, supported upload normally.
- Drag/pick only supported files → uploads as before (documents + tables), duplicate confirmation still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)