### PR TITLE
[front] fix: allow local Poke login without Cloudflare config

### DIFF
--- a/front-api/middlewares/poke_auth.ts
+++ b/front-api/middlewares/poke_auth.ts
@@ -82,7 +82,7 @@ export const pokeAuth = createMiddleware<PokeCtx>(async (ctx, next) => {
     ctx.set("pokeRoles", pokeRoles);
     await next();
     return;
-  } else if (accessConfig && !accessToken) {
+  } else if (!accessToken) {
     if (!isDevelopment()) {
       logger.warn(
         "[Poke Auth] Request missing Cloudflare Access token; rejececting request"

--- a/front-api/middlewares/poke_auth.ts
+++ b/front-api/middlewares/poke_auth.ts
@@ -85,7 +85,7 @@ export const pokeAuth = createMiddleware<PokeCtx>(async (ctx, next) => {
   } else if (!accessToken) {
     if (!isDevelopment()) {
       logger.warn(
-        "[Poke Auth] Request missing Cloudflare Access token; rejececting request"
+        "[Poke Auth] Request missing Cloudflare Access token; rejecting request"
       );
     } else {
       logger.info(


### PR DESCRIPTION
## Description

Local Poke redirects back through login when Cloudflare Access is not configured because the development WorkOS fallback is skipped.

Allow the fallback when no Access token is present, without requiring Cloudflare configuration. It remains restricted to development.

## Tests

- Tested locally.

## Risk

- Low. No impact in production.

## Deploy Plan

- Deploy front.
