### PR TITLE
feat(microsoft): browse SharePoint lists in the connector picker

### DIFF
--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -10,6 +10,7 @@ import {
 import {
   getDriveAsContentNode,
   getFolderAsContentNode,
+  getListAsContentNode,
   getMicrosoftNodeAsContentNode,
   getSiteAsContentNode,
 } from "@connectors/connectors/microsoft/lib/content_nodes";
@@ -18,6 +19,7 @@ import {
   getAllPaginatedEntities,
   getDrives,
   getFilesAndFolders,
+  getLists,
   getSites,
   getSubSites,
 } from "@connectors/connectors/microsoft/lib/graph_api";
@@ -433,9 +435,17 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
           const drives = await getAllPaginatedEntities((nextLink) =>
             getDrives(logger, client, parentInternalId, nextLink)
           );
+          const lists = await getAllPaginatedEntities((nextLink) =>
+            getLists(logger, client, parentInternalId, nextLink)
+          );
+          const { itemAPIPath: siteItemAPIPath } =
+            typeAndPathFromInternalId(parentInternalId);
           nodes.push(
             ...subSites.map((n) => getSiteAsContentNode(n, parentInternalId)),
-            ...drives.map((n) => getDriveAsContentNode(n, parentInternalId))
+            ...drives.map((n) => getDriveAsContentNode(n, parentInternalId)),
+            ...lists.map((n) =>
+              getListAsContentNode(n, parentInternalId, siteItemAPIPath)
+            )
           );
           break;
         }
@@ -454,6 +464,7 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
         case "page":
         case "message":
         case "worksheet":
+        case "list":
           throw new Error(
             `Unexpected node type ${nodeType} for retrievePermissions`
           );
