### PR TITLE
[front] Skip the excess-credit buffer on PAYG-provisioned contracts

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
@@ -9,6 +9,7 @@ import {
   ensureMetronomeCustomerForWorkspace,
   provisionMetronomeContract,
 } from "@app/lib/metronome/contracts";
+import { removeAwuContractExcessCreditsForContract } from "@app/lib/metronome/payg_excess_credits";
 import {
   remapMembershipSeatTypesForContract,
   syncSeatCount,
@@ -64,6 +65,16 @@ vi.mock("@app/lib/metronome/seats", async () => {
     ...actual,
     remapMembershipSeatTypesForContract: vi.fn(),
     syncSeatCount: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/metronome/payg_excess_credits", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/payg_excess_credits")
+  >("@app/lib/metronome/payg_excess_credits");
+  return {
+    ...actual,
+    removeAwuContractExcessCreditsForContract: vi.fn(),
   };
 });
 
@@ -295,6 +306,9 @@ beforeEach(() => {
   );
   vi.mocked(provisionMetronomeContract).mockResolvedValue(
     new Ok({ metronomeContractId: NEW_CONTRACT_ID, recovered: false })
+  );
+  vi.mocked(removeAwuContractExcessCreditsForContract).mockResolvedValue(
+    new Ok({ archivedCredits: 0 })
   );
   vi.mocked(remapMembershipSeatTypesForContract).mockResolvedValue(
     new Ok(undefined)
@@ -626,6 +640,8 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — guards", () => {
 
     expect(response.status).toBe(200);
     expect(scheduleSubscriptionCancellation).not.toHaveBeenCalled();
+    // PAYG off: the package-default excess buffer is left in place.
+    expect(removeAwuContractExcessCreditsForContract).not.toHaveBeenCalled();
   });
 });
 
@@ -643,6 +659,10 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
     );
 
     expect(response.status).toBe(200);
+    // PAYG on: the excess buffer is removed from the newly provisioned contract.
+    expect(removeAwuContractExcessCreditsForContract).toHaveBeenCalledWith(
+      expect.objectContaining({ metronomeContractId: NEW_CONTRACT_ID })
+    );
 
     const adminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -34,6 +34,7 @@ import {
   ensureMetronomeCustomerForWorkspace,
   provisionMetronomeContract,
 } from "@app/lib/metronome/contracts";
