### PR TITLE
[Agents] Default agent queries to alphabetical ordering

### DIFF
--- a/front/lib/api/assistant/configuration/views.test.ts
+++ b/front/lib/api/assistant/configuration/views.test.ts
@@ -1,6 +1,7 @@
 import { archiveAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import logger from "@app/logger/logger";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -32,6 +33,56 @@ async function listAgentIdsForAnalytics(auth: Authenticator) {
 }
 
 const REPORTING_ROLES = ["admin", "manager"] as const;
+
+describe("getAgentConfigurationsForView, limited results", () => {
+  it.each([
+    undefined,
+    "updatedAt",
+  ] as const)("uses configuration IDs to break ties with sort=%s", async (sort) => {
+    const { workspace, authenticator } = await createResourceTest({});
+    const first = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Ordering C" }
+    );
+    const second = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Ordering B" }
+    );
+    const third = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Ordering A" }
+    );
+    // Tie timestamps, then move the first row by updating it without creating a new version.
+    await AgentConfigurationModel.update(
+      {
+        description: "Ordering fixture",
+        updatedAt: new Date("2026-09-01T00:00:00Z"),
+      },
+      {
+        where: {
+          workspaceId: workspace.id,
+          id: [first.id, second.id, third.id],
+        },
+        silent: true,
+      }
+    );
+    await AgentConfigurationModel.update(
+      { description: "Edited description" },
+      { where: { workspaceId: workspace.id, id: first.id }, silent: true }
+    );
+
+    const agents = await getAgentConfigurationsForView({
+      auth: authenticator,
+      agentsGetView: "list",
+      variant: "light",
+      agentPrefix: "Ordering",
+      limit: 2,
+      sort,
+    });
+
+    expect(agents.map((agent) => agent.sId)).toEqual([first.sId, second.sId]);
+  });
+});
 
 describe("getAgentConfigurationsForView, 'analytics' view", () => {
   it.each(

--- a/front/lib/api/assistant/configuration/views.test.ts
+++ b/front/lib/api/assistant/configuration/views.test.ts
@@ -1,7 +1,6 @@
 import { archiveAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { Authenticator } from "@app/lib/auth";
-import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import logger from "@app/logger/logger";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -34,41 +33,23 @@ async function listAgentIdsForAnalytics(auth: Authenticator) {
 
 const REPORTING_ROLES = ["admin", "manager"] as const;
 
-describe("getAgentConfigurationsForView, limited results", () => {
+describe("getAgentConfigurationsForView, default ordering", () => {
   it.each([
     undefined,
-    "updatedAt",
-  ] as const)("uses configuration IDs to break ties with sort=%s", async (sort) => {
-    const { workspace, authenticator } = await createResourceTest({});
-    const first = await AgentConfigurationFactory.createTestAgent(
+    2,
+  ])("defaults to alphabetical ordering with limit=%s", async (limit) => {
+    const { authenticator } = await createResourceTest({});
+    const agentC = await AgentConfigurationFactory.createTestAgent(
       authenticator,
       { name: "Ordering C" }
     );
-    const second = await AgentConfigurationFactory.createTestAgent(
+    const agentB = await AgentConfigurationFactory.createTestAgent(
       authenticator,
       { name: "Ordering B" }
     );
-    const third = await AgentConfigurationFactory.createTestAgent(
+    const agentA = await AgentConfigurationFactory.createTestAgent(
       authenticator,
       { name: "Ordering A" }
-    );
-    // Tie timestamps, then move the first row by updating it without creating a new version.
-    await AgentConfigurationModel.update(
-      {
-        description: "Ordering fixture",
-        updatedAt: new Date("2026-09-01T00:00:00Z"),
-      },
-      {
-        where: {
-          workspaceId: workspace.id,
-          id: [first.id, second.id, third.id],
-        },
-        silent: true,
-      }
-    );
-    await AgentConfigurationModel.update(
-      { description: "Edited description" },
-      { where: { workspaceId: workspace.id, id: first.id }, silent: true }
     );
 
     const agents = await getAgentConfigurationsForView({
@@ -76,11 +57,12 @@ describe("getAgentConfigurationsForView, limited results", () => {
       agentsGetView: "list",
       variant: "light",
       agentPrefix: "Ordering",
-      limit: 2,
-      sort,
+      limit,
     });
 
-    expect(agents.map((agent) => agent.sId)).toEqual([first.sId, second.sId]);
+    expect(agents.map((agent) => agent.sId)).toEqual(
+      [agentA.sId, agentB.sId, agentC.sId].slice(0, limit)
+    );
   });
 });
 

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -25,7 +25,6 @@ import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { WorkspaceType } from "@app/types/user";
-import type { Order } from "sequelize";
 import { Op, Sequelize } from "sequelize";
 
 const HEAVY_AGENT_CONFIGURATION_ATTRIBUTES = [
@@ -51,7 +50,7 @@ function editorWhere(filter: EditorFilter) {
   }
 }
 
-const sortStrategies = {
+const sortStrategies: Record<SortStrategyType, SortStrategy> = {
   alphabetical: {
     dbOrder: [["name", "ASC"]],
     compareFunction: (a: AgentConfigurationType, b: AgentConfigurationType) =>
@@ -65,7 +64,7 @@ const sortStrategies = {
     dbOrder: [["updatedAt", "DESC"]],
     compareFunction: () => 0,
   },
-} satisfies Record<SortStrategyType, SortStrategy>;
+};
 
 function makeApplySortAndLimit(sort?: SortStrategyType, limit?: number) {
   return (results: AgentConfigurationType[]) => {
@@ -153,8 +152,8 @@ async function fetchGlobalAgentConfigurationForView(
 }
 
 /**
- * @cc [owner:philipperolet,label:backend] deterministic-limited-agent-queries
- * Queries with a limit MUST order by the requested sort, if any, then by configuration ID.
+ * @cc [owner:philipperolet,label:backend] default-agent-query-order
+ * Active-agent queries MUST default to name order when no sort is requested.
  */
 async function fetchWorkspaceAgentConfigurationsWithoutActions(
   auth: Authenticator,
@@ -176,7 +175,9 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
     omitHeavyAttributes?: boolean;
   }
 ): Promise<AgentConfigurationModel[]> {
-  const sortStrategy = sort && sortStrategies[sort];
+  // Active names are unique per workspace; their (workspaceId, name) index can supply this
+  // default order without a separate sort or an ID tie-breaker.
+  const sortStrategy = sortStrategies[sort ?? "alphabetical"];
 
   const baseWhereConditions = {
     workspaceId: owner.id,
@@ -192,13 +193,9 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
       ? { attributes: { exclude: [...new Set(attributesToExclude)] } }
       : {};
 
-  const order: Order | undefined =
-    limit === undefined
-      ? sortStrategy?.dbOrder
-      : [...(sortStrategy?.dbOrder ?? []), ["id", "ASC"]];
   const baseAgentsSequelizeQuery = {
     limit,
-    order,
+    order: sortStrategy.dbOrder,
     ...excludeAttributesFromSelect,
   };
 

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -25,6 +25,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { WorkspaceType } from "@app/types/user";
+import type { Order } from "sequelize";
 import { Op, Sequelize } from "sequelize";
 
 const HEAVY_AGENT_CONFIGURATION_ATTRIBUTES = [
@@ -50,7 +51,7 @@ function editorWhere(filter: EditorFilter) {
   }
 }
 
-const sortStrategies: Record<SortStrategyType, SortStrategy> = {
+const sortStrategies = {
   alphabetical: {
     dbOrder: [["name", "ASC"]],
     compareFunction: (a: AgentConfigurationType, b: AgentConfigurationType) =>
@@ -64,7 +65,7 @@ const sortStrategies: Record<SortStrategyType, SortStrategy> = {
     dbOrder: [["updatedAt", "DESC"]],
     compareFunction: () => 0,
   },
-};
+} satisfies Record<SortStrategyType, SortStrategy>;
 
 function makeApplySortAndLimit(sort?: SortStrategyType, limit?: number) {
   return (results: AgentConfigurationType[]) => {
@@ -151,6 +152,10 @@ async function fetchGlobalAgentConfigurationForView(
   return matchingGlobalAgents.filter((a) => a.status === "active");
 }
 
+/**
+ * @cc [owner:philipperolet,label:backend] deterministic-limited-agent-queries
+ * Queries with a limit MUST order by the requested sort, if any, then by configuration ID.
+ */
 async function fetchWorkspaceAgentConfigurationsWithoutActions(
   auth: Authenticator,
   {
@@ -187,9 +192,14 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
       ? { attributes: { exclude: [...new Set(attributesToExclude)] } }
       : {};
 
+  // A unique order keeps legacy and grant queries on the same page despite different query plans.
+  const order: Order | undefined =
+    limit === undefined
+      ? sortStrategy?.dbOrder
+      : [...(sortStrategy?.dbOrder ?? []), ["id", "ASC"]];
   const baseAgentsSequelizeQuery = {
     limit,
-    order: sortStrategy?.dbOrder,
+    order,
     ...excludeAttributesFromSelect,
   };
 

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -192,7 +192,6 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
       ? { attributes: { exclude: [...new Set(attributesToExclude)] } }
       : {};
 
-  // A unique order keeps legacy and grant queries on the same page despite different query plans.
   const order: Order | undefined =
     limit === undefined
       ? sortStrategy?.dbOrder


### PR DESCRIPTION
## Description

Give active-agent queries a stable alphabetical order when no sort is requested. We noticed this missing default while comparing the old and new permission checks, so this PR adds it using the existing name index.

## Risks

Blast radius: Active-agent lists without an explicit sort in the API and agent tools.
Risk: low

## Deploy Plan

- Deploy front-api and front workers. No migration.

## Tests

- [x] Agent views, agent configuration, and Sidekick context tests (116 tests).
- [x] Default alphabetical ordering with and without a limit.
