### PR TITLE
Self improving skill: entirely disable on mobile

### DIFF
--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -33,7 +33,10 @@ import { submitSkillBuilderForm } from "@app/components/skill_builder/submitSkil
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useNavigationLock } from "@app/hooks/useNavigationLock";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { useSkillSuggestions } from "@app/hooks/useSkillSuggestions";
+import {
+  useAreSkillSuggestionsEnabled,
+  useSkillSuggestions,
+} from "@app/hooks/useSkillSuggestions";
 import { useIsSelfImprovementAvailable } from "@app/lib/client/self_improvement";
 import { useAppRouter } from "@app/lib/platform";
 import { useSkillHistory } from "@app/lib/swr/skill_configurations";
@@ -41,7 +44,6 @@ import {
   useSkillEditors,
   useUpdateSkillEditors,
 } from "@app/lib/swr/skill_editors";
-import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { removeParamFromRouter } from "@app/lib/utils/router_util";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
@@ -75,7 +77,6 @@ export default function SkillBuilder({ skill, onSaved }: SkillBuilderProps) {
   const [isSaving, setIsSaving] = useState(false);
   const [isCreatedDialogOpen, setIsCreatedDialogOpen] = useState(false);
   const [isAddingSelfAsEditor, setIsAddingSelfAsEditor] = useState(false);
-  const isMobile = useIsMobile();
 
   const { editors, isEditorsError, isEditorsLoading, mutateEditors } =
     useSkillEditors({
@@ -95,12 +96,13 @@ export default function SkillBuilder({ skill, onSaved }: SkillBuilderProps) {
   });
 
   const hasSelfImprovingSkills = useIsSelfImprovementAvailable();
+  const areSuggestionsEnabled = useAreSkillSuggestionsEnabled();
 
   const { suggestions } = useSkillSuggestions({
     skillId: skill?.sId ?? null,
     states: ["pending"],
     workspaceId: owner.sId,
-    disabled: !skill || !hasSelfImprovingSkills,
+    disabled: !skill || !areSuggestionsEnabled,
   });
 
   const hasPendingSuggestions = suggestions.length > 0;
@@ -276,7 +278,7 @@ export default function SkillBuilder({ skill, onSaved }: SkillBuilderProps) {
   };
 
   const showSuggestionsPanel =
-    skill && !isMobile && hasSelfImprovingSkills && hasPendingSuggestions;
+    skill && areSuggestionsEnabled && hasPendingSuggestions;
 
   const leftPanel = (
     <div className="flex h-full w-full flex-col">

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -20,9 +20,11 @@ import type {
 import type { ReferenceSummaryItem } from "@app/components/skill_builder/SkillBuilderInstructionsReferenceSummary";
 import { SkillBuilderInstructionsReferenceSummary } from "@app/components/skill_builder/SkillBuilderInstructionsReferenceSummary";
 import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
-import { useSkillSuggestions } from "@app/hooks/useSkillSuggestions";
+import {
+  useAreSkillSuggestionsEnabled,
+  useSkillSuggestions,
+} from "@app/hooks/useSkillSuggestions";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { useIsSelfImprovementAvailable } from "@app/lib/client/self_improvement";
 import {
   postProcessMarkdown,
   preprocessMarkdownForEditor,
@@ -262,7 +264,7 @@ export function SkillBuilderInstructionsEditor({
   >(null);
   const [selectedServerViewForDetails, setSelectedServerViewForDetails] =
     useState<MCPServerViewType | null>(null);
-  const hasSelfImprovement = useIsSelfImprovementAvailable();
+  const areSuggestionsEnabled = useAreSkillSuggestionsEnabled();
 
   const { field: instructionsField, fieldState: instructionsFieldState } =
     useController<SkillBuilderFormData, typeof INSTRUCTIONS_FIELD_NAME>({
@@ -485,7 +487,7 @@ export function SkillBuilderInstructionsEditor({
     skillId,
     states: ["pending"],
     workspaceId: owner.sId,
-    disabled: !skillId || !hasSelfImprovement,
+    disabled: !skillId || !areSuggestionsEnabled,
   });
 
   const hasSuggestions = suggestions.length > 0;

--- a/front/hooks/useSkillSuggestions.ts
+++ b/front/hooks/useSkillSuggestions.ts
@@ -1,4 +1,5 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import { useIsSelfImprovementAvailable } from "@app/lib/client/self_improvement";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
@@ -6,6 +7,7 @@ import {
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import type {
   GetSkillSuggestionsQuery,
   GetSkillSuggestionsResponseBody,
@@ -14,6 +16,13 @@ import type {
 } from "@app/types/api/assistant/skills/suggestions";
 import { useCallback } from "react";
 import type { Fetcher } from "swr";
+
+export function useAreSkillSuggestionsEnabled(): boolean {
+  const isSelfImprovementAvailable = useIsSelfImprovementAvailable();
+  const isMobile = useIsMobile();
+
+  return isSelfImprovementAvailable && !isMobile;
+}
 
 interface UseSkillSuggestionsParams {
   skillId: string | null;


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/7742

Before this PR, the editor was in a read only mode without the ability to approve suggestions.
This disables the self improving skills suggestion entirely on mobile.
Long term, people will be able to accept suggestions without entering the builder anyway

r? @frankaloia 

## Tests

tested locally: I can edit skill even with existing suggestions on mobile

## Risk

low, purely UI + only for user on mobile, with self improving suggestion, in the builder so really not common.

## Deploy Plan

deploy front
