### PR TITLE
fix(review-bot): parse @handles anywhere on an r? line

### DIFF
--- a/.github/actions/review-bot/README.md
+++ b/.github/actions/review-bot/README.md
@@ -6,6 +6,8 @@ their reviews and a contract review. Use `r? cc` to request only a contract revi
 ```text
 r? @spolu @flvndvd
 r? @spolu please take a look
+r? @pmilliotte or @Nils-Fedrigo
+r? please review @spolu and @flvndvd
 r? cc
 r? @spolu cc @flvndvd PMRR
 ```
@@ -15,12 +17,12 @@ review summary containing a request requests reviews again, including from users
 reviewed. Opening a PR with a request also works. Title edits, pushes, and comment edits do not
 request reviews.
 
-The `r?` must start the line without indentation. Surrounding lines and trailing prose are allowed;
-only consecutive GitHub mentions and bare `cc` tokens immediately after `r?` are reviewers. `cc` is
-case-insensitive; `@cc` requests the GitHub user instead. Team mentions and tokens after trailing
-prose are ignored. Markdown filtering is best-effort: simple fenced blocks, HTML comments, and
-explicitly quoted lines are skipped. Inline code, nested blocks, lazy quote continuations, and
-interactions between comments and fences may cause missed or extra requests.
+The `r?` must start the line without indentation. Surrounding lines and prose between mentions are
+allowed; every whitespace-delimited GitHub mention and bare `cc` token after `r?` is collected.
+`cc` is case-insensitive anywhere on the line; `@cc` requests the GitHub user instead. Team mentions
+and other non-mention tokens are ignored. Markdown filtering is best-effort: simple fenced blocks,
+HTML comments, and explicitly quoted lines are skipped. Inline code, nested blocks, lazy quote
+continuations, and interactions between comments and fences may cause missed or extra requests.
 
 GitHub reviews, contract reviews, and Slack notifications require a human requester with repository
 `write`, `maintain`, or `admin` permission.

--- a/.github/actions/review-bot/package.json
+++ b/.github/actions/review-bot/package.json
@@ -1,7 +1,4 @@
 {
   "private": true,
-  "type": "module",
-  "scripts": {
-    "test": "node --experimental-strip-types --test review-bot.test.ts"
-  }
+  "type": "module"
 }

--- a/.github/actions/review-bot/package.json
+++ b/.github/actions/review-bot/package.json
@@ -1,4 +1,7 @@
 {
   "private": true,
-  "type": "module"
+  "type": "module",
+  "scripts": {
+    "test": "node --experimental-strip-types --test review-bot.test.ts"
+  }
 }

--- a/.github/actions/review-bot/review-bot.test.ts
+++ b/.github/actions/review-bot/review-bot.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { parseReviewRequests } from "./review-bot.ts";
+
+describe("parseReviewRequests", () => {
+  it("collects consecutive mentions after r?", () => {
+    assert.deepEqual(parseReviewRequests("r? @spolu @flvndvd"), [
+      {
+        line: "r? @spolu @flvndvd",
+        reviewers: ["spolu", "flvndvd"],
+        contractReview: false,
+      },
+    ]);
+  });
+
+  it("collects mentions separated by prose such as or", () => {
+    assert.deepEqual(parseReviewRequests("r? @pmilliotte or @Nils-Fedrigo"), [
+      {
+        line: "r? @pmilliotte or @Nils-Fedrigo",
+        reviewers: ["pmilliotte", "nils-fedrigo"],
+        contractReview: false,
+      },
+    ]);
+  });
+
+  it("collects mentions that appear after leading prose", () => {
+    assert.deepEqual(
+      parseReviewRequests("r? please review @spolu and @flvndvd thanks"),
+      [
+        {
+          line: "r? please review @spolu and @flvndvd thanks",
+          reviewers: ["spolu", "flvndvd"],
+          contractReview: false,
+        },
+      ]
+    );
+  });
+
+  it("recognizes bare cc anywhere on the request line", () => {
+    assert.deepEqual(parseReviewRequests("r? @spolu please cc @flvndvd"), [
+      {
+        line: "r? @spolu please cc @flvndvd",
+        reviewers: ["spolu", "flvndvd"],
+        contractReview: true,
+      },
+    ]);
+  });
+
+  it("treats @cc as a GitHub mention, not contract review", () => {
+    assert.deepEqual(parseReviewRequests("r? @cc please"), [
+      {
+        line: "r? @cc please",
+        reviewers: ["cc"],
+        contractReview: false,
+      },
+    ]);
+  });
+
+  it("deduplicates handles case-insensitively", () => {
+    assert.deepEqual(parseReviewRequests("r? @Spolu or @spolu"), [
+      {
+        line: "r? @Spolu or @spolu",
+        reviewers: ["spolu"],
+        contractReview: false,
+      },
+    ]);
+  });
+
+  it("ignores team mentions and invalid tokens", () => {
+    assert.deepEqual(
+      parseReviewRequests("r? @dust-tt/eng or @spolu @not_valid"),
+      [
+        {
+          line: "r? @dust-tt/eng or @spolu @not_valid",
+          reviewers: ["spolu"],
+          contractReview: false,
+        },
+      ]
+    );
+  });
+
+  it("skips fenced code blocks", () => {
+    assert.deepEqual(parseReviewRequests("```\nr? @spolu\n```\nr? @flvndvd"), [
+      {
+        line: "r? @flvndvd",
+        reviewers: ["flvndvd"],
+        contractReview: false,
+      },
+    ]);
+  });
+});

