### PR TITLE
Fix Frames v2 export

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -9195,7 +9195,7 @@
     "/api/w/{wId}/files/{fileId}": {
       "get": {
         "summary": "Get or download a file",
-        "description": "View or download a file. Skill attachments require read access to their associated skill. Use query parameters `version` (original, processed, public) and `action` (view, download).",
+        "description": "View or download a file. Skill attachments require read access to their associated skill. Use query parameters `version` (original, processed, public) and `action` (view, download). Downloading a Frames v2 file redirects to its source folder as a ZIP archive.",
         "tags": [
           "Private Files"
         ],
@@ -9264,7 +9264,7 @@
             }
           },
           "302": {
-            "description": "Redirect to signed download URL"
+            "description": "Redirect to a signed download URL, or to the source folder ZIP archive for a Frames v2 file"
           },
           "404": {
             "description": "File not found"

--- a/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
@@ -8,8 +8,10 @@ import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_ap
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { FRAME_MANIFEST_FILE } from "@app/types/api/frame_manifest";
 import { getFramePublicationUiBundlePath } from "@app/types/api/frame_storage";
 import { frameContentType, frameV2ContentType } from "@app/types/files";
+import { getConversationFilesBasePath } from "@app/types/mount_path";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -251,6 +253,105 @@ describe("GET /api/w/:wId/files/:fileId", () => {
       error: {
         type: "file_not_found",
         message: "Published Frame not found.",
+      },
+    });
+  });
+
+  it("redirects a Frames v2 download to its source folder archive", async () => {
+    const { auth, user, workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [new Date()],
+    });
+    const frame = await FileFactory.create(auth, user, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: 128,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+      mountFilePath: `${getConversationFilesBasePath({
+        workspaceId: workspace.sId,
+        conversationId: conversation.sId,
+      })}My Frame/${FRAME_MANIFEST_FILE}`,
+    });
+
+    const response = await honoApp.request(
+      fileUrl(workspace, frame.sId, "?action=download"),
+      { redirect: "manual" }
+    );
+
+    expect(response.status).toBe(302);
+    const location = response.headers.get("location");
+    expect(location).toBe(
+      `/api/w/${workspace.sId}/files/path/conversation-${conversation.sId}/My%20Frame?archive=zip`
+    );
+
+    // The redirect target must actually serve the Frame sources.
+    const sourcePrefix = `${getConversationFilesBasePath({
+      workspaceId: workspace.sId,
+      conversationId: conversation.sId,
+    })}My Frame/`;
+    const entryPointPath = `${sourcePrefix}index.tsx`;
+    fileStorageMock.setFilesByPrefix((prefix) =>
+      prefix === sourcePrefix
+        ? [
+            {
+              name: entryPointPath,
+              metadata: { contentType: "text/plain", size: "7" },
+            },
+          ]
+        : null
+    );
+    fileStorageMock.setFileExists((path) => path === entryPointPath);
+    fileStorageMock.setFileContent((path) =>
+      path === entryPointPath ? "export;" : null
+    );
+
+    const archiveResponse = await honoApp.request(location ?? "");
+
+    expect(archiveResponse.status).toBe(200);
+    expect(archiveResponse.headers.get("content-type")).toBe("application/zip");
+    expect(archiveResponse.headers.get("content-disposition")).toContain(
+      'filename="My Frame.zip"'
+    );
+  });
+
+  it("returns 404 when a Frames v2 file has no source folder of its own", async () => {
+    const { auth, user, workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [new Date()],
+    });
+    const frame = await FileFactory.create(auth, user, {
+      contentType: frameV2ContentType,
+      fileName: FRAME_MANIFEST_FILE,
+      fileSize: 128,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+      mountFilePath: `${getConversationFilesBasePath({
+        workspaceId: workspace.sId,
+        conversationId: conversation.sId,
+      })}${FRAME_MANIFEST_FILE}`,
+    });
+
+    const response = await honoApp.request(
+      fileUrl(workspace, frame.sId, "?action=download"),
+      { redirect: "manual" }
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "file_not_found",
+        message: "Frame source folder not found.",
       },
     });
   });

