### PR TITLE
[Admin Governance] Repair unended memberships for revoked editors

### DIFF
--- a/front/migrations/20260910_repair_agent_editor_memberships.test.ts
+++ b/front/migrations/20260910_repair_agent_editor_memberships.test.ts
@@ -1,3 +1,4 @@
+import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
 import { AgentResource } from "@app/lib/resources/agent_resource";
@@ -78,6 +79,76 @@ async function seedRevokedEditor() {
 describe("repairEditorMemberships", () => {
   afterEach(() => vi.useRealTimers());
 
+  it.each([
+    false,
+    true,
+  ])("repairs never-ended editor memberships (already rejoined: %s)", async (rejoined) => {
+    const { auth, workspace, user, unrelated, grant, target, legacy } =
+      await seedRevokedEditor();
+    // Reproduce workspace-only revocation: no ended memberships remain in the legacy group.
+    await GroupMembershipModel.update(
+      { endAt: null },
+      {
+        where: {
+          workspaceId: workspace.id,
+          groupId: legacy.id,
+          userId: user.id,
+        },
+      }
+    );
+    if (rejoined) {
+      await MembershipFactory.associate(workspace, user, { role: "user" });
+    } else {
+      assert((await target.delete(auth)).isOk());
+    }
+    const before = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    expect(before.getGrantedVerbs("agent", grant.resourceId)).not.toContain(
+      "write"
+    );
+    const spec = {
+      wId: workspace.sId,
+      logger: logger.child({}, { level: "silent" }),
+    };
+    for (const execute of [false, false, true]) {
+      await expect(
+        repairEditorMemberships({ ...spec, execute })
+      ).resolves.toEqual({ ended: 0, active: 1 });
+    }
+    await expect(
+      repairEditorMemberships({ ...spec, execute: true })
+    ).resolves.toEqual({ ended: 0, active: 0 });
+    const repaired = await GroupPermissionResource.findRegularAutoGroupForGrant(
+      auth,
+      grant
+    );
+    assert(repaired);
+    expect(await repaired.isMember(unrelated)).toBe(false);
+    expect((await repaired.getActiveMembers(auth)).map(({ id }) => id)).toEqual(
+      rejoined ? [user.id] : []
+    );
+    const after = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    expect(
+      after.getGrantedVerbs("agent", grant.resourceId).includes("write")
+    ).toBe(rejoined);
+
+    if (!rejoined) {
+      await MembershipFactory.associate(workspace, user, { role: "user" });
+      const restored = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+      expect(restored.getGrantedVerbs("agent", grant.resourceId)).toContain(
+        "write"
+      );
+    }
+  });
+
   it("rebuilds orphans from all current legacy editors and legacy history", async () => {
     const {
       auth,
@@ -110,7 +181,7 @@ describe("repairEditorMemberships", () => {
     };
     await expect(
       repairEditorMemberships({ ...spec, execute: false })
-    ).resolves.toEqual({ ended: 1, active: 1 });
+    ).resolves.toEqual({ ended: 1, active: 2 });
     expect(await target.isMember(staleEditor)).toBe(true);
     expect(
       await GroupPermissionResource.findRegularAutoGroupForGrant(auth, grant)
@@ -118,7 +189,7 @@ describe("repairEditorMemberships", () => {
 
     await expect(
       repairEditorMemberships({ ...spec, execute: true })
-    ).resolves.toEqual({ ended: 1, active: 1 });
+    ).resolves.toEqual({ ended: 1, active: 2 });
     const rebuilt = await GroupPermissionResource.findRegularAutoGroupForGrant(
       auth,
       grant
@@ -131,7 +202,7 @@ describe("repairEditorMemberships", () => {
     expect((await rebuilt.getActiveMembers(auth)).map(({ id }) => id)).toEqual([
       currentEditor.id,
     ]);
-    expect(await rebuilt.isMember(user)).toBe(false);
+    expect(await rebuilt.isMember(user)).toBe(true);
     const history = await GroupMembershipModel.findOne({
       where: {
         workspaceId: workspace.id,

--- a/front/migrations/20260910_repair_agent_editor_memberships.ts
+++ b/front/migrations/20260910_repair_agent_editor_memberships.ts
@@ -38,6 +38,7 @@ type Counts = { ended: number; active: number };
 async function fetchEditorGroups(afterGroupId: ModelId, wId?: string) {
   // Walk group IDs, not workspaces. Membership probes use (workspaceId, groupId, status, startAt).
   // Each editor group belongs to one agent; (agentId, version) supports the latest-version check.
+  // Workspace history uses (workspaceId, userId, startAt, endAt), scoped to each editor.
   return frontSequelize.query<EditorGroup>(
     `SELECT DISTINCT g.id AS "groupModelId", c."agentId" AS "agentModelId", w."sId" AS "workspaceId"
      FROM groups g
@@ -51,7 +52,12 @@ async function fetchEditorGroups(afterGroupId: ModelId, wId?: string) {
        AND EXISTS (
          SELECT 1 FROM group_memberships m
          WHERE m."workspaceId" = g."workspaceId" AND m."groupId" = g.id
-           AND m.status = 'active' AND m."endAt" <= NOW()
+           AND m.status = 'active' AND m."startAt" <= NOW()
+           AND (m."endAt" <= NOW() OR EXISTS (
+             SELECT 1 FROM memberships wm
+             WHERE wm."workspaceId" = m."workspaceId" AND wm."userId" = m."userId"
+               AND wm."endAt" <= NOW()
+           ))
        )
        -- Versions share their editor group; retain only the latest non-draft link.
        AND NOT EXISTS (
@@ -112,7 +118,7 @@ async function fetchGroupHistory(
   });
 }
 
-async function fetchActiveWorkspaceUsers(
+async function fetchPastWorkspaceUsers(
   workspaceId: ModelId,
   userIds: ModelId[],
   now: Date,
@@ -125,7 +131,7 @@ async function fetchActiveWorkspaceUsers(
       workspaceId,
       userId: userIds,
       startAt: { [Op.lte]: now },
-      [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
+      endAt: { [Op.lte]: now },
     },
     transaction,
   });
@@ -135,14 +141,14 @@ async function fetchActiveWorkspaceUsers(
 function selectMissingMemberships(
   source: MembershipHistory[],
   target: MembershipHistory[],
-  activeUserIds: Set<ModelId>
+  eligibleUserIds: Set<ModelId>
 ): MembershipToCopy[] {
   // Match history by user/end time; any current target row covers current access.
   const existingKeys = new Set(target.map((membership) => membership.key));
   const missing: MembershipToCopy[] = [];
   for (const membership of source) {
-    // Preserve ended history even for revoked users. Current access requires workspace membership.
-    if (membership.active && !activeUserIds.has(membership.userId)) {
+    // Preserve current rows for revoked users too; Authenticator still requires workspace membership.
+    if (membership.active && !eligibleUserIds.has(membership.userId)) {
       continue;
     }
     if (existingKeys.has(membership.key)) {
@@ -182,21 +188,20 @@ async function fetchMissingMemberships(
   const target = memberships.filter(
     (membership) => membership.groupId === targetGroupModelId
   );
-  // Normally only history-bearing users contribute active rows. Orphans need all legacy editors.
-  const eligibleUserIds = [
-    ...new Set(
-      source
-        .filter((membership) => rebuild || !membership.active)
-        .map((membership) => membership.userId)
-    ),
-  ];
-  const activeUserIds = await fetchActiveWorkspaceUsers(
+  // Workspace revocation can leave editor-group memberships unended.
+  const eligibleUserIds = await fetchPastWorkspaceUsers(
     workspaceId,
-    eligibleUserIds,
+    [...new Set(source.map((membership) => membership.userId))],
     now,
     transaction
   );
-  return selectMissingMemberships(source, target, activeUserIds);
+  // Group history also qualifies users. Orphan rebuilds need all legacy editors.
+  for (const membership of source) {
+    if (rebuild || !membership.active) {
+      eligibleUserIds.add(membership.userId);
+    }
+  }
+  return selectMissingMemberships(source, target, eligibleUserIds);
 }
 
 /**
@@ -313,8 +318,9 @@ async function copyMemberships(
  */
 /**
  * @cc [owner:philipperolet,label:security] repair-current-editors-only
- * Active grants MUST only be copied for users currently in both the legacy group and workspace.
- * Limit this to history-bearing users unless rebuilding an orphan, which needs all legacy editors.
+ * Current group memberships MUST come from current legacy memberships, including revoked users.
+ * Limit this to users with ended group or workspace memberships unless rebuilding an orphan.
+ * Copied rows MUST NOT grant permissions while the user's workspace membership is revoked.
  */
 /**
  * @cc [owner:philipperolet,label:migration] atomic-orphan-rebuild


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/32205 and https://github.com/dust-tt/dust/pull/32287.

Revoking a workspace membership can leave its agent editor memberships unended. The original migration skipped revoked users, and the repair missed these memberships because it only selected ended editor-group history. When the user returns, legacy editor access works but the new grants are missing.

Also select editors with ended workspace memberships and copy their missing legacy group memberships, including users who are still revoked. Workspace membership still gates their grants, so they regain access only when they return. Keep the existing group-ID batching, orphan handling, and deduplication; no runtime or Resource changes. The `active` count refers to unended group memberships, not necessarily active workspace members.

## Risks

Blast radius: Agent editor memberships when manually running the repair backfill.
Risk: standard

## Deploy Plan

- Make the updated script available after the existing regional repair run finishes.
- Dry-run `front/migrations/20260910_repair_agent_editor_memberships.ts --wId <workspace>` on affected workspaces and inspect the counts.
- After approval, rerun with `--execute` in each region, starting at `--afterGroupId 0` to include newly eligible groups before the old cursor. Subsequent resumes can use a completed batch's cursor from this new run.
- Dry-run again to verify zero remaining changes, then check shadow mismatch logs. No production writes were run for this PR.

## Tests

- [x] 54 tests across the repair, original editor backfill, and group-permission suites.
- [x] Never-ended memberships: users already restored, users still revoked, access after rejoining, dry runs, reruns, and unrelated editors left untouched.
