### PR TITLE
Relocation is routed by cell, not by region

### DIFF
--- a/front/scripts/relocation/get_data_source_documents.ts
+++ b/front/scripts/relocation/get_data_source_documents.ts
@@ -1,7 +1,7 @@
 import { makeScript } from "@app/scripts/helpers";
 import { getDataSourceDocuments } from "@app/temporal/relocation/activities/source_region/core";
 import { CORE_API_LIST_NODES_BATCH_SIZE } from "@app/temporal/relocation/activities/types";
-import { isRegionType, SUPPORTED_REGIONS } from "@app/types/region";
+import { isCellType, SUPPORTED_CELLS } from "@app/types/cell";
 
 makeScript(
   {
@@ -24,9 +24,9 @@ makeScript(
       description: "The workspace ID",
       required: true,
     },
-    sourceRegion: {
+    sourceCell: {
       type: "string",
-      choices: SUPPORTED_REGIONS,
+      choices: SUPPORTED_CELLS,
       required: true,
     },
     pageCursor: {
@@ -45,7 +45,7 @@ makeScript(
       dataSourceId,
       projectId,
       workspaceId,
-      sourceRegion,
+      sourceCell,
       pageCursor,
       fileName,
       limit,
@@ -53,8 +53,8 @@ makeScript(
     },
     logger
   ) => {
-    if (!isRegionType(sourceRegion)) {
-      logger.error("Invalid region.");
+    if (!isCellType(sourceCell)) {
+      logger.error("Invalid cell.");
       return;
     }
 
@@ -70,7 +70,7 @@ makeScript(
         dustAPIProjectId: projectId,
       },
       pageCursor,
-      sourceRegion,
+      sourceCell,
       workspaceId,
       fileName,
       limit: limit ?? CORE_API_LIST_NODES_BATCH_SIZE,

--- a/front/scripts/relocation/get_data_source_tables.ts
+++ b/front/scripts/relocation/get_data_source_tables.ts
@@ -1,7 +1,7 @@
 import { makeScript } from "@app/scripts/helpers";
 import { getDataSourceTables } from "@app/temporal/relocation/activities/source_region/core/tables";
 import { CORE_API_LIST_TABLES_BATCH_SIZE } from "@app/temporal/relocation/activities/types";
-import { isRegionType, SUPPORTED_REGIONS } from "@app/types/region";
+import { isCellType, SUPPORTED_CELLS } from "@app/types/cell";
 
 makeScript(
   {
@@ -24,9 +24,9 @@ makeScript(
       description: "The workspace ID",
       required: true,
     },
-    sourceRegion: {
+    sourceCell: {
       type: "string",
-      choices: SUPPORTED_REGIONS,
+      choices: SUPPORTED_CELLS,
       required: true,
     },
     pageCursor: {
@@ -42,15 +42,15 @@ makeScript(
       dataSourceId,
       projectId,
       workspaceId,
-      sourceRegion,
+      sourceCell,
       pageCursor,
       limit,
       execute,
     },
     logger
   ) => {
-    if (!isRegionType(sourceRegion)) {
-      logger.error("Invalid region.");
+    if (!isCellType(sourceCell)) {
+      logger.error("Invalid cell.");
       return;
     }
 
@@ -66,7 +66,7 @@ makeScript(
         dustAPIProjectId: projectId,
       },
       pageCursor,
-      sourceRegion,
+      sourceCell,
       workspaceId,
       limit: limit ?? CORE_API_LIST_TABLES_BATCH_SIZE,
     });

--- a/front/scripts/relocation/read_front_table_chunk.ts
+++ b/front/scripts/relocation/read_front_table_chunk.ts
@@ -1,23 +1,23 @@
-import { config } from "@app/lib/api/regions/config";
+import { config } from "@app/lib/api/cells/config";
 import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { readFrontTableChunk } from "@app/temporal/relocation/activities/source_region/front";
-import type { RegionType } from "@app/types/region";
-import { isRegionType, SUPPORTED_REGIONS } from "@app/types/region";
+import type { CellType } from "@app/types/cell";
+import { isCellType, SUPPORTED_CELLS } from "@app/types/cell";
 
-function assertCorrectRegion(region: RegionType) {
-  if (config.getCurrentRegion() !== region) {
+function assertCurrentCell(cell: CellType) {
+  if (config.getCurrentCell().name !== cell) {
     throw new Error(
-      `Relocation must be run from ${region}. Current region is ${config.getCurrentRegion()}.`
+      `Relocation must be run from ${cell}. Current cell is ${config.getCurrentCell().name}.`
     );
   }
 }
 
 makeScript(
   {
-    destRegion: {
+    destCell: {
       type: "string",
-      choices: SUPPORTED_REGIONS,
+      choices: SUPPORTED_CELLS,
       required: true,
     },
     lastId: {
@@ -27,9 +27,9 @@ makeScript(
       type: "number",
       require: true,
     },
-    sourceRegion: {
+    sourceCell: {
       type: "string",
-      choices: SUPPORTED_REGIONS,
+      choices: SUPPORTED_CELLS,
     },
     tableName: {
       type: "string",
@@ -44,33 +44,33 @@ makeScript(
     },
   },
   async ({
-    destRegion,
+    destCell,
     lastId,
     limit,
-    sourceRegion,
+    sourceCell,
     tableName,
     workspaceId,
     fileName,
     execute,
   }) => {
-    if (!isRegionType(sourceRegion) || !isRegionType(destRegion)) {
-      logger.error("Invalid region.");
+    if (!isCellType(sourceCell) || !isCellType(destCell)) {
+      logger.error("Invalid cell.");
       return;
     }
 
-    if (sourceRegion === destRegion) {
-      logger.error("Source and destination regions must be different.");
+    if (sourceCell === destCell) {
+      logger.error("Source and destination cells must be different.");
       return;
     }
 
-    assertCorrectRegion(sourceRegion);
+    assertCurrentCell(sourceCell);
 
     if (execute) {
       try {
         const res = await readFrontTableChunk({
-          destRegion,
+          destCell,
           lastId,
-          sourceRegion,
+          sourceCell,
           tableName,
           workspaceId,
           limit,

--- a/front/scripts/relocation/relocate_app_workflow.ts
+++ b/front/scripts/relocation/relocate_app_workflow.ts
@@ -1,8 +1,8 @@
 import { makeScript } from "@app/scripts/helpers";
-import { RELOCATION_QUEUES_PER_REGION } from "@app/temporal/relocation/config";
+import { RELOCATION_QUEUES_PER_CELL } from "@app/temporal/relocation/config";
 import { getTemporalRelocationClient } from "@app/temporal/relocation/temporal";
 import { workspaceRelocateAppWorkflow } from "@app/temporal/relocation/workflows";
-import { isRegionType, SUPPORTED_REGIONS } from "@app/types/region";
+import { isCellType, SUPPORTED_CELLS } from "@app/types/cell";
 import { WorkflowNotFoundError } from "@temporalio/common";
 
 makeScript(
@@ -12,14 +12,14 @@ makeScript(
       type: "string",
       demandOption: true,
     },
-    sourceRegion: {
+    sourceCell: {
       type: "string",
-      choices: SUPPORTED_REGIONS,
+      choices: SUPPORTED_CELLS,
       demandOption: true,
     },
-    destRegion: {
+    destCell: {
       type: "string",
-      choices: SUPPORTED_REGIONS,
+      choices: SUPPORTED_CELLS,
       demandOption: true,
     },
     projectId: {
@@ -27,17 +27,14 @@ makeScript(
       require: true,
     },
   },
-  async (
-    { workspaceId, sourceRegion, destRegion, projectId, execute },
-    logger
-  ) => {
-    if (!isRegionType(sourceRegion) || !isRegionType(destRegion)) {
-      logger.error("Invalid region.");
+  async ({ workspaceId, sourceCell, destCell, projectId, execute }, logger) => {
+    if (!isCellType(sourceCell) || !isCellType(destCell)) {
+      logger.error("Invalid cell.");
       return;
     }
 
-    if (sourceRegion === destRegion) {
-      logger.error("Source and destination regions must be different.");
+    if (sourceCell === destCell) {
+      logger.error("Source and destination cells must be different.");
       return;
     }
 
@@ -67,9 +64,9 @@ makeScript(
       logger.info(
         {
           workspaceId,
-          sourceRegion,
-          destRegion,
-          queue: RELOCATION_QUEUES_PER_REGION[sourceRegion],
+          sourceCell,
+          destCell,
+          queue: RELOCATION_QUEUES_PER_CELL[sourceCell],
           workflowId,
         },
         "starting workspaceRelocateAppsWorkflow"
@@ -79,12 +76,12 @@ makeScript(
         args: [
           {
             workspaceId,
-            sourceRegion,
-            destRegion,
+            sourceCell,
+            destCell,
             dustAPIProjectId: projectId,
           },
         ],
-        taskQueue: RELOCATION_QUEUES_PER_REGION[sourceRegion],
+        taskQueue: RELOCATION_QUEUES_PER_CELL[sourceCell],
         workflowId,
         memo: { workspaceId },
       });

--- a/front/scripts/relocation/relocate_apps_workflow.ts
+++ b/front/scripts/relocation/relocate_apps_workflow.ts
@@ -1,8 +1,8 @@
 import { makeScript } from "@app/scripts/helpers";
-import { RELOCATION_QUEUES_PER_REGION } from "@app/temporal/relocation/config";
+import { RELOCATION_QUEUES_PER_CELL } from "@app/temporal/relocation/config";
 import { getTemporalRelocationClient } from "@app/temporal/relocation/temporal";
 import { workspaceRelocateAppsWorkflow } from "@app/temporal/relocation/workflows";
-import { isRegionType, SUPPORTED_REGIONS } from "@app/types/region";
+import { isCellType, SUPPORTED_CELLS } from "@app/types/cell";
 import { WorkflowNotFoundError } from "@temporalio/common";
 
 makeScript(
@@ -12,31 +12,28 @@ makeScript(
       type: "string",
       demandOption: true,
     },
-    sourceRegion: {
+    sourceCell: {
       type: "string",
-      choices: SUPPORTED_REGIONS,
+      choices: SUPPORTED_CELLS,
       demandOption: true,
     },
-    destRegion: {
+    destCell: {
       type: "string",
-      choices: SUPPORTED_REGIONS,
+      choices: SUPPORTED_CELLS,
       demandOption: true,
     },
     suffix: {
       type: "string",
     },
   },
-  async (
-    { workspaceId, sourceRegion, destRegion, suffix, execute },
-    logger
-  ) => {
-    if (!isRegionType(sourceRegion) || !isRegionType(destRegion)) {
-      logger.error("Invalid region.");
+  async ({ workspaceId, sourceCell, destCell, suffix, execute }, logger) => {
+    if (!isCellType(sourceCell) || !isCellType(destCell)) {
+      logger.error("Invalid cell.");
       return;
     }
 
-    if (sourceRegion === destRegion) {
-      logger.error("Source and destination regions must be different.");
+    if (sourceCell === destCell) {
+      logger.error("Source and destination cells must be different.");
       return;
     }
 
@@ -70,17 +67,17 @@ makeScript(
       logger.info(
         {
           workspaceId,
-          sourceRegion,
-          destRegion,
-          queue: RELOCATION_QUEUES_PER_REGION[sourceRegion],
+          sourceCell,
+          destCell,
+          queue: RELOCATION_QUEUES_PER_CELL[sourceCell],
           workflowId,
         },
         "starting workspaceRelocateAppsWorkflow"
       );
 
       await client.workflow.start(workspaceRelocateAppsWorkflow, {
-        args: [{ workspaceId, sourceRegion, destRegion }],
-        taskQueue: RELOCATION_QUEUES_PER_REGION[sourceRegion],
+        args: [{ workspaceId, sourceCell, destCell }],
+        taskQueue: RELOCATION_QUEUES_PER_CELL[sourceCell],
         workflowId,
         memo: { workspaceId },
       });

--- a/front/scripts/relocation/relocate_core_data_source.ts
+++ b/front/scripts/relocation/relocate_core_data_source.ts
@@ -1,8 +1,8 @@
-import { config } from "@app/lib/api/regions/config";
+import { config } from "@app/lib/api/cells/config";
 import { Authenticator } from "@app/lib/auth";
 import { makeScript } from "@app/scripts/helpers";
 import { launchCoreDataSourceRelocationWorkflow } from "@app/temporal/relocation/client";
-import { isRegionType, SUPPORTED_REGIONS } from "@app/types/region";
+import { isCellType, SUPPORTED_CELLS } from "@app/types/cell";
 import assert from "assert";
 
 makeScript(
@@ -12,14 +12,14 @@ makeScript(
       type: "string",
       demandOption: true,
     },
-    sourceRegion: {
+    sourceCell: {
       type: "string",
-      choices: SUPPORTED_REGIONS,
+      choices: SUPPORTED_CELLS,
       demandOption: true,
     },
-    destinationRegion: {
+    destinationCell: {
       type: "string",
-      choices: SUPPORTED_REGIONS,
+      choices: SUPPORTED_CELLS,
       demandOption: true,
     },
     dataSourceCoreIds: {
@@ -31,7 +31,7 @@ makeScript(
     destIds: {
       type: "string",
       description:
-        "The ids of the data source in the destination region (stringified JSON)",
+        "The ids of the data source in the destination cell (stringified JSON)",
       demandOption: true,
     },
     pageCursor: {
@@ -44,21 +44,21 @@ makeScript(
     {
       dataSourceCoreIds,
       destIds,
-      destinationRegion,
+      destinationCell,
       execute,
       pageCursor,
-      sourceRegion,
+      sourceCell,
       workspaceId,
     },
     logger
   ) => {
-    if (!isRegionType(sourceRegion) || !isRegionType(destinationRegion)) {
-      logger.error("Invalid region.");
+    if (!isCellType(sourceCell) || !isCellType(destinationCell)) {
+      logger.error("Invalid cell.");
       return;
     }
 
-    if (sourceRegion === destinationRegion) {
-      logger.error("Source and destination regions must be different.");
+    if (sourceCell === destinationCell) {
+      logger.error("Source and destination cells must be different.");
       return;
     }
 
@@ -71,8 +71,8 @@ makeScript(
     }
 
     assert(
-      config.getCurrentRegion() === sourceRegion,
-      "Must run from source region"
+      config.getCurrentCell().name === sourceCell,
+      "Must run from the source cell"
     );
 
     const parsedDataSourceCoreIds = JSON.parse(dataSourceCoreIds);
@@ -82,9 +82,9 @@ makeScript(
       await launchCoreDataSourceRelocationWorkflow({
         dataSourceCoreIds: parsedDataSourceCoreIds,
         destIds: parsedDestIds,
-        destRegion: destinationRegion,
+        destCell: destinationCell,
         pageCursor,
-        sourceRegion,
+        sourceCell,
         workspaceId,
       });
     }

--- a/front/scripts/relocation/relocate_data_source.ts
+++ b/front/scripts/relocation/relocate_data_source.ts
@@ -1,11 +1,11 @@
-import { config } from "@app/lib/api/regions/config";
+import { config } from "@app/lib/api/cells/config";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { makeScript } from "@app/scripts/helpers";
-import { RELOCATION_QUEUES_PER_REGION } from "@app/temporal/relocation/config";
+import { RELOCATION_QUEUES_PER_CELL } from "@app/temporal/relocation/config";
 import { getTemporalRelocationClient } from "@app/temporal/relocation/temporal";
 import { workspaceRelocateDataSourceCoreWorkflow } from "@app/temporal/relocation/workflows";
-import { isRegionType, SUPPORTED_REGIONS } from "@app/types/region";
+import { isCellType, SUPPORTED_CELLS } from "@app/types/cell";
 import assert from "assert";
 
 makeScript(
@@ -15,14 +15,14 @@ makeScript(
       type: "string",
       required: true,
     },
-    sourceRegion: {
+    sourceCell: {
       type: "string",
-      choices: SUPPORTED_REGIONS,
+      choices: SUPPORTED_CELLS,
       demandOption: true,
     },
-    destRegion: {
+    destCell: {
       type: "string",
-      choices: SUPPORTED_REGIONS,
+      choices: SUPPORTED_CELLS,
       demandOption: true,
     },
     dataSourceId: {
@@ -32,22 +32,22 @@ makeScript(
     },
   },
   async (
-    { workspaceId, sourceRegion, destRegion, dataSourceId, execute },
+    { workspaceId, sourceCell, destCell, dataSourceId, execute },
     logger
   ) => {
-    if (!isRegionType(sourceRegion) || !isRegionType(destRegion)) {
-      logger.error("Invalid region.");
+    if (!isCellType(sourceCell) || !isCellType(destCell)) {
+      logger.error("Invalid cell.");
       return;
     }
 
-    if (sourceRegion === destRegion) {
-      logger.error("Source and destination regions must be different.");
+    if (sourceCell === destCell) {
+      logger.error("Source and destination cells must be different.");
       return;
     }
 
     assert(
-      config.getCurrentRegion() === sourceRegion,
-      "Must run from source region"
+      config.getCurrentCell().name === sourceCell,
+      "Must run from the source cell"
     );
 
     const dataSource = await DataSourceModel.findByPk(dataSourceId, {
@@ -87,12 +87,12 @@ makeScript(
               dustAPIProjectId: dataSource.dustAPIProjectId,
               dustAPIDataSourceId: dataSource.dustAPIDataSourceId,
             },
-            destRegion,
-            sourceRegion,
+            destCell,
+            sourceCell,
             workspaceId,
           },
         ],
-        taskQueue: RELOCATION_QUEUES_PER_REGION[sourceRegion],
+        taskQueue: RELOCATION_QUEUES_PER_CELL[sourceCell],
       });
     }
   }

--- a/front/scripts/relocation/relocate_workspace.ts
+++ b/front/scripts/relocation/relocate_workspace.ts
@@ -81,10 +81,6 @@ makeScript(
     { destinationCell, sourceCell, step, workspaceId, execute },
     logger
   ) => {
-    logger.warn(
-      "Note: the relocation script does NOT support moving between cells within the same region."
-    );
-
     if (!isCellType(sourceCell) || !isCellType(destinationCell)) {
       logger.error("Invalid cell.");
       return;
@@ -162,15 +158,15 @@ makeScript(
           // 5) Launch the relocation workflow.
           await launchWorkspaceRelocationWorkflow({
             workspaceId: owner.sId,
-            sourceRegion: cellConfig.getCellInfo(sourceCell).region,
-            destRegion: cellConfig.getCellInfo(destinationCell).region,
+            sourceCell,
+            destCell: destinationCell,
           });
           break;
 
         case "cutover":
           assertCurrentCell(sourceCell);
 
-          // 1) Set the workspace in the source region as relocated.
+          // 1) Set the workspace in the source cell as relocated.
           const workspaceRelocatedRes = await setWorkspaceRelocated(owner);
           if (workspaceRelocatedRes.isErr()) {
             logger.error(
@@ -218,7 +214,7 @@ makeScript(
             return;
           }
 
-          // 3) Unpause all webcrawler connectors in the destination region.
+          // 3) Unpause all webcrawler connectors in the destination cell.
           const unpauseDestConnectorsRes = await unpauseAllManagedDataSources(
             auth,
             ["webcrawler"]
@@ -263,7 +259,7 @@ makeScript(
         case "rollback":
           assertCurrentCell(sourceCell);
 
-          // 1) Clear workspace maintenance metadata in source region.
+          // 1) Clear workspace maintenance metadata in source cell.
           const clearSrcWorkspaceMetadataRes = await updateWorkspaceMetadata(
             owner,
             {
@@ -277,7 +273,7 @@ makeScript(
             return;
           }
 
-          // 2) Unpause all connectors in the source region.
+          // 2) Unpause all connectors in the source cell.
           const unpauseSrcConnectorsRes =
             await unpauseAllManagedDataSources(auth);
           if (unpauseSrcConnectorsRes.isErr()) {
@@ -341,7 +337,7 @@ makeScript(
             return;
           }
 
-          // 2) Delete the workspace in the source region.
+          // 2) Delete the workspace in the source cell.
           const deleteWorkspaceRes = await deleteWorkspace(owner, {
             workspaceHasBeenRelocated: true,
           });
@@ -352,10 +348,10 @@ makeScript(
             return;
           }
 
-          logger.info("Workspace marked for deletion in source region.");
+          logger.info("Workspace marked for deletion in the source cell.");
           break;
 
-        // Can be run from any region.
+        // Can be run from any cell.
         case "compute-statistics":
           const statsRes = await computeWorkspaceStatistics(auth);
           if (statsRes.isErr()) {

--- a/front/temporal/relocation/activities/config.ts
+++ b/front/temporal/relocation/activities/config.ts
@@ -4,8 +4,12 @@ const config = {
   getGcsRelocationBucket: (): string => {
     return EnvironmentConfig.getEnvVariable("DUST_RELOCATION_BUCKET");
   },
-  getGcsSourceProjectId: (): string => {
-    return EnvironmentConfig.getEnvVariable("GCP_PROJECT_ID");
+  // The project that runs the Storage Transfer jobs, dust-infra. One transfer agent
+  // that every cell grants on its buckets, instead of every cell granting every other.
+  getGcsTransferProjectId: (): string => {
+    return EnvironmentConfig.getEnvVariable(
+      "DUST_RELOCATION_TRANSFER_PROJECT_ID"
+    );
   },
 };
 

--- a/front/temporal/relocation/activities/destination_region/connectors/sql.ts
+++ b/front/temporal/relocation/activities/destination_region/connectors/sql.ts
@@ -12,22 +12,22 @@ import { QueryTypes } from "sequelize";
 export async function processConnectorsTableChunk({
   connectorId,
   dataPath,
-  destRegion,
-  sourceRegion,
+  destCell,
+  sourceCell,
   tableName,
   workspaceId,
 }: {
   connectorId?: ModelId;
   dataPath: string;
-  destRegion: string;
-  sourceRegion: string;
+  destCell: string;
+  sourceCell: string;
   tableName: string;
   workspaceId: string;
 }) {
   const localLogger = logger.child({
     connectorId,
-    destRegion,
-    sourceRegion,
+    destCell,
+    sourceCell,
     tableName,
     workspaceId,
   });

--- a/front/temporal/relocation/activities/destination_region/core/apps.ts
+++ b/front/temporal/relocation/activities/destination_region/core/apps.ts
@@ -4,25 +4,25 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { CoreAppAPIRelocationBlob } from "@app/temporal/relocation/activities/types";
 import { readFromRelocationStorage } from "@app/temporal/relocation/lib/file_storage/relocation";
+import type { CellType } from "@app/types/cell";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { RegionType } from "@app/types/region";
 
 export async function processApp({
   dustAPIProjectId,
   dataPath,
-  destRegion,
-  sourceRegion,
+  destCell,
+  sourceCell,
   workspaceId,
 }: {
   dustAPIProjectId: string;
   dataPath: string;
-  destRegion: RegionType;
-  sourceRegion: RegionType;
+  destCell: CellType;
+  sourceCell: CellType;
   workspaceId: string;
 }) {
   const localLogger = logger.child({
-    destRegion,
-    sourceRegion,
+    destCell,
+    sourceCell,
     workspaceId,
     dustAPIProjectId,
   });

--- a/front/temporal/relocation/activities/destination_region/core/data_sources.ts
+++ b/front/temporal/relocation/activities/destination_region/core/data_sources.ts
@@ -7,21 +7,21 @@ import type {
   CreateDataSourceProjectResult,
   DataSourceCoreIds,
 } from "@app/temporal/relocation/activities/types";
+import type { CellType } from "@app/types/cell";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { CoreAPIDataSource } from "@app/types/core/data_source";
-import type { RegionType } from "@app/types/region";
 
 export async function createDataSourceProject({
-  destRegion,
-  sourceRegionCoreDataSource,
+  destCell,
+  sourceCoreDataSource,
   workspaceId,
 }: {
-  destRegion: RegionType;
-  sourceRegionCoreDataSource: CoreAPIDataSource;
+  destCell: CellType;
+  sourceCoreDataSource: CoreAPIDataSource;
   workspaceId: string;
 }): Promise<CreateDataSourceProjectResult> {
   const localLogger = logger.child({
-    destRegion,
+    destCell,
     workspaceId,
   });
 
@@ -43,10 +43,10 @@ export async function createDataSourceProject({
 
   const dustDataSource = await coreAPI.createDataSource({
     projectId: dustProject.value.project.project_id.toString(),
-    config: sourceRegionCoreDataSource.config,
+    config: sourceCoreDataSource.config,
     credentials,
     // Temporary to unblock migration. Name was not returned by the core API.
-    name: sourceRegionCoreDataSource.name ?? "",
+    name: sourceCoreDataSource.name ?? "",
   });
 
   if (dustDataSource.isErr()) {

--- a/front/temporal/relocation/activities/destination_region/core/documents.ts
+++ b/front/temporal/relocation/activities/destination_region/core/documents.ts
@@ -13,27 +13,27 @@ import {
   deleteFromRelocationStorage,
   readFromRelocationStorage,
 } from "@app/temporal/relocation/lib/file_storage/relocation";
+import type { CellType } from "@app/types/cell";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { RegionType } from "@app/types/region";
 
 export async function processDataSourceDocuments({
   destIds,
   dataPath,
-  destRegion,
-  sourceRegion,
-  sourceRegionApiBaseUrl,
+  destCell,
+  sourceCell,
+  sourceApiBaseUrl,
   workspaceId,
 }: {
   destIds: CreateDataSourceProjectResult;
   dataPath: string;
-  destRegion: RegionType;
-  sourceRegion: RegionType;
-  sourceRegionApiBaseUrl: string;
+  destCell: CellType;
+  sourceCell: CellType;
+  sourceApiBaseUrl: string;
   workspaceId: string;
 }) {
   const localLogger = logger.child({
-    destRegion,
-    sourceRegion,
+    destCell,
+    sourceCell,
     workspaceId,
   });
 
@@ -51,10 +51,10 @@ export async function processDataSourceDocuments({
   const res = await concurrentExecutor(
     data.blobs.documents,
     async (d) => {
-      // If the source URL starts with the source region Dust URL, replace it with the destination region Dust URL.
+      // If the source URL starts with the source cell Dust URL, replace it with the destination cell Dust URL.
       const sourceUrl =
-        d.source_url && d.source_url.startsWith(sourceRegionApiBaseUrl)
-          ? d.source_url.replace(sourceRegionApiBaseUrl, destRegionApiBaseUrl)
+        d.source_url && d.source_url.startsWith(sourceApiBaseUrl)
+          ? d.source_url.replace(sourceApiBaseUrl, destRegionApiBaseUrl)
           : d.source_url;
 
       // There are some issues with the parents field.
@@ -77,7 +77,7 @@ export async function processDataSourceDocuments({
         !d.title || d.title.trim().length === 0 ? UNTITLED_TITLE : d.title;
 
       return coreAPI.upsertDataSourceDocument({
-        // Override the project and data source ids to the ones in the destination region.
+        // Override the project and data source ids to the ones in the destination cell.
         projectId: destIds.dustAPIProjectId,
         dataSourceId: destIds.dustAPIDataSourceId,
         documentId: d.document_id,

--- a/front/temporal/relocation/activities/destination_region/core/folders.ts
+++ b/front/temporal/relocation/activities/destination_region/core/folders.ts
@@ -10,27 +10,27 @@ import {
   deleteFromRelocationStorage,
   readFromRelocationStorage,
 } from "@app/temporal/relocation/lib/file_storage/relocation";
+import type { CellType } from "@app/types/cell";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { RegionType } from "@app/types/region";
 
 export async function processDataSourceFolders({
   destIds,
   dataPath,
-  destRegion,
-  sourceRegion,
-  sourceRegionApiBaseUrl,
+  destCell,
+  sourceCell,
+  sourceApiBaseUrl,
   workspaceId,
 }: {
   destIds: CreateDataSourceProjectResult;
   dataPath: string;
-  destRegion: RegionType;
-  sourceRegion: RegionType;
-  sourceRegionApiBaseUrl: string;
+  destCell: CellType;
+  sourceCell: CellType;
+  sourceApiBaseUrl: string;
   workspaceId: string;
 }) {
   const localLogger = logger.child({
-    destRegion,
-    sourceRegion,
+    destCell,
+    sourceCell,
     workspaceId,
   });
 
@@ -46,10 +46,10 @@ export async function processDataSourceFolders({
   const res = await concurrentExecutor(
     data.blobs.folders,
     async (d) => {
-      // If the source URL starts with the source region Dust URL, replace it with the destination region Dust URL.
+      // If the source URL starts with the source cell Dust URL, replace it with the destination cell Dust URL.
       const sourceUrl =
-        d.source_url && d.source_url.startsWith(sourceRegionApiBaseUrl)
-          ? d.source_url.replace(sourceRegionApiBaseUrl, destRegionApiBaseUrl)
+        d.source_url && d.source_url.startsWith(sourceApiBaseUrl)
+          ? d.source_url.replace(sourceApiBaseUrl, destRegionApiBaseUrl)
           : d.source_url;
 
       return coreAPI.upsertDataSourceFolder({

--- a/front/temporal/relocation/activities/destination_region/core/tables.ts
+++ b/front/temporal/relocation/activities/destination_region/core/tables.ts
@@ -11,27 +11,27 @@ import {
   deleteFromRelocationStorage,
   readFromRelocationStorage,
 } from "@app/temporal/relocation/lib/file_storage/relocation";
+import type { CellType } from "@app/types/cell";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { RegionType } from "@app/types/region";
 
 export async function processDataSourceTables({
   destIds,
   dataPath,
-  destRegion,
-  sourceRegion,
-  sourceRegionApiBaseUrl,
+  destCell,
+  sourceCell,
+  sourceApiBaseUrl,
   workspaceId,
 }: {
   destIds: CreateDataSourceProjectResult;
   dataPath: string;
-  destRegion: RegionType;
-  sourceRegion: RegionType;
-  sourceRegionApiBaseUrl: string;
+  destCell: CellType;
+  sourceCell: CellType;
+  sourceApiBaseUrl: string;
   workspaceId: string;
 }) {
   const localLogger = logger.child({
-    destRegion,
-    sourceRegion,
+    destCell,
+    sourceCell,
     workspaceId,
   });
 
@@ -47,10 +47,10 @@ export async function processDataSourceTables({
   const res = await concurrentExecutor(
     data.blobs.tables,
     async (d) => {
-      // If the source URL starts with the source region Dust URL, replace it with the destination region Dust URL.
+      // If the source URL starts with the source cell Dust URL, replace it with the destination cell Dust URL.
       const sourceUrl =
-        d.source_url && d.source_url.startsWith(sourceRegionApiBaseUrl)
-          ? d.source_url.replace(sourceRegionApiBaseUrl, destRegionApiBaseUrl)
+        d.source_url && d.source_url.startsWith(sourceApiBaseUrl)
+          ? d.source_url.replace(sourceApiBaseUrl, destRegionApiBaseUrl)
           : d.source_url;
 
       // There are some issues with the parents field.

--- a/front/temporal/relocation/activities/destination_region/front/id_normalization.ts
+++ b/front/temporal/relocation/activities/destination_region/front/id_normalization.ts
@@ -12,7 +12,7 @@ import {
   writeToRelocationStorage,
 } from "@app/temporal/relocation/lib/file_storage/relocation";
 import { getUserReferencingColumns } from "@app/temporal/relocation/lib/sql/schema/introspection";
-import type { RegionType } from "@app/types/region";
+import type { CellType } from "@app/types/cell";
 import type { ModelId } from "@app/types/shared/model_id";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { Op, QueryTypes } from "sequelize";
@@ -60,13 +60,13 @@ function getStatementColumns({ columns, sql }: RelocationStatement): string[] {
 }
 
 function getDestinationIdNormalizationFileName({
-  destRegion,
-  sourceRegion,
+  destCell,
+  sourceCell,
 }: {
-  destRegion: RegionType;
-  sourceRegion: RegionType;
+  destCell: CellType;
+  sourceCell: CellType;
 }) {
-  return `${sourceRegion}-${destRegion}`;
+  return `${sourceCell}-${destCell}`;
 }
 
 export function buildIdMapping(
@@ -249,14 +249,14 @@ export async function buildDestinationIdNormalization({
 }
 
 export async function writeDestinationIdNormalization({
-  destRegion,
+  destCell,
   normalization,
-  sourceRegion,
+  sourceCell,
   workspaceId,
 }: {
-  destRegion: RegionType;
+  destCell: CellType;
   normalization: DestinationIdNormalization;
-  sourceRegion: RegionType;
+  sourceCell: CellType;
   workspaceId: string;
 }): Promise<void> {
   await writeToRelocationStorage(normalization, {
@@ -264,19 +264,19 @@ export async function writeDestinationIdNormalization({
     type: "front",
     operation: DESTINATION_ID_NORMALIZATION_OPERATION,
     fileName: getDestinationIdNormalizationFileName({
-      destRegion,
-      sourceRegion,
+      destCell,
+      sourceCell,
     }),
   });
 }
 
 export async function readDestinationIdNormalization({
-  destRegion,
-  sourceRegion,
+  destCell,
+  sourceCell,
   workspaceId,
 }: {
-  destRegion: RegionType;
-  sourceRegion: RegionType;
+  destCell: CellType;
+  sourceCell: CellType;
   workspaceId: string;
 }): Promise<DestinationIdNormalization> {
   const dataPath = getRelocationStoragePath({
@@ -284,8 +284,8 @@ export async function readDestinationIdNormalization({
     type: "front",
     operation: DESTINATION_ID_NORMALIZATION_OPERATION,
     fileName: getDestinationIdNormalizationFileName({
-      destRegion,
-      sourceRegion,
+      destCell,
+      sourceCell,
     }),
   });
 

--- a/front/temporal/relocation/activities/destination_region/front/sql.ts
+++ b/front/temporal/relocation/activities/destination_region/front/sql.ts
@@ -17,26 +17,26 @@ import {
   deleteFromRelocationStorage,
   readFromRelocationStorage,
 } from "@app/temporal/relocation/lib/file_storage/relocation";
-import type { RegionType } from "@app/types/region";
+import type { CellType } from "@app/types/cell";
 import assert from "assert";
 import { QueryTypes } from "sequelize";
 
 interface WriteCoreEntitiesParams {
   dataPath: string;
-  destRegion: RegionType;
-  sourceRegion: RegionType;
+  destCell: CellType;
+  sourceCell: CellType;
   workspaceId: string;
 }
 
 export async function writeCoreEntitiesToDestinationRegionWithIdNormalization({
   dataPath,
-  destRegion,
-  sourceRegion,
+  destCell,
+  sourceCell,
   workspaceId,
 }: WriteCoreEntitiesParams) {
   const localLogger = logger.child({
-    destRegion,
-    sourceRegion,
+    destCell,
+    sourceCell,
     workspaceId,
   });
 
@@ -48,9 +48,9 @@ export async function writeCoreEntitiesToDestinationRegionWithIdNormalization({
 
   const normalization = await buildDestinationIdNormalization({ blob });
   await writeDestinationIdNormalization({
-    destRegion,
+    destCell,
     normalization,
-    sourceRegion,
+    sourceCell,
     workspaceId,
   });
 
@@ -118,22 +118,22 @@ export async function writeCoreEntitiesToDestinationRegionWithIdNormalization({
 
 interface ProcessFrontTableChunkParams {
   dataPath: string;
-  destRegion: RegionType;
-  sourceRegion: RegionType;
+  destCell: CellType;
+  sourceCell: CellType;
   tableName: string;
   workspaceId: string;
 }
 
 export async function processFrontTableChunkWithIdNormalization({
   dataPath,
-  destRegion,
-  sourceRegion,
+  destCell,
+  sourceCell,
   tableName,
   workspaceId,
 }: ProcessFrontTableChunkParams) {
   const localLogger = logger.child({
-    destRegion,
-    sourceRegion,
+    destCell,
+    sourceCell,
     tableName,
     workspaceId,
   });
@@ -159,8 +159,8 @@ export async function processFrontTableChunkWithIdNormalization({
   }
 
   const normalization = await readDestinationIdNormalization({
-    destRegion,
-    sourceRegion,
+    destCell,
+    sourceCell,
     workspaceId,
   });
 

--- a/front/temporal/relocation/activities/source_region/connectors/sql.ts
+++ b/front/temporal/relocation/activities/source_region/connectors/sql.ts
@@ -71,18 +71,18 @@ export async function getTablesWithConnectorIdOrder() {
 
 export async function readConnectorsTableChunk({
   connectorId,
-  destRegion,
+  destCell,
   lastId,
   limit,
-  sourceRegion,
+  sourceCell,
   tableName,
   workspaceId,
 }: ReadTableChunkParams & { connectorId: ModelId }) {
   const localLogger = logger.child({
     connectorId,
-    destRegion,
+    destCell,
     lastId,
-    sourceRegion,
+    sourceCell,
     tableName,
     workspaceId,
   });

--- a/front/temporal/relocation/activities/source_region/core/apps.ts
+++ b/front/temporal/relocation/activities/source_region/core/apps.ts
@@ -5,9 +5,9 @@ import type { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import logger from "@app/logger/logger";
 import type { CoreAppAPIRelocationBlob } from "@app/temporal/relocation/activities/types";
 import { writeToRelocationStorage } from "@app/temporal/relocation/lib/file_storage/relocation";
+import type { CellType } from "@app/types/cell";
 import type { CoreAPIDataset } from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { RegionType } from "@app/types/region";
 import type { ModelId } from "@app/types/shared/model_id";
 import assert from "assert";
 import type { WhereOptions } from "sequelize";
@@ -64,17 +64,17 @@ export async function retrieveAppsCoreIdsBatch({
 export async function getApp({
   dustAPIProjectId,
   workspaceId,
-  sourceRegion,
+  sourceCell,
 }: {
   dustAPIProjectId: string;
   workspaceId: string;
-  sourceRegion: RegionType;
+  sourceCell: CellType;
 }): Promise<{
   dataPath: string;
 }> {
   const localLogger = logger.child({
     dustAPIProjectId,
-    sourceRegion,
+    sourceCell,
   });
 
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);

--- a/front/temporal/relocation/activities/source_region/core/documents.ts
+++ b/front/temporal/relocation/activities/source_region/core/documents.ts
@@ -10,33 +10,33 @@ import {
   withJSONSerializationRetry,
   writeToRelocationStorage,
 } from "@app/temporal/relocation/lib/file_storage/relocation";
+import type { CellType } from "@app/types/cell";
 import type {
   CoreAPINodesSearchFilter,
   CoreAPISearchCursorRequest,
 } from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { CoreAPIDocumentBlob } from "@app/types/core/data_source";
-import type { RegionType } from "@app/types/region";
 import type { Ok } from "@app/types/shared/result";
 
 export async function getDataSourceDocuments({
   dataSourceCoreIds,
   pageCursor,
-  sourceRegion,
+  sourceCell,
   workspaceId,
   fileName,
   limit,
 }: {
   dataSourceCoreIds: DataSourceCoreIds;
   pageCursor: string | null;
-  sourceRegion: RegionType;
+  sourceCell: CellType;
   workspaceId: string;
   fileName?: string;
   limit: number;
 }) {
   const localLogger = logger.child({
     dataSourceCoreIds,
-    sourceRegion,
+    sourceCell,
   });
 
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), localLogger);

--- a/front/temporal/relocation/activities/source_region/core/folders.ts
+++ b/front/temporal/relocation/activities/source_region/core/folders.ts
@@ -6,27 +6,27 @@ import type {
 } from "@app/temporal/relocation/activities/types";
 import { CORE_API_LIST_NODES_BATCH_SIZE } from "@app/temporal/relocation/activities/types";
 import { writeToRelocationStorage } from "@app/temporal/relocation/lib/file_storage/relocation";
+import type { CellType } from "@app/types/cell";
 import type {
   CoreAPINodesSearchFilter,
   CoreAPISearchCursorRequest,
 } from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { RegionType } from "@app/types/region";
 
 export async function getDataSourceFolders({
   dataSourceCoreIds,
   pageCursor,
-  sourceRegion,
+  sourceCell,
   workspaceId,
 }: {
   dataSourceCoreIds: DataSourceCoreIds;
   pageCursor: string | null;
-  sourceRegion: RegionType;
+  sourceCell: CellType;
   workspaceId: string;
 }) {
   const localLogger = logger.child({
     dataSourceCoreIds,
-    sourceRegion,
+    sourceCell,
   });
 
   localLogger.info("[Core] Retrieving data source folders");

--- a/front/temporal/relocation/activities/source_region/core/tables.ts
+++ b/front/temporal/relocation/activities/source_region/core/tables.ts
@@ -13,32 +13,32 @@ import {
   withJSONSerializationRetry,
   writeToRelocationStorage,
 } from "@app/temporal/relocation/lib/file_storage/relocation";
+import type { CellType } from "@app/types/cell";
 import type {
   CoreAPINodesSearchFilter,
   CoreAPISearchCursorRequest,
 } from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { CoreAPITableBlob } from "@app/types/core/data_source";
-import type { RegionType } from "@app/types/region";
 import type { Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 
 export async function getDataSourceTables({
   dataSourceCoreIds,
   pageCursor,
-  sourceRegion,
+  sourceCell,
   workspaceId,
   limit,
 }: {
   dataSourceCoreIds: DataSourceCoreIds;
   pageCursor: string | null;
-  sourceRegion: RegionType;
+  sourceCell: CellType;
   workspaceId: string;
   limit: number;
 }) {
   const localLogger = logger.child({
     dataSourceCoreIds,
-    sourceRegion,
+    sourceCell,
   });
 
   localLogger.info("[Core] Retrieving data source tables");

--- a/front/temporal/relocation/activities/source_region/front/file_storage.ts
+++ b/front/temporal/relocation/activities/source_region/front/file_storage.ts
@@ -8,27 +8,27 @@ import type {
   DataSourceCoreIds,
 } from "@app/temporal/relocation/activities/types";
 import { StorageTransferService } from "@app/temporal/relocation/lib/file_storage/transfer";
+import type { CellType } from "@app/types/cell";
 import { getBaseMountPathForWorkspace } from "@app/types/mount_path";
-import type { RegionType } from "@app/types/region";
 
 export async function startTransferFrontPublicFiles({
   destBucket,
-  destRegion,
-  sourceRegion,
+  destCell,
+  sourceCell,
   workspaceId,
 }: {
   destBucket: string;
-  destRegion: RegionType;
-  sourceRegion: RegionType;
+  destCell: CellType;
+  sourceCell: CellType;
   workspaceId: string;
 }): Promise<string> {
   const storageTransferService = new StorageTransferService();
 
   const localLogger = logger.child({
     destBucket,
-    destRegion,
+    destCell,
     path: FileResource.getBaseCloudStorageForWorkspace({ workspaceId }),
-    sourceRegion,
+    sourceCell,
     workspaceId,
   });
 
@@ -41,13 +41,13 @@ export async function startTransferFrontPublicFiles({
     destPath: FileResource.getBaseCloudStorageForWorkspace({
       workspaceId,
     }),
-    destRegion,
+    destCell,
     sourceBucket: fileStorageConfig.getGcsPublicUploadBucket(),
     sourcePath: FileResource.getBaseCloudStorageForWorkspace({
       workspaceId,
     }),
-    sourceProjectId: config.getGcsSourceProjectId(),
-    sourceRegion,
+    transferProjectId: config.getGcsTransferProjectId(),
+    sourceCell,
     workspaceId,
   });
 
@@ -74,22 +74,22 @@ export async function startTransferFrontPublicFiles({
 
 export async function startTransferFrontPrivateFiles({
   destBucket,
-  destRegion,
-  sourceRegion,
+  destCell,
+  sourceCell,
   workspaceId,
 }: {
   destBucket: string;
-  destRegion: RegionType;
-  sourceRegion: RegionType;
+  destCell: CellType;
+  sourceCell: CellType;
   workspaceId: string;
 }): Promise<string> {
   const storageTransferService = new StorageTransferService();
 
   const localLogger = logger.child({
     destBucket,
-    destRegion,
+    destCell,
     path: FileResource.getBaseCloudStorageForWorkspace({ workspaceId }),
-    sourceRegion,
+    sourceCell,
     workspaceId,
   });
 
@@ -100,15 +100,15 @@ export async function startTransferFrontPrivateFiles({
   // Tranfer both private files and content fragments in the same job.
   const transferResult = await storageTransferService.createTransferJob({
     destBucket,
-    destRegion,
+    destCell,
     includePrefixes: [
       FileResource.getBaseCloudStorageForWorkspace({ workspaceId }),
       getContentFragmentBaseCloudStorageForWorkspace(workspaceId),
       getBaseMountPathForWorkspace({ workspaceId }),
     ],
     sourceBucket: fileStorageConfig.getGcsPrivateUploadsBucket(),
-    sourceProjectId: config.getGcsSourceProjectId(),
-    sourceRegion,
+    transferProjectId: config.getGcsTransferProjectId(),
+    sourceCell,
     workspaceId,
   });
 
@@ -142,7 +142,7 @@ export async function isFileStorageTransferComplete({
 
   const result = await storageTransfer.isTransferJobDone({
     jobName,
-    sourceProjectId: config.getGcsSourceProjectId(),
+    transferProjectId: config.getGcsTransferProjectId(),
   });
 
   if (result.isErr()) {
@@ -164,15 +164,15 @@ export async function startTransferCoreTableFiles({
   dataSourceCoreIds,
   destBucket,
   destIds,
-  destRegion,
-  sourceRegion,
+  destCell,
+  sourceCell,
   workspaceId,
 }: {
   dataSourceCoreIds: DataSourceCoreIds;
   destBucket: string;
   destIds: CreateDataSourceProjectResult;
-  destRegion: RegionType;
-  sourceRegion: RegionType;
+  destCell: CellType;
+  sourceCell: CellType;
   workspaceId: string;
 }): Promise<string> {
   const storageTransferService = new StorageTransferService();
@@ -181,9 +181,9 @@ export async function startTransferCoreTableFiles({
 
   const localLogger = logger.child({
     destBucket,
-    destRegion,
+    destCell,
     path: sourcePath,
-    sourceRegion,
+    sourceCell,
     workspaceId,
   });
 
@@ -192,11 +192,11 @@ export async function startTransferCoreTableFiles({
   const transferResult = await storageTransferService.createTransferJob({
     destBucket,
     destPath: makeCoreTableDestPath(destIds),
-    destRegion,
+    destCell,
     sourceBucket: fileStorageConfig.getDustTablesBucket(),
     sourcePath,
-    sourceProjectId: config.getGcsSourceProjectId(),
-    sourceRegion,
+    transferProjectId: config.getGcsTransferProjectId(),
+    sourceCell,
     workspaceId,
   });
 

--- a/front/temporal/relocation/activities/source_region/front/sql.ts
+++ b/front/temporal/relocation/activities/source_region/front/sql.ts
@@ -21,23 +21,23 @@ import {
 } from "@app/temporal/relocation/lib/file_storage/relocation";
 import { generateParameterizedInsertStatements } from "@app/temporal/relocation/lib/sql/insert";
 import { getTopologicalOrder } from "@app/temporal/relocation/lib/sql/schema/dependencies";
-import type { RegionType } from "@app/types/region";
+import type { CellType } from "@app/types/cell";
 import type { ModelId } from "@app/types/shared/model_id";
 import assert from "assert";
 import { Op, QueryTypes } from "sequelize";
 
 export async function readCoreEntitiesFromSourceRegion({
-  destRegion,
-  sourceRegion,
+  destCell,
+  sourceCell,
   workspaceId,
 }: {
-  destRegion: RegionType;
-  sourceRegion: RegionType;
+  destCell: CellType;
+  sourceCell: CellType;
   workspaceId: string;
 }) {
   const localLogger = logger.child({
-    destRegion,
-    sourceRegion,
+    destCell,
+    sourceCell,
     workspaceId,
   });
 
@@ -72,7 +72,7 @@ export async function readCoreEntitiesFromSourceRegion({
 
   // Fetch all associated users metadata of the workspace.
   // Only fetch metadata where workspaceId is null (global) or matches the workspace being
-  // relocated. This avoids FK violations when inserting into destination region for metadata
+  // relocated. This avoids FK violations when inserting into destination cell for metadata
   // referencing other workspaces.
   const userMetadata = await UserMetadataModel.findAll({
     where: {
@@ -154,18 +154,18 @@ export async function getTablesWithWorkspaceIdOrder() {
 }
 
 export async function readFrontTableChunk({
-  destRegion,
+  destCell,
   lastId,
   limit,
-  sourceRegion,
+  sourceCell,
   tableName,
   workspaceId,
   fileName,
 }: ReadTableChunkParams) {
   const localLogger = logger.child({
-    destRegion,
+    destCell,
     lastId,
-    sourceRegion,
+    sourceCell,
     tableName,
     workspaceId,
     fileName,

--- a/front/temporal/relocation/activities/types.ts
+++ b/front/temporal/relocation/activities/types.ts
@@ -1,10 +1,10 @@
+import type { CellType } from "@app/types/cell";
 import type { CoreAPIContentNode } from "@app/types/core/content_node";
 import type { CoreAPIDataset } from "@app/types/core/core_api";
 import type {
   CoreAPIDocumentBlob,
   CoreAPITableBlob,
 } from "@app/types/core/data_source";
-import type { RegionType } from "@app/types/region";
 import type { ModelId } from "@app/types/shared/model_id";
 import isPlainObject from "lodash/isPlainObject";
 
@@ -24,10 +24,10 @@ export type CoreEntitiesRelocationBlob = RelocationBlob<
 >;
 
 export interface ReadTableChunkParams {
-  destRegion: RegionType;
+  destCell: CellType;
   lastId?: ModelId;
   limit: number;
-  sourceRegion: RegionType;
+  sourceCell: CellType;
   tableName: string;
   workspaceId: string;
   fileName?: string;

--- a/front/temporal/relocation/client.ts
+++ b/front/temporal/relocation/client.ts
@@ -2,28 +2,28 @@ import type {
   CreateDataSourceProjectResult,
   DataSourceCoreIds,
 } from "@app/temporal/relocation/activities/types";
-import { RELOCATION_QUEUES_PER_REGION } from "@app/temporal/relocation/config";
+import { RELOCATION_QUEUES_PER_CELL } from "@app/temporal/relocation/config";
 import { getTemporalRelocationClient } from "@app/temporal/relocation/temporal";
 import {
   workspaceRelocateCoreDataSourceResourcesWorkflow,
   workspaceRelocationWorkflow,
 } from "@app/temporal/relocation/workflows";
-import type { RegionType } from "@app/types/region";
+import type { CellType } from "@app/types/cell";
 
 export async function launchWorkspaceRelocationWorkflow({
   workspaceId,
-  sourceRegion,
-  destRegion,
+  sourceCell,
+  destCell,
 }: {
   workspaceId: string;
-  sourceRegion: RegionType;
-  destRegion: RegionType;
+  sourceCell: CellType;
+  destCell: CellType;
 }) {
   const client = await getTemporalRelocationClient();
 
   await client.workflow.start(workspaceRelocationWorkflow, {
-    args: [{ workspaceId, sourceRegion, destRegion }],
-    taskQueue: RELOCATION_QUEUES_PER_REGION[sourceRegion],
+    args: [{ workspaceId, sourceCell, destCell }],
+    taskQueue: RELOCATION_QUEUES_PER_CELL[sourceCell],
     workflowId: `relocate-workspace-${workspaceId}`,
   });
 }
@@ -31,16 +31,16 @@ export async function launchWorkspaceRelocationWorkflow({
 export async function launchCoreDataSourceRelocationWorkflow({
   dataSourceCoreIds,
   destIds,
-  destRegion,
+  destCell,
   pageCursor,
-  sourceRegion,
+  sourceCell,
   workspaceId,
 }: {
   dataSourceCoreIds: DataSourceCoreIds;
   destIds: CreateDataSourceProjectResult;
-  destRegion: RegionType;
+  destCell: CellType;
   pageCursor: string | null;
-  sourceRegion: RegionType;
+  sourceCell: CellType;
   workspaceId: string;
 }) {
   const client = await getTemporalRelocationClient();
@@ -57,13 +57,13 @@ export async function launchCoreDataSourceRelocationWorkflow({
         {
           dataSourceCoreIds,
           destIds,
-          destRegion,
+          destCell,
           pageCursor,
-          sourceRegion,
+          sourceCell,
           workspaceId,
         },
       ],
-      taskQueue: RELOCATION_QUEUES_PER_REGION[sourceRegion],
+      taskQueue: RELOCATION_QUEUES_PER_CELL[sourceCell],
     }
   );
 }

--- a/front/temporal/relocation/config.ts
+++ b/front/temporal/relocation/config.ts
@@ -1,8 +1,16 @@
-import type { RegionType } from "@app/types/region";
+import type { CellType } from "@app/types/cell";
+import { SUPPORTED_CELLS } from "@app/types/cell";
 
-const QUEUE_VERSION = 1;
+// Bumped when the queue layout changes: a workflow started on one version never
+// meets a worker on another.
+const QUEUE_VERSION = 2;
 
-export const RELOCATION_QUEUES_PER_REGION: Record<RegionType, string> = {
-  "europe-west1": `relocation-queue-eu-v${QUEUE_VERSION}`,
-  "us-central1": `relocation-queue-us-v${QUEUE_VERSION}`,
-};
+// One task queue per cell. Source and destination activities are routed by cell,
+// so two cells in the same region never pick up each other's work.
+export const RELOCATION_QUEUES_PER_CELL: Record<CellType, string> =
+  Object.fromEntries(
+    SUPPORTED_CELLS.map((cell) => [
+      cell,
+      `relocation-queue-${cell}-v${QUEUE_VERSION}`,
+    ])
+  ) as Record<CellType, string>;

--- a/front/temporal/relocation/lib/file_storage/relocation.ts
+++ b/front/temporal/relocation/lib/file_storage/relocation.ts
@@ -10,6 +10,24 @@ import { isDevelopment } from "@app/types/shared/env";
 
 const RELOCATION_PATH_PREFIX = "relocations";
 
+// A staging reference names its bucket: the source stages in the bucket of its own
+// location and the destination reads wherever the reference points, so a move inside
+// the EU never crosses to the US bucket. Bare paths are read from the local bucket.
+function parseRelocationStorageRef(ref: string): {
+  bucket: string;
+  path: string;
+} {
+  const match = ref.match(/^gs:\/\/([^/]+)\/(.+)$/);
+  if (match) {
+    return { bucket: match[1], path: match[2] };
+  }
+  return { bucket: config.getGcsRelocationBucket(), path: ref };
+}
+
+function getRelocationBucket(bucket: string) {
+  return getBucketInstance(bucket, { useServiceAccount: isDevelopment() });
+}
+
 interface RelocationStorageOptions {
   workspaceId: string;
   type: "front" | "connectors" | "core";
@@ -39,9 +57,8 @@ export async function writeToRelocationStorage(
     fileName: fileName ?? Date.now().toString(),
   });
 
-  const relocationBucket = getBucketInstance(config.getGcsRelocationBucket(), {
-    useServiceAccount: isDevelopment(),
-  });
+  const bucket = config.getGcsRelocationBucket();
+  const relocationBucket = getRelocationBucket(bucket);
 
   try {
     await relocationBucket.uploadRawContentToBucket({
@@ -63,27 +80,25 @@ export async function writeToRelocationStorage(
     throw err;
   }
 
-  return path;
+  return `gs://${bucket}/${path}`;
 }
 
 export async function readFromRelocationStorage<T = unknown>(
   dataPath: string
 ): Promise<T> {
-  const relocationBucket = getBucketInstance(config.getGcsRelocationBucket(), {
-    useServiceAccount: isDevelopment(),
-  });
+  const { bucket, path } = parseRelocationStorageRef(dataPath);
+  const relocationBucket = getRelocationBucket(bucket);
 
-  const content = await relocationBucket.fetchFileContent(dataPath);
+  const content = await relocationBucket.fetchFileContent(path);
 
   return JSON.parse(content) as T;
 }
 
 export async function deleteFromRelocationStorage(dataPath: string) {
-  const relocationBucket = getBucketInstance(config.getGcsRelocationBucket(), {
-    useServiceAccount: isDevelopment(),
-  });
+  const { bucket, path } = parseRelocationStorageRef(dataPath);
+  const relocationBucket = getRelocationBucket(bucket);
 
-  await relocationBucket.delete(dataPath, { ignoreNotFound: true });
+  await relocationBucket.delete(path, { ignoreNotFound: true });
 }
 
 export async function withJSONSerializationRetry<

--- a/front/temporal/relocation/lib/file_storage/transfer.ts
+++ b/front/temporal/relocation/lib/file_storage/transfer.ts
@@ -1,5 +1,5 @@
 import config from "@app/lib/api/config";
-import type { RegionType } from "@app/types/region";
+import type { CellType } from "@app/types/cell";
 import { isDevelopment } from "@app/types/shared/env";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -12,12 +12,12 @@ import type { google } from "@google-cloud/storage-transfer/build/protos/protos"
 interface TransferConfig {
   destBucket: string;
   destPath?: string;
-  destRegion: RegionType;
+  destCell: CellType;
   includePrefixes?: string[];
   sourceBucket: string;
   sourcePath?: string;
-  sourceProjectId: string;
-  sourceRegion: RegionType;
+  sourceCell: CellType;
+  transferProjectId: string;
   workspaceId: string;
 }
 
@@ -39,12 +39,12 @@ export class StorageTransferService {
   async createTransferJob({
     destBucket,
     destPath,
-    destRegion,
+    destCell,
     includePrefixes,
     sourceBucket,
     sourcePath,
-    sourceProjectId,
-    sourceRegion,
+    sourceCell,
+    transferProjectId,
     workspaceId,
   }: TransferConfig): Promise<Result<string, Error>> {
     const spec: google.storagetransfer.v1.ITransferSpec = {
@@ -69,8 +69,8 @@ export class StorageTransferService {
     }
 
     const transferJob: google.storagetransfer.v1.ITransferJob = {
-      description: `Migrate workspace ${workspaceId} from region ${sourceRegion} to ${destRegion}`,
-      projectId: sourceProjectId,
+      description: `Relocate workspace ${workspaceId} from ${sourceCell} to ${destCell}`,
+      projectId: transferProjectId,
       transferSpec: spec,
       // Schedule the transfer to start immediately.
       schedule: {
@@ -106,15 +106,15 @@ export class StorageTransferService {
 
   async isTransferJobDone({
     jobName,
-    sourceProjectId,
+    transferProjectId,
   }: {
     jobName: string;
-    sourceProjectId: string;
+    transferProjectId: string;
   }): Promise<Result<boolean, Error>> {
     try {
       const [transferJob] = await this.transferClient.getTransferJob({
         jobName,
-        projectId: sourceProjectId,
+        projectId: transferProjectId,
       });
 
       const { latestOperationName } = transferJob;

--- a/front/temporal/relocation/worker.ts
+++ b/front/temporal/relocation/worker.ts
@@ -1,4 +1,4 @@
-import { config } from "@app/lib/api/regions/config";
+import { config } from "@app/lib/api/cells/config";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
 import {
@@ -11,7 +11,7 @@ import * as frontDestinationActivities from "@app/temporal/relocation/activities
 import * as connectorsSourceActivities from "@app/temporal/relocation/activities/source_region/connectors/sql";
 import * as coreSourceActivities from "@app/temporal/relocation/activities/source_region/core";
 import * as frontSourceActivities from "@app/temporal/relocation/activities/source_region/front";
-import { RELOCATION_QUEUES_PER_REGION } from "@app/temporal/relocation/config";
+import { RELOCATION_QUEUES_PER_CELL } from "@app/temporal/relocation/config";
 import { getTemporalRelocationWorkerConnection } from "@app/temporal/relocation/temporal";
 import type { Context } from "@temporalio/activity";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
@@ -20,7 +20,7 @@ import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 
 export async function runRelocationWorker() {
-  const currentRegion = config.getCurrentRegion();
+  const currentCell = config.getCurrentCell().name;
 
   const { connection, namespace } =
     await getTemporalRelocationWorkerConnection();
@@ -37,7 +37,7 @@ export async function runRelocationWorker() {
       ...frontDestinationActivities,
       ...frontSourceActivities,
     },
-    taskQueue: RELOCATION_QUEUES_PER_REGION[currentRegion],
+    taskQueue: RELOCATION_QUEUES_PER_CELL[currentCell],
     maxConcurrentActivityTaskExecutions: 8,
     connection,
     namespace,

--- a/front/temporal/relocation/workflows.ts
+++ b/front/temporal/relocation/workflows.ts
@@ -13,8 +13,8 @@ import {
   CORE_API_LIST_NODES_BATCH_SIZE,
   CORE_API_LIST_TABLES_BATCH_SIZE,
 } from "@app/temporal/relocation/activities/types";
-import { RELOCATION_QUEUES_PER_REGION } from "@app/temporal/relocation/config";
-import type { RegionType } from "@app/types/region";
+import { RELOCATION_QUEUES_PER_CELL } from "@app/temporal/relocation/config";
+import type { CellType } from "@app/types/cell";
 import type { ModelId } from "@app/types/shared/model_id";
 import {
   continueAsNew,
@@ -32,14 +32,14 @@ const INITIAL_BACKOFF_DELAY_MS = 1000;
 const MAX_BACKOFF_DELAY_MS = 60_000;
 
 interface RelocationWorkflowBase {
-  sourceRegion: RegionType;
-  destRegion: RegionType;
+  sourceCell: CellType;
+  destCell: CellType;
   workspaceId: string;
 }
 
 export async function workspaceRelocationWorkflow({
-  sourceRegion,
-  destRegion,
+  sourceCell,
+  destCell,
   workspaceId,
 }: RelocationWorkflowBase) {
   const { searchAttributes: parentSearchAttributes, memo } = workflowInfo();
@@ -62,29 +62,29 @@ export async function workspaceRelocationWorkflow({
       await executeChild(w.workflow, {
         workflowId: `${w.name}-${workspaceId}`,
         searchAttributes: parentSearchAttributes,
-        args: [{ sourceRegion, destRegion, workspaceId }],
+        args: [{ sourceCell, destCell, workspaceId }],
         memo,
       });
     },
     { concurrency: 2 }
   );
 
-  // 3) Relocate the core data source documents to the destination region.
+  // 3) Relocate the core data source documents to the destination cell.
   await executeChild(workspaceRelocateCoreWorkflow, {
     workflowId: `workspaceRelocateCoreWorkflow-${workspaceId}`,
     searchAttributes: parentSearchAttributes,
-    args: [{ sourceRegion, destRegion, workspaceId }],
+    args: [{ sourceCell, destCell, workspaceId }],
   });
 
-  // 4) Relocate the apps to the destination region.
+  // 4) Relocate the apps to the destination cell.
   await executeChild(workspaceRelocateAppsWorkflow, {
     workflowId: `workspaceRelocateAppsWorkflow-${workspaceId}`,
     searchAttributes: parentSearchAttributes,
     args: [
       {
         workspaceId,
-        sourceRegion,
-        destRegion,
+        sourceCell,
+        destCell,
       },
     ],
     memo,
@@ -95,61 +95,60 @@ export async function workspaceRelocationWorkflow({
  * Front relocation workflows.
  */
 
-const getFrontSourceRegionActivities = (region: RegionType) => {
+const getFrontSourceCellActivities = (cell: CellType) => {
   return proxyActivities<typeof frontSourceActivities>({
     startToCloseTimeout: "10 minutes",
-    taskQueue: RELOCATION_QUEUES_PER_REGION[region],
+    taskQueue: RELOCATION_QUEUES_PER_CELL[cell],
   });
 };
 
-const getFrontDestinationRegionActivities = (region: RegionType) => {
+const getFrontDestinationCellActivities = (cell: CellType) => {
   return proxyActivities<typeof frontDestinationActivities>({
     startToCloseTimeout: "10 minutes",
-    taskQueue: RELOCATION_QUEUES_PER_REGION[region],
+    taskQueue: RELOCATION_QUEUES_PER_CELL[cell],
   });
 };
 
 export async function workspaceRelocateFrontWorkflow({
-  sourceRegion,
-  destRegion,
+  sourceCell,
+  destCell,
   workspaceId,
 }: RelocationWorkflowBase) {
-  const sourceRegionActivities = getFrontSourceRegionActivities(sourceRegion);
-  const destinationRegionActivities =
-    getFrontDestinationRegionActivities(destRegion);
+  const sourceCellActivities = getFrontSourceCellActivities(sourceCell);
+  const destinationCellActivities = getFrontDestinationCellActivities(destCell);
 
   const { searchAttributes: parentSearchAttributes, memo } = workflowInfo();
 
-  // 1) Relocate the workspace, users and plan in the destination region.
+  // 1) Relocate the workspace, users and plan in the destination cell.
   const coreEntitiesDataPath =
-    await sourceRegionActivities.readCoreEntitiesFromSourceRegion({
-      destRegion,
-      sourceRegion,
+    await sourceCellActivities.readCoreEntitiesFromSourceRegion({
+      destCell,
+      sourceCell,
       workspaceId,
     });
 
-  await destinationRegionActivities.writeCoreEntitiesToDestinationRegionWithIdNormalization(
+  await destinationCellActivities.writeCoreEntitiesToDestinationRegionWithIdNormalization(
     {
       dataPath: coreEntitiesDataPath,
-      destRegion,
-      sourceRegion,
+      destCell,
+      sourceCell,
       workspaceId,
     }
   );
 
   const tablesOrder =
-    await sourceRegionActivities.getTablesWithWorkspaceIdOrder();
+    await sourceCellActivities.getTablesWithWorkspaceIdOrder();
 
-  // 2) Relocate front tables to the destination region.
+  // 2) Relocate front tables to the destination cell.
   for (const tableName of tablesOrder) {
     await executeChild(workspaceRelocateFrontTableWorkflow, {
       workflowId: `workspaceRelocateFrontTableWorkflow-${workspaceId}-${tableName}`,
       searchAttributes: parentSearchAttributes,
       args: [
         {
-          sourceRegion,
+          sourceCell,
           tableName,
-          destRegion,
+          destCell,
           workspaceId,
         },
       ],
@@ -157,27 +156,27 @@ export async function workspaceRelocateFrontWorkflow({
     });
   }
 
-  // 3) Relocate the associated files from the file storage to the destination region.
+  // 3) Relocate the associated files from the file storage to the destination cell.
   await executeChild(workspaceRelocateFrontFileStorageWorkflow, {
     workflowId: `workspaceRelocateFrontFileStorageWorkflow-${workspaceId}`,
     searchAttributes: parentSearchAttributes,
     args: [
       {
-        sourceRegion,
-        destRegion,
+        sourceCell,
+        destCell,
         workspaceId,
       },
     ],
   });
 
-  // 4) Recreate Elasticsearch indices in the destination region.
+  // 4) Recreate Elasticsearch indices in the destination cell.
   await executeChild(workspaceRelocateFrontEsIndexationWorkflow, {
     workflowId: `workspaceRelocateFrontEsIndexationWorkflow-${workspaceId}`,
     searchAttributes: parentSearchAttributes,
     args: [
       {
-        sourceRegion,
-        destRegion,
+        sourceCell,
+        destCell,
         workspaceId,
       },
     ],
@@ -187,18 +186,17 @@ export async function workspaceRelocateFrontWorkflow({
 
 export async function workspaceRelocateFrontTableWorkflow({
   lastProcessedId,
-  sourceRegion,
+  sourceCell,
   tableName,
-  destRegion,
+  destCell,
   workspaceId,
 }: RelocationWorkflowBase & {
   tableName: string;
   lastProcessedId?: ModelId;
 }) {
   // Create activity proxies with dynamic task queues.
-  const sourceRegionActivities = getFrontSourceRegionActivities(sourceRegion);
-  const destinationRegionActivities =
-    getFrontDestinationRegionActivities(destRegion);
+  const sourceCellActivities = getFrontSourceCellActivities(sourceCell);
+  const destinationCellActivities = getFrontDestinationCellActivities(destCell);
 
   let hasMoreRows = true;
   let currentId: ModelId | undefined = lastProcessedId;
@@ -207,8 +205,8 @@ export async function workspaceRelocateFrontTableWorkflow({
   do {
     if (workflowInfo().historyLength > TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH) {
       await continueAsNew<typeof workspaceRelocateFrontTableWorkflow>({
-        sourceRegion,
-        destRegion,
+        sourceCell,
+        destCell,
         workspaceId,
         tableName,
         lastProcessedId: currentId,
@@ -221,22 +219,22 @@ export async function workspaceRelocateFrontTableWorkflow({
       lastId,
       nextLimit,
     }: Awaited<ReturnType<typeof frontSourceActivities.readFrontTableChunk>> =
-      await sourceRegionActivities.readFrontTableChunk({
+      await sourceCellActivities.readFrontTableChunk({
         lastId: currentId,
         workspaceId,
         tableName,
-        sourceRegion,
-        destRegion,
+        sourceCell,
+        destCell,
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         limit: limit || CHUNK_SIZE,
       });
 
     if (dataPath) {
-      await destinationRegionActivities.processFrontTableChunkWithIdNormalization(
+      await destinationCellActivities.processFrontTableChunkWithIdNormalization(
         {
           dataPath,
-          destRegion,
-          sourceRegion,
+          destCell,
+          sourceCell,
           tableName,
           workspaceId,
         }
@@ -250,23 +248,22 @@ export async function workspaceRelocateFrontTableWorkflow({
 }
 
 export async function workspaceRelocateFrontFileStorageWorkflow({
-  sourceRegion,
-  destRegion,
+  sourceCell,
+  destCell,
   workspaceId,
 }: RelocationWorkflowBase) {
-  const sourceRegionActivities = getFrontSourceRegionActivities(sourceRegion);
-  const destinationRegionActivities =
-    getFrontDestinationRegionActivities(destRegion);
+  const sourceCellActivities = getFrontSourceCellActivities(sourceCell);
+  const destinationCellActivities = getFrontDestinationCellActivities(destCell);
 
   // 1) Relocate public files.
   const destPublicBucket =
-    await destinationRegionActivities.getDestinationPublicBucket();
+    await destinationCellActivities.getDestinationPublicBucket();
 
   const publicFilesJobName =
-    await sourceRegionActivities.startTransferFrontPublicFiles({
+    await sourceCellActivities.startTransferFrontPublicFiles({
       destBucket: destPublicBucket,
-      destRegion,
-      sourceRegion,
+      destCell,
+      sourceCell,
       workspaceId,
     });
 
@@ -274,7 +271,7 @@ export async function workspaceRelocateFrontFileStorageWorkflow({
   let isPublicFilesTransferComplete = false;
   while (!isPublicFilesTransferComplete) {
     isPublicFilesTransferComplete =
-      await sourceRegionActivities.isFileStorageTransferComplete({
+      await sourceCellActivities.isFileStorageTransferComplete({
         jobName: publicFilesJobName,
       });
 
@@ -286,13 +283,13 @@ export async function workspaceRelocateFrontFileStorageWorkflow({
 
   // 2) Relocate private files.
   const destPrivateBucket =
-    await destinationRegionActivities.getDestinationPrivateBucket();
+    await destinationCellActivities.getDestinationPrivateBucket();
 
   const privateFilesJobName =
-    await sourceRegionActivities.startTransferFrontPrivateFiles({
+    await sourceCellActivities.startTransferFrontPrivateFiles({
       destBucket: destPrivateBucket,
-      destRegion,
-      sourceRegion,
+      destCell,
+      sourceCell,
       workspaceId,
     });
 
@@ -300,7 +297,7 @@ export async function workspaceRelocateFrontFileStorageWorkflow({
   let isPrivateFilesTransferComplete = false;
   while (!isPrivateFilesTransferComplete) {
     isPrivateFilesTransferComplete =
-      await sourceRegionActivities.isFileStorageTransferComplete({
+      await sourceCellActivities.isFileStorageTransferComplete({
         jobName: privateFilesJobName,
       });
 
@@ -312,62 +309,60 @@ export async function workspaceRelocateFrontFileStorageWorkflow({
 }
 
 export async function workspaceRelocateFrontEsIndexationWorkflow({
-  destRegion,
+  destCell,
   workspaceId,
 }: RelocationWorkflowBase) {
-  const destinationRegionActivities =
-    getFrontDestinationRegionActivities(destRegion);
+  const destinationCellActivities = getFrontDestinationCellActivities(destCell);
 
   // Recreate user search index.
-  await destinationRegionActivities.recreateUserSearchIndex({ workspaceId });
+  await destinationCellActivities.recreateUserSearchIndex({ workspaceId });
 }
 
 /**
  * Connectors relocation workflows.
  */
 
-const getConnectorsSourceRegionActivities = (region: RegionType) => {
+const getConnectorsSourceCellActivities = (cell: CellType) => {
   return proxyActivities<typeof connectorsSourceActivities>({
     startToCloseTimeout: "10 minutes",
-    taskQueue: RELOCATION_QUEUES_PER_REGION[region],
+    taskQueue: RELOCATION_QUEUES_PER_CELL[cell],
   });
 };
 
-const getConnectorsDestinationRegionActivities = (region: RegionType) => {
+const getConnectorsDestinationCellActivities = (cell: CellType) => {
   return proxyActivities<typeof connectorsDestinationActivities>({
     startToCloseTimeout: "10 minutes",
-    taskQueue: RELOCATION_QUEUES_PER_REGION[region],
+    taskQueue: RELOCATION_QUEUES_PER_CELL[cell],
   });
 };
 
 export async function workspaceRelocateConnectorsWorkflow({
-  sourceRegion,
-  destRegion,
+  sourceCell,
+  destCell,
   workspaceId,
 }: RelocationWorkflowBase) {
   const { searchAttributes: parentSearchAttributes, memo } = workflowInfo();
 
-  const sourceRegionActivities =
-    getConnectorsSourceRegionActivities(sourceRegion);
-  const destinationRegionActivities =
-    getConnectorsDestinationRegionActivities(destRegion);
+  const sourceCellActivities = getConnectorsSourceCellActivities(sourceCell);
+  const destinationCellActivities =
+    getConnectorsDestinationCellActivities(destCell);
 
   // 1) List all connectors in the workspace.
   const { connectors, dataPath } =
-    await sourceRegionActivities.getAllConnectorsForWorkspace({
+    await sourceCellActivities.getAllConnectorsForWorkspace({
       workspaceId,
     });
 
-  // 2) Relocate connectors entries to the destination region.
-  await destinationRegionActivities.processConnectorsTableChunk({
+  // 2) Relocate connectors entries to the destination cell.
+  await destinationCellActivities.processConnectorsTableChunk({
     dataPath,
-    destRegion,
-    sourceRegion,
+    destCell,
+    sourceCell,
     tableName: "connectors",
     workspaceId,
   });
 
-  // 3) Relocate connectors tables to the destination region for each connector.
+  // 3) Relocate connectors tables to the destination cell for each connector.
   for (const c of connectors) {
     await executeChild(workspaceRelocateConnectorWorkflow, {
       workflowId: `workspaceRelocateConnectorWorkflow-${workspaceId}-${c.id}`,
@@ -375,8 +370,8 @@ export async function workspaceRelocateConnectorsWorkflow({
       args: [
         {
           connectorId: c.id,
-          destRegion,
-          sourceRegion,
+          destCell,
+          sourceCell,
           workspaceId,
         },
       ],
@@ -387,17 +382,16 @@ export async function workspaceRelocateConnectorsWorkflow({
 
 export async function workspaceRelocateConnectorWorkflow({
   connectorId,
-  sourceRegion,
-  destRegion,
+  sourceCell,
+  destCell,
   workspaceId,
 }: RelocationWorkflowBase & { connectorId: ModelId }) {
   const { searchAttributes: parentSearchAttributes, memo } = workflowInfo();
 
-  const sourceRegionActivities =
-    getConnectorsSourceRegionActivities(sourceRegion);
+  const sourceCellActivities = getConnectorsSourceCellActivities(sourceCell);
 
   const tablesOrder =
-    await sourceRegionActivities.getTablesWithConnectorIdOrder();
+    await sourceCellActivities.getTablesWithConnectorIdOrder();
 
   for (const tableName of tablesOrder) {
     await executeChild(workspaceRelocateConnectorsTableWorkflow, {
@@ -406,8 +400,8 @@ export async function workspaceRelocateConnectorWorkflow({
       args: [
         {
           connectorId,
-          destRegion,
-          sourceRegion,
+          destCell,
+          sourceCell,
           tableName,
           workspaceId,
         },
@@ -420,19 +414,18 @@ export async function workspaceRelocateConnectorWorkflow({
 export async function workspaceRelocateConnectorsTableWorkflow({
   connectorId,
   lastProcessedId,
-  sourceRegion,
+  sourceCell,
   tableName,
-  destRegion,
+  destCell,
   workspaceId,
 }: RelocationWorkflowBase & {
   connectorId: ModelId;
   tableName: string;
   lastProcessedId?: ModelId;
 }) {
-  const sourceRegionActivities =
-    getConnectorsSourceRegionActivities(sourceRegion);
-  const destinationRegionActivities =
-    getConnectorsDestinationRegionActivities(destRegion);
+  const sourceCellActivities = getConnectorsSourceCellActivities(sourceCell);
+  const destinationCellActivities =
+    getConnectorsDestinationCellActivities(destCell);
 
   let hasMoreRows = true;
   let currentId: ModelId | undefined = lastProcessedId;
@@ -441,8 +434,8 @@ export async function workspaceRelocateConnectorsTableWorkflow({
     if (workflowInfo().historyLength > TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH) {
       await continueAsNew<typeof workspaceRelocateConnectorsTableWorkflow>({
         connectorId,
-        sourceRegion,
-        destRegion,
+        sourceCell,
+        destCell,
         workspaceId,
         tableName,
         lastProcessedId: currentId,
@@ -450,14 +443,14 @@ export async function workspaceRelocateConnectorsTableWorkflow({
     }
 
     const { dataPath, hasMore, lastId } =
-      await sourceRegionActivities.readConnectorsTableChunk({
+      await sourceCellActivities.readConnectorsTableChunk({
         connectorId,
         lastId: currentId,
         limit: CHUNK_SIZE,
         workspaceId,
         tableName,
-        sourceRegion,
-        destRegion,
+        sourceCell,
+        destCell,
       });
 
     hasMoreRows = hasMore;
@@ -468,11 +461,11 @@ export async function workspaceRelocateConnectorsTableWorkflow({
       continue;
     }
 
-    await destinationRegionActivities.processConnectorsTableChunk({
+    await destinationCellActivities.processConnectorsTableChunk({
       connectorId,
       dataPath,
-      destRegion,
-      sourceRegion,
+      destCell,
+      sourceCell,
       tableName,
       workspaceId,
     });
@@ -483,29 +476,29 @@ export async function workspaceRelocateConnectorsTableWorkflow({
  * Core relocation workflows.
  */
 
-const getCoreSourceRegionActivities = (region: RegionType) => {
+const getCoreSourceCellActivities = (cell: CellType) => {
   return proxyActivities<typeof coreSourceActivities>({
     startToCloseTimeout: "10 minutes",
-    taskQueue: RELOCATION_QUEUES_PER_REGION[region],
+    taskQueue: RELOCATION_QUEUES_PER_CELL[cell],
   });
 };
 
-const getCoreDestinationRegionActivities = (region: RegionType) => {
+const getCoreDestinationCellActivities = (cell: CellType) => {
   return proxyActivities<typeof coreDestinationActivities>({
     startToCloseTimeout: "10 minutes",
-    taskQueue: RELOCATION_QUEUES_PER_REGION[region],
+    taskQueue: RELOCATION_QUEUES_PER_CELL[cell],
   });
 };
 
 export async function workspaceRelocateCoreWorkflow({
-  destRegion,
+  destCell,
   lastProcessedId,
-  sourceRegion,
+  sourceCell,
   workspaceId,
 }: RelocationWorkflowBase & { lastProcessedId?: ModelId }) {
   const { searchAttributes: parentSearchAttributes, memo } = workflowInfo();
 
-  const sourceRegionActivities = getCoreSourceRegionActivities(sourceRegion);
+  const sourceCellActivities = getCoreSourceCellActivities(sourceCell);
 
   let hasMoreRows = true;
   let currentId: ModelId | undefined = lastProcessedId;
@@ -513,15 +506,15 @@ export async function workspaceRelocateCoreWorkflow({
   do {
     if (workflowInfo().historyLength > TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH) {
       await continueAsNew<typeof workspaceRelocateCoreWorkflow>({
-        destRegion,
+        destCell,
         lastProcessedId: currentId,
-        sourceRegion,
+        sourceCell,
         workspaceId,
       });
     }
 
     const { dataSourceCoreIds, hasMore, lastId } =
-      await sourceRegionActivities.retrieveDataSourceCoreIdsBatch({
+      await sourceCellActivities.retrieveDataSourceCoreIdsBatch({
         lastId: currentId,
         workspaceId,
       });
@@ -538,8 +531,8 @@ export async function workspaceRelocateCoreWorkflow({
           args: [
             {
               dataSourceCoreIds: dsc,
-              destRegion,
-              sourceRegion,
+              destCell,
+              sourceCell,
               workspaceId,
             },
           ],
@@ -550,35 +543,33 @@ export async function workspaceRelocateCoreWorkflow({
   } while (hasMoreRows);
 }
 
-// TODO: Below is not idempotent, we need to handle the case where the data source is already created in the destination region.
+// TODO: Below is not idempotent, we need to handle the case where the data source is already created in the destination cell.
 export async function workspaceRelocateDataSourceCoreWorkflow({
   dataSourceCoreIds,
-  destRegion,
-  sourceRegion,
+  destCell,
+  sourceCell,
   workspaceId,
 }: RelocationWorkflowBase & { dataSourceCoreIds: DataSourceCoreIds }) {
   const { searchAttributes: parentSearchAttributes, memo } = workflowInfo();
 
-  const sourceRegionActivities = getCoreSourceRegionActivities(sourceRegion);
-  const destinationRegionActivities =
-    getCoreDestinationRegionActivities(destRegion);
+  const sourceCellActivities = getCoreSourceCellActivities(sourceCell);
+  const destinationCellActivities = getCoreDestinationCellActivities(destCell);
 
-  // 1) Get the data source from the source region.
-  const sourceRegionCoreDataSource =
-    await sourceRegionActivities.getCoreDataSource({
-      dataSourceCoreIds,
-      workspaceId,
-    });
-
-  // 2) Create the project and data source in the destination region.
-  const destIds = await destinationRegionActivities.createDataSourceProject({
-    destRegion,
-    sourceRegionCoreDataSource,
+  // 1) Get the data source from the source cell.
+  const sourceCoreDataSource = await sourceCellActivities.getCoreDataSource({
+    dataSourceCoreIds,
     workspaceId,
   });
 
-  // 3) Update the data source in the destination region with the new core ids.
-  await destinationRegionActivities.updateDataSourceCoreIds({
+  // 2) Create the project and data source in the destination cell.
+  const destIds = await destinationCellActivities.createDataSourceProject({
+    destCell,
+    sourceCoreDataSource,
+    workspaceId,
+  });
+
+  // 3) Update the data source in the destination cell with the new core ids.
+  await destinationCellActivities.updateDataSourceCoreIds({
     dataSourceCoreIds,
     destIds,
     workspaceId,
@@ -591,9 +582,9 @@ export async function workspaceRelocateDataSourceCoreWorkflow({
       {
         dataSourceCoreIds,
         destIds,
-        destRegion,
+        destCell,
         pageCursor: null,
-        sourceRegion,
+        sourceCell,
         workspaceId,
       },
     ],
@@ -604,9 +595,9 @@ export async function workspaceRelocateDataSourceCoreWorkflow({
 export async function workspaceRelocateCoreDataSourceResourcesWorkflow({
   dataSourceCoreIds,
   destIds,
-  destRegion,
+  destCell,
   pageCursor,
-  sourceRegion,
+  sourceCell,
   workspaceId,
 }: RelocationWorkflowBase & {
   destIds: CreateDataSourceProjectResult;
@@ -644,9 +635,9 @@ export async function workspaceRelocateCoreDataSourceResourcesWorkflow({
           {
             dataSourceCoreIds,
             destIds,
-            destRegion,
+            destCell,
             pageCursor,
-            sourceRegion,
+            sourceCell,
             workspaceId,
           },
         ],
@@ -660,18 +651,17 @@ export async function workspaceRelocateCoreDataSourceResourcesWorkflow({
 export async function workspaceRelocateDataSourceDocumentsWorkflow({
   dataSourceCoreIds,
   destIds,
-  destRegion,
+  destCell,
   pageCursor: initialPageCursor,
-  sourceRegion,
+  sourceCell,
   workspaceId,
 }: RelocationWorkflowBase & {
   destIds: CreateDataSourceProjectResult;
   dataSourceCoreIds: DataSourceCoreIds;
   pageCursor: string | null;
 }) {
-  const sourceRegionActivities = getCoreSourceRegionActivities(sourceRegion);
-  const destinationRegionActivities =
-    getCoreDestinationRegionActivities(destRegion);
+  const sourceCellActivities = getCoreSourceCellActivities(sourceCell);
+  const destinationCellActivities = getCoreDestinationCellActivities(destCell);
 
   let pageCursor: string | null = initialPageCursor;
   let limit: number | null = null;
@@ -680,9 +670,9 @@ export async function workspaceRelocateDataSourceDocumentsWorkflow({
       await continueAsNew<typeof workspaceRelocateDataSourceDocumentsWorkflow>({
         dataSourceCoreIds,
         destIds,
-        destRegion,
+        destCell,
         pageCursor,
-        sourceRegion,
+        sourceCell,
         workspaceId,
       });
     }
@@ -692,25 +682,24 @@ export async function workspaceRelocateDataSourceDocumentsWorkflow({
       nextPageCursor,
       nextLimit,
     }: Awaited<ReturnType<typeof coreSourceActivities.getDataSourceDocuments>> =
-      await sourceRegionActivities.getDataSourceDocuments({
+      await sourceCellActivities.getDataSourceDocuments({
         pageCursor,
         dataSourceCoreIds,
-        sourceRegion,
+        sourceCell,
         workspaceId,
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         limit: limit || CORE_API_LIST_NODES_BATCH_SIZE,
       });
 
     if (dataPath) {
-      const sourceRegionApiBaseUrl =
-        await sourceRegionActivities.getRegionApiBaseUrl();
+      const sourceApiBaseUrl = await sourceCellActivities.getRegionApiBaseUrl();
 
-      await destinationRegionActivities.processDataSourceDocuments({
+      await destinationCellActivities.processDataSourceDocuments({
         destIds,
         dataPath,
-        destRegion,
-        sourceRegion,
-        sourceRegionApiBaseUrl,
+        destCell,
+        sourceCell,
+        sourceApiBaseUrl,
         workspaceId,
       });
     }
@@ -723,18 +712,17 @@ export async function workspaceRelocateDataSourceDocumentsWorkflow({
 export async function workspaceRelocateDataSourceFoldersWorkflow({
   dataSourceCoreIds,
   destIds,
-  destRegion,
+  destCell,
   pageCursor: initialPageCursor,
-  sourceRegion,
+  sourceCell,
   workspaceId,
 }: RelocationWorkflowBase & {
   destIds: CreateDataSourceProjectResult;
   dataSourceCoreIds: DataSourceCoreIds;
   pageCursor: string | null;
 }) {
-  const sourceRegionActivities = getCoreSourceRegionActivities(sourceRegion);
-  const destinationRegionActivities =
-    getCoreDestinationRegionActivities(destRegion);
+  const sourceCellActivities = getCoreSourceCellActivities(sourceCell);
+  const destinationCellActivities = getCoreDestinationCellActivities(destCell);
 
   let pageCursor: string | null = initialPageCursor;
 
@@ -743,30 +731,29 @@ export async function workspaceRelocateDataSourceFoldersWorkflow({
       await continueAsNew<typeof workspaceRelocateDataSourceFoldersWorkflow>({
         dataSourceCoreIds,
         destIds,
-        destRegion,
+        destCell,
         pageCursor,
-        sourceRegion,
+        sourceCell,
         workspaceId,
       });
     }
 
     const { dataPath, nextPageCursor } =
-      await sourceRegionActivities.getDataSourceFolders({
+      await sourceCellActivities.getDataSourceFolders({
         pageCursor,
         dataSourceCoreIds,
-        sourceRegion,
+        sourceCell,
         workspaceId,
       });
 
-    const sourceRegionApiBaseUrl =
-      await sourceRegionActivities.getRegionApiBaseUrl();
+    const sourceApiBaseUrl = await sourceCellActivities.getRegionApiBaseUrl();
 
-    await destinationRegionActivities.processDataSourceFolders({
+    await destinationCellActivities.processDataSourceFolders({
       destIds,
       dataPath,
-      destRegion,
-      sourceRegion,
-      sourceRegionApiBaseUrl,
+      destCell,
+      sourceCell,
+      sourceApiBaseUrl,
       workspaceId,
     });
 
@@ -777,18 +764,17 @@ export async function workspaceRelocateDataSourceFoldersWorkflow({
 export async function workspaceRelocateDataSourceTablesWorkflow({
   dataSourceCoreIds,
   destIds,
-  destRegion,
+  destCell,
   pageCursor: initialPageCursor,
-  sourceRegion,
+  sourceCell,
   workspaceId,
 }: RelocationWorkflowBase & {
   destIds: CreateDataSourceProjectResult;
   dataSourceCoreIds: DataSourceCoreIds;
   pageCursor: string | null;
 }) {
-  const sourceRegionActivities = getCoreSourceRegionActivities(sourceRegion);
-  const destinationRegionActivities =
-    getCoreDestinationRegionActivities(destRegion);
+  const sourceCellActivities = getCoreSourceCellActivities(sourceCell);
+  const destinationCellActivities = getCoreDestinationCellActivities(destCell);
 
   let pageCursor: string | null = initialPageCursor;
   let limit: number | null = null;
@@ -797,9 +783,9 @@ export async function workspaceRelocateDataSourceTablesWorkflow({
       await continueAsNew<typeof workspaceRelocateDataSourceTablesWorkflow>({
         dataSourceCoreIds,
         destIds,
-        destRegion,
+        destCell,
         pageCursor,
-        sourceRegion,
+        sourceCell,
         workspaceId,
       });
     }
@@ -809,24 +795,23 @@ export async function workspaceRelocateDataSourceTablesWorkflow({
       nextPageCursor,
       nextLimit,
     }: Awaited<ReturnType<typeof coreSourceActivities.getDataSourceTables>> =
-      await sourceRegionActivities.getDataSourceTables({
+      await sourceCellActivities.getDataSourceTables({
         pageCursor,
         dataSourceCoreIds,
-        sourceRegion,
+        sourceCell,
         workspaceId,
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         limit: limit || CORE_API_LIST_TABLES_BATCH_SIZE,
       });
     if (dataPath) {
-      const sourceRegionApiBaseUrl =
-        await sourceRegionActivities.getRegionApiBaseUrl();
+      const sourceApiBaseUrl = await sourceCellActivities.getRegionApiBaseUrl();
 
-      await destinationRegionActivities.processDataSourceTables({
+      await destinationCellActivities.processDataSourceTables({
         destIds,
         dataPath,
-        destRegion,
-        sourceRegion,
-        sourceRegionApiBaseUrl,
+        destCell,
+        sourceCell,
+        sourceApiBaseUrl,
         workspaceId,
       });
     }
@@ -839,28 +824,27 @@ export async function workspaceRelocateDataSourceTablesWorkflow({
 export async function workspaceRelocateTableStorageWorkflow({
   dataSourceCoreIds,
   destIds,
-  destRegion,
-  sourceRegion,
+  destCell,
+  sourceCell,
   workspaceId,
 }: RelocationWorkflowBase & {
   dataSourceCoreIds: DataSourceCoreIds;
   destIds: CreateDataSourceProjectResult;
 }) {
-  const sourceRegionActivities = getFrontSourceRegionActivities(sourceRegion);
-  const destinationRegionActivities =
-    getFrontDestinationRegionActivities(destRegion);
+  const sourceCellActivities = getFrontSourceCellActivities(sourceCell);
+  const destinationCellActivities = getFrontDestinationCellActivities(destCell);
 
   // 1) Relocate tables files.
   const destTablesBucket =
-    await destinationRegionActivities.getDestinationTablesBucket();
+    await destinationCellActivities.getDestinationTablesBucket();
 
   const tableFilesJobName =
-    await sourceRegionActivities.startTransferCoreTableFiles({
+    await sourceCellActivities.startTransferCoreTableFiles({
       dataSourceCoreIds,
       destBucket: destTablesBucket,
       destIds,
-      destRegion,
-      sourceRegion,
+      destCell,
+      sourceCell,
       workspaceId,
     });
 
@@ -869,7 +853,7 @@ export async function workspaceRelocateTableStorageWorkflow({
   let backoffDelayMs = INITIAL_BACKOFF_DELAY_MS;
   while (!isTableFilesTransferComplete) {
     isTableFilesTransferComplete =
-      await sourceRegionActivities.isFileStorageTransferComplete({
+      await sourceCellActivities.isFileStorageTransferComplete({
         jobName: tableFilesJobName,
       });
 
@@ -883,19 +867,18 @@ export async function workspaceRelocateTableStorageWorkflow({
 export async function workspaceRelocateAppsWorkflow({
   workspaceId,
   lastProcessedId,
-  sourceRegion,
-  destRegion,
+  sourceCell,
+  destCell,
 }: RelocationWorkflowBase & { lastProcessedId?: ModelId }) {
-  const sourceRegionActivities = getCoreSourceRegionActivities(sourceRegion);
-  const destinationRegionActivities =
-    getCoreDestinationRegionActivities(destRegion);
+  const sourceCellActivities = getCoreSourceCellActivities(sourceCell);
+  const destinationCellActivities = getCoreDestinationCellActivities(destCell);
 
   let hasMoreRows = true;
   let currentId: ModelId | undefined = lastProcessedId;
 
   do {
     const { dustAPIProjectIds, hasMore, lastId } =
-      await sourceRegionActivities.retrieveAppsCoreIdsBatch({
+      await sourceCellActivities.retrieveAppsCoreIdsBatch({
         lastId: currentId,
         workspaceId,
       });
@@ -904,17 +887,17 @@ export async function workspaceRelocateAppsWorkflow({
     currentId = lastId;
 
     for (const dustAPIProjectId of dustAPIProjectIds) {
-      const { dataPath } = await sourceRegionActivities.getApp({
+      const { dataPath } = await sourceCellActivities.getApp({
         dustAPIProjectId,
         workspaceId,
-        sourceRegion,
+        sourceCell,
       });
 
-      await destinationRegionActivities.processApp({
+      await destinationCellActivities.processApp({
         dustAPIProjectId,
         dataPath,
-        destRegion,
-        sourceRegion,
+        destCell,
+        sourceCell,
         workspaceId,
       });
     }
@@ -923,25 +906,24 @@ export async function workspaceRelocateAppsWorkflow({
 
 export async function workspaceRelocateAppWorkflow({
   workspaceId,
-  sourceRegion,
-  destRegion,
+  sourceCell,
+  destCell,
   dustAPIProjectId,
 }: RelocationWorkflowBase & { dustAPIProjectId: string }) {
-  const sourceRegionActivities = getCoreSourceRegionActivities(sourceRegion);
-  const destinationRegionActivities =
-    getCoreDestinationRegionActivities(destRegion);
+  const sourceCellActivities = getCoreSourceCellActivities(sourceCell);
+  const destinationCellActivities = getCoreDestinationCellActivities(destCell);
 
-  const { dataPath } = await sourceRegionActivities.getApp({
+  const { dataPath } = await sourceCellActivities.getApp({
     dustAPIProjectId,
     workspaceId,
-    sourceRegion,
+    sourceCell,
   });
 
-  await destinationRegionActivities.processApp({
+  await destinationCellActivities.processApp({
     dustAPIProjectId,
     dataPath,
-    destRegion,
-    sourceRegion,
+    destCell,
+    sourceCell,
     workspaceId,
   });
 }


### PR DESCRIPTION
## Description

Relocation is keyed by region end to end, and that stopped being true of the fleet the day cell-00002 came up in europe-west1 next to cell-00001. The two task queues are `relocation-queue-eu` and `-us`, the worker picks its queue from the `REGION` env var, so a relocation worker on cell-00002 would poll the same queue as cell-00001 and Temporal would hand source and destination activities to whichever cell answered first. The CLI already speaks cells, and then downgrades them to regions when it launches the workflow, with a warning that same-region moves are not supported. That warning is the bug.

After this PR the region does not appear in the relocation module. There is one task queue per supported cell, the worker binds to its own from `CELL`, the workflow carries a source cell and a destination cell, the six activity proxies route by cell, and the id normalization blob is named after the two cells so an EU to EU move is not ambiguous. The queue version is bumped, a workflow started on the old layout never meets a worker on the new one, and nothing is in flight. The seven scripts take `--sourceCell` and `--destinationCell` from the supported cell list and refuse the same cell twice, nothing else.

Two things change under the hood to match the infra side (dust-tt/dust-infra#1096). The Storage Transfer jobs that move upload files are created in the dust-infra project, read from a new `DUST_RELOCATION_TRANSFER_PROJECT_ID`, instead of the source project: one transfer agent that every cell grants once, instead of every project granting every other. And a staging reference now carries its bucket, `gs://<bucket>/<path>`, so the source stages in the bucket of its own location and the destination reads wherever the reference points. An EU to EU move never touches the US bucket. Bare paths still read from the local bucket.

Not renamed here, to keep the diff readable: the `source_region` and `destination_region` activity directories and the activity names that mention a region. They are labels, they route by cell now, and they can move in a follow-up.

## Tests

The rename was checked by grepping the module for every remaining `region`, what is left is directory names, activity names and one comment about same-region cells that is now the point. `tsc` on front reports no error in the touched files (the 24 it reports in this checkout are stale sparkle types in unrelated components). Biome is clean. The runtime paths, queue routing across two cells, a transfer job created in dust-infra, a staging blob read across buckets, need a real relocation: the first one after the infra PR is applied is the proof, and it should be a rehearsal workspace, not a customer.

## Risk

Relocation only, no serving path changes. Until dust-tt/dust-infra#1096 is applied and the two env vars are set, a relocation would fail at the first staging write or the first transfer job, which is safe: the workspace stays in maintenance and the rollback step is unchanged. Nothing is in flight.

## Deploy Plan

1. Apply dust-tt/dust-infra#1096 (global root, then the two legacy roots).
2. In each legacy region's `front-relocation-worker` bundle, set `DUST_RELOCATION_BUCKET` to the staging bucket of the region's location and `DUST_RELOCATION_TRANSFER_PROJECT_ID` to `dust-infra`.
3. Merge and deploy front to all cells, the relocation worker ships with it. cell-00002 gets its worker when its descriptor turns `features.relocation` on, after this is live.
4. Rehearse one relocation before the next customer move.