--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -72,7 +72,7 @@ const app = createHono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
  * /api/w/{wId}/files/{fileId}:
  *   get:
  *     summary: Get or download a file
- *     description: View or download a file. Skill attachments require read access to their associated skill. Use query parameters `version` (original, processed, public) and `action` (view, download).
+ *     description: View or download a file. Skill attachments require read access to their associated skill. Use query parameters `version` (original, processed, public) and `action` (view, download). Downloading a Frames v2 file redirects to its source folder as a ZIP archive.
  *     tags:
  *       - Private Files
  *     parameters:
@@ -113,7 +113,7 @@ const app = createHono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
  *               type: string
  *               format: binary
  *       302:
- *         description: Redirect to signed download URL
+ *         description: Redirect to a signed download URL, or to the source folder ZIP archive for a Frames v2 file
  *       404:
  *         description: File not found
  *   post:
@@ -254,6 +254,10 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
       status: 200,
       headers: { "Content-Type": file.contentType },
     });
+  }
+
+  if (file.isFrameV2) {
+    return redirectToFrameSourceArchive(ctx, file);
   }
 
   // Redirect to a signed URL.
@@ -465,6 +469,40 @@ app.route("/rename", rename);
 app.route("/save-in-project", saveInProject);
 app.route("/share", shareApp);
 app.route("/signed-url", signedUrl);
