### PR TITLE
Fair-use companion card no longer promises a credit reset

### DIFF
--- a/front/components/credits/PersonalUsageCard.tsx
+++ b/front/components/credits/PersonalUsageCard.tsx
@@ -30,15 +30,15 @@ function formatRefillDay(isoDate: string): string {
     now.getUTCMonth(),
     now.getUTCDate()
   );
-  const daysUntilRefill = Math.round((refillDayMs - currentDayMs) / ONE_DAY_MS);
+  const refillDelayDays = Math.round((refillDayMs - currentDayMs) / ONE_DAY_MS);
 
-  if (daysUntilRefill <= 0) {
+  if (refillDelayDays <= 0) {
     return "today";
   }
-  if (daysUntilRefill === 1) {
+  if (refillDelayDays === 1) {
     return "tomorrow";
   }
-  if (daysUntilRefill < 7) {
+  if (refillDelayDays < 7) {
     return `on ${refillAt.toLocaleDateString("en-US", {
       weekday: "long",
       timeZone: "UTC",

--- a/front/components/credits/PersonalUsageCard.tsx
+++ b/front/components/credits/PersonalUsageCard.tsx
@@ -2,9 +2,9 @@ import { UsageUpgradeButton } from "@app/components/credits/UsageUpgradeButton";
 import { AwuUsageBar } from "@app/components/workspace/MembersUsageTable";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import {
-  formatCreditResetCountdown,
   formatCredits,
-  formatFairUseAllowance,
+  formatCreditValue,
+  formatLimitTimeframe,
 } from "@app/lib/client/credits";
 import { useMyUsage, useSeatPlan } from "@app/lib/swr/credits";
 import { useFairUseCredits } from "@app/lib/swr/fair_use_credits";
@@ -14,6 +14,42 @@ import { ONE_DAY_MS, ordinalDay } from "@app/types/shared/utils/date_utils";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { WorkspaceType } from "@app/types/user";
 import { ProgressBar, Separator, Spinner, Stars02 } from "@dust-tt/sparkle";
+
+// Relative day label for a refill date: "today", "tomorrow", a weekday within
+// the week, or the calendar date beyond that.
+function formatRefillDay(isoDate: string): string {
+  const refillAt = new Date(isoDate);
+  const now = new Date();
+  const refillDayMs = Date.UTC(
+    refillAt.getUTCFullYear(),
+    refillAt.getUTCMonth(),
+    refillAt.getUTCDate()
+  );
+  const currentDayMs = Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate()
+  );
+  const daysUntilRefill = Math.round((refillDayMs - currentDayMs) / ONE_DAY_MS);
+
+  if (daysUntilRefill <= 0) {
+    return "today";
+  }
+  if (daysUntilRefill === 1) {
+    return "tomorrow";
+  }
+  if (daysUntilRefill < 7) {
+    return `on ${refillAt.toLocaleDateString("en-US", {
+      weekday: "long",
+      timeZone: "UTC",
+    })}`;
+  }
+  return `on ${refillAt.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  })}`;
+}
 
 interface PersonalUsageCardProps {
   owner: WorkspaceType;
@@ -75,47 +111,19 @@ export function PersonalUsageCard({
   const isPremiumModelUsageAtLimit = premiumModelUsage
     ? premiumModelUsage.usedMessages >= premiumModelUsage.limitMessages
     : false;
-  const nextPremiumModelRefillDate = (() => {
-    if (!premiumModelUsage?.nextRefill) {
-      return null;
-    }
-
-    const availableAt = new Date(premiumModelUsage.nextRefill.availableAt);
-    const now = new Date();
-    const availableDayMs = Date.UTC(
-      availableAt.getUTCFullYear(),
-      availableAt.getUTCMonth(),
-      availableAt.getUTCDate()
-    );
-    const currentDayMs = Date.UTC(
-      now.getUTCFullYear(),
-      now.getUTCMonth(),
-      now.getUTCDate()
-    );
-    const daysUntilAvailable = Math.round(
-      (availableDayMs - currentDayMs) / ONE_DAY_MS
-    );
-
-    if (daysUntilAvailable === 0) {
-      return "today";
-    }
-    if (daysUntilAvailable === 1) {
-      return "tomorrow";
-    }
-    return `on ${availableAt.toLocaleDateString("en-US", {
-      weekday: "long",
-      timeZone: "UTC",
-    })}`;
-  })();
+  const nextPremiumModelRefillDate = premiumModelUsage?.nextRefill
+    ? formatRefillDay(premiumModelUsage.nextRefill.availableAt)
+    : null;
   const fairUseCreditsPercentage = fairUseAwuCreditsState
     ? Math.min(
         (fairUseAwuCreditsState.count / fairUseAwuCreditsState.limit) * 100,
         100
       )
     : 0;
-  const fairUseCreditsSubtitle = fairUseAwuCreditsState?.nextResetAt
-    ? formatCreditResetCountdown(fairUseAwuCreditsState.nextResetAt)
-    : null;
+  const isFairUseCreditsAtLimit = fairUseAwuCreditsState
+    ? fairUseAwuCreditsState.count >= fairUseAwuCreditsState.limit
+    : false;
+  const nextFairUseRefill = fairUseAwuCreditsState?.refillSchedule?.[0] ?? null;
   const isLoading = isMyUsageLoading || isFairUseCreditsLoading;
 
   return (
@@ -190,8 +198,11 @@ export function PersonalUsageCard({
                     Credits consumption
                   </span>
                   <span className="text-xs text-muted-foreground">
-                    {fairUseCreditsSubtitle ??
-                      formatFairUseAllowance(fairUseAwuCreditsState.timeframe)}
+                    Used{" "}
+                    {formatLimitTimeframe(
+                      fairUseAwuCreditsState.timeframe,
+                      "compact"
+                    )}
                   </span>
                 </div>
                 <span className="text-sm tabular-nums text-muted-foreground">
@@ -213,6 +224,12 @@ export function PersonalUsageCard({
                   },
                 ]}
               />
+              {isFairUseCreditsAtLimit && nextFairUseRefill ? (
+                <span className="text-xs text-muted-foreground">
+                  {formatCreditValue(nextFairUseRefill.credits)} available again{" "}
+                  {formatRefillDay(nextFairUseRefill.date)}
+                </span>
+              ) : null}
             </div>
           ) : null}
           {showPremiumModelUsage && premiumModelUsage ? (

--- a/front/lib/client/credits.test.ts
+++ b/front/lib/client/credits.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  formatAvgCredits,
-  formatCreditResetCountdown,
-  formatFairUseAllowance,
-} from "./credits";
+import { formatAvgCredits } from "./credits";
 
 describe("formatAvgCredits", () => {
   it.each([
@@ -13,32 +9,5 @@ describe("formatAvgCredits", () => {
     [0, "0.0"],
   ])("formats %s with exactly one decimal", (credits, expected) => {
     expect(formatAvgCredits(credits)).toBe(expected);
-  });
-});
-
-describe("formatFairUseAllowance", () => {
-  it.each([
-    ["day", "Daily allowance"],
-    ["week", "Weekly allowance"],
-    ["month", "Monthly allowance"],
-    ["lifetime", "Monthly allowance"],
-  ] as const)("formats the %s timeframe", (timeframe, expected) => {
-    expect(formatFairUseAllowance(timeframe)).toBe(expected);
-  });
-});
-
-describe("formatCreditResetCountdown", () => {
-  const nowMs = Date.parse("2026-08-26T12:00:00.000Z");
-
-  it.each([
-    ["2026-08-26T12:00:00.000Z", "Reset today"],
-    ["2026-08-27T11:59:59.000Z", "Reset in 1 day"],
-    ["2026-09-01T12:00:00.000Z", "Reset in 6 days"],
-  ])("formats %s", (nextResetAt, expected) => {
-    expect(formatCreditResetCountdown(nextResetAt, nowMs)).toBe(expected);
-  });
-
-  it("returns null for an invalid date", () => {
-    expect(formatCreditResetCountdown("not-a-date", nowMs)).toBeNull();
   });
 });

--- a/front/lib/client/credits.ts
+++ b/front/lib/client/credits.ts
@@ -85,44 +85,6 @@ export function formatLimitTimeframe(
     : `over the past ${windowLabel}`;
 }
 
-export function formatFairUseAllowance(
-  timeframe: MaxAwuCreditsTimeframeType
-): string {
-  switch (timeframe) {
-    case "day":
-      return "Daily allowance";
-    case "week":
-      return "Weekly allowance";
-    case "month":
-    case "lifetime":
-      return "Monthly allowance";
-    default:
-      assertNeverAndIgnore(timeframe);
-      return "Usage allowance";
-  }
-}
-
-export function formatCreditResetCountdown(
-  nextResetAt: string,
-  nowMs = Date.now()
-): string | null {
-  const nextResetAtMs = Date.parse(nextResetAt);
-  if (!Number.isFinite(nextResetAtMs)) {
-    return null;
-  }
-
-  const daysUntilReset = Math.max(
-    0,
-    Math.ceil((nextResetAtMs - nowMs) / (24 * 60 * 60 * 1000))
-  );
-
-  if (daysUntilReset === 0) {
-    return "Reset today";
-  }
-
-  return `Reset in ${daysUntilReset} day${pluralize(daysUntilReset)}`;
-}
-
 export function formatCreditsCompact(credits: number): string {
   return credits.toLocaleString("en-US", {
     notation: "compact",


### PR DESCRIPTION
## Description

On legacy plans with a fair-use credit limit, the companion card told members their credits would "Reset in 6 days". The limit is a rolling window, so nothing ever resets: the date was the moment the oldest consumption entry falls out of the window, which only frees that entry's credits. Members read it as a full refill on that date, waited for it, then found the bar barely moved.

The subtitle now describes the window itself, "Used in the last 7 days" (24 hours or 30 days for daily and monthly limits), which is the same sentence the sidebar user menu already uses for fair use. When a member has actually hit the limit, a second line under the bar says when the next batch comes back, "120 credits available again tomorrow", taken from the refill schedule the endpoint already returns. This mirrors how the premium-messages block in the same card behaves, and the day-label logic is now shared between the two.

Example:
<img width="318" height="134" alt="image" src="https://github.com/user-attachments/assets/899517c7-c6e2-42a7-8417-367f8b37bd48" />

## Tests

## Risk

Display only, no API or data change. Safe to roll back.

## Deploy Plan

Deploy front.
