### PR TITLE
Parse inline GitHub handles in review requests

### DIFF
--- a/.github/actions/review-bot/README.md
+++ b/.github/actions/review-bot/README.md
@@ -71,8 +71,7 @@ review and progress status on the captured PR head.
 
 Each review run reports a distinct `Review Code Contracts (<run-id>)` commit status linked to the
 workflow, including progress, completion, failure, and cancellation. Success means the review
-completed; findings remain in the comment review. Concurrent runs cannot overwrite one another's
-status.
+completed; findings remain in the comment review. Concurrent runs cannot overwrite one another's status.
 
 The request job needs `actions: write` to dispatch. Review execution needs `contents: read`,
 `pull-requests: write`, `statuses: write`, and `actions: read` to resolve delegated requesters.

--- a/.github/actions/review-bot/README.md
+++ b/.github/actions/review-bot/README.md
@@ -5,7 +5,7 @@ their reviews and a contract review. Use `r? cc` to request only a contract revi
 
 ```text
 r? @spolu @flvndvd
-r? @spolu please take a look
+r? please take a look at @spolu
 r? cc
 r? @spolu cc @flvndvd PMRR
 ```
@@ -16,10 +16,10 @@ reviewed. Opening a PR with a request also works. Title edits, pushes, and comme
 request reviews.
 
 The `r?` must start the line without indentation. Surrounding lines and trailing prose are allowed;
-only consecutive GitHub mentions and bare `cc` tokens immediately after `r?` are reviewers. `cc` is
-case-insensitive; `@cc` requests the GitHub user instead. Team mentions and tokens after trailing
-prose are ignored. Markdown filtering is best-effort: simple fenced blocks, HTML comments, and
-explicitly quoted lines are skipped. Inline code, nested blocks, lazy quote continuations, and
+all GitHub mentions anywhere after `r?` are reviewers. Bare `cc` tokens anywhere on the request line
+request a contract review. `cc` is case-insensitive; `@cc` requests the GitHub user instead. Team
+mentions are not supported. Markdown filtering is best-effort: simple fenced blocks, HTML comments,
+and explicitly quoted lines are skipped. Inline code, nested blocks, lazy quote continuations, and
 interactions between comments and fences may cause missed or extra requests.
 
 GitHub reviews, contract reviews, and Slack notifications require a human requester with repository
@@ -66,12 +66,13 @@ preserves the human requester's identity and request across dispatches and retri
 rechecks that person's access before reviewing.
 
 Inline comments and review summaries invoke the action directly in their request workflow because
-the imported action does not yet accept these events as delegated requests. They still publish a
+ the imported action does not yet accept these events as delegated requests. They still publish a
 review and progress status on the captured PR head.
 
 Each review run reports a distinct `Review Code Contracts (<run-id>)` commit status linked to the
 workflow, including progress, completion, failure, and cancellation. Success means the review
-completed; findings remain in the comment review. Concurrent runs cannot overwrite one another's status.
+completed; findings remain in the comment review. Concurrent runs cannot overwrite one another's
+status.
 
 The request job needs `actions: write` to dispatch. Review execution needs `contents: read`,
 `pull-requests: write`, `statuses: write`, and `actions: read` to resolve delegated requesters.

--- a/.github/actions/review-bot/README.md
+++ b/.github/actions/review-bot/README.md
@@ -66,7 +66,7 @@ preserves the human requester's identity and request across dispatches and retri
 rechecks that person's access before reviewing.
 
 Inline comments and review summaries invoke the action directly in their request workflow because
- the imported action does not yet accept these events as delegated requests. They still publish a
+the imported action does not yet accept these events as delegated requests. They still publish a
 review and progress status on the captured PR head.
 
 Each review run reports a distinct `Review Code Contracts (<run-id>)` commit status linked to the

--- a/.github/actions/review-bot/review-bot.test.ts
+++ b/.github/actions/review-bot/review-bot.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseReviewRequests } from "./review-bot.ts";
+
+test("parses GitHub handles anywhere in a review request line", () => {
+  assert.deepEqual(parseReviewRequests("r? please ask @Nils-Fedrigo and @fabien."), [
+    {
+      line: "r? please ask @Nils-Fedrigo and @fabien.",
+      reviewers: ["nils-fedrigo", "fabien"],
+      contractReview: false,
+    },
+  ]);
+});
+
+test("parses handles next to punctuation and preserves contract review tokens", () => {
+  assert.deepEqual(parseReviewRequests("r? @nils, please ask @fabien; cc"), [
+    {
+      line: "r? @nils, please ask @fabien; cc",
+      reviewers: ["nils", "fabien"],
+      contractReview: true,
+    },
+  ]);
+});
+
+test("does not parse mentions from lines without an r? request", () => {
+  assert.deepEqual(parseReviewRequests("Please ask @nils to review this."), []);
+});

