### PR TITLE
Fix "Ask agent to fix" in Frames v2

### DIFF
--- a/front/lib/api/frames/build_and_publish.ts
+++ b/front/lib/api/frames/build_and_publish.ts
@@ -230,11 +230,13 @@ export async function buildAndPublishFramePublication(
     frame,
     manifest,
     sourceFiles,
+    publishedByAgentConfigurationId,
   }: {
     conversation: ConversationWithoutContentType;
     frame: FileResource;
     manifest: FrameManifest;
     sourceFiles: FramePublicationSourceFile[];
+    publishedByAgentConfigurationId?: string;
   }
 ): Promise<
   Result<
@@ -257,5 +259,6 @@ export async function buildAndPublishFramePublication(
     manifest,
     sourceFiles,
     uiBundleCode: buildResult.value.uiBundleCode,
+    publishedByAgentConfigurationId,
   });
 }

--- a/front/lib/api/frames/publication_storage.ts
+++ b/front/lib/api/frames/publication_storage.ts
@@ -528,9 +528,11 @@ export async function activateFramePublication(
   {
     frame,
     publicationId,
+    publishedByAgentConfigurationId,
   }: {
     frame: FileResource;
     publicationId: string;
+    publishedByAgentConfigurationId?: string;
   }
 ): Promise<Result<void, FramePublicationError>> {
   const descriptor = await loadFramePublicationDescriptor(auth, {
@@ -601,6 +603,7 @@ export async function activateFramePublication(
         publicationId,
         name: descriptor.value.manifest.name,
         description: descriptor.value.manifest.description,
+        publishedByAgentConfigurationId,
       },
       transaction
     );
@@ -651,12 +654,14 @@ export async function publishFramePublication(
     manifest,
     sourceFiles,
     uiBundleCode,
+    publishedByAgentConfigurationId,
   }: {
     frame: FileResource;
     functionArtifacts: FramePublicationFunctionArtifact[];
     manifest: FrameManifest;
     sourceFiles: FramePublicationSourceFile[];
     uiBundleCode: string;
+    publishedByAgentConfigurationId?: string;
   }
 ): Promise<
   Result<
@@ -691,6 +696,7 @@ export async function publishFramePublication(
     const activation = await activateFramePublication(auth, {
       frame,
       publicationId: storedPublication.value.publicationId,
+      publishedByAgentConfigurationId,
     });
     if (activation.isErr()) {
       return activation;

--- a/front/lib/api/frames/publish_from_source.ts
+++ b/front/lib/api/frames/publish_from_source.ts
@@ -157,6 +157,7 @@ export async function publishFrameFromSource(
       conversation,
       frame,
       manifestPath: normalizedPath,
+      publishedByAgentConfigurationId,
     });
     if (publication.isErr()) {
       return new Err(publication.error);
@@ -431,10 +432,12 @@ async function publishFrameV2FromSourceWithSourceLockHeld(
     conversation,
     frame,
     manifestPath,
+    publishedByAgentConfigurationId,
   }: {
     conversation: ConversationWithoutContentType;
     frame: FileResource;
     manifestPath: string;
+    publishedByAgentConfigurationId?: string;
   }
 ): Promise<
   Result<
@@ -454,6 +457,7 @@ async function publishFrameV2FromSourceWithSourceLockHeld(
     conversation,
     frame,
     ...source.value,
+    publishedByAgentConfigurationId,
   });
 }
 
@@ -463,10 +467,12 @@ export async function publishFrameV2FromSource(
     conversation,
     frame,
     manifestPath,
+    publishedByAgentConfigurationId,
   }: {
     conversation: ConversationWithoutContentType;
     frame: FileResource;
     manifestPath: string;
+    publishedByAgentConfigurationId?: string;
   }
 ): Promise<
   Result<
@@ -494,6 +500,7 @@ export async function publishFrameV2FromSource(
       conversation,
       frame: freshFrame,
       manifestPath,
+      publishedByAgentConfigurationId,
     });
   });
   if (publication.isErr()) {

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -1062,12 +1062,25 @@ export class FileResource extends BaseResource<FileModel> {
     });
   }
 
+  /**
+   * @cc [owner:davidebbo,label:product;backend] frame-publication-records-agent
+   * When `publishedByAgentConfigurationId` is given, `useCaseMetadata.lastEditedByAgentConfigurationId`
+   * MUST be set to it. The conversation UI reads this field to enable "Ask agent to fix" on a
+   * Frame runtime error; if a publication path omits it, the retry affordance stays silently
+   * unavailable for every publication of that Frame, not just the failing one.
+   */
   async setActiveFramePublication(
     {
       publicationId,
       name,
       description,
-    }: { publicationId: string; name: string; description: string },
+      publishedByAgentConfigurationId,
+    }: {
+      publicationId: string;
+      name: string;
+      description: string;
+      publishedByAgentConfigurationId?: string;
+    },
     transaction?: Transaction
   ) {
     return this.update(
@@ -1077,6 +1090,12 @@ export class FileResource extends BaseResource<FileModel> {
           activePublicationId: publicationId,
           frameName: name,
           frameDescription: description,
+          ...(publishedByAgentConfigurationId
+            ? {
+                lastEditedByAgentConfigurationId:
+                  publishedByAgentConfigurationId,
+              }
+            : {}),
         },
       },
       transaction


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/10386

## Summary

It was broken because we were not setting`lastEditedByAgentConfigurationId` in the `useCaseMetadata` field for v2 frames. And this is what `useVisualizationRetry` looks for to trigger this UI.