### PR TITLE
GA the files as Pod tab feature.

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -1,7 +1,6 @@
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { ProjectFileFactory } from "@app/tests/utils/ProjectFileFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
@@ -245,8 +244,6 @@ describe("PATCH /api/w/:wId/spaces/:spaceId/project_metadata", () => {
     const { workspace, auth, user } = await createPrivateApiMockRequest({
       role: "admin",
     });
-
-    await FeatureFlagFactory.basic(auth, "pod_frame_tabs");
 
     const projectSpace = await SpaceFactory.project(workspace, user.id);
 

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -1,7 +1,6 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { validatePodFileTabs } from "@app/lib/api/projects/file_tabs";
 import { validatePinnedFramePath } from "@app/lib/api/projects/pinned_frame";
-import { hasFeatureFlag } from "@app/lib/auth";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
@@ -104,16 +103,6 @@ app.patch(
           api_error: {
             type: "invalid_request_error",
             message: "frameTabs and tabsOrder must be provided together.",
-          },
-        });
-      }
-
-      if (!(await hasFeatureFlag(auth, "pod_frame_tabs"))) {
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "feature_flag_not_found",
-            message: "Pod file tabs are not enabled for this workspace.",
           },
         });
       }

--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -117,8 +117,6 @@ export function ConversationFileExplorer({
     isEditor: canEditPod,
   });
 
