### PR TITLE
[admin governance] remove builder role from api keys

### DIFF
--- a/front/lib/resources/storage/models/keys.ts
+++ b/front/lib/resources/storage/models/keys.ts
@@ -68,7 +68,7 @@ KeyModel.init(
     },
     role: {
       type: DataTypes.STRING,
-      defaultValue: "builder",
+      defaultValue: "user",
       allowNull: false,
     },
     monthlyCapMicroUsd: {

--- a/front/migrations/20260911_migrate_key_builder_role_to_user.ts
+++ b/front/migrations/20260911_migrate_key_builder_role_to_user.ts
@@ -1,0 +1,61 @@
+import { KeyModel } from "@app/lib/resources/storage/models/keys";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+
+/**
+ * The `builder` role can no longer be assigned (new keys are created as `user`
+ * or `admin`). This flips the remaining legacy public API keys still stored
+ * with `role: "builder"` over to `user`.
+ *
+ * System keys are always created with `role: "admin"`, so they never match; we
+ * additionally scope to `isSystem: false` to make the intent explicit.
+ */
+
+makeScript({}, async ({ execute }, logger) => {
+  let totalMatched = 0;
+  let totalMigrated = 0;
+
+  await runOnAllWorkspaces(async (workspace) => {
+    const where = {
+      workspaceId: workspace.id,
+      isSystem: false,
+      role: "builder" as const,
+    };
+
+    if (!execute) {
+      const matched = await KeyModel.count({ where });
+      if (matched > 0) {
+        totalMatched += matched;
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            workspaceModelId: workspace.id,
+            matched,
+          },
+          "Would flip key builder -> user (DB only)"
+        );
+      }
+      return;
+    }
+
+    const [migrated] = await KeyModel.update({ role: "user" }, { where });
+    if (migrated > 0) {
+      totalMigrated += migrated;
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          workspaceModelId: workspace.id,
+          migrated,
+        },
+        "Flipped key builder -> user (DB only)"
+      );
+    }
+  });
+
+  logger.info(
+    execute ? { totalMigrated } : { totalMatched },
+    execute
+      ? "Key builder -> user migration complete"
+      : "Key builder -> user migration dry run complete"
+  );
+});

--- a/front/migrations/pre-deploy/20260911120529_keys_role_default_builder_to_user.sql
+++ b/front/migrations/pre-deploy/20260911120529_keys_role_default_builder_to_user.sql
@@ -1,0 +1,11 @@
+/*
+Pre-deploy: change the default of keys."role" from the now-deprecated 'builder'
+to 'user'.
+
+Keys are always created with an explicit role ('user' / 'admin'), so this
+default is a fallback only and nothing relies on it. Flipping it before the
+builder -> user backfill (migrations/20260911_migrate_key_builder_role_to_user.ts)
+ensures no new row can be born 'builder' while the backfill runs.
+ */
+ALTER TABLE "public"."keys"
+    ALTER COLUMN "role" SET DEFAULT 'user';


### PR DESCRIPTION
## Description
This PR is to migrate builder role keys to user role keys. In US we have 8,382 and in EU 2,381. 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://app.notion.com/p/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
I run `./scripts/run-migrations.sh pre-deploy front ` to update the default value in db and then `npx tsx front/migrations/20260911_migrate_key_builder_role_to_user.ts` to migrate all the builder roles

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
