### PR TITLE
[front] fix: stop sticky human mention re-inserting in the composer

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -712,6 +712,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
                 user={context.user}
                 onSubmit={context.handleSubmit}
                 stickyMentions={autoMentions}
+                stickyMentionsSourceId={lastUserMessage?.sId ?? null}
                 lastRequestedModel={lastRequestedModel}
                 conversation={context.conversation}
                 draftKey={context.draftKey}

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -90,6 +90,7 @@ interface InputBarProps {
   conversation?: ConversationWithoutContentType;
   space?: SpaceType;
   stickyMentions?: RichMention[];
+  stickyMentionsSourceId?: string | null;
   defaultAgentId?: string | null;
   isDefaultAgentLoading?: boolean;
   lastRequestedModel?: ModelSelectionType | null;
@@ -121,6 +122,7 @@ export const InputBar = React.memo(function InputBar({
   draftKey,
   space,
   stickyMentions,
+  stickyMentionsSourceId,
   defaultAgentId,
   isDefaultAgentLoading,
   lastRequestedModel = null,
@@ -767,6 +769,7 @@ export const InputBar = React.memo(function InputBar({
             pendingInputText={pendingInputText}
             onEnterKeyDown={handleSubmit}
             stickyMentions={stickyMentions}
+            stickyMentionsSourceId={stickyMentionsSourceId}
             defaultAgentId={defaultAgentId}
             isDefaultAgentLoading={isDefaultAgentLoading}
             lastRequestedModel={lastRequestedModel}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -261,7 +261,7 @@ export interface InputBarContainerProps {
    * re-arms only when the user sends a new message (new source id) or switches conversation, not
    * on unrelated conversation updates (streaming, other participants' messages). Re-inserting on
    * every update re-adds the mention to the empty composer and prevents the user from dismissing
-   * it (#10353).
+   * it.
    */
   stickyMentionsSourceId?: string | null;
   user: UserType | null;
@@ -868,7 +868,7 @@ const InputBarContainer = ({
   // Tracks the (conversation, source message) for which sticky human mentions were last
   // prefilled, so we insert them once per source rather than on every re-render. Without this,
   // streaming updates and other participants' messages would keep re-inserting the mention into
-  // the empty composer, and the user could not dismiss it (see #10353).
+  // the empty composer, and the user could not dismiss it.
   const appliedStickyMentionKeyRef = useRef<string | null>(null);
 
   const saveCurrentDraftWithSelectedSpaces = useCallback(
@@ -1440,8 +1440,8 @@ const InputBarContainer = ({
     // No draft — insert sticky user mentions into the editor, but only once per source message.
     // The effect re-runs on every conversation update (streaming, other participants' messages),
     // so without this key it would keep re-inserting the mention into the empty composer and the
-    // user could never dismiss it (#10353). The key changes when the current user sends a new
-    // message (new source id) or switches conversation, which is exactly when we want to re-prefill.
+    // user could never dismiss it. The key changes when the current user sends a new message (new
+    // source id) or switches conversation, which is exactly when we want to re-prefill.
     const stickyUserMentions = stickyMentions?.filter(isRichUserMention) ?? [];
     const stickyMentionKey = `${conversation?.sId ?? "new"}::${stickyMentionsSourceId ?? ""}`;
     if (

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -253,6 +253,17 @@ export interface InputBarContainerProps {
   isSelectableSpacesLoading?: boolean;
   onSelectedSpaceIdsChange?: (spaceIds: string[]) => Promise<string[] | null>;
   stickyMentions?: RichMention[];
+  /**
+   * @cc [owner:frankaloia,label:react] sticky-human-mentions-prefill-once-per-source
+   * Sticky human mentions MUST be prefilled into the composer at most once per
+   * (conversation, source message). `stickyMentionsSourceId` identifies that source — the sId of
+   * the current user's last message the mentions derive from. Callers MUST set it so the prefill
+   * re-arms only when the user sends a new message (new source id) or switches conversation, not
+   * on unrelated conversation updates (streaming, other participants' messages). Re-inserting on
+   * every update re-adds the mention to the empty composer and prevents the user from dismissing
+   * it (#10353).
+   */
+  stickyMentionsSourceId?: string | null;
   user: UserType | null;
 }
 
@@ -278,6 +289,7 @@ const InputBarContainer = ({
   selectedAgent,
   pendingInputText,
   stickyMentions,
+  stickyMentionsSourceId,
   actions,
   disableAutoFocus,
   disableUserMentions,
@@ -853,6 +865,11 @@ const InputBarContainer = ({
   selectedSingleAgentRef.current = selectedSingleAgent;
   // Skip auto-save (especially clearDraft on empty) until initial content is restored.
   const hasCompletedInitialContentRestoreRef = useRef(false);
+  // Tracks the (conversation, source message) for which sticky human mentions were last
+  // prefilled, so we insert them once per source rather than on every re-render. Without this,
+  // streaming updates and other participants' messages would keep re-inserting the mention into
+  // the empty composer, and the user could not dismiss it (see #10353).
+  const appliedStickyMentionKeyRef = useRef<string | null>(null);
 
   const saveCurrentDraftWithSelectedSpaces = useCallback(
     (spaceIds: string[]) => {
@@ -1387,7 +1404,6 @@ const InputBarContainer = ({
 
   // Restore draft text when switching conversations (including new conversations).
   // Agent selection is handled by useHandleMention.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   useEffect(() => {
     hasCompletedInitialContentRestoreRef.current = false;
 
@@ -1421,10 +1437,19 @@ const InputBarContainer = ({
       return;
     }
 
-    // No draft — insert sticky user mentions into the editor
+    // No draft — insert sticky user mentions into the editor, but only once per source message.
+    // The effect re-runs on every conversation update (streaming, other participants' messages),
+    // so without this key it would keep re-inserting the mention into the empty composer and the
+    // user could never dismiss it (#10353). The key changes when the current user sends a new
+    // message (new source id) or switches conversation, which is exactly when we want to re-prefill.
     const stickyUserMentions = stickyMentions?.filter(isRichUserMention) ?? [];
-    if (stickyUserMentions.length > 0) {
+    const stickyMentionKey = `${conversation?.sId ?? "new"}::${stickyMentionsSourceId ?? ""}`;
+    if (
+      stickyUserMentions.length > 0 &&
+      appliedStickyMentionKeyRef.current !== stickyMentionKey
+    ) {
       editorService.resetWithMentions(stickyUserMentions, disableAutoFocus);
+      appliedStickyMentionKeyRef.current = stickyMentionKey;
     }
 
     hasCompletedInitialContentRestoreRef.current = true;
@@ -1436,6 +1461,7 @@ const InputBarContainer = ({
     editorService,
     getDraft,
     stickyMentions,
+    stickyMentionsSourceId,
     disableAutoFocus,
   ]);
 


### PR DESCRIPTION
## Summary

Fixes [dust-tt/tasks#10353](https://github.com/dust-tt/tasks/issues/10353).

In a multi-user conversation, the user's handle kept popping back into the composer after every message/answer and couldn't be dismissed.

### Root cause

The "sticky human mentions" feature (#25480). The sticky mention is derived from **your own last sent message**:

```ts
const lastUserMessage = allMessages.filter(isUserMessage).findLast(
  (m) => ... && m.user?.id === context.user.id && ...   // your messages only
);
// autoMentions = lastUserMessage.richMentions, iff they are all human mentions
```

`autoMentions` becomes `stickyMentions`, and the draft-restore effect in `InputBarContainer.tsx` inserts them via `editorService.resetWithMentions(...)`. That effect re-runs whenever `stickyMentions` changes reference — and `stickyMentions` derives from `lastUserMessage`, which gets a **new object reference on every conversation store update** (another participant's message, an agent answer, each streaming tick). Its only guard was `editorService.isEmpty()`, so whenever the composer was empty it re-inserted the mention.

So `stickyMentions` = "the human mentions in the last message *I* sent," and whether it reappears is entirely a function of **what you last sent**:

- **You send with `@B` still in it** — the default, because the composer pre-fills `@B`, so unless you delete the chip whatever you type goes out as "@B …". Your new last message still mentions `@B` → `autoMentions` is still `[@B]` → after the composer clears it re-inserts `@B`. This is the vicious loop: the prefill guarantees your next message keeps the mention, which keeps it sticky, which prefills again.
- **You send without `@B`** (deleted the chip, sent a plain message) — your last message has no mention → `autoMentions` returns `[]` → nothing inserted. Cleared.

Two consequences:
- It reappears after every message/answer (your last message still carries the mention, and the churn re-inserts it on every store update while the box is empty).
- You can't dismiss it: deleting the chip empties the composer, and the next update (or the clear/re-render during your own send) re-inserts it before you can get a mention-less message out. Once it's back, the "editor not empty" guard stops the later-empty derivation from removing it — so the only escape is to send a message without the mention.

### Fix

Gate the insertion on an idempotency key `(conversation.sId, source message sId)` held in a ref — insert **at most once per source message**:
- **Deleting the chip now sticks** — same source id, already offered → not re-inserted.
- **Streaming / other participants' messages** don't re-insert — your last message's `sId` is unchanged.
- **Re-prefill still works** — sending a new message that keeps the mention changes the source id, so it re-arms (preserving the intended stickiness; the submit handler only clears the editor and relies on this effect to re-prefill).
- Sending a message with no mention clears it naturally (`autoMentions` returns `[]`).

Plumbs `stickyMentionsSourceId` (the current user's last message `sId`) through `AgentInputBar → InputBar → InputBarContainer`, documented with a `@cc [label:react]` contract on the prop.

### Pattern

The guard is the codebase's standard "run once per id" ref idiom — same shape as `useAutoOpenSidePanel.ts` (`autoOpenedFilesForRef === agentMessage.sId`), the composite-key `initKey` guards (`MCPServerAuthConnection.tsx`), and the sibling `useHandleMentions.tsx` (`prevConversationIdRef`) that handles agent sticky mentions.

## Testing

- `npx tsgo --noEmit` (front): no new errors (pre-existing unrelated `archiver` decl only).
- `biome check` + `cc-check format`/`list` on the changed file: clean; the new contract is discoverable.

Behavior reasoned through the effect's re-run conditions; there's no automated harness for this tiptap+Virtuoso composer.

## Risk

Low, scoped to the sticky human-mention prefill. Agent-mention selection (`useHandleMentions`) is untouched. Agent builder passes no source id and only has agent sticky mentions, so it's unaffected.

## Deploy Plan
1. Deploy fron

## Reviewer
r? @ykmsd Eng runner ticket https://github.com/dust-tt/tasks/issues/10353