### PR TITLE
The deploy card stops re-pinging authors on back-to-back deploys

### DIFF
--- a/.github/actions/deploy-card/action.yml
+++ b/.github/actions/deploy-card/action.yml
@@ -118,6 +118,25 @@ runs:
             } catch (e) { core.warning(`no versions file for ${cell}: ${e.message}`); }
           }
 
+          // A deploy of this component still in flight has not pinned the versions files
+          // yet, so the files still hold what IT is replacing: diffing against them would
+          // announce its commits a second time. Baseline on what the in-flight run ships
+          // (its head sha) instead. Not run for reverts, a revert must diff against the
+          // file to show what is being rolled back.
+          const inflightTags = new Set();
+          if (!revert) {
+            try {
+              const { data } = await github.rest.actions.listWorkflowRuns({ owner, repo, workflow_id: 'deploy.yml', per_page: 30 });
+              for (const r of data.workflow_runs) {
+                if (r.id === context.runId) continue;
+                if (!['queued', 'waiting', 'pending', 'in_progress'].includes(r.status)) continue;
+                if (!(r.display_title || '').startsWith(`Deploy ${component} `)) continue;
+                inflightTags.add(r.head_sha.slice(0, tag.length));
+              }
+            } catch (e) { core.warning(`could not list in-flight deploys: ${e.message}`); }
+          }
+          const baselines = inflightTags.size > 0 ? inflightTags : currentTags;
+
           // The changelog is the widest range among the cells, so whoever has a commit landing
           // on any of them is on the card. A revert lists what is being rolled back.
           const compare = async (base, head) => {
@@ -132,7 +151,7 @@ runs:
             return { commits, total };
           };
           let shipping = { commits: [], total: 0 };
