### PR TITLE
Tag the LLM latency metrics with the served service tier

### DIFF
--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -15,6 +15,7 @@ import {
   emitLLMTimeToFirstTokenMs,
   llmAttemptLogFields,
   requestedReasoningEffortTag,
+  serviceTierTags,
 } from "@app/lib/api/llm/telemetry";
 import type { LLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import {
@@ -48,6 +49,7 @@ import { USAGE_TYPE_FREE } from "@app/lib/metronome/constants";
 import { getUsageType } from "@app/lib/metronome/events";
 import type { UsageType } from "@app/lib/metronome/types";
 import type { Host } from "@app/lib/model_constructors/types/hosts";
+import type { ServiceTier } from "@app/lib/model_constructors/types/input/configuration";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { statsDMetrics } from "@app/lib/utils/statsd";
@@ -85,6 +87,7 @@ export abstract class LLM<
   protected bypassFeatureFlag: boolean;
   protected metadata: LLMClientMetadata;
   protected host: Host;
+  private serviceTier: ServiceTier | undefined;
   // Temporary during the router migration; "new" is set by BaseTransition.
   protected readonly router: "legacy" | "new" = "legacy";
 
@@ -184,6 +187,7 @@ export abstract class LLM<
     return [
       ...this.getTelemetryTags({ surface }),
       requestedReasoningEffortTag(this.reasoningEffort),
+      ...serviceTierTags(this.serviceTier),
     ];
   }
 
@@ -327,6 +331,7 @@ export abstract class LLM<
     let currentEvent: LLMEvent | null = null;
     let timeToFirstEventMs: number | undefined;
     let timeToFirstTokenMs: number | undefined;
+    this.serviceTier = undefined;
 
     try {
       for await (const event of this.completeStream(
@@ -352,11 +357,10 @@ export abstract class LLM<
         // Providers report usage exactly once per response, at end of stream. Emitting here in
         // the base class covers both the new router and the legacy clients.
         if (currentEvent.type === "token_usage") {
+          this.serviceTier = currentEvent.content.serviceTier;
           emitTokenUsageMetrics(currentEvent.content, [
             ...metricTags,
-            ...(currentEvent.content.serviceTier
-              ? [`service_tier:${currentEvent.content.serviceTier}`]
-              : []),
+            ...serviceTierTags(this.serviceTier),
           ]);
         }
 
@@ -386,6 +390,7 @@ export abstract class LLM<
           timeToFirstEventMs,
           timeToFirstTokenMs,
           requestedReasoningEffort: this.reasoningEffort,
+          serviceTier: this.serviceTier,
           surface: "stream",
         });
 

--- a/front/lib/api/llm/run_lifecycle.test.ts
+++ b/front/lib/api/llm/run_lifecycle.test.ts
@@ -603,6 +603,9 @@ describe("LLM stream telemetry", () => {
         "requested_reasoning_effort:none",
       ])
     );
+    expect(durationTags).not.toEqual(
+      expect.arrayContaining([expect.stringMatching(/^service_tier:/)])
+    );
 
     expect(info).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -844,6 +847,85 @@ describe("LLM stream telemetry", () => {
     expect(callsNamed(increment, "llm_success.count")).toHaveLength(0);
     expect(callsNamed(increment, "llm_error.count")).toHaveLength(0);
     expect(callsNamed(distribution, "llm_duration_ms")).toHaveLength(0);
+  });
+});
+
+describe("LLM served service tier telemetry", () => {
+  class FlexServedNoopStream extends DustNoopNoopGlobalNoopStream {
+    override async *rawStreamOutputToEvents(
+      raw: AsyncGenerator<string>
+    ): AsyncGenerator<ModelResponseEvent> {
+      for await (const event of super.rawStreamOutputToEvents(raw)) {
+        if (event.type === "success") {
+          yield {
+            type: "token_usage",
+            content: {
+              longCacheCreated: 0,
+              shortCacheCreated: 0,
+              cacheCreated: 0,
+              cacheHit: 0,
+              standardInput: 90,
+              totalOutput: 25,
+              serviceTier: "flex",
+            },
+            metadata: event.metadata,
+          };
+        }
+        yield event;
+      }
+    }
+  }
+
+  it("tags latency and usage with the tier the provider served on", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const { increment, distribution, info } = spyTelemetry();
+    const llm = makeNoopLLM(auth, FlexServedNoopStream, makeTraceContext(auth));
+
+    await consumeStream(llm);
+
+    for (const metric of [
+      "llm_duration_ms",
+      "llm_time_to_first_event_ms",
+      "llm_time_to_first_token_ms",
+      "llm_usage.output_tokens",
+    ]) {
+      expect(callsNamed(distribution, metric)).toHaveLength(1);
+      expect(tagsOf(callsNamed(distribution, metric)[0])).toEqual(
+        expect.arrayContaining(["service_tier:flex"])
+      );
+    }
+
+    expect(tagsOf(callsNamed(increment, "llm_success.count")[0])).not.toEqual(
+      expect.arrayContaining([expect.stringMatching(/^service_tier:/)])
+    );
+
+    expect(info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        llmEventType: "success",
+        serviceTier: "flex",
+      }),
+      "LLM Success"
+    );
+  });
+
+  it("leaves the tier off when the attempt fails before reporting usage", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const { distribution, error } = spyTelemetry();
+    const llm = makeNoopLLM(
+      auth,
+      ImmediateProviderErrorStream,
+      makeTraceContext(auth)
+    );
+
+    await consumeStream(llm);
+
+    expect(tagsOf(callsNamed(distribution, "llm_duration_ms")[0])).not.toEqual(
+      expect.arrayContaining([expect.stringMatching(/^service_tier:/)])
+    );
+    const errorPayload = error.mock.calls.find(
+      ([, message]) => message === "LLM Error"
+    )?.[0];
+    expect(errorPayload).not.toHaveProperty("serviceTier");
   });
 });
 