@@ -845,7 +856,7 @@ export async function retrieveChildrenNodes(
   microsoftNode: MicrosoftNodeResource,
   expandWorksheet: boolean
 ): Promise<Result<ContentNode[], Error>> {
-  const nodeType: MicrosoftNodeType[] = ["file", "folder", "drive"];
+  const nodeType: MicrosoftNodeType[] = ["file", "folder", "drive", "list"];
   if (expandWorksheet) {
     nodeType.push("worksheet");
   }

--- a/connectors/src/connectors/microsoft/lib/content_nodes.ts
+++ b/connectors/src/connectors/microsoft/lib/content_nodes.ts
@@ -1,6 +1,7 @@
 import {
   getDriveInternalId,
   getDriveItemInternalId,
+  getListInternalId,
   getSiteAPIPath,
 } from "@connectors/connectors/microsoft/lib/graph_api";
 import type { DriveItem } from "@connectors/connectors/microsoft/lib/types";
@@ -8,7 +9,8 @@ import { internalIdFromTypeAndPath } from "@connectors/connectors/microsoft/lib/
 import type { MicrosoftNodeResource } from "@connectors/resources/microsoft_resource";
 import type { ContentNode, ContentNodeType } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
-import type { Drive, Site } from "@microsoft/microsoft-graph-types";
+import { assertNever } from "@dust-tt/client";
+import type { Drive, List, Site } from "@microsoft/microsoft-graph-types";
 
 export function getRootNodes(): ContentNode[] {
   return [getSitesRootAsContentNode()];
@@ -94,26 +96,68 @@ export function getFolderAsContentNode(
   };
 }
 
+export function getListAsContentNode(
+  list: List,
+  parentInternalId: string,
+  siteItemAPIPath: string
+): ContentNode {
+  return {
+    internalId: getListInternalId(list, siteItemAPIPath),
+    parentInternalId,
+    // A SharePoint list is a single structured table (unlike an Excel file which
+    // expands to several worksheets), so it is a directly-selectable leaf.
+    type: "table",
+    title: list.displayName || list.name || "unnamed",
+    sourceUrl: list.webUrl ?? null,
+    lastUpdatedAt: null,
+    expandable: false,
+    permission: "none",
+    mimeType: INTERNAL_MIME_TYPES.MICROSOFT.LIST,
+  };
+}
+
 export function getMicrosoftNodeAsContentNode(
   node: MicrosoftNodeResource,
   expandWorksheet: boolean
 ): ContentNode {
-  // When table picking we want spreadsheets to expand to select the different
-  // sheets. While extracting data we want to treat them as regular files.
+  // A SharePoint list is a single leaf table. Spreadsheets expand into their
+  // worksheets, but only while table-picking; otherwise treat them as files.
   const isExpandable =
-    !node.mimeType ||
-    (node.mimeType ===
-      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" &&
-      expandWorksheet);
+    node.nodeType !== "list" &&
+    (!node.mimeType ||
+      (node.mimeType ===
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" &&
+        expandWorksheet));
   let type: ContentNodeType;
-  if (["drive", "folder"].includes(node.nodeType)) {
-    type = "folder";
-  } else if (node.nodeType === "worksheet") {
-    type = expandWorksheet ? "table" : "document";
-  } else if (node.nodeType === "file") {
-    type = "document";
-  } else {
-    throw new Error(`Unsupported nodeType ${node.nodeType}.`);
+  let mimeType: string;
+  switch (node.nodeType) {
+    case "drive":
+    case "folder":
+      type = "folder";
+      mimeType = INTERNAL_MIME_TYPES.MICROSOFT.FOLDER;
+      break;
+    case "worksheet":
+      type = expandWorksheet ? "table" : "document";
+      mimeType =
+        type === "table"
+          ? INTERNAL_MIME_TYPES.MICROSOFT.SPREADSHEET
+          : node.mimeType || INTERNAL_MIME_TYPES.MICROSOFT.FOLDER;
+      break;
+    case "list":
+      type = "table";
+      mimeType = INTERNAL_MIME_TYPES.MICROSOFT.LIST;
+      break;
+    case "file":
+      type = "document";
+      mimeType = node.mimeType || INTERNAL_MIME_TYPES.MICROSOFT.FOLDER;
+      break;
+    case "sites-root":
+    case "site":
+    case "page":
+    case "message":
+      throw new Error(`Unsupported nodeType ${node.nodeType}.`);
+    default:
+      assertNever(node.nodeType);
   }
 
   return {
@@ -125,11 +169,6 @@ export function getMicrosoftNodeAsContentNode(
     lastUpdatedAt: null,
     expandable: isExpandable,
     permission: "none",
-    mimeType:
-      type === "table"
-        ? INTERNAL_MIME_TYPES.MICROSOFT.SPREADSHEET
-        : type === "folder"
-          ? INTERNAL_MIME_TYPES.MICROSOFT.FOLDER
-          : node.mimeType || INTERNAL_MIME_TYPES.MICROSOFT.FOLDER,
+    mimeType,
   };
 }

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -10,6 +10,7 @@ import {
   DRIVE_ITEM_DELTA_SELECTS,
   DRIVE_ITEM_EXPANDS_AND_SELECTS,
   DRIVE_ITEM_EXPANDS_AND_SELECTS_WITH_LABELS,
+  LIST_ITEM_EXPANDS_AND_SELECTS,
 } from "@connectors/connectors/microsoft/lib/types";
 import {
   internalIdFromTypeAndPath,
@@ -28,6 +29,8 @@ import type {
   Drive,
   Entity,
   ItemReference,
+  List,
+  ListItem,
   Organization,
   Site,
   WorkbookRange,
@@ -151,6 +154,92 @@ export async function getDrives(
   const res = nextLink
     ? await clientApiGet(logger, client, nextLink)
     : await clientApiGet(logger, client, `${parentResourcePath}/drives`);
+
+  if ("@odata.nextLink" in res) {
+    return {
+      results: res.value,
+      nextLink: res["@odata.nextLink"],
+    };
+  }
+
+  return { results: res.value };
+}
+
+// Only user-created custom lists ("genericList") are synced. SharePoint
+// provisions many built-in lists under other templates — document/picture/page
+// libraries, workflow tasks, publishing reports, calendars, etc. — which are
+// noise as structured tables. Structured system templates (events, tasks,
+// issueTracking, ...) can be added here later if customers ask for them.
+const SYNCABLE_LIST_TEMPLATES = new Set(["genericList"]);
+
+/**
+ * Returns whether a SharePoint list should be synced as a structured table.
+ * Hidden lists are internal SharePoint plumbing; everything that is not a
+ * user-created custom list (`genericList`) is excluded (see
+ * SYNCABLE_LIST_TEMPLATES). Document libraries in particular are already synced
+ * as drives.
+ */
+export function isSyncableList(list: List): boolean {
+  const info = list.list;
+  if (!info || info.hidden) {
+    return false;
+  }
+  return !!info.template && SYNCABLE_LIST_TEMPLATES.has(info.template);
+}
+
+export async function getLists(
+  logger: LoggerInterface,
+  client: Client,
+  parentInternalId: string,
+  nextLink?: string
+): Promise<{ results: List[]; nextLink?: string }> {
+  const { nodeType, itemAPIPath: parentResourcePath } =
+    typeAndPathFromInternalId(parentInternalId);
+
+  if (nodeType !== "site") {
+    throw new Error(
+      `Invalid node type: ${nodeType} for getLists, expected site`
+    );
+  }
+
+  const endpoint = `${parentResourcePath}/lists?$select=id,name,displayName,webUrl,createdDateTime,lastModifiedDateTime,list`;
+
+  const res = nextLink
+    ? await clientApiGet(logger, client, nextLink)
+    : await clientApiGet(logger, client, endpoint);
+
+  const lists: List[] = res.value;
+  const results = lists.filter(isSyncableList);
+
+  if ("@odata.nextLink" in res) {
+    return {
+      results,
+      nextLink: res["@odata.nextLink"],
+    };
+  }
+
+  return { results };
+}
+
+export async function getListItems(
+  logger: LoggerInterface,
+  client: Client,
+  listInternalId: string,
+  nextLink?: string
+): Promise<{ results: ListItem[]; nextLink?: string }> {
+  const { nodeType, itemAPIPath } = typeAndPathFromInternalId(listInternalId);
+
+  if (nodeType !== "list") {
+    throw new Error(
+      `Invalid node type: ${nodeType} for getListItems, expected list`
+    );
+  }
+
+  const endpoint = `${itemAPIPath}/items?${LIST_ITEM_EXPANDS_AND_SELECTS}`;
+
+  const res = nextLink
+    ? await clientApiGet(logger, client, nextLink)
+    : await clientApiGet(logger, client, endpoint);
 
   if ("@odata.nextLink" in res) {
     return {
@@ -569,6 +658,16 @@ export function getWorksheetInternalId(
   return internalIdFromTypeAndPath({
     itemAPIPath: `${parentItemApiPath}/workbook/worksheets/${item.id}`,
     nodeType: "worksheet",
+  });
+}
+
+export function getListInternalId(list: List, siteItemAPIPath: string) {
+  if (!list.id) {
+    throw new Error("Unexpected: no id for list");
+  }
+  return internalIdFromTypeAndPath({
+    nodeType: "list",
+    itemAPIPath: `${siteItemAPIPath}/lists/${list.id}`,
   });
 }
 

--- a/connectors/src/connectors/microsoft/lib/types.ts
+++ b/connectors/src/connectors/microsoft/lib/types.ts
@@ -46,6 +46,12 @@ export const DRIVE_ITEM_DELTA_SELECTS =
 export const MICROSOFT_SKIP_REASON_SENSITIVITY_LABEL_NOT_ALLOWED =
   "sensitivity_label_not_allowed" as const;
 
+// SharePoint list items are fetched with their `fields` expanded so we get every
+// custom column value in a single call. Unlike driveItems, list items carry no
+// download URL and no heavy binary payload, so this projection stays lean.
+export const LIST_ITEM_EXPANDS_AND_SELECTS =
+  "$expand=fields&$select=id,webUrl,createdDateTime,lastModifiedDateTime,createdBy,lastModifiedBy";
+
 export const MICROSOFT_NODE_TYPES = [
   "sites-root",
   "site",
@@ -55,6 +61,7 @@ export const MICROSOFT_NODE_TYPES = [
   "page",
   "message",
   "worksheet",
+  "list",
 ] as const;
 export type MicrosoftNodeType = (typeof MICROSOFT_NODE_TYPES)[number];
 

--- a/connectors/src/types/shared/internal_mime_types.ts
+++ b/connectors/src/types/shared/internal_mime_types.ts
@@ -97,7 +97,8 @@ export const INTERNAL_MIME_TYPES = {
     // Spreadsheets may contain many sheets, thus resemble folders and are
     // stored as such, but with the special mimeType below.
     // For files and sheets, we keep Microsoft's mime types.
-    resourceTypes: ["FOLDER", "SPREADSHEET"],
+    // LIST is a SharePoint list synced as a structured table.
+    resourceTypes: ["FOLDER", "SPREADSHEET", "LIST"],
   }),
   NOTION: generateMimeTypes({
     provider: "notion",

--- a/sdks/js/src/internal_mime_types.ts
+++ b/sdks/js/src/internal_mime_types.ts
@@ -122,7 +122,8 @@ export const CONTENT_NODE_MIME_TYPES = {
     // Spreadsheets may contain many sheets, thus resemble folders and are
     // stored as such, but with the special mimeType below.
     // For files and sheets, we keep Microsoft's mime types.
-    resourceTypes: ["FOLDER", "SPREADSHEET"],
+    // LIST is a SharePoint list synced as a structured table.
+    resourceTypes: ["FOLDER", "SPREADSHEET", "LIST"],
   }),
   NOTION: generateConnectorRelativeMimeTypes({
     provider: "notion",


### PR DESCRIPTION
## Description

Introduces the SharePoint `list` node type and lets users browse and select lists in the Microsoft connector's content picker. First of a 3-PR stack (browse → sync module → wire). Part of dust-tt/tasks#9234. No sync yet — selecting a list does nothing until the rest of the stack lands.

## Tests

`tsgo` clean on connectors + sdks/js. Browsing/selection verified against a live SharePoint tenant on the combined branch.

## Risk

Low; purely additive. Only `genericList` lists are surfaced (document/picture/page libraries and hidden system lists excluded).

## Deploy Plan

Standard connectors + SDK deploy (adds the `MICROSOFT.LIST` mime type). No migration, no new OAuth scopes.