### PR TITLE
Check Frame function calls at publish validation

### DIFF
--- a/front/lib/api/files/content_validation.ts
+++ b/front/lib/api/files/content_validation.ts
@@ -4,7 +4,7 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import * as ts from "typescript";
 
 export interface ValidationWarning {
-  type: "tailwind" | "typescript";
+  type: "frame_function" | "tailwind" | "typescript";
   message: string;
   oldString?: string;
   suggestion?: string;

--- a/front/lib/api/files/content_validation.ts
+++ b/front/lib/api/files/content_validation.ts
@@ -4,7 +4,7 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import * as ts from "typescript";
 
 export interface ValidationWarning {
-  type: "frame_function" | "tailwind" | "typescript";
+  type: "tailwind" | "typescript";
   message: string;
   oldString?: string;
   suggestion?: string;

--- a/front/lib/api/frames/build_and_publish.test.ts
+++ b/front/lib/api/frames/build_and_publish.test.ts
@@ -216,6 +216,39 @@ describe("buildAndPublishFramePublication", () => {
     expect(fileStorageMock.saveFileCalls).toHaveLength(0);
   });
 
+  it("refuses to publish a UI that calls an undeclared function", async () => {
+    const { auth, conversation, frame } = await setup();
+
+    const result = await buildAndPublishFramePublication(auth, {
+      conversation,
+      frame,
+      manifest: uiOnlyManifest,
+      sourceFiles: [
+        {
+          ...sourceFiles[0],
+          content: Buffer.from(
+            'import { usePodFunction } from "@dust/react-hooks";\n' +
+              "export default function App() {\n" +
+              '  usePodFunction("list-tasks", {});\n' +
+              "  return <main>Tasks</main>;\n" +
+              "}\n"
+          ),
+        },
+      ],
+    });
+
+    expect(result.isErr() && result.error).toMatchObject({
+      code: "invalid_function_reference",
+    });
+    // The reference check runs before any build work, so nothing was bundled or stored.
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+    expect(ensureConversationSandboxReadyWithScope).not.toHaveBeenCalled();
+    expect(
+      (await FileResource.fetchById(auth, frame.sId))?.useCaseMetadata
+        ?.activePublicationId
+    ).toBeUndefined();
+  });
+
   it("builds and publishes the UI without starting a sandbox", async () => {
     const { auth, conversation, frame } = await setup();
 

--- a/front/lib/api/frames/build_and_publish.ts
+++ b/front/lib/api/frames/build_and_publish.ts
@@ -11,10 +11,7 @@ import {
   publishFramePublication,
 } from "@app/lib/api/frames/publication_storage";
 import { withStagedFrameSource } from "@app/lib/api/frames/source_staging";
-import {
-  collectFrameFunctionWarnings,
-  validateFrameFunctionReferences,
-} from "@app/lib/api/frames/validate_frame_functions";
+import { validateFrameFunctionReferences } from "@app/lib/api/frames/validate_frame_functions";
 import { ensureConversationSandboxReadyWithScope } from "@app/lib/api/sandbox/lifecycle";
 import { buildSandboxFunctionOnReadySandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
@@ -228,17 +225,7 @@ export async function validateFramePublication(
     return contracts;
   }
 
-  const functionWarnings = await collectFrameFunctionWarnings({
-    functions: contracts.value.functions,
-    sourceFiles,
-  });
-
-  return new Ok({
-    warnings: [
-      ...collectFrameTailwindWarnings(sourceFiles),
-      ...functionWarnings,
-    ],
-  });
+  return new Ok({ warnings: collectFrameTailwindWarnings(sourceFiles) });
 }
 
 /**

--- a/front/lib/api/frames/build_and_publish.ts
+++ b/front/lib/api/frames/build_and_publish.ts
@@ -11,7 +11,10 @@ import {
   publishFramePublication,
 } from "@app/lib/api/frames/publication_storage";
 import { withStagedFrameSource } from "@app/lib/api/frames/source_staging";
-import { collectFrameFunctionWarnings } from "@app/lib/api/frames/validate_frame_functions";
+import {
+  collectFrameFunctionWarnings,
+  validateFrameFunctionReferences,
+} from "@app/lib/api/frames/validate_frame_functions";
 import { ensureConversationSandboxReadyWithScope } from "@app/lib/api/sandbox/lifecycle";
 import { buildSandboxFunctionOnReadySandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
@@ -91,6 +94,15 @@ async function buildFramePublication(
       );
     }
     seenSourcePaths.add(sourceFile.relativePath);
+  }
+
+  // Before any build work: syntactic, and a bad reference can never resolve at run time.
+  const references = validateFrameFunctionReferences({
+    declaredFunctionNames: manifest.functions.map((fn) => fn.name),
+    sourceFiles,
+  });
+  if (references.isErr()) {
+    return references;
   }
 
   const uiBundle = await buildFrameUiBundle({ manifest, sourceFiles });

--- a/front/lib/api/frames/build_and_publish.ts
+++ b/front/lib/api/frames/build_and_publish.ts
@@ -11,6 +11,7 @@ import {
   publishFramePublication,
 } from "@app/lib/api/frames/publication_storage";
 import { withStagedFrameSource } from "@app/lib/api/frames/source_staging";
+import { collectFrameFunctionWarnings } from "@app/lib/api/frames/validate_frame_functions";
 import { ensureConversationSandboxReadyWithScope } from "@app/lib/api/sandbox/lifecycle";
 import { buildSandboxFunctionOnReadySandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
@@ -215,7 +216,17 @@ export async function validateFramePublication(
     return contracts;
   }
 
-  return new Ok({ warnings: collectFrameTailwindWarnings(sourceFiles) });
+  const functionWarnings = await collectFrameFunctionWarnings({
+    functions: contracts.value.functions,
+    sourceFiles,
+  });
+
+  return new Ok({
+    warnings: [
+      ...collectFrameTailwindWarnings(sourceFiles),
+      ...functionWarnings,
+    ],
+  });
 }
 
 /**

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -67,6 +67,7 @@ export class FramePublicationError extends Error {
     readonly code:
       | "invalid_frame"
       | "invalid_function_artifact"
+      | "invalid_function_reference"
       | "invalid_manifest"
       | "invalid_publication"
       | "invalid_source"

--- a/front/lib/api/frames/validate_frame_functions.test.ts
+++ b/front/lib/api/frames/validate_frame_functions.test.ts
@@ -1,62 +1,29 @@
 // @vitest-environment node
 
-import {
-  collectFrameFunctionWarnings,
-  validateFrameFunctionReferences,
-} from "@app/lib/api/frames/validate_frame_functions";
+import { validateFrameFunctionReferences } from "@app/lib/api/frames/validate_frame_functions";
 import assert from "assert";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { describe, expect, it } from "vitest";
 
-const ADD_TASK_INPUT_SCHEMA: JSONSchema = {
-  additionalProperties: false,
-  properties: {
-    done: { type: "boolean" },
-    title: { type: "string" },
-  },
-  required: ["title"],
-  type: "object",
-};
+const DECLARED_FUNCTION_NAMES = ["add-task", "list-tasks"];
 
-const LIST_TASKS_INPUT_SCHEMA: JSONSchema = {
-  additionalProperties: false,
-  properties: {},
-  type: "object",
-};
-
-const FUNCTIONS = [
-  { inputSchema: ADD_TASK_INPUT_SCHEMA, name: "add-task" },
-  { inputSchema: LIST_TASKS_INPUT_SCHEMA, name: "list-tasks" },
-];
-
-function sourceFiles(
-  files: Record<string, string>
-): { content: Buffer; relativePath: string }[] {
-  return Object.entries(files).map(([relativePath, content]) => ({
-    content: Buffer.from(content, "utf8"),
-    relativePath,
-  }));
-}
-
-async function warningsFor(
+function referencesFor(
   files: Record<string, string>,
-  functions = FUNCTIONS
+  declaredFunctionNames = DECLARED_FUNCTION_NAMES
 ) {
-  return collectFrameFunctionWarnings({
-    functions,
-    sourceFiles: sourceFiles(files),
-  });
-}
-
-function referencesFor(files: Record<string, string>, functions = FUNCTIONS) {
   return validateFrameFunctionReferences({
-    declaredFunctionNames: functions.map((fn) => fn.name),
-    sourceFiles: sourceFiles(files),
+    declaredFunctionNames,
+    sourceFiles: Object.entries(files).map(([relativePath, content]) => ({
+      content: Buffer.from(content, "utf8"),
+      relativePath,
+    })),
   });
 }
 
-function referenceError(files: Record<string, string>, functions = FUNCTIONS) {
-  const result = referencesFor(files, functions);
+function referenceError(
+  files: Record<string, string>,
+  declaredFunctionNames = DECLARED_FUNCTION_NAMES
+) {
+  const result = referencesFor(files, declaredFunctionNames);
   assert(result.isErr(), "expected a reference error");
 
   return result.error;
@@ -100,27 +67,12 @@ export default function App() {
     });
 
     expect(error.code).toBe("invalid_function_reference");
-    expect(error.message).toContain("index.tsx:5:18");
-    expect(error.message).toContain("'add-tasks'");
+    expect(error.message).toContain(
+      "index.tsx:5:18: usePodFunction('add-tasks')"
+    );
     expect(error.message).toContain(
       "Declared functions: 'add-task', 'list-tasks'."
     );
-  });
-
-  it("rejects a Pod-style reference and names the bare form", () => {
-    const error = referenceError({
-      "index.tsx": `
-import { usePodFunction } from "@dust/react-hooks";
-
-export default function App() {
-  usePodFunction("spc_1234/add-task", { title: "Write tests" });
-  return null;
-}
-`,
-    });
-
-    expect(error.message).toContain("<podId>/<slug>");
-    expect(error.message).toContain("Use 'add-task'.");
   });
 
   it("follows an aliased import", () => {
@@ -135,7 +87,7 @@ export default function App() {
 `,
     });
 
-    expect(error.message).toContain("'nope'");
+    expect(error.message).toContain("usePodFunction('nope')");
   });
 
   it("follows a namespace import", () => {
@@ -150,7 +102,22 @@ export default function App() {
 `,
     });
 
-    expect(error.message).toContain("'nope'");
+    expect(error.message).toContain("usePodFunction('nope')");
+  });
+
+  it("ignores hooks that are not imported from @dust/react-hooks", () => {
+    const result = referencesFor({
+      "index.tsx": `
+import { usePodFunction } from "./my-hooks";
+
+export default function App() {
+  usePodFunction("nope", {});
+  return null;
+}
+`,
+    });
+
+    expect(result.isOk()).toBe(true);
   });
 
   it("accepts a computed reference", () => {
@@ -227,154 +194,5 @@ ${calls}
     expect(error.message).toContain("'missing-4'");
     expect(error.message).not.toContain("'missing-5'");
     expect(error.message).toContain("2 more not shown.");
-  });
-});
-
-describe("collectFrameFunctionWarnings", () => {
-  it("returns nothing when the UI calls no function hook", async () => {
-    const warnings = await warningsFor({
-      "index.tsx": `export default function App() { return <div>Hi</div>; }`,
-    });
-
-    expect(warnings).toEqual([]);
-  });
-
-  it("returns nothing for a declared reference with a matching input", async () => {
-    const warnings = await warningsFor({
-      "index.tsx": `
-import { usePodFunction } from "@dust/react-hooks";
-
-export default function App() {
-  const { data } = usePodFunction("add-task", { title: "Write tests" });
-  return <div>{JSON.stringify(data)}</div>;
-}
-`,
-    });
-
-    expect(warnings).toEqual([]);
-  });
-
-  it("flags an input that does not match the declared contract", async () => {
-    const warnings = await warningsFor({
-      "index.tsx": `
-import { usePodFunction } from "@dust/react-hooks";
-
-export default function App() {
-  usePodFunction("add-task", { titel: "Misspelled property" });
-  return null;
-}
-`,
-    });
-
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].type).toBe("frame_function");
-    expect(warnings[0].message).toContain("index.tsx:5:32");
-    expect(warnings[0].message).toContain(
-      "'titel' does not exist in type 'Input'. Did you mean to write 'title'?"
-    );
-  });
-
-  it("flags a missing required input property", async () => {
-    const warnings = await warningsFor({
-      "index.tsx": `
-import { usePodFunction } from "@dust/react-hooks";
-
-export default function App() {
-  usePodFunction("add-task", { done: false });
-  return null;
-}
-`,
-    });
-
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].message).toContain("title");
-  });
-
-  it("flags a mutation triggered with a mismatched input", async () => {
-    const warnings = await warningsFor({
-      "index.tsx": `
-import { usePodFunctionMutation } from "@dust/react-hooks";
-
-export default function App() {
-  const { trigger } = usePodFunctionMutation("add-task");
-  return <button onClick={() => trigger({ title: 42 })}>Add</button>;
-}
-`,
-    });
-
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].message).toContain("index.tsx:6:43");
-  });
-
-  it("returns nothing for a mutation triggered with a matching input", async () => {
-    const warnings = await warningsFor({
-      "index.tsx": `
-import { usePodFunctionMutation } from "@dust/react-hooks";
-
-export default function App() {
-  const { trigger } = usePodFunctionMutation("add-task");
-  return <button onClick={() => trigger({ title: "ok" })}>Add</button>;
-}
-`,
-    });
-
-    expect(warnings).toEqual([]);
-  });
-
-  it("checks a hook call in an imported component", async () => {
-    const warnings = await warningsFor({
-      "components/TaskList.tsx": `
-import { usePodFunction } from "@dust/react-hooks";
-
-export function TaskList() {
-  usePodFunction("add-task", { title: false });
-  return null;
-}
-`,
-      "index.tsx": `
-import { TaskList } from "./components/TaskList";
-
-export default function App() { return <TaskList />; }
-`,
-    });
-
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].message).toContain("components/TaskList.tsx");
-  });
-
-  it("returns nothing when the manifest declares no functions", async () => {
-    const warnings = await warningsFor(
-      {
-        "index.tsx": `
-import { usePodFunction } from "@dust/react-hooks";
-
-export default function App() {
-  usePodFunction("add-task", { title: "No manifest entry" });
-  return null;
-}
-`,
-      },
-      []
-    );
-
-    // An empty contract map would make `keyof` never and reject every input. The reference check
-    // owns this case, and it blocks the publish outright.
-    expect(warnings).toEqual([]);
-  });
-
-  it("ignores type errors outside the function inputs", async () => {
-    const warnings = await warningsFor({
-      "index.tsx": `
-import { usePodFunction } from "@dust/react-hooks";
-
-export default function App() {
-  const broken: number = "not a number";
-  usePodFunction("add-task", { title: "fine" });
-  return <div>{broken}</div>;
-}
-`,
-    });
-
-    expect(warnings).toEqual([]);
   });
 });

--- a/front/lib/api/frames/validate_frame_functions.test.ts
+++ b/front/lib/api/frames/validate_frame_functions.test.ts
@@ -1,0 +1,304 @@
+// @vitest-environment node
+
+import { collectFrameFunctionWarnings } from "@app/lib/api/frames/validate_frame_functions";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { describe, expect, it } from "vitest";
+
+const ADD_TASK_INPUT_SCHEMA: JSONSchema = {
+  additionalProperties: false,
+  properties: {
+    done: { type: "boolean" },
+    title: { type: "string" },
+  },
+  required: ["title"],
+  type: "object",
+};
+
+const LIST_TASKS_INPUT_SCHEMA: JSONSchema = {
+  additionalProperties: false,
+  properties: {},
+  type: "object",
+};
+
+const FUNCTIONS = [
+  { inputSchema: ADD_TASK_INPUT_SCHEMA, name: "add-task" },
+  { inputSchema: LIST_TASKS_INPUT_SCHEMA, name: "list-tasks" },
+];
+
+function sourceFiles(
+  files: Record<string, string>
+): { content: Buffer; relativePath: string }[] {
+  return Object.entries(files).map(([relativePath, content]) => ({
+    content: Buffer.from(content, "utf8"),
+    relativePath,
+  }));
+}
+
+async function warningsFor(
+  files: Record<string, string>,
+  functions = FUNCTIONS
+) {
+  return collectFrameFunctionWarnings({
+    functions,
+    sourceFiles: sourceFiles(files),
+  });
+}
+
+describe("collectFrameFunctionWarnings", () => {
+  it("returns nothing when the UI calls no function hook", async () => {
+    const warnings = await warningsFor({
+      "index.tsx": `export default function App() { return <div>Hi</div>; }`,
+    });
+
+    expect(warnings).toEqual([]);
+  });
+
+  it("returns nothing for a declared reference with a matching input", async () => {
+    const warnings = await warningsFor({
+      "index.tsx": `
+import { usePodFunction } from "@dust/react-hooks";
+
+export default function App() {
+  const { data } = usePodFunction("add-task", { title: "Write tests" });
+  return <div>{JSON.stringify(data)}</div>;
+}
+`,
+    });
+
+    expect(warnings).toEqual([]);
+  });
+
+  it("flags a reference the manifest does not declare", async () => {
+    const warnings = await warningsFor({
+      "index.tsx": `
+import { usePodFunction } from "@dust/react-hooks";
+
+export default function App() {
+  usePodFunction("add-tasks", { title: "Typo" });
+  return null;
+}
+`,
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].type).toBe("frame_function");
+    expect(warnings[0].message).toContain("index.tsx:5:18");
+    expect(warnings[0].message).toContain("'add-tasks'");
+    expect(warnings[0].suggestion).toBe(
+      "Declared functions: 'add-task', 'list-tasks'."
+    );
+  });
+
+  it("flags a Pod-style reference and suggests the bare name", async () => {
+    const warnings = await warningsFor({
+      "index.tsx": `
+import { usePodFunction } from "@dust/react-hooks";
+
+export default function App() {
+  usePodFunction("spc_1234/add-task", { title: "Write tests" });
+  return null;
+}
+`,
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toContain("<podId>/<slug>");
+    expect(warnings[0].suggestion).toBe("Use 'add-task'.");
+  });
+
+  it("flags an input that does not match the declared contract", async () => {
+    const warnings = await warningsFor({
+      "index.tsx": `
+import { usePodFunction } from "@dust/react-hooks";
+
+export default function App() {
+  usePodFunction("add-task", { titel: "Misspelled property" });
+  return null;
+}
+`,
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].type).toBe("frame_function");
+    expect(warnings[0].message).toContain("index.tsx:5:32");
+    expect(warnings[0].message).toContain(
+      "'titel' does not exist in type 'Input'. Did you mean to write 'title'?"
+    );
+  });
+
+  it("flags a missing required input property", async () => {
+    const warnings = await warningsFor({
+      "index.tsx": `
+import { usePodFunction } from "@dust/react-hooks";
+
+export default function App() {
+  usePodFunction("add-task", { done: false });
+  return null;
+}
+`,
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toContain("title");
+  });
+
+  it("flags a mutation triggered with a mismatched input", async () => {
+    const warnings = await warningsFor({
+      "index.tsx": `
+import { usePodFunctionMutation } from "@dust/react-hooks";
+
+export default function App() {
+  const { trigger } = usePodFunctionMutation("add-task");
+  return <button onClick={() => trigger({ title: 42 })}>Add</button>;
+}
+`,
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toContain("index.tsx:6:43");
+  });
+
+  it("returns nothing for a mutation triggered with a matching input", async () => {
+    const warnings = await warningsFor({
+      "index.tsx": `
+import { usePodFunctionMutation } from "@dust/react-hooks";
+
+export default function App() {
+  const { trigger } = usePodFunctionMutation("add-task");
+  return <button onClick={() => trigger({ title: "ok" })}>Add</button>;
+}
+`,
+    });
+
+    expect(warnings).toEqual([]);
+  });
+
+  it("follows an aliased import", async () => {
+    const warnings = await warningsFor({
+      "index.tsx": `
+import { usePodFunction as useFrameFunction } from "@dust/react-hooks";
+
+export default function App() {
+  useFrameFunction("nope", {});
+  return null;
+}
+`,
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toContain("'nope'");
+  });
+
+  it("follows a namespace import", async () => {
+    const warnings = await warningsFor({
+      "index.tsx": `
+import * as hooks from "@dust/react-hooks";
+
+export default function App() {
+  hooks.usePodFunction("nope", {});
+  return null;
+}
+`,
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toContain("'nope'");
+  });
+
+  it("skips a computed reference", async () => {
+    const warnings = await warningsFor({
+      "index.tsx": `
+import { usePodFunction } from "@dust/react-hooks";
+
+export default function App({ name }: { name: string }) {
+  usePodFunction(name, { anything: true });
+  return null;
+}
+`,
+    });
+
+    expect(warnings).toEqual([]);
+  });
+
+  it("checks a hook call in an imported component", async () => {
+    const warnings = await warningsFor({
+      "components/TaskList.tsx": `
+import { usePodFunction } from "@dust/react-hooks";
+
+export function TaskList() {
+  usePodFunction("add-task", { title: false });
+  return null;
+}
+`,
+      "index.tsx": `
+import { TaskList } from "./components/TaskList";
+
+export default function App() { return <TaskList />; }
+`,
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toContain("components/TaskList.tsx");
+  });
+
+  it("reports the reference when the manifest declares no functions", async () => {
+    const warnings = await warningsFor(
+      {
+        "index.tsx": `
+import { usePodFunction } from "@dust/react-hooks";
+
+export default function App() {
+  usePodFunction("add-task", { title: "No manifest entry" });
+  return null;
+}
+`,
+      },
+      []
+    );
+
+    // An empty contract map would make `keyof` never and reject the input too; only the reference
+    // is reported.
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].suggestion).toBe(
+      "This Frame's manifest declares no functions."
+    );
+  });
+
+  it("caps the reported warnings", async () => {
+    const calls = Array.from(
+      { length: 7 },
+      (_, index) => `  usePodFunction("missing-${index}", {});`
+    ).join("\n");
+    const warnings = await warningsFor({
+      "index.tsx": `
+import { usePodFunction } from "@dust/react-hooks";
+
+export default function App() {
+${calls}
+  return null;
+}
+`,
+    });
+
+    expect(warnings).toHaveLength(6);
+    expect(warnings[5].message).toBe(
+      "2 more Frame function warning(s) not shown."
+    );
+  });
+
+  it("ignores type errors outside the function inputs", async () => {
+    const warnings = await warningsFor({
+      "index.tsx": `
+import { usePodFunction } from "@dust/react-hooks";
+
+export default function App() {
+  const broken: number = "not a number";
+  usePodFunction("add-task", { title: "fine" });
+  return <div>{broken}</div>;
+}
+`,
+    });
+
+    expect(warnings).toEqual([]);
+  });
+});

--- a/front/lib/api/frames/validate_frame_functions.test.ts
+++ b/front/lib/api/frames/validate_frame_functions.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment node
 
-import { collectFrameFunctionWarnings } from "@app/lib/api/frames/validate_frame_functions";
+import {
+  collectFrameFunctionWarnings,
+  validateFrameFunctionReferences,
+} from "@app/lib/api/frames/validate_frame_functions";
+import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { describe, expect, it } from "vitest";
 
@@ -44,6 +48,188 @@ async function warningsFor(
   });
 }
 
+function referencesFor(files: Record<string, string>, functions = FUNCTIONS) {
+  return validateFrameFunctionReferences({
+    declaredFunctionNames: functions.map((fn) => fn.name),
+    sourceFiles: sourceFiles(files),
+  });
+}
+
+function referenceError(files: Record<string, string>, functions = FUNCTIONS) {
+  const result = referencesFor(files, functions);
+  assert(result.isErr(), "expected a reference error");
+
+  return result.error;
+}
+
+describe("validateFrameFunctionReferences", () => {
+  it("accepts a Frame whose UI calls no function hook", () => {
+    const result = referencesFor({
+      "index.tsx": `export default function App() { return <div>Hi</div>; }`,
+    });
+
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("accepts every declared reference", () => {
+    const result = referencesFor({
+      "index.tsx": `
+import { usePodFunction, usePodFunctionMutation } from "@dust/react-hooks";
+
+export default function App() {
+  usePodFunction("list-tasks", {});
+  usePodFunctionMutation("add-task");
+  return null;
+}
+`,
+    });
+
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("rejects a reference the manifest does not declare", () => {
+    const error = referenceError({
+      "index.tsx": `
+import { usePodFunction } from "@dust/react-hooks";
+
+export default function App() {
+  usePodFunction("add-tasks", { title: "Typo" });
+  return null;
+}
+`,
+    });
+
+    expect(error.code).toBe("invalid_function_reference");
+    expect(error.message).toContain("index.tsx:5:18");
+    expect(error.message).toContain("'add-tasks'");
+    expect(error.message).toContain(
+      "Declared functions: 'add-task', 'list-tasks'."
+    );
+  });
+
+  it("rejects a Pod-style reference and names the bare form", () => {
+    const error = referenceError({
+      "index.tsx": `
+import { usePodFunction } from "@dust/react-hooks";
+
+export default function App() {
+  usePodFunction("spc_1234/add-task", { title: "Write tests" });
+  return null;
+}
+`,
+    });
+
+    expect(error.message).toContain("<podId>/<slug>");
+    expect(error.message).toContain("Use 'add-task'.");
+  });
+
+  it("follows an aliased import", () => {
+    const error = referenceError({
+      "index.tsx": `
+import { usePodFunction as useFrameFunction } from "@dust/react-hooks";
+
+export default function App() {
+  useFrameFunction("nope", {});
+  return null;
+}
+`,
+    });
+
+    expect(error.message).toContain("'nope'");
+  });
+
+  it("follows a namespace import", () => {
+    const error = referenceError({
+      "index.tsx": `
+import * as hooks from "@dust/react-hooks";
+
+export default function App() {
+  hooks.usePodFunction("nope", {});
+  return null;
+}
+`,
+    });
+
+    expect(error.message).toContain("'nope'");
+  });
+
+  it("accepts a computed reference", () => {
+    const result = referencesFor({
+      "index.tsx": `
+import { usePodFunction } from "@dust/react-hooks";
+
+export default function App({ name }: { name: string }) {
+  usePodFunction(name, { anything: true });
+  return null;
+}
+`,
+    });
+
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("rejects a reference from an imported component", () => {
+    const error = referenceError({
+      "components/TaskList.tsx": `
+import { usePodFunction } from "@dust/react-hooks";
+
+export function TaskList() {
+  usePodFunction("nope", {});
+  return null;
+}
+`,
+      "index.tsx": `
+import { TaskList } from "./components/TaskList";
+
+export default function App() { return <TaskList />; }
+`,
+    });
+
+    expect(error.message).toContain("components/TaskList.tsx");
+  });
+
+  it("rejects a reference when the manifest declares no functions", () => {
+    const error = referenceError(
+      {
+        "index.tsx": `
+import { usePodFunction } from "@dust/react-hooks";
+
+export default function App() {
+  usePodFunction("add-task", { title: "No manifest entry" });
+  return null;
+}
+`,
+      },
+      []
+    );
+
+    expect(error.message).toContain(
+      "This Frame's manifest declares no functions."
+    );
+  });
+
+  it("caps the listed references", () => {
+    const calls = Array.from(
+      { length: 7 },
+      (_, index) => `  usePodFunction("missing-${index}", {});`
+    ).join("\n");
+    const error = referenceError({
+      "index.tsx": `
+import { usePodFunction } from "@dust/react-hooks";
+
+export default function App() {
+${calls}
+  return null;
+}
+`,
+    });
+
+    expect(error.message).toContain("'missing-4'");
+    expect(error.message).not.toContain("'missing-5'");
+    expect(error.message).toContain("2 more not shown.");
+  });
+});
+
 describe("collectFrameFunctionWarnings", () => {
   it("returns nothing when the UI calls no function hook", async () => {
     const warnings = await warningsFor({
@@ -66,44 +252,6 @@ export default function App() {
     });
 
     expect(warnings).toEqual([]);
-  });
-
-  it("flags a reference the manifest does not declare", async () => {
-    const warnings = await warningsFor({
-      "index.tsx": `
-import { usePodFunction } from "@dust/react-hooks";
-
-export default function App() {
-  usePodFunction("add-tasks", { title: "Typo" });
-  return null;
-}
-`,
-    });
-
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].type).toBe("frame_function");
-    expect(warnings[0].message).toContain("index.tsx:5:18");
-    expect(warnings[0].message).toContain("'add-tasks'");
-    expect(warnings[0].suggestion).toBe(
-      "Declared functions: 'add-task', 'list-tasks'."
-    );
-  });
-
-  it("flags a Pod-style reference and suggests the bare name", async () => {
-    const warnings = await warningsFor({
-      "index.tsx": `
-import { usePodFunction } from "@dust/react-hooks";
-
-export default function App() {
-  usePodFunction("spc_1234/add-task", { title: "Write tests" });
-  return null;
-}
-`,
-    });
-
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].message).toContain("<podId>/<slug>");
-    expect(warnings[0].suggestion).toBe("Use 'add-task'.");
   });
 
   it("flags an input that does not match the declared contract", async () => {
@@ -173,53 +321,6 @@ export default function App() {
     expect(warnings).toEqual([]);
   });
 
-  it("follows an aliased import", async () => {
-    const warnings = await warningsFor({
-      "index.tsx": `
-import { usePodFunction as useFrameFunction } from "@dust/react-hooks";
-
-export default function App() {
-  useFrameFunction("nope", {});
-  return null;
-}
-`,
-    });
-
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].message).toContain("'nope'");
-  });
-
-  it("follows a namespace import", async () => {
-    const warnings = await warningsFor({
-      "index.tsx": `
-import * as hooks from "@dust/react-hooks";
-
-export default function App() {
-  hooks.usePodFunction("nope", {});
-  return null;
-}
-`,
-    });
-
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].message).toContain("'nope'");
-  });
-
-  it("skips a computed reference", async () => {
-    const warnings = await warningsFor({
-      "index.tsx": `
-import { usePodFunction } from "@dust/react-hooks";
-
-export default function App({ name }: { name: string }) {
-  usePodFunction(name, { anything: true });
-  return null;
-}
-`,
-    });
-
-    expect(warnings).toEqual([]);
-  });
-
   it("checks a hook call in an imported component", async () => {
     const warnings = await warningsFor({
       "components/TaskList.tsx": `
@@ -241,7 +342,7 @@ export default function App() { return <TaskList />; }
     expect(warnings[0].message).toContain("components/TaskList.tsx");
   });
 
-  it("reports the reference when the manifest declares no functions", async () => {
+  it("returns nothing when the manifest declares no functions", async () => {
     const warnings = await warningsFor(
       {
         "index.tsx": `
@@ -256,34 +357,9 @@ export default function App() {
       []
     );
 
-    // An empty contract map would make `keyof` never and reject the input too; only the reference
-    // is reported.
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].suggestion).toBe(
-      "This Frame's manifest declares no functions."
-    );
-  });
-
-  it("caps the reported warnings", async () => {
-    const calls = Array.from(
-      { length: 7 },
-      (_, index) => `  usePodFunction("missing-${index}", {});`
-    ).join("\n");
-    const warnings = await warningsFor({
-      "index.tsx": `
-import { usePodFunction } from "@dust/react-hooks";
-
-export default function App() {
-${calls}
-  return null;
-}
-`,
-    });
-
-    expect(warnings).toHaveLength(6);
-    expect(warnings[5].message).toBe(
-      "2 more Frame function warning(s) not shown."
-    );
+    // An empty contract map would make `keyof` never and reject every input. The reference check
+    // owns this case, and it blocks the publish outright.
+    expect(warnings).toEqual([]);
   });
 
   it("ignores type errors outside the function inputs", async () => {

--- a/front/lib/api/frames/validate_frame_functions.ts
+++ b/front/lib/api/frames/validate_frame_functions.ts
@@ -1,8 +1,11 @@
 import path from "node:path";
 import type { ValidationWarning } from "@app/lib/api/files/content_validation";
 import type { FramePublicationSourceFile } from "@app/lib/api/frames/publication_storage";
+import { FramePublicationError } from "@app/lib/api/frames/publication_storage";
 import logger from "@app/logger/logger";
 import type { FramePublicationDescriptor } from "@app/types/api/frame_publication";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { JSONSchema4 } from "json-schema";
 import { compile } from "json-schema-to-typescript";
@@ -31,7 +34,7 @@ const PERMISSIVE_MODULE_EXPORTS = [
   "useUserIdentity",
 ] as const;
 
-const MAX_REPORTED_WARNINGS = 5;
+const MAX_REPORTED_PROBLEMS = 5;
 const MAX_LISTED_FUNCTION_NAMES = 12;
 
 const INPUT_DIAGNOSTIC_CODES = new Set([
@@ -46,6 +49,11 @@ const CALL_DIAGNOSTIC_CODES = new Set([
   2554, // Call has the wrong number of arguments.
   2769, // No overload accepts the provided arguments.
 ]);
+
+type FrameSourceInput = Pick<
+  FramePublicationSourceFile,
+  "content" | "relativePath"
+>;
 
 type FrameFunctionContract = Pick<
   FramePublicationDescriptor["functions"][number],
@@ -202,17 +210,12 @@ function describeDeclaredFunctions(declaredNames: readonly string[]): string {
   return `Declared functions: ${listed.map((name) => `'${name}'`).join(", ")}${suffix}.`;
 }
 
-/**
- * A Frames v2 UI addresses its own functions by bare manifest name; `resolveFrameFunctionReference`
- * rejects everything else. A reference that names nothing in the manifest fails only when a viewer
- * triggers the call, so report it here.
- */
-function collectReferenceWarnings(
+function collectReferenceProblems(
   hookCalls: readonly HookCall[],
   declaredNames: readonly string[]
-): ValidationWarning[] {
+): string[] {
   const declared = new Set(declaredNames);
-  const warnings: ValidationWarning[] = [];
+  const problems: string[] = [];
 
   for (const { hook, reference, sourceFile } of hookCalls) {
     // A computed reference cannot be checked statically.
@@ -224,30 +227,23 @@ function collectReferenceWarnings(
     const [, ...rest] = reference.text.split("/");
     const trailingSegment = rest.length > 0 ? rest.join("/") : null;
     if (trailingSegment !== null) {
-      warnings.push({
-        type: "frame_function",
-        message:
-          `${position}: ${hook}('${reference.text}') uses a '<podId>/<slug>' Pod function ` +
-          "reference. A Frames v2 UI calls its own functions by bare manifest name.",
-        oldString: reference.text,
-        suggestion: declared.has(trailingSegment)
-          ? `Use '${trailingSegment}'.`
-          : describeDeclaredFunctions(declaredNames),
-      });
+      const fix = declared.has(trailingSegment)
+        ? `Use '${trailingSegment}'.`
+        : describeDeclaredFunctions(declaredNames);
+      problems.push(
+        `${position}: ${hook}('${reference.text}') uses a '<podId>/<slug>' Pod function ` +
+          `reference. A Frames v2 UI calls its own functions by bare manifest name. ${fix}`
+      );
       continue;
     }
 
-    warnings.push({
-      type: "frame_function",
-      message:
-        `${position}: ${hook}('${reference.text}') names a function this Frame's manifest does ` +
-        "not declare. The call fails at run time, when a viewer triggers it.",
-      oldString: reference.text,
-      suggestion: describeDeclaredFunctions(declaredNames),
-    });
+    problems.push(
+      `${position}: ${hook}('${reference.text}') names a function this Frame's manifest does ` +
+        `not declare. ${describeDeclaredFunctions(declaredNames)}`
+    );
   }
 
-  return warnings;
+  return problems;
 }
 
 /**
@@ -546,32 +542,9 @@ async function collectInputWarnings({
   return warnings;
 }
 
-/**
- * Statically check how a Frame's UI calls the Frame's own functions: that every literal reference
- * names a declared function, and that the input it passes matches that function's contract. Both
- * only surface at run time otherwise, when a viewer triggers the call.
- *
- * Warnings, never errors: the UI source is not type-checked anywhere else (esbuild strips types
- * without checking them), so this pass reports on code that has never had to satisfy a compiler.
- */
-/**
- * @cc [owner:davidebbo,label:product;error-handling] frame-function-check-stays-advisory
- * This pass MUST only ever produce warnings, and MUST NOT throw. It type-checks UI source that no
- * other step compiles, against JSON Schema derived from Zod contracts whose runtime-only
- * refinements TypeScript cannot express — so it is heuristic in both directions, and every finding
- * is a lead rather than a verdict. Turning one into a `FramePublicationError`, or letting an
- * exception escape, would block publishing a Frame that works.
- */
-export async function collectFrameFunctionWarnings({
-  functions,
-  sourceFiles,
-}: {
-  functions: readonly FrameFunctionContract[];
-  sourceFiles: readonly Pick<
-    FramePublicationSourceFile,
-    "content" | "relativePath"
-  >[];
-}): Promise<ValidationWarning[]> {
+function readFrameSources(
+  sourceFiles: readonly FrameSourceInput[]
+): Map<string, string> {
   const sources = new Map<string, string>();
   for (const sourceFile of sourceFiles) {
     if (isSourceFile(sourceFile.relativePath)) {
@@ -579,41 +552,106 @@ export async function collectFrameFunctionWarnings({
     }
   }
 
-  const hookCalls = Array.from(sources).flatMap(([relativePath, code]) =>
+  return sources;
+}
+
+function collectFrameHookCalls(
+  sources: ReadonlyMap<string, string>
+): HookCall[] {
+  return Array.from(sources).flatMap(([relativePath, code]) =>
     collectHookCalls(parseSource(relativePath, code))
   );
+}
+
+/**
+ * Reject a Frame whose UI names a function its own manifest does not declare.
+ *
+ * This runs on the publish path, not only on validation, because unlike the input check below it is
+ * exact rather than heuristic: `resolveFrameFunctionReference` pins a v2 reference to
+ * `<frameId>/<name>`, so a literal that matches no declared name cannot resolve for any input or
+ * any viewer. Publishing it ships a Frame with a button that always fails. Computed references are
+ * skipped, so a UI that builds names at run time stays publishable.
+ */
+export function validateFrameFunctionReferences({
+  declaredFunctionNames,
+  sourceFiles,
+}: {
+  declaredFunctionNames: readonly string[];
+  sourceFiles: readonly FrameSourceInput[];
+}): Result<undefined, FramePublicationError> {
+  const hookCalls = collectFrameHookCalls(readFrameSources(sourceFiles));
   if (hookCalls.length === 0) {
+    return new Ok(undefined);
+  }
+
+  const problems = collectReferenceProblems(hookCalls, declaredFunctionNames);
+  if (problems.length === 0) {
+    return new Ok(undefined);
+  }
+
+  const listed = problems.slice(0, MAX_REPORTED_PROBLEMS);
+  const remaining = problems.length - listed.length;
+
+  return new Err(
+    new FramePublicationError(
+      "invalid_function_reference",
+      `Frame UI calls a function that is not declared in its manifest:\n${listed.join("\n")}` +
+        (remaining > 0 ? `\n${remaining} more not shown.` : "")
+    )
+  );
+}
+
+/**
+ * Statically check the input a Frame's UI passes to its own functions. Mismatches otherwise surface
+ * only at run time, when a viewer triggers the call.
+ *
+ * @cc [owner:davidebbo,label:product;error-handling] frame-function-input-check-stays-advisory
+ * This check MUST only ever produce warnings, and MUST NOT throw. It type-checks UI source that no
+ * other step compiles, against JSON Schema derived from Zod contracts whose runtime-only
+ * refinements TypeScript cannot express — so it is heuristic in both directions, and every finding
+ * is a lead rather than a verdict. Turning one into a `FramePublicationError`, or letting an
+ * exception escape, would block publishing a Frame that works. This is the opposite of
+ * `validateFrameFunctionReferences`, which is exact and therefore does block.
+ */
+export async function collectFrameFunctionWarnings({
+  functions,
+  sourceFiles,
+}: {
+  functions: readonly FrameFunctionContract[];
+  sourceFiles: readonly FrameSourceInput[];
+}): Promise<ValidationWarning[]> {
+  // Nothing to check inputs against, and a `keyof` over an empty map would reject every call.
+  if (functions.length === 0) {
     return [];
   }
 
-  const declaredNames = functions.map((fn) => fn.name);
-  const warnings = collectReferenceWarnings(hookCalls, declaredNames);
-
-  // Nothing to check inputs against, and a `keyof` over an empty map would reject every call.
-  if (functions.length > 0) {
-    try {
-      warnings.push(
-        ...(await collectInputWarnings({ contracts: functions, sources }))
-      );
-    } catch (error) {
-      // This pass is advisory. A schema the converter cannot express, or a compiler failure, must
-      // not stand between an author and a publish.
-      logger.warn(
-        { error: normalizeError(error).message },
-        "Frame function input validation failed; skipping input warnings."
-      );
-    }
+  const sources = readFrameSources(sourceFiles);
+  if (collectFrameHookCalls(sources).length === 0) {
+    return [];
   }
 
-  if (warnings.length <= MAX_REPORTED_WARNINGS) {
+  let warnings: ValidationWarning[];
+  try {
+    warnings = await collectInputWarnings({ contracts: functions, sources });
+  } catch (error) {
+    // A schema the converter cannot express, or a compiler failure, must not stand between an
+    // author and a publish.
+    logger.warn(
+      { error: normalizeError(error).message },
+      "Frame function input validation failed; skipping input warnings."
+    );
+    return [];
+  }
+
+  if (warnings.length <= MAX_REPORTED_PROBLEMS) {
     return warnings;
   }
 
   return [
-    ...warnings.slice(0, MAX_REPORTED_WARNINGS),
+    ...warnings.slice(0, MAX_REPORTED_PROBLEMS),
     {
       type: "frame_function",
-      message: `${warnings.length - MAX_REPORTED_WARNINGS} more Frame function warning(s) not shown.`,
+      message: `${warnings.length - MAX_REPORTED_PROBLEMS} more Frame function warning(s) not shown.`,
     },
   ];
 }

--- a/front/lib/api/frames/validate_frame_functions.ts
+++ b/front/lib/api/frames/validate_frame_functions.ts
@@ -1,124 +1,41 @@
 import path from "node:path";
-import type { ValidationWarning } from "@app/lib/api/files/content_validation";
 import type { FramePublicationSourceFile } from "@app/lib/api/frames/publication_storage";
 import { FramePublicationError } from "@app/lib/api/frames/publication_storage";
-import logger from "@app/logger/logger";
-import type { FramePublicationDescriptor } from "@app/types/api/frame_publication";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
-import type { JSONSchema4 } from "json-schema";
-import { compile } from "json-schema-to-typescript";
 import ts from "typescript";
 
 const DUST_REACT_HOOKS_MODULE = "@dust/react-hooks";
-const VIRTUAL_FRAME_ROOT = "/__dust_frame__";
-const VIRTUAL_DUST_REACT_HOOKS_PATH = `${VIRTUAL_FRAME_ROOT}/node_modules/@dust/react-hooks/index.d.ts`;
-const SOURCE_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js"] as const;
-const RESOLVE_EXTENSIONS = ["", ".tsx", ".ts", ".jsx", ".js"] as const;
 
 // The two hooks a Frame's UI calls its own functions through. `callFunction` is deliberately not
 // here: it addressed Pod functions, which no longer exist.
-const QUERY_HOOK = "usePodFunction";
-const MUTATION_HOOK = "usePodFunctionMutation";
-const FRAME_FUNCTION_HOOKS = [QUERY_HOOK, MUTATION_HOOK] as const;
-
-// Every other `@dust/react-hooks` export, declared permissively so importing one is not an error
-// in the virtual program.
-const PERMISSIVE_MODULE_EXPORTS = [
-  "SandboxFunctionCallError",
-  "callFunction",
-  "captureScreenshot",
-  "triggerUserFileDownload",
-  "useFile",
-  "useUserIdentity",
-] as const;
-
-const MAX_REPORTED_PROBLEMS = 5;
-const MAX_LISTED_FUNCTION_NAMES = 12;
-
-const INPUT_DIAGNOSTIC_CODES = new Set([
-  2322, // Type is not assignable to the expected input type.
-  2345, // Argument is not assignable to the input parameter.
-  2353, // Object literal contains an unknown property.
-  2561, // Object literal contains a near-miss misspelling of a known property.
-  2739, // Input is missing several required properties.
-  2741, // Input is missing a required property.
+const FRAME_FUNCTION_HOOKS = new Set([
+  "usePodFunction",
+  "usePodFunctionMutation",
 ]);
-const CALL_DIAGNOSTIC_CODES = new Set([
-  2554, // Call has the wrong number of arguments.
-  2769, // No overload accepts the provided arguments.
+
+const SCRIPT_KIND_BY_EXTENSION = new Map<string, ts.ScriptKind>([
+  [".js", ts.ScriptKind.JS],
+  [".jsx", ts.ScriptKind.JSX],
+  [".ts", ts.ScriptKind.TS],
+  [".tsx", ts.ScriptKind.TSX],
 ]);
+
+const MAX_REPORTED_REFERENCES = 5;
 
 type FrameSourceInput = Pick<
   FramePublicationSourceFile,
   "content" | "relativePath"
 >;
 
-type FrameFunctionContract = Pick<
-  FramePublicationDescriptor["functions"][number],
-  "name" | "inputSchema"
->;
-
-function isSourceFile(relativePath: string): boolean {
-  return SOURCE_EXTENSIONS.some((extension) =>
-    relativePath.endsWith(extension)
-  );
-}
-
-function extensionForPath(filePath: string): ts.Extension {
-  if (filePath.endsWith(".tsx")) {
-    return ts.Extension.Tsx;
-  }
-  if (filePath.endsWith(".ts")) {
-    return ts.Extension.Ts;
-  }
-  if (filePath.endsWith(".jsx")) {
-    return ts.Extension.Jsx;
-  }
-
-  return ts.Extension.Js;
-}
-
-function scriptKindForPath(filePath: string): ts.ScriptKind {
-  if (filePath.endsWith(".tsx")) {
-    return ts.ScriptKind.TSX;
-  }
-  if (filePath.endsWith(".ts") || filePath.endsWith(".d.ts")) {
-    return ts.ScriptKind.TS;
-  }
-  if (filePath.endsWith(".jsx")) {
-    return ts.ScriptKind.JSX;
-  }
-
-  return ts.ScriptKind.JS;
-}
-
-function parseSource(relativePath: string, code: string): ts.SourceFile {
-  return ts.createSourceFile(
-    relativePath,
-    code,
-    ts.ScriptTarget.Latest,
-    true,
-    scriptKindForPath(relativePath)
-  );
-}
-
-function formatPosition(sourceFile: ts.SourceFile, position: number): string {
-  const { line, character } =
-    sourceFile.getLineAndCharacterOfPosition(position);
-
-  return `${sourceFile.fileName}:${line + 1}:${character + 1}`;
-}
-
-/**
- * Local names the Frame's function hooks are reachable under in one source file: their named
- * imports (following aliases) and any namespace import of the module.
- */
-function collectHookBindings(sourceFile: ts.SourceFile): {
+type HookBindings = {
+  // Local name -> hook, for named imports (following aliases).
   hookByLocalName: Map<string, string>;
   namespaceNames: Set<string>;
-} {
+};
+
+/** Local names the Frame's function hooks are reachable under in one source file. */
+function collectHookBindings(sourceFile: ts.SourceFile): HookBindings {
   const hookByLocalName = new Map<string, string>();
   const namespaceNames = new Set<string>();
 
@@ -141,7 +58,7 @@ function collectHookBindings(sourceFile: ts.SourceFile): {
     }
     for (const element of bindings.elements) {
       const imported = element.propertyName?.text ?? element.name.text;
-      if (FRAME_FUNCTION_HOOKS.some((hook) => hook === imported)) {
+      if (FRAME_FUNCTION_HOOKS.has(imported)) {
         hookByLocalName.set(element.name.text, imported);
       }
     }
@@ -150,42 +67,50 @@ function collectHookBindings(sourceFile: ts.SourceFile): {
   return { hookByLocalName, namespaceNames };
 }
 
-type HookCall = {
-  hook: string;
-  reference: ts.StringLiteralLike | null;
-  sourceFile: ts.SourceFile;
-};
-
-function collectHookCalls(sourceFile: ts.SourceFile): HookCall[] {
-  const { hookByLocalName, namespaceNames } = collectHookBindings(sourceFile);
-  if (hookByLocalName.size === 0 && namespaceNames.size === 0) {
-    return [];
+function hookForCallee(
+  callee: ts.Expression,
+  { hookByLocalName, namespaceNames }: HookBindings
+): string | undefined {
+  if (ts.isIdentifier(callee)) {
+    return hookByLocalName.get(callee.text);
+  }
+  if (
+    ts.isPropertyAccessExpression(callee) &&
+    ts.isIdentifier(callee.expression) &&
+    namespaceNames.has(callee.expression.text) &&
+    FRAME_FUNCTION_HOOKS.has(callee.name.text)
+  ) {
+    return callee.name.text;
   }
 
-  const calls: HookCall[] = [];
+  return undefined;
+}
+
+/** One `<file>:<line>:<column>: <hook>('<name>')` line per literal reference not in `declared`. */
+function collectUndeclaredReferences(
+  sourceFile: ts.SourceFile,
+  declared: ReadonlySet<string>
+): string[] {
+  const bindings = collectHookBindings(sourceFile);
+  const undeclared: string[] = [];
+
   const visit = (node: ts.Node): void => {
     if (ts.isCallExpression(node)) {
-      const callee = node.expression;
-      let hook: string | undefined;
-      if (ts.isIdentifier(callee)) {
-        hook = hookByLocalName.get(callee.text);
-      } else if (
-        ts.isPropertyAccessExpression(callee) &&
-        ts.isIdentifier(callee.expression) &&
-        namespaceNames.has(callee.expression.text) &&
-        FRAME_FUNCTION_HOOKS.some((candidate) => candidate === callee.name.text)
+      const hook = hookForCallee(node.expression, bindings);
+      const reference = node.arguments[0];
+      // A computed reference cannot be checked statically.
+      if (
+        hook &&
+        reference &&
+        ts.isStringLiteralLike(reference) &&
+        !declared.has(reference.text)
       ) {
-        hook = callee.name.text;
-      }
-
-      if (hook) {
-        const argument = node.arguments[0];
-        calls.push({
-          hook,
-          reference:
-            argument && ts.isStringLiteralLike(argument) ? argument : null,
-          sourceFile,
-        });
+        const { line, character } = sourceFile.getLineAndCharacterOfPosition(
+          reference.getStart(sourceFile)
+        );
+        undeclared.push(
+          `${sourceFile.fileName}:${line + 1}:${character + 1}: ${hook}('${reference.text}')`
+        );
       }
     }
 
@@ -193,384 +118,16 @@ function collectHookCalls(sourceFile: ts.SourceFile): HookCall[] {
   };
   visit(sourceFile);
 
-  return calls;
-}
-
-function describeDeclaredFunctions(declaredNames: readonly string[]): string {
-  if (declaredNames.length === 0) {
-    return "This Frame's manifest declares no functions.";
-  }
-
-  const listed = declaredNames.slice(0, MAX_LISTED_FUNCTION_NAMES);
-  const suffix =
-    declaredNames.length > listed.length
-      ? `, and ${declaredNames.length - listed.length} more`
-      : "";
-
-  return `Declared functions: ${listed.map((name) => `'${name}'`).join(", ")}${suffix}.`;
-}
-
-function collectReferenceProblems(
-  hookCalls: readonly HookCall[],
-  declaredNames: readonly string[]
-): string[] {
-  const declared = new Set(declaredNames);
-  const problems: string[] = [];
-
-  for (const { hook, reference, sourceFile } of hookCalls) {
-    // A computed reference cannot be checked statically.
-    if (!reference || declared.has(reference.text)) {
-      continue;
-    }
-
-    const position = formatPosition(sourceFile, reference.getStart());
-    const [, ...rest] = reference.text.split("/");
-    const trailingSegment = rest.length > 0 ? rest.join("/") : null;
-    if (trailingSegment !== null) {
-      const fix = declared.has(trailingSegment)
-        ? `Use '${trailingSegment}'.`
-        : describeDeclaredFunctions(declaredNames);
-      problems.push(
-        `${position}: ${hook}('${reference.text}') uses a '<podId>/<slug>' Pod function ` +
-          `reference. A Frames v2 UI calls its own functions by bare manifest name. ${fix}`
-      );
-      continue;
-    }
-
-    problems.push(
-      `${position}: ${hook}('${reference.text}') names a function this Frame's manifest does ` +
-        `not declare. ${describeDeclaredFunctions(declaredNames)}`
-    );
-  }
-
-  return problems;
-}
-
-/**
- * Declare the module so a declared function's name selects its input type.
- *
- * The input is typed through a conditional on the inferred name rather than by constraining the
- * name to `keyof`, which matters in both directions: a name outside the map resolves the input to
- * `any`, so an unknown or computed reference falls through untyped instead of cascading onto the
- * input that the reference warning already covers — and, unlike an overload pair, there is no
- * permissive signature for a mistyped input to fall back to, which would silently pass everything.
- */
-async function buildDustReactHooksDeclaration(
-  contracts: readonly FrameFunctionContract[]
-): Promise<string> {
-  const declarations: string[] = [];
-  const entries: string[] = [];
-
-  for (const [index, contract] of contracts.entries()) {
-    const namespace = `FrameFunctionContract${index}`;
-    // The converter supports draft 7 but exposes a draft 4 input type.
-    const schema = contract.inputSchema as JSONSchema4;
-    const typeDeclaration = await compile(schema, "Input", {
-      // Function schemas only need internal references.
-      $refOptions: { resolve: { external: false, file: false, http: false } },
-      bannerComment: "",
-      enableConstEnums: false,
-      format: false,
-      ignoreMinAndMaxItems: true,
-      unknownAny: true,
-    });
-
-    declarations.push(`export namespace ${namespace} {\n${typeDeclaration}\n}`);
-    entries.push(`  ${JSON.stringify(contract.name)}: ${namespace}.Input;`);
-  }
-
-  // Results stay permissive: this pass checks what the Frame sends, not what it does with what
-  // comes back. Typing `data` would move diagnostics out of the call arguments, where nothing
-  // separates them from the Frame's own unchecked type errors.
-  return `${declarations.join("\n")}
-export interface FrameFunctionInputs {
-${entries.join("\n")}
-}
-
-export interface UsePodFunctionResult {
-  data: any;
-  error: Error | undefined;
-  isLoading: boolean;
-  isValidating: boolean;
-  mutate: (...args: any[]) => any;
-}
-
-export interface UsePodFunctionMutationResult<TInput> {
-  data: any;
-  error: Error | undefined;
-  isMutating: boolean;
-  reset: () => void;
-  trigger: (input: TInput) => Promise<any>;
-}
-
-export declare function ${QUERY_HOOK}<TFunction extends string | null>(
-  functionName: TFunction,
-  input: TFunction extends keyof FrameFunctionInputs
-    ? FrameFunctionInputs[TFunction]
-    : any
-): UsePodFunctionResult;
-
-export declare function ${MUTATION_HOOK}<TFunction extends string | null>(
-  functionName: TFunction
-): UsePodFunctionMutationResult<
-  TFunction extends keyof FrameFunctionInputs
-    ? FrameFunctionInputs[TFunction]
-    : any
->;
-
-${PERMISSIVE_MODULE_EXPORTS.map((name) => `export declare const ${name}: any;`).join("\n")}
-`;
-}
-
-function resolveRelativeModule(
-  moduleName: string,
-  containingFile: string,
-  virtualSources: ReadonlyMap<string, string>
-): ts.ResolvedModuleFull | undefined {
-  const base = path.posix.normalize(
-    path.posix.join(path.posix.dirname(containingFile), moduleName)
-  );
-  const candidates = RESOLVE_EXTENSIONS.flatMap((extension) => [
-    `${base}${extension}`,
-    extension ? `${base}/index${extension}` : null,
-  ]).filter((candidate): candidate is string => candidate !== null);
-  const resolvedFileName = candidates.find((candidate) =>
-    virtualSources.has(candidate)
-  );
-  if (!resolvedFileName) {
-    return undefined;
-  }
-
-  return {
-    resolvedFileName,
-    extension: extensionForPath(resolvedFileName),
-    isExternalLibraryImport: false,
-  };
-}
-
-function createVirtualProgram(
-  virtualSources: ReadonlyMap<string, string>
-): ts.Program {
-  const compilerOptions: ts.CompilerOptions = {
-    allowJs: true,
-    checkJs: true,
-    jsx: ts.JsxEmit.Preserve,
-    module: ts.ModuleKind.ESNext,
-    moduleResolution: ts.ModuleResolutionKind.Bundler,
-    noEmit: true,
-    skipLibCheck: true,
-    strict: true,
-    target: ts.ScriptTarget.ES2020,
-    types: [],
-  };
-  const defaultHost = ts.createCompilerHost(compilerOptions);
-  const host: ts.CompilerHost = {
-    ...defaultHost,
-    fileExists: (fileName) =>
-      virtualSources.has(fileName) || defaultHost.fileExists(fileName),
-    getCurrentDirectory: () => VIRTUAL_FRAME_ROOT,
-    getSourceFile: (fileName, languageVersion) => {
-      const source = virtualSources.get(fileName);
-      return source === undefined
-        ? defaultHost.getSourceFile(fileName, languageVersion)
-        : ts.createSourceFile(
-            fileName,
-            source,
-            languageVersion,
-            true,
-            scriptKindForPath(fileName)
-          );
-    },
-    readFile: (fileName) =>
-      virtualSources.get(fileName) ?? defaultHost.readFile(fileName),
-    resolveModuleNames: (moduleNames, containingFile) =>
-      moduleNames.map((moduleName) => {
-        if (moduleName === DUST_REACT_HOOKS_MODULE) {
-          return {
-            resolvedFileName: VIRTUAL_DUST_REACT_HOOKS_PATH,
-            extension: ts.Extension.Dts,
-            isExternalLibraryImport: true,
-          };
-        }
-
-        return moduleName.startsWith(".")
-          ? resolveRelativeModule(moduleName, containingFile, virtualSources)
-          : undefined;
-      }),
-    writeFile: () => undefined,
-  };
-
-  return ts.createProgram({
-    rootNames: Array.from(virtualSources.keys()).filter(
-      (fileName) => fileName !== VIRTUAL_DUST_REACT_HOOKS_PATH
-    ),
-    options: compilerOptions,
-    host,
-  });
-}
-
-/** The argument carrying a function's input, or undefined for a call that passes none. */
-function getInputArgumentRange(
-  call: ts.CallExpression,
-  checker: ts.TypeChecker
-): { end: number; start: number } | undefined {
-  const declaration = checker.getResolvedSignature(call)?.declaration;
-  // A named declaration is one of the hooks; the unnamed function type is the mutation's
-  // `trigger`, whose only argument is the input.
-  const hook =
-    declaration && ts.isFunctionDeclaration(declaration) && declaration.name
-      ? declaration.name.text
-      : null;
-  if (hook === MUTATION_HOOK) {
-    return undefined;
-  }
-
-  const argument = hook === QUERY_HOOK ? call.arguments[1] : call.arguments[0];
-
-  return argument
-    ? { end: argument.getEnd(), start: argument.getStart() }
-    : undefined;
-}
-
-function formatDiagnostic(diagnostic: ts.Diagnostic): string {
-  const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
-  if (!diagnostic.file || diagnostic.start === undefined) {
-    return `error TS${diagnostic.code}: ${message}`;
-  }
-
-  const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(
-    diagnostic.start
-  );
-  const relativePath = path.posix.relative(
-    VIRTUAL_FRAME_ROOT,
-    diagnostic.file.fileName
-  );
-
-  return `${relativePath}:${line + 1}:${character + 1}: error TS${diagnostic.code}: ${message}`;
-}
-
-/**
- * Type-check what the Frame passes to its own functions against the input schemas extracted from
- * their published contracts.
- *
- * Contracts are authored in Zod but checked here through their extracted JSON Schema. Runtime-only
- * refinements are not always expressible as TypeScript types, so an input can pass here and still
- * fail the authoritative Zod validation when the function runs — which is why these are warnings.
- */
-async function collectInputWarnings({
-  contracts,
-  sources,
-}: {
-  contracts: readonly FrameFunctionContract[];
-  sources: ReadonlyMap<string, string>;
-}): Promise<ValidationWarning[]> {
-  const virtualSources = new Map<string, string>();
-  for (const [relativePath, code] of sources) {
-    virtualSources.set(path.posix.join(VIRTUAL_FRAME_ROOT, relativePath), code);
-  }
-  virtualSources.set(
-    VIRTUAL_DUST_REACT_HOOKS_PATH,
-    await buildDustReactHooksDeclaration(contracts)
-  );
-
-  const program = createVirtualProgram(virtualSources);
-  const checker = program.getTypeChecker();
-  const inputRangesBySource = new Map<
-    ts.SourceFile,
-    { end: number; start: number }[]
-  >();
-
-  for (const sourceFile of program.getSourceFiles()) {
-    if (sourceFile.fileName === VIRTUAL_DUST_REACT_HOOKS_PATH) {
-      continue;
-    }
-
-    const visit = (node: ts.Node): void => {
-      if (ts.isCallExpression(node)) {
-        const signatures = checker
-          .getTypeAtLocation(node.expression)
-          .getCallSignatures();
-        // Reaches the hooks and the `trigger` they return, whatever the Frame named them.
-        const isFrameFunctionCall = signatures.some(
-          (signature) =>
-            signature.declaration?.getSourceFile().fileName ===
-            VIRTUAL_DUST_REACT_HOOKS_PATH
-        );
-        if (isFrameFunctionCall) {
-          const range = getInputArgumentRange(node, checker);
-          if (range) {
-            const ranges = inputRangesBySource.get(sourceFile) ?? [];
-            ranges.push(range);
-            inputRangesBySource.set(sourceFile, ranges);
-          }
-        }
-      }
-
-      ts.forEachChild(node, visit);
-    };
-    visit(sourceFile);
-  }
-
-  const warnings: ValidationWarning[] = [];
-  for (const diagnostic of program.getSemanticDiagnostics()) {
-    const { file, start } = diagnostic;
-    if (!file || start === undefined) {
-      continue;
-    }
-    const ranges = inputRangesBySource.get(file);
-    const withinInput = ranges?.some(
-      (range) => start >= range.start && start < range.end
-    );
-    if (!withinInput) {
-      continue;
-    }
-    if (
-      !INPUT_DIAGNOSTIC_CODES.has(diagnostic.code) &&
-      !CALL_DIAGNOSTIC_CODES.has(diagnostic.code)
-    ) {
-      continue;
-    }
-
-    warnings.push({
-      type: "frame_function",
-      message: `${formatDiagnostic(diagnostic)}`,
-      suggestion:
-        "Match the function's declared input, or update the function's `schema.input`.",
-    });
-  }
-
-  return warnings;
-}
-
-function readFrameSources(
-  sourceFiles: readonly FrameSourceInput[]
-): Map<string, string> {
-  const sources = new Map<string, string>();
-  for (const sourceFile of sourceFiles) {
-    if (isSourceFile(sourceFile.relativePath)) {
-      sources.set(sourceFile.relativePath, sourceFile.content.toString("utf8"));
-    }
-  }
-
-  return sources;
-}
-
-function collectFrameHookCalls(
-  sources: ReadonlyMap<string, string>
-): HookCall[] {
-  return Array.from(sources).flatMap(([relativePath, code]) =>
-    collectHookCalls(parseSource(relativePath, code))
-  );
+  return undeclared;
 }
 
 /**
  * Reject a Frame whose UI names a function its own manifest does not declare.
  *
- * This runs on the publish path, not only on validation, because unlike the input check below it is
- * exact rather than heuristic: `resolveFrameFunctionReference` pins a v2 reference to
+ * This runs on the publish path because the check is exact: a v2 reference resolves to
  * `<frameId>/<name>`, so a literal that matches no declared name cannot resolve for any input or
- * any viewer. Publishing it ships a Frame with a button that always fails. Computed references are
- * skipped, so a UI that builds names at run time stays publishable.
+ * any viewer, and publishing it ships a Frame with a button that always fails. Computed references
+ * are skipped, so a UI that builds names at run time stays publishable.
  */
 export function validateFrameFunctionReferences({
   declaredFunctionNames,
@@ -579,79 +136,46 @@ export function validateFrameFunctionReferences({
   declaredFunctionNames: readonly string[];
   sourceFiles: readonly FrameSourceInput[];
 }): Result<undefined, FramePublicationError> {
-  const hookCalls = collectFrameHookCalls(readFrameSources(sourceFiles));
-  if (hookCalls.length === 0) {
+  const declared = new Set(declaredFunctionNames);
+  const undeclared: string[] = [];
+
+  for (const { content, relativePath } of sourceFiles) {
+    const scriptKind = SCRIPT_KIND_BY_EXTENSION.get(
+      path.posix.extname(relativePath)
+    );
+    if (scriptKind === undefined) {
+      continue;
+    }
+    const sourceFile = ts.createSourceFile(
+      relativePath,
+      content.toString("utf8"),
+      ts.ScriptTarget.Latest,
+      false,
+      scriptKind
+    );
+    undeclared.push(...collectUndeclaredReferences(sourceFile, declared));
+  }
+
+  if (undeclared.length === 0) {
     return new Ok(undefined);
   }
 
-  const problems = collectReferenceProblems(hookCalls, declaredFunctionNames);
-  if (problems.length === 0) {
-    return new Ok(undefined);
-  }
-
-  const listed = problems.slice(0, MAX_REPORTED_PROBLEMS);
-  const remaining = problems.length - listed.length;
+  const listed = undeclared.slice(0, MAX_REPORTED_REFERENCES);
+  const remaining = undeclared.length - listed.length;
+  const declaredSummary =
+    declaredFunctionNames.length === 0
+      ? "This Frame's manifest declares no functions."
+      : `Declared functions: ${declaredFunctionNames.map((name) => `'${name}'`).join(", ")}.`;
 
   return new Err(
     new FramePublicationError(
       "invalid_function_reference",
-      `Frame UI calls a function that is not declared in its manifest:\n${listed.join("\n")}` +
-        (remaining > 0 ? `\n${remaining} more not shown.` : "")
+      [
+        "Frame UI calls a function that is not declared in its manifest:",
+        ...listed,
+        ...(remaining > 0 ? [`${remaining} more not shown.`] : []),
+        declaredSummary,
+      ].join("\n")
     )
   );
-}
-
-/**
- * Statically check the input a Frame's UI passes to its own functions. Mismatches otherwise surface
- * only at run time, when a viewer triggers the call.
- *
- * @cc [owner:davidebbo,label:product;error-handling] frame-function-input-check-stays-advisory
- * This check MUST only ever produce warnings, and MUST NOT throw. It type-checks UI source that no
- * other step compiles, against JSON Schema derived from Zod contracts whose runtime-only
- * refinements TypeScript cannot express — so it is heuristic in both directions, and every finding
- * is a lead rather than a verdict. Turning one into a `FramePublicationError`, or letting an
- * exception escape, would block publishing a Frame that works. This is the opposite of
- * `validateFrameFunctionReferences`, which is exact and therefore does block.
- */
-export async function collectFrameFunctionWarnings({
-  functions,
-  sourceFiles,
-}: {
-  functions: readonly FrameFunctionContract[];
-  sourceFiles: readonly FrameSourceInput[];
-}): Promise<ValidationWarning[]> {
-  // Nothing to check inputs against, and a `keyof` over an empty map would reject every call.
-  if (functions.length === 0) {
-    return [];
-  }
-
-  const sources = readFrameSources(sourceFiles);
-  if (collectFrameHookCalls(sources).length === 0) {
-    return [];
-  }
-
-  let warnings: ValidationWarning[];
-  try {
-    warnings = await collectInputWarnings({ contracts: functions, sources });
-  } catch (error) {
-    // A schema the converter cannot express, or a compiler failure, must not stand between an
-    // author and a publish.
-    logger.warn(
-      { error: normalizeError(error).message },
-      "Frame function input validation failed; skipping input warnings."
-    );
-    return [];
-  }
-
-  if (warnings.length <= MAX_REPORTED_PROBLEMS) {
-    return warnings;
-  }
-
-  return [
-    ...warnings.slice(0, MAX_REPORTED_PROBLEMS),
-    {
-      type: "frame_function",
-      message: `${warnings.length - MAX_REPORTED_PROBLEMS} more Frame function warning(s) not shown.`,
-    },
-  ];
 }

--- a/front/lib/api/frames/validate_frame_functions.ts
+++ b/front/lib/api/frames/validate_frame_functions.ts
@@ -1,0 +1,619 @@
+import path from "node:path";
+import type { ValidationWarning } from "@app/lib/api/files/content_validation";
+import type { FramePublicationSourceFile } from "@app/lib/api/frames/publication_storage";
+import logger from "@app/logger/logger";
+import type { FramePublicationDescriptor } from "@app/types/api/frame_publication";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { JSONSchema4 } from "json-schema";
+import { compile } from "json-schema-to-typescript";
+import ts from "typescript";
+
+const DUST_REACT_HOOKS_MODULE = "@dust/react-hooks";
+const VIRTUAL_FRAME_ROOT = "/__dust_frame__";
+const VIRTUAL_DUST_REACT_HOOKS_PATH = `${VIRTUAL_FRAME_ROOT}/node_modules/@dust/react-hooks/index.d.ts`;
+const SOURCE_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js"] as const;
+const RESOLVE_EXTENSIONS = ["", ".tsx", ".ts", ".jsx", ".js"] as const;
+
+// The two hooks a Frame's UI calls its own functions through. `callFunction` is deliberately not
+// here: it addressed Pod functions, which no longer exist.
+const QUERY_HOOK = "usePodFunction";
+const MUTATION_HOOK = "usePodFunctionMutation";
+const FRAME_FUNCTION_HOOKS = [QUERY_HOOK, MUTATION_HOOK] as const;
+
+// Every other `@dust/react-hooks` export, declared permissively so importing one is not an error
+// in the virtual program.
+const PERMISSIVE_MODULE_EXPORTS = [
+  "SandboxFunctionCallError",
+  "callFunction",
+  "captureScreenshot",
+  "triggerUserFileDownload",
+  "useFile",
+  "useUserIdentity",
+] as const;
+
+const MAX_REPORTED_WARNINGS = 5;
+const MAX_LISTED_FUNCTION_NAMES = 12;
+
+const INPUT_DIAGNOSTIC_CODES = new Set([
+  2322, // Type is not assignable to the expected input type.
+  2345, // Argument is not assignable to the input parameter.
+  2353, // Object literal contains an unknown property.
+  2561, // Object literal contains a near-miss misspelling of a known property.
+  2739, // Input is missing several required properties.
+  2741, // Input is missing a required property.
+]);
+const CALL_DIAGNOSTIC_CODES = new Set([
+  2554, // Call has the wrong number of arguments.
+  2769, // No overload accepts the provided arguments.
+]);
+
+type FrameFunctionContract = Pick<
+  FramePublicationDescriptor["functions"][number],
+  "name" | "inputSchema"
+>;
+
+function isSourceFile(relativePath: string): boolean {
+  return SOURCE_EXTENSIONS.some((extension) =>
+    relativePath.endsWith(extension)
+  );
+}
+
+function extensionForPath(filePath: string): ts.Extension {
+  if (filePath.endsWith(".tsx")) {
+    return ts.Extension.Tsx;
+  }
+  if (filePath.endsWith(".ts")) {
+    return ts.Extension.Ts;
+  }
+  if (filePath.endsWith(".jsx")) {
+    return ts.Extension.Jsx;
+  }
+
+  return ts.Extension.Js;
+}
+
+function scriptKindForPath(filePath: string): ts.ScriptKind {
+  if (filePath.endsWith(".tsx")) {
+    return ts.ScriptKind.TSX;
+  }
+  if (filePath.endsWith(".ts") || filePath.endsWith(".d.ts")) {
+    return ts.ScriptKind.TS;
+  }
+  if (filePath.endsWith(".jsx")) {
+    return ts.ScriptKind.JSX;
+  }
+
+  return ts.ScriptKind.JS;
+}
+
+function parseSource(relativePath: string, code: string): ts.SourceFile {
+  return ts.createSourceFile(
+    relativePath,
+    code,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKindForPath(relativePath)
+  );
+}
+
+function formatPosition(sourceFile: ts.SourceFile, position: number): string {
+  const { line, character } =
+    sourceFile.getLineAndCharacterOfPosition(position);
+
+  return `${sourceFile.fileName}:${line + 1}:${character + 1}`;
+}
+
+/**
+ * Local names the Frame's function hooks are reachable under in one source file: their named
+ * imports (following aliases) and any namespace import of the module.
+ */
+function collectHookBindings(sourceFile: ts.SourceFile): {
+  hookByLocalName: Map<string, string>;
+  namespaceNames: Set<string>;
+} {
+  const hookByLocalName = new Map<string, string>();
+  const namespaceNames = new Set<string>();
+
+  for (const statement of sourceFile.statements) {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      statement.moduleSpecifier.text !== DUST_REACT_HOOKS_MODULE
+    ) {
+      continue;
+    }
+
+    const bindings = statement.importClause?.namedBindings;
+    if (!bindings) {
+      continue;
+    }
+    if (ts.isNamespaceImport(bindings)) {
+      namespaceNames.add(bindings.name.text);
+      continue;
+    }
+    for (const element of bindings.elements) {
+      const imported = element.propertyName?.text ?? element.name.text;
+      if (FRAME_FUNCTION_HOOKS.some((hook) => hook === imported)) {
+        hookByLocalName.set(element.name.text, imported);
+      }
+    }
+  }
+
+  return { hookByLocalName, namespaceNames };
+}
+
+type HookCall = {
+  hook: string;
+  reference: ts.StringLiteralLike | null;
+  sourceFile: ts.SourceFile;
+};
+
+function collectHookCalls(sourceFile: ts.SourceFile): HookCall[] {
+  const { hookByLocalName, namespaceNames } = collectHookBindings(sourceFile);
+  if (hookByLocalName.size === 0 && namespaceNames.size === 0) {
+    return [];
+  }
+
+  const calls: HookCall[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      let hook: string | undefined;
+      if (ts.isIdentifier(callee)) {
+        hook = hookByLocalName.get(callee.text);
+      } else if (
+        ts.isPropertyAccessExpression(callee) &&
+        ts.isIdentifier(callee.expression) &&
+        namespaceNames.has(callee.expression.text) &&
+        FRAME_FUNCTION_HOOKS.some((candidate) => candidate === callee.name.text)
+      ) {
+        hook = callee.name.text;
+      }
+
+      if (hook) {
+        const argument = node.arguments[0];
+        calls.push({
+          hook,
+          reference:
+            argument && ts.isStringLiteralLike(argument) ? argument : null,
+          sourceFile,
+        });
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+
+  return calls;
+}
+
+function describeDeclaredFunctions(declaredNames: readonly string[]): string {
+  if (declaredNames.length === 0) {
+    return "This Frame's manifest declares no functions.";
+  }
+
+  const listed = declaredNames.slice(0, MAX_LISTED_FUNCTION_NAMES);
+  const suffix =
+    declaredNames.length > listed.length
+      ? `, and ${declaredNames.length - listed.length} more`
+      : "";
+
+  return `Declared functions: ${listed.map((name) => `'${name}'`).join(", ")}${suffix}.`;
+}
+
+/**
+ * A Frames v2 UI addresses its own functions by bare manifest name; `resolveFrameFunctionReference`
+ * rejects everything else. A reference that names nothing in the manifest fails only when a viewer
+ * triggers the call, so report it here.
+ */
+function collectReferenceWarnings(
+  hookCalls: readonly HookCall[],
+  declaredNames: readonly string[]
+): ValidationWarning[] {
+  const declared = new Set(declaredNames);
+  const warnings: ValidationWarning[] = [];
+
+  for (const { hook, reference, sourceFile } of hookCalls) {
+    // A computed reference cannot be checked statically.
+    if (!reference || declared.has(reference.text)) {
+      continue;
+    }
+
+    const position = formatPosition(sourceFile, reference.getStart());
+    const [, ...rest] = reference.text.split("/");
+    const trailingSegment = rest.length > 0 ? rest.join("/") : null;
+    if (trailingSegment !== null) {
+      warnings.push({
+        type: "frame_function",
+        message:
+          `${position}: ${hook}('${reference.text}') uses a '<podId>/<slug>' Pod function ` +
+          "reference. A Frames v2 UI calls its own functions by bare manifest name.",
+        oldString: reference.text,
+        suggestion: declared.has(trailingSegment)
+          ? `Use '${trailingSegment}'.`
+          : describeDeclaredFunctions(declaredNames),
+      });
+      continue;
+    }
+
+    warnings.push({
+      type: "frame_function",
+      message:
+        `${position}: ${hook}('${reference.text}') names a function this Frame's manifest does ` +
+        "not declare. The call fails at run time, when a viewer triggers it.",
+      oldString: reference.text,
+      suggestion: describeDeclaredFunctions(declaredNames),
+    });
+  }
+
+  return warnings;
+}
+
+/**
+ * Declare the module so a declared function's name selects its input type.
+ *
+ * The input is typed through a conditional on the inferred name rather than by constraining the
+ * name to `keyof`, which matters in both directions: a name outside the map resolves the input to
+ * `any`, so an unknown or computed reference falls through untyped instead of cascading onto the
+ * input that the reference warning already covers — and, unlike an overload pair, there is no
+ * permissive signature for a mistyped input to fall back to, which would silently pass everything.
+ */
+async function buildDustReactHooksDeclaration(
+  contracts: readonly FrameFunctionContract[]
+): Promise<string> {
+  const declarations: string[] = [];
+  const entries: string[] = [];
+
+  for (const [index, contract] of contracts.entries()) {
+    const namespace = `FrameFunctionContract${index}`;
+    // The converter supports draft 7 but exposes a draft 4 input type.
+    const schema = contract.inputSchema as JSONSchema4;
+    const typeDeclaration = await compile(schema, "Input", {
+      // Function schemas only need internal references.
+      $refOptions: { resolve: { external: false, file: false, http: false } },
+      bannerComment: "",
+      enableConstEnums: false,
+      format: false,
+      ignoreMinAndMaxItems: true,
+      unknownAny: true,
+    });
+
+    declarations.push(`export namespace ${namespace} {\n${typeDeclaration}\n}`);
+    entries.push(`  ${JSON.stringify(contract.name)}: ${namespace}.Input;`);
+  }
+
+  // Results stay permissive: this pass checks what the Frame sends, not what it does with what
+  // comes back. Typing `data` would move diagnostics out of the call arguments, where nothing
+  // separates them from the Frame's own unchecked type errors.
+  return `${declarations.join("\n")}
+export interface FrameFunctionInputs {
+${entries.join("\n")}
+}
+
+export interface UsePodFunctionResult {
+  data: any;
+  error: Error | undefined;
+  isLoading: boolean;
+  isValidating: boolean;
+  mutate: (...args: any[]) => any;
+}
+
+export interface UsePodFunctionMutationResult<TInput> {
+  data: any;
+  error: Error | undefined;
+  isMutating: boolean;
+  reset: () => void;
+  trigger: (input: TInput) => Promise<any>;
+}
+
+export declare function ${QUERY_HOOK}<TFunction extends string | null>(
+  functionName: TFunction,
+  input: TFunction extends keyof FrameFunctionInputs
+    ? FrameFunctionInputs[TFunction]
+    : any
+): UsePodFunctionResult;
+
+export declare function ${MUTATION_HOOK}<TFunction extends string | null>(
+  functionName: TFunction
+): UsePodFunctionMutationResult<
+  TFunction extends keyof FrameFunctionInputs
+    ? FrameFunctionInputs[TFunction]
+    : any
+>;
+
+${PERMISSIVE_MODULE_EXPORTS.map((name) => `export declare const ${name}: any;`).join("\n")}
+`;
+}
+
+function resolveRelativeModule(
+  moduleName: string,
+  containingFile: string,
+  virtualSources: ReadonlyMap<string, string>
+): ts.ResolvedModuleFull | undefined {
+  const base = path.posix.normalize(
+    path.posix.join(path.posix.dirname(containingFile), moduleName)
+  );
+  const candidates = RESOLVE_EXTENSIONS.flatMap((extension) => [
+    `${base}${extension}`,
+    extension ? `${base}/index${extension}` : null,
+  ]).filter((candidate): candidate is string => candidate !== null);
+  const resolvedFileName = candidates.find((candidate) =>
+    virtualSources.has(candidate)
+  );
+  if (!resolvedFileName) {
+    return undefined;
+  }
+
+  return {
+    resolvedFileName,
+    extension: extensionForPath(resolvedFileName),
+    isExternalLibraryImport: false,
+  };
+}
+
+function createVirtualProgram(
+  virtualSources: ReadonlyMap<string, string>
+): ts.Program {
+  const compilerOptions: ts.CompilerOptions = {
+    allowJs: true,
+    checkJs: true,
+    jsx: ts.JsxEmit.Preserve,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    noEmit: true,
+    skipLibCheck: true,
+    strict: true,
+    target: ts.ScriptTarget.ES2020,
+    types: [],
+  };
+  const defaultHost = ts.createCompilerHost(compilerOptions);
+  const host: ts.CompilerHost = {
+    ...defaultHost,
+    fileExists: (fileName) =>
+      virtualSources.has(fileName) || defaultHost.fileExists(fileName),
+    getCurrentDirectory: () => VIRTUAL_FRAME_ROOT,
+    getSourceFile: (fileName, languageVersion) => {
+      const source = virtualSources.get(fileName);
+      return source === undefined
+        ? defaultHost.getSourceFile(fileName, languageVersion)
+        : ts.createSourceFile(
+            fileName,
+            source,
+            languageVersion,
+            true,
+            scriptKindForPath(fileName)
+          );
+    },
+    readFile: (fileName) =>
+      virtualSources.get(fileName) ?? defaultHost.readFile(fileName),
+    resolveModuleNames: (moduleNames, containingFile) =>
+      moduleNames.map((moduleName) => {
+        if (moduleName === DUST_REACT_HOOKS_MODULE) {
+          return {
+            resolvedFileName: VIRTUAL_DUST_REACT_HOOKS_PATH,
+            extension: ts.Extension.Dts,
+            isExternalLibraryImport: true,
+          };
+        }
+
+        return moduleName.startsWith(".")
+          ? resolveRelativeModule(moduleName, containingFile, virtualSources)
+          : undefined;
+      }),
+    writeFile: () => undefined,
+  };
+
+  return ts.createProgram({
+    rootNames: Array.from(virtualSources.keys()).filter(
+      (fileName) => fileName !== VIRTUAL_DUST_REACT_HOOKS_PATH
+    ),
+    options: compilerOptions,
+    host,
+  });
+}
+
+/** The argument carrying a function's input, or undefined for a call that passes none. */
+function getInputArgumentRange(
+  call: ts.CallExpression,
+  checker: ts.TypeChecker
+): { end: number; start: number } | undefined {
+  const declaration = checker.getResolvedSignature(call)?.declaration;
+  // A named declaration is one of the hooks; the unnamed function type is the mutation's
+  // `trigger`, whose only argument is the input.
+  const hook =
+    declaration && ts.isFunctionDeclaration(declaration) && declaration.name
+      ? declaration.name.text
+      : null;
+  if (hook === MUTATION_HOOK) {
+    return undefined;
+  }
+
+  const argument = hook === QUERY_HOOK ? call.arguments[1] : call.arguments[0];
+
+  return argument
+    ? { end: argument.getEnd(), start: argument.getStart() }
+    : undefined;
+}
+
+function formatDiagnostic(diagnostic: ts.Diagnostic): string {
+  const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
+  if (!diagnostic.file || diagnostic.start === undefined) {
+    return `error TS${diagnostic.code}: ${message}`;
+  }
+
+  const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(
+    diagnostic.start
+  );
+  const relativePath = path.posix.relative(
+    VIRTUAL_FRAME_ROOT,
+    diagnostic.file.fileName
+  );
+
+  return `${relativePath}:${line + 1}:${character + 1}: error TS${diagnostic.code}: ${message}`;
+}
+
+/**
+ * Type-check what the Frame passes to its own functions against the input schemas extracted from
+ * their published contracts.
+ *
+ * Contracts are authored in Zod but checked here through their extracted JSON Schema. Runtime-only
+ * refinements are not always expressible as TypeScript types, so an input can pass here and still
+ * fail the authoritative Zod validation when the function runs — which is why these are warnings.
+ */
+async function collectInputWarnings({
+  contracts,
+  sources,
+}: {
+  contracts: readonly FrameFunctionContract[];
+  sources: ReadonlyMap<string, string>;
+}): Promise<ValidationWarning[]> {
+  const virtualSources = new Map<string, string>();
+  for (const [relativePath, code] of sources) {
+    virtualSources.set(path.posix.join(VIRTUAL_FRAME_ROOT, relativePath), code);
+  }
+  virtualSources.set(
+    VIRTUAL_DUST_REACT_HOOKS_PATH,
+    await buildDustReactHooksDeclaration(contracts)
+  );
+
+  const program = createVirtualProgram(virtualSources);
+  const checker = program.getTypeChecker();
+  const inputRangesBySource = new Map<
+    ts.SourceFile,
+    { end: number; start: number }[]
+  >();
+
+  for (const sourceFile of program.getSourceFiles()) {
+    if (sourceFile.fileName === VIRTUAL_DUST_REACT_HOOKS_PATH) {
+      continue;
+    }
+
+    const visit = (node: ts.Node): void => {
+      if (ts.isCallExpression(node)) {
+        const signatures = checker
+          .getTypeAtLocation(node.expression)
+          .getCallSignatures();
+        // Reaches the hooks and the `trigger` they return, whatever the Frame named them.
+        const isFrameFunctionCall = signatures.some(
+          (signature) =>
+            signature.declaration?.getSourceFile().fileName ===
+            VIRTUAL_DUST_REACT_HOOKS_PATH
+        );
+        if (isFrameFunctionCall) {
+          const range = getInputArgumentRange(node, checker);
+          if (range) {
+            const ranges = inputRangesBySource.get(sourceFile) ?? [];
+            ranges.push(range);
+            inputRangesBySource.set(sourceFile, ranges);
+          }
+        }
+      }
+
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+  }
+
+  const warnings: ValidationWarning[] = [];
+  for (const diagnostic of program.getSemanticDiagnostics()) {
+    const { file, start } = diagnostic;
+    if (!file || start === undefined) {
+      continue;
+    }
+    const ranges = inputRangesBySource.get(file);
+    const withinInput = ranges?.some(
+      (range) => start >= range.start && start < range.end
+    );
+    if (!withinInput) {
+      continue;
+    }
+    if (
+      !INPUT_DIAGNOSTIC_CODES.has(diagnostic.code) &&
+      !CALL_DIAGNOSTIC_CODES.has(diagnostic.code)
+    ) {
+      continue;
+    }
+
+    warnings.push({
+      type: "frame_function",
+      message: `${formatDiagnostic(diagnostic)}`,
+      suggestion:
+        "Match the function's declared input, or update the function's `schema.input`.",
+    });
+  }
+
+  return warnings;
+}
+
+/**
+ * Statically check how a Frame's UI calls the Frame's own functions: that every literal reference
+ * names a declared function, and that the input it passes matches that function's contract. Both
+ * only surface at run time otherwise, when a viewer triggers the call.
+ *
+ * Warnings, never errors: the UI source is not type-checked anywhere else (esbuild strips types
+ * without checking them), so this pass reports on code that has never had to satisfy a compiler.
+ */
+/**
+ * @cc [owner:davidebbo,label:product;error-handling] frame-function-check-stays-advisory
+ * This pass MUST only ever produce warnings, and MUST NOT throw. It type-checks UI source that no
+ * other step compiles, against JSON Schema derived from Zod contracts whose runtime-only
+ * refinements TypeScript cannot express — so it is heuristic in both directions, and every finding
+ * is a lead rather than a verdict. Turning one into a `FramePublicationError`, or letting an
+ * exception escape, would block publishing a Frame that works.
+ */
+export async function collectFrameFunctionWarnings({
+  functions,
+  sourceFiles,
+}: {
+  functions: readonly FrameFunctionContract[];
+  sourceFiles: readonly Pick<
+    FramePublicationSourceFile,
+    "content" | "relativePath"
+  >[];
+}): Promise<ValidationWarning[]> {
+  const sources = new Map<string, string>();
+  for (const sourceFile of sourceFiles) {
+    if (isSourceFile(sourceFile.relativePath)) {
+      sources.set(sourceFile.relativePath, sourceFile.content.toString("utf8"));
+    }
+  }
+
+  const hookCalls = Array.from(sources).flatMap(([relativePath, code]) =>
+    collectHookCalls(parseSource(relativePath, code))
+  );
+  if (hookCalls.length === 0) {
+    return [];
+  }
+
+  const declaredNames = functions.map((fn) => fn.name);
+  const warnings = collectReferenceWarnings(hookCalls, declaredNames);
+
+  // Nothing to check inputs against, and a `keyof` over an empty map would reject every call.
+  if (functions.length > 0) {
+    try {
+      warnings.push(
+        ...(await collectInputWarnings({ contracts: functions, sources }))
+      );
+    } catch (error) {
+      // This pass is advisory. A schema the converter cannot express, or a compiler failure, must
+      // not stand between an author and a publish.
+      logger.warn(
+        { error: normalizeError(error).message },
+        "Frame function input validation failed; skipping input warnings."
+      );
+    }
+  }
+
+  if (warnings.length <= MAX_REPORTED_WARNINGS) {
+    return warnings;
+  }
+
+  return [
+    ...warnings.slice(0, MAX_REPORTED_WARNINGS),
+    {
+      type: "frame_function",
+      message: `${warnings.length - MAX_REPORTED_WARNINGS} more Frame function warning(s) not shown.`,
+    },
+  ];
+}

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -336,10 +336,14 @@ Before publishing a Frames v2 manifest, validate the current source snapshot:
 dsbx frame validate /files/<scope>/<frame-folder>/manifest.json
 \`\`\`
 
-This runs the manifest, UI, function-build, database-contract, and Tailwind checks without storing or
-activating a publication or reconciling Frame-owned databases. Fix every error and Tailwind warning
-before publishing. Use this command instead of \`bun build\` or an ad hoc regex scan: those do not use
-the Frame build context and report unrelated or noisy failures.
+This runs the manifest, UI, function-build, database-contract, Tailwind, and function-call checks
+without storing or activating a publication or reconciling Frame-owned databases. The function-call
+check reports UI code that calls a function this manifest does not declare, or that passes an input
+the function's \`schema.input\` rejects — both of which otherwise fail only once a viewer triggers
+the call. Fix every error and every warning before publishing.
+
+Use this command instead of \`bun build\` or an ad hoc regex scan: those do not use the Frame build
+context and report unrelated or noisy failures.
 
 There is no separate v2 function publish. Once validation is clean, publish the manifest once; the
 UI source, all declared functions, and all declared database schemas are built or reconciled,

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -338,9 +338,14 @@ dsbx frame validate /files/<scope>/<frame-folder>/manifest.json
 
 This runs the manifest, UI, function-build, database-contract, Tailwind, and function-call checks
 without storing or activating a publication or reconciling Frame-owned databases. The function-call
-check reports UI code that calls a function this manifest does not declare, or that passes an input
-the function's \`schema.input\` rejects — both of which otherwise fail only once a viewer triggers
-the call. Fix every error and every warning before publishing.
+check covers UI code that calls a function this manifest does not declare, which is an error and
+also blocks \`publish\`, and UI code that passes an input the function's \`schema.input\` rejects,
+which is a warning. Both otherwise fail only once a viewer triggers the call. Fix every error and
+every warning before publishing.
+
+A function name passed to \`usePodFunction\` or \`usePodFunctionMutation\` as a literal must be a
+bare name declared in this manifest: publishing fails otherwise, listing the declared names. A name
+computed at run time is not checked.
 
 Use this command instead of \`bun build\` or an ad hoc regex scan: those do not use the Frame build
 context and report unrelated or noisy failures.

--- a/front/lib/resources/skill/code_defined/global/frames_v2.ts
+++ b/front/lib/resources/skill/code_defined/global/frames_v2.ts
@@ -336,16 +336,14 @@ Before publishing a Frames v2 manifest, validate the current source snapshot:
 dsbx frame validate /files/<scope>/<frame-folder>/manifest.json
 \`\`\`
 
-This runs the manifest, UI, function-build, database-contract, Tailwind, and function-call checks
-without storing or activating a publication or reconciling Frame-owned databases. The function-call
-check covers UI code that calls a function this manifest does not declare, which is an error and
-also blocks \`publish\`, and UI code that passes an input the function's \`schema.input\` rejects,
-which is a warning. Both otherwise fail only once a viewer triggers the call. Fix every error and
-every warning before publishing.
+This runs the manifest, UI, function-build, database-contract, Tailwind, and function-reference
+checks without storing or activating a publication or reconciling Frame-owned databases. Fix every
+error and Tailwind warning before publishing.
 
 A function name passed to \`usePodFunction\` or \`usePodFunctionMutation\` as a literal must be a
-bare name declared in this manifest: publishing fails otherwise, listing the declared names. A name
-computed at run time is not checked.
+bare name declared in this manifest; otherwise validation and \`publish\` fail, listing the declared
+names, where the call would otherwise fail only once a viewer triggers it. A name computed at run
+time is not checked.
 
 Use this command instead of \`bun build\` or an ad hoc regex scan: those do not use the Frame build
 context and report unrelated or noisy failures.

--- a/front/package.json
+++ b/front/package.json
@@ -166,7 +166,6 @@
     "jose": "^6.2.10",
     "jsdom": "^26.0.0",
     "jsforce": "^3.8.2",
-    "json-schema-to-typescript": "^15.0.4",
     "jsonwebtoken": "^9.0.0",
     "jwks-rsa": "^3.1.0",
     "libphonenumber-js": "^1.12.33",

--- a/package-lock.json
+++ b/package-lock.json
@@ -426,7 +426,6 @@
         "jose": "^6.2.10",
         "jsdom": "^26.0.0",
         "jsforce": "^3.8.2",
-        "json-schema-to-typescript": "^15.0.4",
         "jsonwebtoken": "^9.0.0",
         "jwks-rsa": "^3.1.0",
         "libphonenumber-js": "^1.12.33",
@@ -19902,6 +19901,7 @@
       "version": "4.17.24",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
       "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/long": {
@@ -33269,6 +33269,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -33310,6 +33311,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -34240,46 +34242,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/json-schema-to-typescript": {
-      "version": "15.0.4",
-      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-15.0.4.tgz",
-      "integrity": "sha512-Su9oK8DR4xCmDsLlyvadkXzX6+GGXJpbhwoLtOGArAG61dvbW4YQmSEno2y66ahpIdmLMg6YUf/QHLgiwvkrHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^11.5.5",
-        "@types/json-schema": "^7.0.15",
-        "@types/lodash": "^4.17.7",
-        "is-glob": "^4.0.3",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "minimist": "^1.2.8",
-        "prettier": "^3.2.5",
-        "tinyglobby": "^0.2.9"
-      },
-      "bin": {
-        "json2ts": "dist/src/cli.js"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/json-schema-to-typescript/node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "11.9.3",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
-      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.15",
-        "js-yaml": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/philsturgeon"
       }
     },
     "node_modules/json-schema-traverse": {


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/10366

The Frames v2 equivalent of the publish-time check that `validate_frame_pod_functions.ts` used to do for Pod functions, but this was lost in the transition. This brings it back for Frames v2.

Tested by adding a bad `usePodFunction("list-todos-bad", {})` and calling validate, which got:

```json
{
  "timestamp": "2026-09-11T08:12:12.908360Z",
  "level": "ERROR",
  "fields": {
    "message": "dsbx command failed",
    "error": "POST https://localhost/api/v1/w/BHWrN3HaUa/sandbox/frames/validate: API error 400 (invalid_request): Frame UI calls a function that is not declared in its manifest:\nindex.tsx:21:32: usePodFunction('list-todos-bad')\nDeclared functions: 'list-todos', 'add-todo', 'toggle-todo'."
  },
  "target": "dsbx"
}
```