### PR TITLE
The deploy card ignores zombie runs

### DIFF
--- a/.github/actions/deploy-card/action.yml
+++ b/.github/actions/deploy-card/action.yml
@@ -131,10 +131,16 @@ runs:
           // over changelog width across cells.
           const inflightTags = new Set();
           if (!revert) {
+            // Zombie guard: a real rollout lives minutes (dust-infra caps a deploy at 40),
+            // but GitHub keeps abandoned runs queued for weeks and their ancient head
+            // shas would explode the changelog (a 5-week-old queued run once produced a
+            // 1770-commit card). Anything older than 3 hours is not a rollout in flight.
+            const freshEnough = (r) => Date.now() - new Date(r.created_at).getTime() < 3 * 60 * 60 * 1000;
             const collect = async (client, repository, workflowFile) => {
               for (const status of ['in_progress', 'queued', 'pending']) {
                 const { data } = await client.rest.actions.listWorkflowRuns({ owner, repo: repository, workflow_id: workflowFile, status, per_page: 50 });
                 for (const r of data.workflow_runs) {
+                  if (!freshEnough(r)) continue;
                   if (!(r.display_title || '').startsWith(`Deploy ${component} `)) continue;
                   if (repository === repo) {
                     if (r.id === context.runId || r.run_number >= context.runNumber) continue;


### PR DESCRIPTION
## Description

The first card posted by the in-flight baseline change announced 1770 commits by everyone. The versions files all held the same fresh tag, so the baseline came from the in-flight hunt: a "Deploy front to all" run sitting in GitHub's queue since August 6, a zombie the queue never reaped, whose five-week-old head sha became the baseline. The hunt guarded against runs queued behind the current one but not against runs queued since forever.

Runs older than three hours are now ignored: a real rollout lives minutes (dust-infra caps a deploy at 40), anything older in queued or in_progress is abandoned, not in flight.

## Tests

The stuck run that produced the 1770-commit card (queued 2026-08-06, head ee12205) is exactly what the guard filters, and today's versions files against the deployed tag give the small honest range. The next deploy is the live proof.

## Risk

Notification logic only. Worst case the guard skips a genuinely in-flight rollout older than three hours, which falls back to yesterday's behavior for that card.

## Deploy Plan

Merge, next deploy picks it up. Independently, the two stuck queued runs (#10741 from August 6 and #11550) deserve a manual cancel so they stop haunting the queue.