-          for (const current of currentTags) {
+          for (const current of baselines) {
             if (current === tag) continue;
             try {
               const range = revert ? await compare(tag, current) : await compare(current, tag);
@@ -169,7 +188,8 @@ runs:
           const count = `${shipping.total} commit${shipping.total === 1 ? '' : 's'}`;
           const authorsLine = shipping.total > 0
             ? (revert ? `Rolling back ${count} by ${people}` : `${count} by ${people}`)
-            : currentTags.size === 0 ? `Previous version unknown, started by ${starter}`
+            : baselines.size === 0 ? `Previous version unknown, started by ${starter}`
+            : inflightTags.size > 0 ? `Nothing new over the deploy already in flight, started by ${starter}`
             : `Same version as today, started by ${starter}`;
 
           const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;

--- a/.github/actions/deploy-card/action.yml
+++ b/.github/actions/deploy-card/action.yml
@@ -132,7 +132,7 @@ runs:
           const inflightTags = new Set();
           if (!revert) {
             const collect = async (client, repository, workflowFile) => {
-              for (const status of ['in_progress', 'queued']) {
+              for (const status of ['in_progress', 'queued', 'pending']) {
                 const { data } = await client.rest.actions.listWorkflowRuns({ owner, repo: repository, workflow_id: workflowFile, status, per_page: 50 });
                 for (const r of data.workflow_runs) {
                   if (!(r.display_title || '').startsWith(`Deploy ${component} `)) continue;

--- a/.github/actions/deploy-card/action.yml
+++ b/.github/actions/deploy-card/action.yml
@@ -118,22 +118,36 @@ runs:
             } catch (e) { core.warning(`no versions file for ${cell}: ${e.message}`); }
           }
 
-          // A deploy of this component still in flight has not pinned the versions files
-          // yet, so the files still hold what IT is replacing: diffing against them would
-          // announce its commits a second time. Baseline on what the in-flight run ships
-          // (its head sha) instead. Not run for reverts, a revert must diff against the
-          // file to show what is being rolled back.
+          // A deploy of this component still rolling out has not pinned the versions
+          // files yet, so they still hold what IT is replacing: diffing against them
+          // would announce and ping its commits a second time. The rollout lives in
+          // dust-infra (the dust-side run ends at the dispatch), its runs are named
+          // "Deploy <component> <tag> to <cells>", so the tag comes from the titles of
+          // its queued and running runs. The dust-side check covers the parallel edge
+          // components, restricted to runs started before this one so a deploy queued
+          // behind us cannot steal our baseline. Reverts are exempt, a revert diffs
+          // against the file to show what it rolls back. When an in-flight rollout
+          // exists the versions baselines are dropped entirely: not re-pinging wins
+          // over changelog width across cells.
           const inflightTags = new Set();
           if (!revert) {
-            try {
-              const { data } = await github.rest.actions.listWorkflowRuns({ owner, repo, workflow_id: 'deploy.yml', per_page: 30 });
-              for (const r of data.workflow_runs) {
-                if (r.id === context.runId) continue;
-                if (!['queued', 'waiting', 'pending', 'in_progress'].includes(r.status)) continue;
-                if (!(r.display_title || '').startsWith(`Deploy ${component} `)) continue;
-                inflightTags.add(r.head_sha.slice(0, tag.length));
+            const collect = async (client, repository, workflowFile) => {
+              for (const status of ['in_progress', 'queued']) {
+                const { data } = await client.rest.actions.listWorkflowRuns({ owner, repo: repository, workflow_id: workflowFile, status, per_page: 50 });
+                for (const r of data.workflow_runs) {
+                  if (!(r.display_title || '').startsWith(`Deploy ${component} `)) continue;
+                  if (repository === repo) {
+                    if (r.id === context.runId || r.run_number >= context.runNumber) continue;
+                    inflightTags.add(r.head_sha.slice(0, tag.length));
+                  } else {
+                    const t = (r.display_title || '').split(' ')[2] || '';
+                    if (/^[0-9a-f]{7,40}$/.test(t)) inflightTags.add(t.slice(0, tag.length));
+                  }
+                }
               }
-            } catch (e) { core.warning(`could not list in-flight deploys: ${e.message}`); }
+            };
+            try { await collect(github, repo, 'deploy.yml'); } catch (e) { core.warning(`in-flight dust deploys: ${e.message}`); }
+            try { await collect(infra, 'dust-infra', 'deploy.yaml'); } catch (e) { core.warning(`in-flight dust-infra rollouts: ${e.message}`); }
           }
           const baselines = inflightTags.size > 0 ? inflightTags : currentTags;
 

--- a/.github/actions/deploy-card/action.yml
+++ b/.github/actions/deploy-card/action.yml
@@ -168,7 +168,7 @@ runs:
               if (login && email) emails.set(login.trim().toLowerCase(), email.trim());
             }
           }
-          const mention = async (login, name) => {
+          const slackMention = async (login, name) => {
             const email = login && emails.get(login.toLowerCase());
             if (email) {
               const res = await slack('users.lookupByEmail', { email });
@@ -176,13 +176,18 @@ runs:
             }
             return esc(name || login || 'someone');
           };
+          // Only front deploys ping the commit authors: front is where the monorepo's
+          // work ships, so the ping means "your PR is going out". Everywhere else the
+          // authors appear by name and only the person who started the run is pinged.
+          const mention = async (login, name) =>
+            component === 'front' ? slackMention(login, name) : esc(name || login || 'someone');
           const authors = new Map();
           for (const c of shipping.commits) {
             const login = c.author && c.author.login;
             const key = login || c.commit.author.name;
             if (!authors.has(key)) authors.set(key, await mention(login, c.commit.author.name));
           }
-          const starter = await mention(context.actor, context.actor);
+          const starter = await slackMention(context.actor, context.actor);
           const list = [...authors.values()];
           const people = list.length === 1 ? list[0] : `${list.slice(0, -1).join(', ')} and ${list[list.length - 1]}`;
           const count = `${shipping.total} commit${shipping.total === 1 ? '' : 's'}`;

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,7 @@ on:
         type: boolean
 
 permissions:
+  actions: read # the deploy card lists in-flight deploy runs
   contents: read
   pull-requests: write
 


### PR DESCRIPTION
## Description

The deployment card diffs the new tag against the versions files in dust-infra to say whose commits are shipping. Those files are only pinned mid-rollout by the dust-infra pipeline, so a deploy started while the previous one is still rolling out baselines on stale state, re-announces the previous deploy's commits, and pings all their authors a second time.

The card now looks for rollouts of the same component still in flight before touching the versions files: queued or running dust-infra deploy runs (which carry the component and tag in their title since https://github.com/dust-tt/dust-infra/pull/1095), plus earlier dust-side runs for the parallel edge components. When any exist, their tags become the baseline, so the card announces only what this deploy adds on top, and says so plainly when that is nothing. A run queued behind the current one is ignored so it cannot steal the baseline, and reverts keep diffing against the files to show what they roll back.

Riding along, the ping policy the card should have had: only front deploys ping commit authors. Front is where the monorepo's work ships, so the ping means your PR is going out. Other components keep their changelog with plain author names, and only the person who started the run is pinged.

## Tests

The embedded script parses, and the title matching was checked against the real run names of both workflows, including that "Deploy front " never matches a front-edge run and that revert titles never match at all. Not exercised against live deploys, the first back-to-back front deploys are the proof, and the failure mode if a query breaks is the old behavior behind a run annotation, never a missing card.

## Risk

Notification logic only, nothing in the build or deploy path.

> [!NOTE]
> On the first run after merge, check the run annotations for an "in-flight dust-infra rollouts" warning: the in-flight query needs the infra app to hold Actions read on dust-infra, and we could not verify that permission from outside. If it warns, grant the app Actions read and the feature comes alive, until then the card just behaves as before.

## Deploy Plan

Merge https://github.com/dust-tt/dust-infra/pull/1095 first (the run titles), then this. Takes effect on the next deploy, nothing to roll out.