### PR TITLE
[front] enh: align Usage page section spacing

### DIFF
--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -399,9 +399,7 @@ export function AnalyticsConsumptionContent({
       />
 
       <div className="flex flex-col gap-4">
-        <div
-          className={cn("flex flex-col", !embedded && "bg-panel-background")}
-        >
+        <div className="flex flex-col">
           <div className="flex items-center justify-between gap-4">
             <h2 className="text-lg font-semibold text-foreground">Explore</h2>
             <UsageFilterPanelComponent

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -121,6 +121,7 @@ import {
   Plus,
   ProgressBar,
   SearchInput,
+  Separator,
   Spinner,
   Tabs,
   TabsContent,
@@ -1093,13 +1094,7 @@ export function UsagePage() {
           currentTotalPoolCredits={totalActiveCredits}
         />
 
-        <div
-          className={
-            showConsumptionAnalytics
-              ? "flex flex-col items-stretch gap-8 pb-20"
-              : "flex flex-col items-stretch gap-10 pb-20"
-          }
-        >
+        <div className="flex flex-col gap-8">
           {showConsumptionAnalytics ? (
             <Page.Header
               title={
@@ -1161,9 +1156,9 @@ export function UsagePage() {
           )}
 
           {isCreditPriced && showConsumptionAnalytics ? (
-            <Page.Vertical gap="none" align="stretch">
+            <div className="flex flex-col gap-4">
               <h2 className="heading-sm text-foreground">Credit Pool</h2>
-              <div className="flex flex-col gap-2 pt-4">
+              <div className="flex flex-col gap-2">
                 {isOverviewLoading ? (
                   <div
                     aria-label="Loading Credit Pool"
@@ -1234,39 +1229,40 @@ export function UsagePage() {
                     </div>
                   </>
                 ) : null}
-                <div className="mt-2 flex flex-col justify-between gap-4 border-t border-border pt-4 sm:flex-row sm:items-center">
-                  <div className="flex min-w-0 flex-1 flex-col gap-1 text-sm text-foreground">
-                    {!isOverviewError &&
-                      consumptionOverview !== null &&
-                      (creditUsage !== null || hasPool) && (
-                        <>
-                          {creditUsageDisplayTarget === "on_target" ? (
-                            <span>
-                              At your current rate, you have enough credits to
-                              finish the cycle.
-                            </span>
-                          ) : resetAt ? (
-                            <span>
-                              At this rate, you&apos;re expected to consume your
-                              full credits by{" "}
-                              <span className="font-semibold">
-                                {formatConsumptionDate(resetAt)}
-                              </span>
-                              .
-                            </span>
-                          ) : null}
-                          {overageCredits !== null && overageCredits > 0 && (
-                            <span className="text-muted-foreground">
-                              {formatCredits(overageCredits)} overage credits
-                            </span>
-                          )}
-                        </>
-                      )}
-                  </div>
-                  {topUpButton}
-                </div>
               </div>
-            </Page.Vertical>
+              <Separator />
+              <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+                <div className="flex min-w-0 flex-1 flex-col gap-1 text-sm text-foreground">
+                  {!isOverviewError &&
+                    consumptionOverview !== null &&
+                    (creditUsage !== null || hasPool) && (
+                      <>
+                        {creditUsageDisplayTarget === "on_target" ? (
+                          <span>
+                            At your current rate, you have enough credits to
+                            finish the cycle.
+                          </span>
+                        ) : resetAt ? (
+                          <span>
+                            At this rate, you&apos;re expected to consume your
+                            full credits by{" "}
+                            <span className="font-semibold">
+                              {formatConsumptionDate(resetAt)}
+                            </span>
+                            .
+                          </span>
+                        ) : null}
+                        {overageCredits !== null && overageCredits > 0 && (
+                          <span className="text-muted-foreground">
+                            {formatCredits(overageCredits)} overage credits
+                          </span>
+                        )}
+                      </>
+                    )}
+                </div>
+                {topUpButton}
+              </div>
+            </div>
           ) : null}
 
           {isNewUsagePage && isCreditPriced ? (
@@ -1360,7 +1356,7 @@ export function UsagePage() {
             <TabsContent value="members" className={TAB_CONTENT_CLASS}>
               <div className="flex flex-col items-stretch gap-4">
                 {searchRow}
-                <div className="flex flex-col gap-2">
+                <div className="flex flex-col gap-4">
                   <div className="flex flex-row items-center justify-between gap-2">
                     {isCreditPriced && (
                       <ButtonsSwitchList
@@ -1398,24 +1394,22 @@ export function UsagePage() {
                       </div>
                     )}
                   </div>
-                  <div className="flex flex-col gap-2 pt-2">
-                    {membersTab === "members" ? (
-                      <>
-                        {membersTable}
-                        {selectionBanner}
-                      </>
-                    ) : (
-                      <UpgradeRequestsTable
-                        requests={filteredUpgradeRequests}
-                        isLoading={isUpgradeRequestsLoading}
-                        seatPlans={seatPlans}
-                        pendingRequestIds={resolvingRequestIds}
-                        onUpgradePlan={handleUpgradePlanRequest}
-                        onEditLimit={handleEditLimitRequest}
-                        onDeny={handleDenyRequest}
-                      />
-                    )}
-                  </div>
+                  {membersTab === "members" ? (
+                    <div className="flex flex-col gap-2">
+                      {membersTable}
+                      {selectionBanner}
+                    </div>
+                  ) : (
+                    <UpgradeRequestsTable
+                      requests={filteredUpgradeRequests}
+                      isLoading={isUpgradeRequestsLoading}
+                      seatPlans={seatPlans}
+                      pendingRequestIds={resolvingRequestIds}
+                      onUpgradePlan={handleUpgradePlanRequest}
+                      onEditLimit={handleEditLimitRequest}
+                      onDeny={handleDenyRequest}
+                    />
+                  )}
                 </div>
               </div>
             </TabsContent>
@@ -1435,7 +1429,7 @@ export function UsagePage() {
 
             {isWorkspaceAdmin && (
               <TabsContent value="settings" className={TAB_CONTENT_CLASS}>
-                <div className="flex flex-col gap-10">
+                <div className="flex flex-col gap-8">
                   {isCreditPriced && (
                     <UsageSettingsCard
                       workspaceId={owner.sId}
@@ -1447,7 +1441,7 @@ export function UsagePage() {
                   {isCreditPriced && (
                     <LockedSection
                       locked={!isAwuPoolSummaryLoading && !hasPool}
-                      className="flex flex-col gap-10"
+                      className="flex flex-col gap-8"
                     >
                       <UsageProgrammaticLimitCard workspaceId={owner.sId} />
                       <UsageNotificationsCard workspaceId={owner.sId} />

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -1094,7 +1094,7 @@ export function UsagePage() {
           currentTotalPoolCredits={totalActiveCredits}
         />
 
-        <div className="flex flex-col gap-8">
+        <Page.Vertical align="stretch" gap="xl">
           {showConsumptionAnalytics ? (
             <Page.Header
               title={
@@ -1429,7 +1429,7 @@ export function UsagePage() {
 
             {isWorkspaceAdmin && (
               <TabsContent value="settings" className={TAB_CONTENT_CLASS}>
-                <div className="flex flex-col gap-8">
+                <Page.Vertical align="stretch" gap="xl">
                   {isCreditPriced && (
                     <UsageSettingsCard
                       workspaceId={owner.sId}
@@ -1447,11 +1447,11 @@ export function UsagePage() {
                       <UsageNotificationsCard workspaceId={owner.sId} />
                     </LockedSection>
                   )}
-                </div>
+                </Page.Vertical>
               </TabsContent>
             )}
           </Tabs>
-        </div>
+        </Page.Vertical>
 
         <ChangeSeatModal
           isOpen={changeSeatMember !== null}

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -331,7 +331,7 @@ export function WorkspaceCreditPoolSection({
   }
 
   return (
-    <div className="flex flex-col items-stretch gap-10">
+    <div className="flex flex-col items-stretch gap-8">
       {cardsStatus === "error" ? (
         <ContentMessage
           title="Failed to load Workspace Credits Pool"

--- a/front/components/workspace/WorkspaceCreditPoolCards.tsx
+++ b/front/components/workspace/WorkspaceCreditPoolCards.tsx
@@ -22,6 +22,7 @@ import {
   cn,
   DataTable,
   LoadingBlock,
+  Page,
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useCallback, useState } from "react";
@@ -331,7 +332,7 @@ export function WorkspaceCreditPoolSection({
   }
 
   return (
-    <div className="flex flex-col items-stretch gap-8">
+    <Page.Vertical align="stretch" gap="xl">
       {cardsStatus === "error" ? (
         <ContentMessage
           title="Failed to load Workspace Credits Pool"
@@ -359,7 +360,7 @@ export function WorkspaceCreditPoolSection({
           />
         </>
       )}
-    </div>
+    </Page.Vertical>
   );
 }
 


### PR DESCRIPTION
## Description

This PR aligns the layout of the Usage page with the other pages in the settings tab (Analytics, Automations, API Keys, etc...): 32px of spacing between main sections, 16px between parts elements within a main section, and the DOM should match the visible page structure.

Small unrelated change on the analytics page, this PR removes the `bg-panel-background`, which adds a border on mobile.

<img width="283" height="78" alt="image" src="https://github.com/user-attachments/assets/a3b0ee93-9eaf-4874-a815-50f297a8d5ac" />

## Tests

- Tested locally + preview.
- Tested without the `enable_usage_page` FF.

## Risk

- Low.

## Deploy Plan

- Deploy front.