--- a/.github/actions/review-bot/review-bot.ts
+++ b/.github/actions/review-bot/review-bot.ts
@@ -72,12 +72,13 @@ type ReviewBotOptions = {
 
 /**
  * @cc [label:product] review-request-syntax
- * Parse consecutive GitHub mentions and bare `cc` tokens after a column-zero `r?` followed by
- * whitespace, retaining the request line for notifications. Bare `cc` requests a contract review
- * case-insensitively; `@cc` remains a GitHub mention. Trailing prose ends the list. Deduplicate
- * handles case-insensitively within each request. Markdown filtering is best-effort: skip simple
- * fenced blocks, HTML comments, and explicitly quoted lines. Inline code, nested blocks, lazy quote
- * continuations, and interactions between comments and fences may cause missed or extra requests.
+ * Parse every whitespace-delimited GitHub mention and bare `cc` token after a column-zero `r?`
+ * followed by whitespace, retaining the request line for notifications. Bare `cc` requests a
+ * contract review case-insensitively anywhere on the line; `@cc` remains a GitHub mention. Prose
+ * between tokens is ignored and does not end the list. Deduplicate handles case-insensitively
+ * within each request. Markdown filtering is best-effort: skip simple fenced blocks, HTML comments,
+ * and explicitly quoted lines. Inline code, nested blocks, lazy quote continuations, and
+ * interactions between comments and fences may cause missed or extra requests.
  */
 export function parseReviewRequests(
   body: string | null | undefined
@@ -118,7 +119,7 @@ export function parseReviewRequests(
         continue;
       }
       if (!/^@[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i.test(token)) {
-        break;
+        continue;
       }
       reviewers.add(token.slice(1).toLowerCase());
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The engbot review parser previously stopped collecting reviewers at the first non-mention token. That meant `r? @pmilliotte or @Nils-Fedrigo` only requested `@pmilliotte`.

This changes `parseReviewRequests` to collect every whitespace-delimited GitHub mention (and bare `cc`) anywhere after a column-zero `r?`, so prose like `or` / `and` / `please` no longer truncates the list.

Also updates the product contract + README, and adds `node:test` coverage for the motivating `or` case and related edge cases.

## Tests

- Added `.github/actions/review-bot/review-bot.test.ts`
- Ran `node --experimental-strip-types --test review-bot.test.ts` in `.github/actions/review-bot` (8/8 passing)

Demo for the Fabien-style request:

```text
input:  r? @pmilliotte or @Nils-Fedrigo
parsed: reviewers: ["pmilliotte", "nils-fedrigo"]
```

## Risk

Low. Behavior is additive for existing consecutive-mention requests. More reviewers may be requested when authors write prose between handles (intended). Team mentions and invalid tokens remain ignored.

## Deploy Plan

Merge to default branch so the review-bot action (loaded from default branch) picks up the parser change. No migration or config change.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://dust4ai.slack.com/archives/C09GELMTTRT/p1789118058442359?thread_ts=1789118058.442359&cid=C09GELMTTRT)

<div><a href="https://cursor.com/agents/bc-a760e347-0e78-5c7b-8312-8468f90f723a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a760e347-0e78-5c7b-8312-8468f90f723a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

