### PR TITLE
[front] fix link option in toolbar

### DIFF
--- a/front/components/editor/EditorSelectionToolbar.tsx
+++ b/front/components/editor/EditorSelectionToolbar.tsx
@@ -94,21 +94,19 @@ export function EditorSelectionToolbar({
     return () => cancelAnimationFrame(frame);
   }, [position]);
 
-  if (!position) {
-    return null;
-  }
-
+  // if there is no position we hide it but keep the component mounted
   return createPortal(
     <div
       className={cn(
         "fixed -translate-x-1/2 -translate-y-full",
         "origin-bottom transition-[opacity,scale] duration-100 ease-out-quart",
         "motion-reduce:transition-none",
-        hasEntered ? "scale-100 opacity-100" : "scale-[0.98] opacity-0"
+        hasEntered ? "scale-100 opacity-100" : "scale-[0.98] opacity-0",
+        !position && "invisible"
       )}
       style={{
-        top: position.top,
-        left: position.left,
+        top: position?.top ?? 0,
+        left: position?.left ?? 0,
         zIndex: TOOLBAR_Z_INDEX,
       }}
       onMouseDown={(event) => event.preventDefault()}


### PR DESCRIPTION
## Description
The link dialog option is broken since https://github.com/dust-tt/dust/pull/31263, we replaced the bubble menu from tiptap's one to our custom solution. When there is no position (focus is not inside the editor), we don't mount the component so we couldn't open the link dialog. The solution is instead of unmounting the component, we keep it invisible. 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://app.notion.com/p/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