+import { removeAwuContractExcessCreditsForContract } from "@app/lib/metronome/payg_excess_credits";
 import {
   addDuration,
   commitmentAmount,
@@ -934,6 +935,31 @@ async function stepContractEdits({
   return null;
 }
 
+// The excess "buffer" recurring credit is baked into every credit-priced
+// package, so a freshly provisioned contract always carries it. With PAYG
+// enabled we don't want that buffer to exist at all (over-consumption must bill
+// as PAYG, not be silently absorbed), so remove it from the new contract right
+// after provisioning. No-op when PAYG is off — the package-default buffer stays.
+async function stepDisableExcessCreditsForPayg({
+  metronomeCustomerId,
+  metronomeContractId,
+  workspaceId,
+  body,
+}: PostProvisionCtx): Promise<string | null> {
+  if (!body.paygEnabled) {
+    return null;
+  }
+  const result = await removeAwuContractExcessCreditsForContract({
+    metronomeCustomerId,
+    workspaceId,
+    metronomeContractId,
+  });
+  if (result.isErr()) {
+    return `excess_credits: ${result.error.message}`;
+  }
+  return null;
+}
+
 // Persist the future-state subscription in `created_backend_only`; the
 // `contract.start` webhook flips it to `active` (and ends the current one).
 // Skip entirely when alignedStart is in the past: Metronome fires contract.start
@@ -1124,6 +1150,7 @@ async function stepScheduleContractEnd({
  *
  * Post-provision (best-effort — failures collected as warnings):
  *   - Net payment terms, initial credits, pending subscription
+ *   - Excess-credit buffer removal when PAYG is enabled
  *   - Stripe cancellation schedule, seat configuration, seat remap/sync
  *   - Contract end date
  *
@@ -1299,6 +1326,7 @@ export async function switchContract({
   };
 
   warn(await stepContractEdits(ctx));
+  warn(await stepDisableExcessCreditsForPayg(ctx));
   warn(await stepSeatRemap(ctx));
   warn(await stepSeatSync(ctx));
   warn(await stepPendingSubscription(ctx));

--- a/front/lib/metronome/payg_excess_credits.test.ts
+++ b/front/lib/metronome/payg_excess_credits.test.ts
@@ -1,4 +1,7 @@
-import { setAwuContractExcessCreditsAmount } from "@app/lib/metronome/payg_excess_credits";
+import {
+  removeAwuContractExcessCreditsForContract,
+  setAwuContractExcessCreditsAmount,
+} from "@app/lib/metronome/payg_excess_credits";
 import { Err, Ok } from "@app/types/shared/result";
 import type { ContractV2 } from "@metronome/sdk/resources";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -399,6 +402,241 @@ describe("payg_excess_credits", () => {
       metronomeCustomerId: CUSTOMER_ID,
       workspaceId: WORKSPACE_ID,
       amount: 0,
+    });
+
+    expect(result.isErr()).toBe(true);
+  });
+});
+
+describe("removeAwuContractExcessCreditsForContract", () => {
+  beforeEach(() => {
+    mockEditMetronomeContract.mockReset();
+    mockGetMetronomeContractById.mockReset();
+    mockListMetronomeContracts.mockReset();
+  });
+
+  it("zeros the recurring credit and archives active/future excess children", async () => {
+    const future = new Date(Date.now() + 1000 * 60 * 60 * 24);
+    const past = new Date(Date.now() - 1000 * 60 * 60 * 24);
+    const farFuture = new Date(Date.now() + 1000 * 60 * 60 * 24 * 60);
+
+    mockGetMetronomeContractById.mockResolvedValue(
+      new Ok(
+        makeContract({
+          id: "contract_new",
+          recurringCredits: [{ id: "rc_excess", productId: EXCESS_PRODUCT.id }],
+          credits: [
+            {
+              id: "credit_expired",
+              recurringCreditId: "rc_excess",
+              productId: EXCESS_PRODUCT.id,
+              scheduleItems: [
+                {
+                  id: "seg_past",
+                  amount: 5000,
+                  startingAt: past.toISOString(),
+                  endingBefore: past.toISOString(),
+                },
+              ],
+            },
+            {
+              id: "credit_current",
+              recurringCreditId: "rc_excess",
+              productId: EXCESS_PRODUCT.id,
+              scheduleItems: [
+                {
+                  id: "seg_current",
+                  amount: 5000,
+                  startingAt: past.toISOString(),
+                  endingBefore: future.toISOString(),
+                },
+              ],
+            },
+            {
+              id: "credit_future",
+              recurringCreditId: "rc_excess",
+              productId: EXCESS_PRODUCT.id,
+              scheduleItems: [
+                {
+                  id: "seg_future",
+                  amount: 5000,
+                  startingAt: future.toISOString(),
+                  endingBefore: farFuture.toISOString(),
+                },
+              ],
+            },
+          ],
+        })
+      )
+    );
+    mockEditMetronomeContract.mockResolvedValue(new Ok({ editId: "edit_1" }));
+
+    const result = await removeAwuContractExcessCreditsForContract({
+      metronomeCustomerId: CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+      metronomeContractId: "contract_new",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.archivedCredits).toBe(2);
+    }
+    expect(mockEditMetronomeContract).toHaveBeenCalledTimes(1);
+    const callArg = mockEditMetronomeContract.mock.calls[0][0];
+    expect(callArg.contract_id).toBe("contract_new");
+    expect(callArg.update_recurring_credits).toEqual([
+      {
+        recurring_credit_id: "rc_excess",
+        access_amount: { unit_price: 0, quantity: 1 },
+      },
+    ]);
+    // Only the active + future children are archived; the expired one is left.
+    const archivedIds = callArg.archive_credits
+      .map((c: { id: string }) => c.id)
+      .sort();
+    expect(archivedIds).toEqual(["credit_current", "credit_future"]);
+  });
+
+  it("zeros the recurring credit even when no child credits exist yet", async () => {
+    mockGetMetronomeContractById.mockResolvedValue(
+      new Ok(
+        makeContract({
+          id: "contract_future_dated",
+          recurringCredits: [{ id: "rc_excess", productId: EXCESS_PRODUCT.id }],
+          credits: [],
+        })
+      )
+    );
+    mockEditMetronomeContract.mockResolvedValue(new Ok({ editId: "edit_2" }));
+
+    const result = await removeAwuContractExcessCreditsForContract({
+      metronomeCustomerId: CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+      metronomeContractId: "contract_future_dated",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.archivedCredits).toBe(0);
+    }
+    const callArg = mockEditMetronomeContract.mock.calls[0][0];
+    expect(callArg.update_recurring_credits).toHaveLength(1);
+    expect(callArg.archive_credits).toBeUndefined();
+  });
+
+  it("no-ops when the contract has no AWU excess recurring credit", async () => {
+    mockGetMetronomeContractById.mockResolvedValue(
+      new Ok(
+        makeContract({
+          id: "contract_no_excess",
+          recurringCredits: [{ id: "rc_other", productId: OTHER_PRODUCT.id }],
+          credits: [],
+        })
+      )
+    );
+
+    const result = await removeAwuContractExcessCreditsForContract({
+      metronomeCustomerId: CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+      metronomeContractId: "contract_no_excess",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockEditMetronomeContract).not.toHaveBeenCalled();
+  });
+
+  it("skips legacy programmatic USD excess recurring credits", async () => {
+    const future = new Date(Date.now() + 1000 * 60 * 60 * 24);
+    const past = new Date(Date.now() - 1000 * 60 * 60 * 24);
+
+    mockGetMetronomeContractById.mockResolvedValue(
+      new Ok(
+        makeContract({
+          id: "contract_legacy",
+          recurringCredits: [
+            {
+              id: "rc_excess_legacy",
+              productId: EXCESS_PRODUCT.id,
+              creditTypeId: PROG_USD_CREDIT_TYPE_ID,
+            },
+          ],
+          credits: [
+            {
+              id: "credit_legacy",
+              recurringCreditId: "rc_excess_legacy",
+              productId: EXCESS_PRODUCT.id,
+              scheduleItems: [
+                {
+                  id: "seg_current",
+                  amount: 50,
+                  startingAt: past.toISOString(),
+                  endingBefore: future.toISOString(),
+                },
+              ],
+            },
+          ],
+        })
+      )
+    );
+
+    const result = await removeAwuContractExcessCreditsForContract({
+      metronomeCustomerId: CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+      metronomeContractId: "contract_legacy",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockEditMetronomeContract).not.toHaveBeenCalled();
+  });
+
+  it("propagates get-contract error", async () => {
+    mockGetMetronomeContractById.mockResolvedValue(new Err(new Error("boom")));
+
+    const result = await removeAwuContractExcessCreditsForContract({
+      metronomeCustomerId: CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+      metronomeContractId: "contract_x",
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(mockEditMetronomeContract).not.toHaveBeenCalled();
+  });
+
+  it("propagates edit error", async () => {
+    const future = new Date(Date.now() + 1000 * 60 * 60 * 24);
+    const past = new Date(Date.now() - 1000 * 60 * 60 * 24);
+
+    mockGetMetronomeContractById.mockResolvedValue(
+      new Ok(
+        makeContract({
+          id: "contract_1",
+          recurringCredits: [{ id: "rc_excess", productId: EXCESS_PRODUCT.id }],
+          credits: [
+            {
+              id: "credit_current",
+              recurringCreditId: "rc_excess",
+              productId: EXCESS_PRODUCT.id,
+              scheduleItems: [
+                {
+                  id: "seg_current",
+                  amount: 5000,
+                  startingAt: past.toISOString(),
+                  endingBefore: future.toISOString(),
+                },
+              ],
+            },
+          ],
+        })
+      )
+    );
+    mockEditMetronomeContract.mockResolvedValue(
+      new Err(new Error("edit-failed"))
+    );
+
+    const result = await removeAwuContractExcessCreditsForContract({
+      metronomeCustomerId: CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+      metronomeContractId: "contract_1",
     });
 
     expect(result.isErr()).toBe(true);

--- a/front/lib/metronome/payg_excess_credits.ts
+++ b/front/lib/metronome/payg_excess_credits.ts
@@ -10,7 +10,21 @@ import {
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import type { ContractV2 } from "@metronome/sdk/resources";
 import type { ContractEditParams } from "@metronome/sdk/resources/v2/contracts";
+
+// The AWU "Excess Credits" recurring credits on a contract. Legacy
+// (programmatic USD) excess recurring credits are excluded by credit type —
+// only AWU excess credits are toggled/removed at runtime.
+function getAwuExcessRecurringCredits(
+  contract: ContractV2
+): NonNullable<ContractV2["recurring_credits"]> {
+  return (contract.recurring_credits ?? []).filter(
+    (rc) =>
+      rc.product.id === getProductExcessCreditsId() &&
+      rc.access_amount.credit_type_id === getCreditTypeAwuId()
+  );
+}
 
 /**
  * Set the per-period amount of every AWU recurring "Excess Credits" credit
@@ -41,7 +55,6 @@ export async function setAwuContractExcessCreditsAmount({
     return new Err(contractsResult.error);
   }
 
-  const awuCreditTypeId = getCreditTypeAwuId();
   let updatedContracts = 0;
 
   for (const summary of contractsResult.value) {
@@ -54,11 +67,7 @@ export async function setAwuContractExcessCreditsAmount({
     }
     const contract = detailResult.value;
 
-    const excessRecurringCredits = (contract.recurring_credits ?? []).filter(
-      (rc) =>
-        rc.product.id === getProductExcessCreditsId() &&
-        rc.access_amount.credit_type_id === awuCreditTypeId
-    );
+    const excessRecurringCredits = getAwuExcessRecurringCredits(contract);
     if (excessRecurringCredits.length === 0) {
       continue;
     }
@@ -129,4 +138,99 @@ export async function setAwuContractExcessCreditsAmount({
   }
 
   return new Ok({ updatedContracts });
+}
+
+/**
+ * Remove the AWU "Excess Credits" buffer from a single freshly-provisioned
+ * contract when PAYG is enabled. Metronome bakes the excess recurring credit
+ * into the package template and offers no way to delete a recurring credit from
+ * a contract, so we neutralize it in place:
+ *
+ *  - archive every child credit the recurring credit has already spawned that
+ *    is still active/future, so no excess buffer credit exists on the contract;
+ *  - zero the recurring credit's per-period amount so no later period
+ *    regenerates a buffer.
+ *
+ * The net effect is that a PAYG contract carries no excess buffer, so
+ * over-consumption past the free credit pool bills as PAYG from the start
+ * instead of being silently absorbed.
+ *
+ * AWU-only by design (legacy programmatic-USD excess credits are skipped) and a
+ * no-op when the contract has no AWU excess recurring credit. Only active/future
+ * child credits are archived — a recovered contract could carry expired,
+ * already-consumed excess credits that must not be touched.
+ */
+export async function removeAwuContractExcessCreditsForContract({
+  metronomeCustomerId,
+  workspaceId,
+  metronomeContractId,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+  metronomeContractId: string;
+}): Promise<Result<{ archivedCredits: number }, Error>> {
+  const now = new Date();
+
+  const detailResult = await getMetronomeContractById({
+    metronomeCustomerId,
+    metronomeContractId,
+  });
+  if (detailResult.isErr()) {
+    return new Err(detailResult.error);
+  }
+  const contract = detailResult.value;
+
+  const excessRecurringCredits = getAwuExcessRecurringCredits(contract);
+  if (excessRecurringCredits.length === 0) {
+    return new Ok({ archivedCredits: 0 });
+  }
+
+  const excessRecurringCreditIds = new Set(
+    excessRecurringCredits.map((rc) => rc.id)
+  );
+
+  const archiveCredits: NonNullable<ContractEditParams["archive_credits"]> = [];
+  for (const credit of contract.credits ?? []) {
+    if (
+      !credit.recurring_credit_id ||
+      !excessRecurringCreditIds.has(credit.recurring_credit_id)
+    ) {
+      continue;
+    }
+
+    const hasActiveOrFutureSegment = (
+      credit.access_schedule?.schedule_items ?? []
+    ).some((item) => new Date(item.ending_before).getTime() > now.getTime());
+    if (!hasActiveOrFutureSegment) {
+      continue;
+    }
+
+    archiveCredits.push({ id: credit.id });
+  }
+
+  const editResult = await editMetronomeContract({
+    customer_id: metronomeCustomerId,
+    contract_id: contract.id,
+    update_recurring_credits: excessRecurringCredits.map((rc) => ({
+      recurring_credit_id: rc.id,
+      access_amount: { unit_price: 0, quantity: 1 },
+    })),
+    ...(archiveCredits.length > 0 ? { archive_credits: archiveCredits } : {}),
+  });
+  if (editResult.isErr()) {
+    return new Err(editResult.error);
+  }
+
+  logger.info(
+    {
+      workspaceId,
+      metronomeCustomerId,
+      contractId: contract.id,
+      recurringCreditIds: excessRecurringCredits.map((rc) => rc.id),
+      archivedCreditCount: archiveCredits.length,
+    },
+    "[Metronome PAYG] Removed AWU excess credits on provisioned contract"
+  );
+
+  return new Ok({ archivedCredits: archiveCredits.length });
 }


### PR DESCRIPTION
## Description

`switchContract` provisioned PAYG contracts kept the package-default "Excess Credits" buffer, so overage was silently absorbed instead of billing as PAYG. Adds a post-provision step that, when PAYG is on, archives the excess child credit(s) and zeros the recurring credit so the new contract carries no buffer.

## Tests

Unit tests for `removeAwuContractExcessCreditsForContract`; existing toggle tests pass; tsgo/biome clean.

## Risk

Low — only runs when PAYG is enabled; best-effort post-provision step, idempotent. Rollback = revert.

## Deploy Plan

Standard `front` deploy. No migration.