--- a/front/lib/api/llm/telemetry.ts
+++ b/front/lib/api/llm/telemetry.ts
@@ -3,6 +3,7 @@
  * the same normalized values so their dimensions cannot drift.
  */
 import type { LLMErrorType } from "@app/lib/api/llm/types/errors";
+import type { ServiceTier } from "@app/lib/model_constructors/types/input/configuration";
 import type { ErrorSource } from "@app/lib/model_constructors/types/output/events";
 import { statsDMetrics } from "@app/lib/utils/statsd";
 import type { ReasoningEffort } from "@app/types/assistant/models/types";
@@ -25,6 +26,12 @@ export function requestedReasoningEffortTag(
   requestedReasoningEffort: ReasoningEffort | null
 ): string {
   return `requested_reasoning_effort:${requestedReasoningEffort ?? "none"}`;
+}
+
+export function serviceTierTags(
+  serviceTier: ServiceTier | undefined
+): string[] {
+  return serviceTier ? [`service_tier:${serviceTier}`] : [];
 }
 
 export function emitLLMDurationMs({
@@ -89,18 +96,21 @@ export function llmAttemptLogFields({
   timeToFirstEventMs,
   timeToFirstTokenMs,
   requestedReasoningEffort,
+  serviceTier,
   surface,
 }: {
   durationMs?: number;
   timeToFirstEventMs?: number;
   timeToFirstTokenMs?: number;
   requestedReasoningEffort: ReasoningEffort | null;
+  serviceTier?: ServiceTier;
   surface: LLMTelemetrySurface;
 }): {
   durationMs?: number;
   timeToFirstEventMs?: number;
   timeToFirstTokenMs?: number;
   requestedReasoningEffort: ReasoningEffort | null;
+  serviceTier?: ServiceTier;
   surface: LLMTelemetrySurface;
 } {
   return {
@@ -108,6 +118,7 @@ export function llmAttemptLogFields({
     ...(timeToFirstEventMs !== undefined ? { timeToFirstEventMs } : {}),
     ...(timeToFirstTokenMs !== undefined ? { timeToFirstTokenMs } : {}),
     requestedReasoningEffort,
+    ...(serviceTier !== undefined ? { serviceTier } : {}),
     surface,
   };
 }


### PR DESCRIPTION
## Description

`llm_duration_ms`, `llm_time_to_first_event_ms` and `llm_time_to_first_token_ms` now carry a
`service_tier:<default|flex>` tag, so flex processing's latency can be compared against the
standard path on Datadog.

The tier is the one the provider reports having served the attempt on, read from the usage event
that arrives before the terminal event (the same source the usage metrics already used). The
usage-metric call site was tagging that dimension inline; both now go through a shared
`serviceTierTags` helper so the tag renders identically on every metric. Providers that report no
tier — every lab but OpenAI — and attempts that end before the usage event leave the tag off
rather than claiming a tier.

The attempt counters (`llm_interaction.count`, `llm_success.count`, `llm_error.count`) stay
untagged so their existing series don't split, same treatment as `requested_reasoning_effort`. The
matching `serviceTier` field is added to the attempt log fields, since that file's rule is that
metrics and logs are built from the same normalized values.

## Tests

`front/lib/api/llm/run_lifecycle.test.ts`:

- New `LLM served service tier telemetry` block: a stream whose usage event reports `flex` tags all
  three latency distributions and the usage distributions with `service_tier:flex` and logs
  `serviceTier`, while the success counter stays untagged; an attempt that errors before reporting
  usage carries no tier on either the metric or the log.
- Extended the existing successful-stream test to assert the noop provider (which reports no tier)
  leaves the dimension off.

The new flex test was checked as a negative control: dropping `serviceTierTags` from the latency
tags fails it.

`npm run test -- lib/api/llm` → 113 passing (9 files). `tsgo --noEmit` clean.

## Risk

Low, and rollback is a revert.

- Tag cardinality: at most two values (`default`, `flex`) on three distributions, and only for
  OpenAI attempts. Existing monitors and dashboards reading these metrics keep working; queries
  that group by all tags will see OpenAI series split from the deploy onward.
- No behavior change to the provider calls, flex pricing or `llm_flex_fallback.count`. No schema,
  API or product surface changes.
- Known gap, inherent to reporting the served tier: an attempt that fails before the usage event
  carries no tier, so a flex attempt that times out is not counted in the flex latency series.
  `llm_flex_fallback.count` covers the refuse-and-replay case.

## Deploy Plan

Normal `front` deploy, no ordering constraints and no migration. After deploy, confirm
`llm_duration_ms` splits by `service_tier` and that `flex` appears for trigger/wake-up runs in
workspaces flagged into `openai_flex_processing`.