-  const hasFileTabs = hasFeature("pod_frame_tabs");
-
   const { removeFileTab, isFileTab } = usePodFileTabs({
     owner,
     podId: isPod ? conversation.spaceId : "",
@@ -152,35 +150,32 @@ export function ConversationFileExplorer({
         },
       ];
 
-      if (hasFileTabs) {
-        const asTab = isFileTab(entry.path);
-        items.push({
-          label: asTab ? "Remove from Pod tabs" : "Add as Pod tab",
-          icon: LayoutAlt02,
-          onClick: (e) => {
-            e.stopPropagation();
-            if (asTab) {
-              void removeFileTab(entry.path, { fileName: entry.fileName });
-              return;
-            }
-            setCreateFileTabDraft({
-              path: entry.path,
-              title: podFileTabBasename(entry.fileName).slice(
-                0,
-                MAX_POD_FILE_TAB_TITLE_LENGTH
-              ),
-              icon: DEFAULT_POD_FILE_TAB_ICON,
-            });
-          },
-        });
-      }
+      const asTab = isFileTab(entry.path);
+      items.push({
+        label: asTab ? "Remove from Pod tabs" : "Add as Pod tab",
+        icon: LayoutAlt02,
+        onClick: (e) => {
+          e.stopPropagation();
+          if (asTab) {
+            void removeFileTab(entry.path, { fileName: entry.fileName });
+            return;
+          }
+          setCreateFileTabDraft({
+            path: entry.path,
+            title: podFileTabBasename(entry.fileName).slice(
+              0,
+              MAX_POD_FILE_TAB_TITLE_LENGTH
+            ),
+            icon: DEFAULT_POD_FILE_TAB_ICON,
+          });
+        },
+      });
 
       return items;
     },
     [
       canEditPod,
       conversation.spaceId,
-      hasFileTabs,
       isFileTab,
       isPinned,
       removeFileTab,

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -12,7 +12,7 @@ import { PodFileTabButton } from "@app/components/pod/files/PodFileTabButton";
 import { useVisualizationRevert } from "@app/hooks/conversations";
 import { useHashParam } from "@app/hooks/useHashParams";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { useClientType } from "@app/lib/context/clientType";
 import { clientFetch } from "@app/lib/egress/client";
 import {
@@ -72,8 +72,6 @@ export function FrameRenderer({
   renderMode,
 }: FrameRendererProps) {
   const { vizUrl } = useAuth();
-  const { hasFeature } = useFeatureFlags();
-  const hasFileTabs = hasFeature("pod_frame_tabs");
   const isMobile = useIsMobile();
   const { isNavigationBarOpen, setIsNavigationBarOpen } =
     useDesktopNavigation();
@@ -396,18 +394,16 @@ export function FrameRenderer({
                 fileName={fileMetadata?.fileName}
                 hidden={!isFrameInPod}
               />
-              {hasFileTabs && (
-                <PodFileTabButton
-                  owner={owner}
-                  spaceId={projectId ?? ""}
-                  fileTabs={projectInfo?.frameTabs ?? []}
-                  tabsOrder={projectInfo?.tabsOrder ?? []}
-                  isEditor={projectInfo?.isEditor ?? false}
-                  filePath={framePath}
-                  fileName={fileMetadata?.fileName}
-                  hidden={!isFrameInPod}
-                />
-              )}
+              <PodFileTabButton
+                owner={owner}
+                spaceId={projectId ?? ""}
+                fileTabs={projectInfo?.frameTabs ?? []}
+                tabsOrder={projectInfo?.tabsOrder ?? []}
+                isEditor={projectInfo?.isEditor ?? false}
+                filePath={framePath}
+                fileName={fileMetadata?.fileName}
+                hidden={!isFrameInPod}
+              />
               {projectSaveState === "saved" && (
                 <Button
                   icon={CheckCircle}

--- a/front/components/pages/pod/PodPage.tsx
+++ b/front/components/pages/pod/PodPage.tsx
@@ -9,11 +9,7 @@ import {
   isValidPodTabValue,
   usePodTabs,
 } from "@app/hooks/useSpaceProjectTabs";
-import {
-  useAuth,
-  useFeatureFlags,
-  useWorkspace,
-} from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { useActivationPod } from "@app/lib/swr/activation";
 import { usePodFiles } from "@app/lib/swr/pods";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
@@ -62,11 +58,9 @@ const MISSING_FILE_TAB_TRIGGER_CLASSNAME = cn(
 export function PodPage() {
   const owner = useWorkspace();
   const { user } = useAuth();
-  const { hasFeature } = useFeatureFlags();
   const podId = useActivePodId();
   const { podKind } = useActivationPod({ workspaceId: owner.sId, podId });
   const isGoalPod = podKind === "goal";
-  const hasFileTabs = hasFeature("pod_frame_tabs");
 
   const {
     spaceInfo: podInfo,
@@ -96,12 +90,11 @@ export function PodPage() {
   const { files: podFiles, isPodFilesLoading } = usePodFiles({
     owner,
     podId,
-    disabled: !hasFileTabs,
   });
 
   const fileTabs = useMemo(
-    () => (hasFileTabs ? sortPodFileTabs(podInfo?.frameTabs ?? []) : []),
-    [hasFileTabs, podInfo?.frameTabs]
+    () => sortPodFileTabs(podInfo?.frameTabs ?? []),
+    [podInfo?.frameTabs]
   );
 
   const podFilePaths = useMemo(
@@ -114,13 +107,11 @@ export function PodPage() {
 
   const tabsOrder = useMemo(
     () =>
-      hasFileTabs
-        ? normalizeTabsOrder(
-            podInfo?.tabsOrder ?? [],
-            fileTabs.map((tab) => tab.path)
-          )
-        : [],
-    [fileTabs, hasFileTabs, podInfo?.tabsOrder]
+      normalizeTabsOrder(
+        podInfo?.tabsOrder ?? [],
+        fileTabs.map((tab) => tab.path)
+      ),
+    [fileTabs, podInfo?.tabsOrder]
   );
 
   const navItemsBeforeSettings = useMemo(
@@ -135,10 +126,10 @@ export function PodPage() {
     if (!filePath) {
       return;
     }
-    if (!hasFileTabs || !fileTabs.some((tab) => tab.path === filePath)) {
+    if (!fileTabs.some((tab) => tab.path === filePath)) {
       handleTabChange("conversations");
     }
-  }, [currentTab, fileTabs, handleTabChange, hasFileTabs]);
+  }, [currentTab, fileTabs, handleTabChange]);
 
   if (isPodsInfoLoading) {
     return (
@@ -221,7 +212,7 @@ export function PodPage() {
                 }
               }
             })}
-            {hasFileTabs && podInfo.isEditor && (
+            {podInfo.isEditor && (
               <PodNavAddFileTabButton
                 owner={owner}
                 podId={podInfo.sId}

--- a/front/components/pod/files/PodFileExplorer.tsx
+++ b/front/components/pod/files/PodFileExplorer.tsx
@@ -27,7 +27,6 @@ import { useFolderPathUrlState } from "@app/hooks/useFolderPathUrlState";
 import { usePinPodBanner } from "@app/hooks/usePinPodBanner";
 import { usePodFileTabs } from "@app/hooks/usePodFileTabs";
 import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import {
   downloadFile,
@@ -272,8 +271,6 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
 
   const isArchived = !!pod.archivedAt;
   const isEditor = pod.isEditor;
-  const { hasFeature } = useFeatureFlags();
-  const hasFileTabs = hasFeature("pod_frame_tabs");
   const { togglePin, isPinned } = usePinPodBanner({
     owner,
     podId: pod.sId,
@@ -324,7 +321,7 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
         entry.kind === "frame_package" ||
         (entry.contentType !== frameV2ContentType &&
           isFilePreviewableContentType(entry.contentType));
-      if (hasFileTabs && canBeTab) {
+      if (canBeTab) {
         const asTab = isFileTab(entry.path);
         items.push({
           label: asTab ? "Remove from Pod tabs" : "Add as Pod tab",
@@ -349,15 +346,7 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
 
       return items;
     },
-    [
-      hasFileTabs,
-      isArchived,
-      isEditor,
-      isFileTab,
-      isPinned,
-      removeFileTab,
-      togglePin,
-    ]
+    [isArchived, isEditor, isFileTab, isPinned, removeFileTab, togglePin]
   );
 
   const canManuallyManagePodKnowledge =
@@ -862,7 +851,7 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
         contentClassName="max-w-4xl mx-auto w-full"
         contentNodes={contentNodeEntries}
         defaultViewMode="list"
-        displayFramePackages={hasFeature("frames_v2")}
+        displayFramePackages={true}
         emptyState={hasFiles ? undefined : emptyState}
         files={podGCSFiles}
         getFileUrl={getFileUrl}

--- a/front/components/pod/files/PodFrameSheet.tsx
+++ b/front/components/pod/files/PodFrameSheet.tsx
@@ -3,7 +3,7 @@ import { ExportContentDropdown } from "@app/components/assistant/conversation/in
 import { ShareFrameSheet } from "@app/components/assistant/conversation/interactive_content/frame/ShareFrameSheet";
 import { PinPodBannerButton } from "@app/components/pod/files/PinPodBannerButton";
 import { PodFileTabButton } from "@app/components/pod/files/PodFileTabButton";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { useFileContent, useFileMetadata } from "@app/lib/swr/files";
 import { getFrameFunctionReferenceKind } from "@app/types/api/frame_function_reference";
 import type { PodFileTab } from "@app/types/pod_file_tab";
@@ -55,8 +55,6 @@ export function PodFrameSheet({
   owner,
 }: PodFrameSheetProps) {
   const { vizUrl } = useAuth();
-  const { hasFeature } = useFeatureFlags();
-  const hasFileTabs = hasFeature("pod_frame_tabs");
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
 
@@ -119,18 +117,16 @@ export function PodFrameSheet({
                   fileName={fileName}
                   hidden={isArchived}
                 />
-                {hasFileTabs && (
-                  <PodFileTabButton
-                    owner={owner}
-                    spaceId={podId}
-                    fileTabs={fileTabs}
-                    tabsOrder={tabsOrder}
-                    isEditor={isEditor}
-                    filePath={framePath}
-                    fileName={fileName}
-                    hidden={isArchived}
-                  />
-                )}
+                <PodFileTabButton
+                  owner={owner}
+                  spaceId={podId}
+                  fileTabs={fileTabs}
+                  tabsOrder={tabsOrder}
+                  isEditor={isEditor}
+                  filePath={framePath}
+                  fileName={fileName}
+                  hidden={isArchived}
+                />
                 <Button
                   icon={isFullscreen ? Minimize01 : Maximize01}
                   variant="ghost"

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -106,7 +106,6 @@ export function PodSettingsTab({
   const { hasFeature } = useFeatureFlags();
   const { isAdmin } = useAuth();
   const hasWorkspaceDefaultAgentFeature = hasFeature("workspace_default_agent");
-  const hasFileTabs = hasFeature("pod_frame_tabs");
   // The pod env vars section stays workspace-admin only (matching the API,
   // which keeps env-vars admin-only). Mirrors that gate — change both together.
   const isPodSandboxAdminEnabled = isAdmin && hasFeature("frames_v2");
@@ -727,15 +726,13 @@ export function PodSettingsTab({
           </div>
         </div>
 
-        {hasFileTabs && (
-          <PodTabsCustomizationSection
-            owner={owner}
-            podId={pod.sId}
-            fileTabs={pod.frameTabs ?? []}
-            tabsOrder={pod.tabsOrder}
-            isEditor={isPodEditor}
-          />
-        )}
+        <PodTabsCustomizationSection
+          owner={owner}
+          podId={pod.sId}
+          fileTabs={pod.frameTabs ?? []}
+          tabsOrder={pod.tabsOrder}
+          isEditor={isPodEditor}
+        />
 
         <div className="flex flex-col gap-3">
           <div className="flex items-center gap-2">

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -365,12 +365,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "dust_only",
     owner: "frankaloia",
   },
-  pod_frame_tabs: {
-    description:
-      "Allow adding previewable Pod files (frames, markdown, and other previews) as custom tabs (title, icon, order) on the pod.",
-    stage: "dust_only",
-    owner: "Fraggle",
-  },
   group_permissions_shadow: {
     description:
       "Admin Governance: evaluate the new group_permissions checks alongside the legacy ones and log mismatches (shadow mode). Serves the legacy result; safe to toggle.",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -878,7 +878,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "self_improvement_beta_tester"
   | "legacy_billing"
   | "plan_mode"
-  | "pod_frame_tabs"
   | "admin_can_see_private_entities"
   | "skill_favorites"
   | "poke_mcp"


### PR DESCRIPTION
## Description

Pod file tabs are now generally available. I removed the `pod_frame_tabs` feature flag and API gate, enabled tab creation/customization and file-tab controls across Pod pages, file explorers, frame renderers, and frame sheets, and made `frame_package` entries visible independently of `frames_v2`. I also removed the flag from the JS SDK feature enum and updated project metadata coverage.

r? @pmilliotte it's a straightforward FF removal.

## Tests

I updated the `PATCH /api/w/:wId/spaces/:spaceId/project_metadata` coverage to validate Pod file-tab metadata without a feature flag. No dedicated UI tests were added in this change.

## Risk

Medium rollout risk: existing workspaces will see Pod file tabs immediately, and the API will accept file-tab metadata without the former flag. The change is safe to roll back by reverting the deployment. Monitor Pod navigation, file previews, and metadata updates after release.

## Deploy Plan

Deploy `front-api` and `front`. No SQL migrations or infrastructure changes. After deployment, verify Pod file-tab creation, removal, ordering, customization, and `frame_package` visibility.