### PR TITLE
chore(analytics): remove the analytics_conversation_panel feature flag

### DIFF
--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -41,11 +41,7 @@ import {
   DEFAULT_CONSUMPTION_GRANULARITY,
   DEFAULT_CONSUMPTION_PERIOD,
 } from "@app/lib/analytics/consumption_period";
-import {
-  useAuth,
-  useFeatureFlags,
-  useWorkspace,
-} from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { isNavigationLocked } from "@app/lib/navigation-lock";
 import type { TrackingExtra } from "@app/lib/tracking";
 import {
@@ -179,10 +175,7 @@ export function AnalyticsConsumptionPage() {
 
   const [isOpen, setIsOpen] = useState(false);
 
-  const { hasFeature } = useFeatureFlags();
-  const analyticsAssistantEnabled =
-    hasFeature("analytics_conversation_panel") &&
-    isWorkspaceAnalyticsEnabled(owner);
+  const analyticsAssistantEnabled = isWorkspaceAnalyticsEnabled(owner);
 
   useEffect(() => {
     trackEvent({

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -16,12 +16,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "self_serve",
     owner: "fontanierh",
   },
-  analytics_conversation_panel: {
-    description:
-      "Enable the Ask @analyst conversation panel on the Analytics page",
-    stage: "dust_only",
-    owner: "achilleburah",
-  },
   advanced_notion_management: {
     description:
       "Advanced features for Notion workspace management shown to admins",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -830,7 +830,6 @@ export type RetrievalDocumentPublicType = z.infer<
 const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "activation_force_nudge"
   | "advanced_notion_management"
-  | "analytics_conversation_panel"
   | "custom_model_feature"
   | "anthropic_vertex_fallback"
   | "archive_inactive_agents"


### PR DESCRIPTION
## Description

The Ask @analyst panel on the Analytics page shipped behind the `analytics_conversation_panel` Dust-only flag. This removes the flag, so the panel is now gated on `isWorkspaceAnalyticsEnabled(owner)` alone, the same check that decides whether the workspace gets the `workspace_analytics` surface at all.


## Tests

Parity between @analyst and the Analytics page is tracked in the [Analyst versus Analytics parity test matrix](https://app.dust.tt/share/frame/f5bd4bf5-8b74-461c-8287-4736a1a4f1e2) Frame. Statuses live in the Frame database and only load for workspace members, so the public link renders them empty.


| Case | What it checks | Status |
| --- | --- | --- |
| CON-01 | Overview uses the same scope | Pass |
| CRD-01 | Total billed credits | Pass |
| CRD-02 | Top contributors by credits | Pass |
| CRD-03 | Model and member attribution | Pass |
| ATR-01 | Message-count rankings | Pass |
| ATR-02 | Tool and skill execution counts | Pass |
| ATR-03 | Source breakdown | Pass |
| TS-01 | Daily credit timeseries | Pass |
| TS-02 | Timeseries breakdown dimension | Pass |
| FIL-01 | Single filter parity | Pass |
| FIL-02 | Combined filter intersection | Pass |
| FIL-03 | Filter persistence across views | Pass |
| EDG-02 | Today and partial-day handling | Pass |
| EDG-03 | Empty result behavior | Pass |
| REC-02 | Ordering and ties | Pass |


Residual gap worth knowing: the queries can sometime differ from the analytics view because of consumption continue evolving live. 

## Risk

Low. 
Every workspace with analytics enabled gets the panel. But the analyst agent was already available from conversations. 

## Deploy Plan

Standard. Rollback to revert.


