### PR TITLE
[front] Reset premium-model weekly message limit from poke

### DIFF
--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -381,6 +381,28 @@ export async function resetFairUseAwuCreditsRateLimitForUser({
   });
 }
 
+export async function resetPremiumModelMessageRateLimitForUser({
+  auth,
+  user,
+}: {
+  auth: Authenticator;
+  user: UserType;
+}) {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const resetResult = await expireRateLimiterKey({
+    key: makePremiumModelMessageRateLimitKeyForUser(workspace, user),
+  });
+  if (resetResult.isErr()) {
+    return resetResult;
+  }
+
+  return new Ok({
+    didResetExistingKey: resetResult.value,
+    limit: PREMIUM_MODEL_MESSAGE_RATE_LIMIT_PER_USER_PER_WEEK,
+  });
+}
+
 export async function getMessageUsageCount(auth: Authenticator): Promise<{
   count: number;
   limit: number;

--- a/front/lib/api/poke/plugins/workspaces/reset_message_rate_limit.ts
+++ b/front/lib/api/poke/plugins/workspaces/reset_message_rate_limit.ts
@@ -1,8 +1,10 @@
 import {
   resetFairUseAwuCreditsRateLimitForUser,
   resetMessageRateLimitForWorkspace,
+  resetPremiumModelMessageRateLimitForUser,
 } from "@app/lib/api/assistant/rate_limits";
 import { createPlugin } from "@app/lib/api/poke/types";
+import type { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { mapToEnumValues } from "@app/types/poke/plugins";
@@ -10,7 +12,16 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { z } from "zod";
 
-const RESET_TARGETS = ["workspace_rate_limit", "user_awu_fair_use"] as const;
+const RESET_TARGETS = [
+  "workspace_rate_limit",
+  "user_awu_fair_use",
+  "user_premium_model_limit",
+] as const;
+
+const USER_SCOPED_RESET_TARGETS = [
+  "user_awu_fair_use",
+  "user_premium_model_limit",
+] as const;
 
 const ResetMessageRateLimitArgsSchema = z
   .object({
@@ -19,20 +30,53 @@ const ResetMessageRateLimitArgsSchema = z
   })
   .refine(
     (args) =>
-      args.resetTarget[0] !== "user_awu_fair_use" ||
+      !USER_SCOPED_RESET_TARGETS.includes(
+        args.resetTarget[0] as (typeof USER_SCOPED_RESET_TARGETS)[number]
+      ) ||
       (args.userEmail !== undefined && args.userEmail.length > 0),
     {
-      message: "User email is required to reset fair-use AWU credits.",
+      message: "User email is required to reset a per-user limit.",
       path: ["userEmail"],
     }
   );
+
+async function resolveActiveWorkspaceUser(
+  auth: Authenticator,
+  userEmail: string | undefined
+) {
+  if (!userEmail) {
+    return new Err(new Error("User email is required."));
+  }
+
+  const user = await UserResource.fetchByEmail(userEmail);
+  if (!user) {
+    return new Err(new Error(`Could not find user with email ${userEmail}.`));
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const membership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user,
+      workspace,
+    });
+  if (!membership) {
+    return new Err(
+      new Error(
+        `User ${user.email} is not an active member of workspace ${workspace.sId}.`
+      )
+    );
+  }
+
+  return new Ok(user);
+}
 
 export const resetMessageRateLimitPlugin = createPlugin({
   manifest: {
     id: "reset-message-rate-limit",
     name: "Reset Message Rate Limits",
     description:
-      "Reset the workspace message rate limit or a user's AWU fair-use limit.",
+      "Reset the workspace message rate limit, a user's AWU fair-use limit, " +
+      "or a user's premium-model weekly message limit.",
     resourceTypes: ["workspaces"],
     args: {
       resetTarget: {
@@ -50,8 +94,8 @@ export const resetMessageRateLimitPlugin = createPlugin({
         type: "string",
         label: "User Email",
         description:
-          "Email of the workspace user whose AWU fair-use counter should be reset.",
-        dependsOn: { field: "resetTarget", value: "user_awu_fair_use" },
+          "Email of the workspace user whose counter should be reset. " +
+          "Required for the AWU fair-use and premium-model resets.",
       },
     },
     requiredRoles: ["support"],
@@ -91,31 +135,14 @@ export const resetMessageRateLimitPlugin = createPlugin({
       }
 
       case "user_awu_fair_use": {
-        const { userEmail } = parseResult.data;
-        if (!userEmail) {
-          return new Err(new Error("User email is required."));
+        const userResult = await resolveActiveWorkspaceUser(
+          auth,
+          parseResult.data.userEmail
+        );
+        if (userResult.isErr()) {
+          return userResult;
         }
-
-        const user = await UserResource.fetchByEmail(userEmail);
-        if (!user) {
-          return new Err(
-            new Error(`Could not find user with email ${userEmail}.`)
-          );
-        }
-
-        const workspace = auth.getNonNullableWorkspace();
-        const membership =
-          await MembershipResource.getActiveMembershipOfUserInWorkspace({
-            user,
-            workspace,
-          });
-        if (!membership) {
-          return new Err(
-            new Error(
-              `User ${user.email} is not an active member of workspace ${workspace.sId}.`
-            )
-          );
-        }
+        const user = userResult.value;
 
         const resetResult = await resetFairUseAwuCreditsRateLimitForUser({
           auth,
@@ -131,6 +158,33 @@ export const resetMessageRateLimitPlugin = createPlugin({
         return new Ok({
           display: "text",
           value: `AWU fair-use limit reset for ${user.email} (${keyStatus}; limit ${resetResult.value.limit} credits per ${resetResult.value.timeframe}).`,
+        });
+      }
+
+      case "user_premium_model_limit": {
+        const userResult = await resolveActiveWorkspaceUser(
+          auth,
+          parseResult.data.userEmail
+        );
+        if (userResult.isErr()) {
+          return userResult;
+        }
+        const user = userResult.value;
+
+        const resetResult = await resetPremiumModelMessageRateLimitForUser({
+          auth,
+          user: user.toJSON(),
+        });
+        if (resetResult.isErr()) {
+          return resetResult;
+        }
+
+        const keyStatus = resetResult.value.didResetExistingKey
+          ? "existing counter cleared"
+          : "no existing counter found";
+        return new Ok({
+          display: "text",
+          value: `Premium-model message limit reset for ${user.email} (${keyStatus}; limit ${resetResult.value.limit} messages per week).`,
         });
       }
 


### PR DESCRIPTION
## Description

Adds a `user_premium_model_limit` reset target to the **Reset Message Rate Limits** poke plugin so support can clear a user's premium-model weekly message counter (25 messages / rolling 7 days, keyed `rate_limiter:workspace:<id>:user:<id>:premium_model_message_count`). Previously the plugin only reset the workspace message limit and a user's AWU fair-use limit — there was no reset path for the premium-model limit.

- `rate_limits.ts`: new `resetPremiumModelMessageRateLimitForUser({ auth, user })`, mirroring the AWU reset. Expires the premium-model key; no plan-limit guard since the cap is a fixed weekly constant (no-op when no key exists).
- `reset_message_rate_limit.ts`: new reset target + case; extracted the shared user-lookup / active-membership check into `resolveActiveWorkspaceUser`; generalized the Zod refinement to require `userEmail` for either per-user target.

Note: the `userEmail` field's `dependsOn` gate was removed because `dependsOn` arrays are AND-ed (no OR), so it can't show for either per-user target. The field now always renders; its description states it is required for the per-user resets.

## Tests

Type-checks clean (`npx tsgo --noEmit`). No behavior change to existing reset targets; new path reuses the established rate-limiter expiry helper.

## Risk

Low. Support-scoped poke plugin; only expires a Redis rate-limiter key.

## Deploy Plan

Standard deploy, no migration.