### PR TITLE
[PRICING] Bill Gemini 3.1 Pro cached input at the discounted rate

### DIFF
--- a/front/lib/api/assistant/token_pricing/global.ts
+++ b/front/lib/api/assistant/token_pricing/global.ts
@@ -367,13 +367,16 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
     },
   },
   // Gemini 3.1 Pro: same pricing structure as 3 Pro (2/12 for <=200k, 4/18 for >200k).
+  // Verified 2026-09-11: https://ai.google.dev/gemini-api/docs/pricing
   "gemini-3.1-pro-preview": {
     input: 2,
     output: 12,
+    cache_read_input_tokens: 0.2,
     long_context: {
       prompt_token_threshold: 200_001,
       input: 4,
       output: 18,
+      cache_read_input_tokens: 0.4,
     },
   },
   "gemini-3-flash-preview": {

--- a/front/lib/api/assistant/token_pricing/index.test.ts
+++ b/front/lib/api/assistant/token_pricing/index.test.ts
@@ -348,6 +348,28 @@ describe("computeTokensCostForUsageInMicroUsd", () => {
     ).toBe(818_004);
   });
 
+  it("discounts Gemini 3.1 Pro cached input through 200k prompt tokens", () => {
+    expect(
+      computeTokensCostForUsageInMicroUsd({
+        modelId: GEMINI_3_1_PRO_MODEL_ID,
+        promptTokens: 200_000,
+        completionTokens: 1_000,
+        cachedTokens: 100_000,
+      })
+    ).toBe(232_000);
+  });
+
+  it("uses Gemini 3.1 Pro long-context cached input pricing above 200k prompt tokens", () => {
+    expect(
+      computeTokensCostForUsageInMicroUsd({
+        modelId: GEMINI_3_1_PRO_MODEL_ID,
+        promptTokens: 200_001,
+        completionTokens: 1_000,
+        cachedTokens: 100_000,
+      })
+    ).toBe(458_004);
+  });
+
   it("uses long-context Grok 4.5 pricing at 200k prompt tokens", () => {
     expect(
       computeTokensCostForUsageInMicroUsd({

--- a/front/lib/model_constructors/configuration.ts
+++ b/front/lib/model_constructors/configuration.ts
@@ -22,7 +22,9 @@ export type BaseEndpointConfiguration<C extends InputConfig = InputConfig> = {
   // side stays open.
   configSchema: z.ZodType<C, z.ZodTypeDef, unknown>;
 
-  // Pricing
+  // Pricing. Unread today — billing runs off `MODEL_PRICING` — but intentionally
+  // kept: see the DO NOT DELETE note on `TokenPricing` for the migration it is
+  // staged for.
   tokenPricing: TokenPricing;
 
   // Tries with flex processing tier on first call, which has FLEX_DISCOUNT_FACTOR

--- a/front/lib/model_constructors/types/token_pricing.ts
+++ b/front/lib/model_constructors/types/token_pricing.ts
@@ -1,4 +1,26 @@
 // Per M tokens
+//
+// DO NOT DELETE, even though nothing reads it today. Every endpoint class
+// declares a `tokenPricing`, but billing currently runs off `MODEL_PRICING` in
+// `lib/api/assistant/token_pricing/global.ts`. These figures are staged work,
+// not leftovers.
+//
+// TODO(new-llm): make `tokenPricing` the source of truth for billing and derive
+// `MODEL_PRICING` from it. Pricing is a property of the *endpoint* — it varies by
+// region and provider API — so it belongs here; `MODEL_PRICING` is keyed by model
+// alone and has to recompute the EU uplift at runtime to compensate.
+//
+// Two things block the switch:
+//   1. No tiered pricing. There is no prompt-token threshold here, so models
+//      with long-context rates cannot be expressed (the `implement progressive
+//      token billing` TODOs on the Google endpoints are this same gap).
+//   2. No agreed convention for those models meanwhile: `gemini-3.1-pro` records
+//      its >200k tier while `gpt-5.6-terra` records its base tier.
+//
+// Until then these values are an unenforced duplicate, so they drift: the
+// Gemini 3.1 Pro endpoint had the correct $0.40 cached-read rate while
+// `MODEL_PRICING` had none at all, and billed cached tokens at the full input
+// rate for the entire life of the entry.
 export type TokenPricing = {
   cacheCreated?: number;
   longCacheCreated?: number;


### PR DESCRIPTION
## Description

Gemini 3.1 Pro had no `cache_read_input_tokens` in `MODEL_PRICING`, so cached reads fell back to the full input rate and were billed 10x over ($2/M instead of $0.20/M, $4/M instead of $0.40/M above the 200k threshold) since the model was added in #21999.

## Tests

Added two unit tests in `token_pricing/index.test.ts` covering the base and long-context tiers.

## Risk

Low going forward, but existing `run_usage` rows keep the inflated `costMicroUsd` — it is persisted at write time, not recomputed on read — so internal cost reporting stays overstated until backfilled; customer credits are unaffected since `attribution_builder` recomputes rates cache-naive by design.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`