+
+/**
+ * @cc [owner:davidebbo,label:product] frame-v2-downloads-its-sources
+ * Downloading a Frames v2 file must serve its whole source folder as a ZIP archive, never a
+ * canonical stored object: a Frame registered from its mount path has none. It must fail with a
+ * 404 when the Frame has no source folder.
+ */
+function redirectToFrameSourceArchive(
+  ctx: Context<WorkspaceAwareCtx & { Bindings: HttpBindings }>,
+  file: FileResource
+) {
+  const auth = ctx.get("auth");
+  const sourceDirectory = file.getFrameV2SourceDirectoryPath(auth);
+  if (!sourceDirectory) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "file_not_found",
+        message: "Frame source folder not found.",
+      },
+    });
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+  const encodedPath = sourceDirectory
+    .split("/")
+    .map(encodeURIComponent)
+    .join("/");
+
+  // The Location is relative on purpose, for the reasons `redirectToSse` documents.
+  return ctx.redirect(
+    `/api/w/${owner.sId}/files/path/${encodedPath}?archive=zip`
+  );
+}
 
 async function canWriteSkillFile(
   auth: Authenticator,

--- a/front/components/assistant/conversation/interactive_content/ExportContentDropdown.tsx
+++ b/front/components/assistant/conversation/interactive_content/ExportContentDropdown.tsx
@@ -1,6 +1,7 @@
 import config from "@app/lib/api/config";
 import { useExportFrameAsPdf } from "@app/lib/swr/frames";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
+import { isFrameV2ContentType } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import { datadogLogs } from "@datadog/browser-logs";
 import {
@@ -23,6 +24,7 @@ interface ExportContentDropdownProps {
   fileId: string;
   fileContent: string | null;
   fileName?: string;
+  contentType?: string;
 }
 
 export function ExportContentDropdown({
@@ -31,6 +33,7 @@ export function ExportContentDropdown({
   fileId,
   fileContent,
   fileName,
+  contentType,
 }: ExportContentDropdownProps) {
   const isMobile = useIsMobile();
   const exportAsPdf = useExportFrameAsPdf({ owner });
@@ -64,6 +67,13 @@ export function ExportContentDropdown({
     setIsExportingPdf(false);
   };
 
+  // A Frames v2 package downloads as a ZIP of its whole source folder, a legacy Frame as its
+  // single code file.
+  const codeDownloadLabel =
+    contentType && isFrameV2ContentType(contentType)
+      ? "Source (.zip)"
+      : "Template";
+
   const handleDownloadAsCode = () => {
     const downloadUrl = `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=download`;
     window.open(downloadUrl, "_blank");
@@ -95,7 +105,7 @@ export function ExportContentDropdown({
         </DropdownMenuSub>
         <DropdownMenuItem onClick={handleExportAsPng}>PNG</DropdownMenuItem>
         <DropdownMenuItem onClick={handleDownloadAsCode}>
-          Template
+          {codeDownloadLabel}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -379,6 +379,7 @@ export function FrameRenderer({
                 fileId={fileId}
                 fileContent={fileContent ?? null}
                 fileName={fileMetadata?.fileName}
+                contentType={fileMetadata?.contentType}
               />
               <ShareFrameSheet
                 key={contentHash ?? fileId}
@@ -443,6 +444,7 @@ export function FrameRenderer({
               fileId={fileId}
               fileContent={fileContent ?? null}
               fileName={fileMetadata?.fileName}
+              contentType={fileMetadata?.contentType}
             />
             <ShareFrameSheet
               key={contentHash ?? fileId}

--- a/front/components/pod/files/PodFrameSheet.tsx
+++ b/front/components/pod/files/PodFrameSheet.tsx
@@ -107,6 +107,7 @@ export function PodFrameSheet({
                   fileId={fileId}
                   fileContent={fileContent ?? null}
                   fileName={fileMetadata?.fileName}
+                  contentType={fileMetadata?.contentType}
                 />
                 <ShareFrameSheet fileId={fileId} owner={owner} />
                 <PinPodBannerButton

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -810,6 +810,28 @@ export class FileResource extends BaseResource<FileModel> {
     }
   }
 
+  /**
+   * @cc [owner:davidebbo,label:product] frame-source-directory-is-a-folder
+   * Returns the scoped path of the folder holding this Frames v2 package's sources, and null
+   * unless this file is a `manifest.json` mounted in a folder under a mount root. A manifest
+   * sitting directly at a mount root has no source folder of its own and must return null.
+   */
+  getFrameV2SourceDirectoryPath(auth: Authenticator): string | null {
+    const manifestPath = this.toScopedPath(auth);
+    if (
+      !manifestPath ||
+      path.posix.basename(manifestPath) !== FRAME_MANIFEST_FILE
+    ) {
+      return null;
+    }
+
+    const sourceDirectory = DustFileSystem.normalizeScopedPath(
+      path.posix.dirname(manifestPath)
+    );
+
+    return sourceDirectory?.includes("/") ? sourceDirectory : null;
+  }
+
   private async deleteFrameV2(
     auth: Authenticator
   ): Promise<Result<undefined, Error>> {
@@ -824,14 +846,8 @@ export class FileResource extends BaseResource<FileModel> {
     if (!manifestPath) {
       return new Err(new Error("Frame source path not found."));
     }
-    const sourceDirectory = DustFileSystem.normalizeScopedPath(
-      path.posix.dirname(manifestPath)
-    );
-    if (
-      !sourceDirectory ||
-      !sourceDirectory.includes("/") ||
-      path.posix.basename(manifestPath) !== FRAME_MANIFEST_FILE
-    ) {
+    const sourceDirectory = this.getFrameV2SourceDirectoryPath(auth);
+    if (!sourceDirectory) {
       return new Err(
         new Error("Frame deletion requires its source folder under /files.")
       );


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/10344

Choosing Export → Template on a Frames v2 Frame showed a raw GCS error page:

```
<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message>
<Details>No such object: dust-private-uploads/files/w/{wId}/{fileId}/original</Details></Error>
```

Fixed to download the zip. Also, relabelled it from Template to "Source (zip)".