--- a/.github/actions/review-bot/review-bot.ts
+++ b/.github/actions/review-bot/review-bot.ts
@@ -72,12 +72,12 @@ type ReviewBotOptions = {
 
 /**
  * @cc [label:product] review-request-syntax
- * Parse consecutive GitHub mentions and bare `cc` tokens after a column-zero `r?` followed by
+ * Parse GitHub mentions and bare `cc` tokens anywhere after a column-zero `r?` followed by
  * whitespace, retaining the request line for notifications. Bare `cc` requests a contract review
- * case-insensitively; `@cc` remains a GitHub mention. Trailing prose ends the list. Deduplicate
- * handles case-insensitively within each request. Markdown filtering is best-effort: skip simple
- * fenced blocks, HTML comments, and explicitly quoted lines. Inline code, nested blocks, lazy quote
- * continuations, and interactions between comments and fences may cause missed or extra requests.
+ * case-insensitively; `@cc` remains a GitHub mention. Deduplicate handles case-insensitively within
+ * each request. Markdown filtering is best-effort: skip simple fenced blocks, HTML comments, and
+ * explicitly quoted lines. Inline code, nested blocks, lazy quote continuations, and interactions
+ * between comments and fences may cause missed or extra requests.
  */
 export function parseReviewRequests(
   body: string | null | undefined
@@ -112,15 +112,15 @@ export function parseReviewRequests(
     }
     const reviewers = new Set<string>();
     let contractReview = false;
+    for (const match of request[1].matchAll(
+      /(?<![a-z\d_-])@[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?/gi
+    )) {
+      reviewers.add(match[0].slice(1).toLowerCase());
+    }
     for (const token of request[1].split(/[ \t]+/)) {
       if (token.toLowerCase() === "cc") {
         contractReview = true;
-        continue;
       }
-      if (!/^@[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i.test(token)) {
-        break;
-      }
-      reviewers.add(token.slice(1).toLowerCase());
     }
     if (reviewers.size > 0 || contractReview) {
       requests.push({ line, reviewers: [...reviewers], contractReview });
@@ -374,9 +374,9 @@ function escapeSlackText(text: string): string {
 /**
  * @cc [label:product] review-request-slack-format
  * Format each eligible `r?` line with trailing prose preserved, prefixed by
- * `from: @requester` and followed by the PR URL and on the same line. Resolve
- * requester and reviewer mentions through `.authors` emails and Slack user
- * lookup; unresolved handles remain plain text.
+ * `from: @requester` and followed by the PR URL and requester on the same line. Resolve
+ * requester and reviewer mentions through `.authors` emails and Slack user lookup; unresolved
+ * handles remain plain text.
  */
 /**
  * @cc [label:error-handling] review-request-slack-delivery
@@ -464,7 +464,7 @@ export async function formatSlackNotification({
     escapeSlackText(`@${notification.requester}`);
   const lines = notification.requests.map(({ line }) =>
     escapeSlackText(line).replace(
-      /(?<!\S)@[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?(?=[ \t]|$)/gi,
+      /(?<![a-z\d_-])@[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?(?![a-z\d_-])/gi,
       (mention) => mentions.get(mention.slice(1).toLowerCase()) ?? mention
     )
   );


### PR DESCRIPTION
## Description

Update the review bot to parse valid GitHub handles anywhere on an `r?` request line, instead of only consecutive handles immediately after `r?`. Slack mention replacement now also handles punctuation adjacent to usernames. Add focused parser tests and update the action README.

## Tests

- `node --experimental-strip-types --test .github/actions/review-bot/review-bot.test.ts`
- `git diff --check`
- Biome was not run because dependencies are not installed in the shallow clone.

## Risk

Low. The change only broadens reviewer detection on existing `r?` request lines and keeps the existing line, fence, and HTML-comment filtering. A malformed or unsupported token is still ignored unless it matches the GitHub handle pattern.

## Deploy Plan

Merge to `main`. The review workflow loads this action from the default branch, so the behavior will activate after the merge.