### PR TITLE
[front] Scope stacked-seat-credit usage read to seats with a stray

### DIFF
--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -13,7 +13,11 @@ import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import type { CachedContract } from "@app/lib/metronome/plan_type";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import { getWorkspacePoolAwuBalance } from "@app/lib/metronome/pool_balance";
-import { correctStackedSeatCreditsFromBalances } from "@app/lib/metronome/stacked_seat_credits";
+import {
+  buildSeatCreditTierMap,
+  computeSeatIdsWithStrays,
+  correctStackedSeatCreditsFromBalances,
+} from "@app/lib/metronome/stacked_seat_credits";
 import { setUserCreditStateReconciled } from "@app/lib/metronome/user_credit_state_machine";
 import {
   expectedPoolCreditStateFromBalance,
@@ -432,7 +436,12 @@ export async function reconcileWorkspaceUserCreditStates({
  * the NEXT segment that only becomes a live balance when that segment starts —
  * exactly when this runs. The N concurrent segment-start events collapse to one
  * execution (see `launchReconcileWorkspaceUserCreditStatesWorkflow`), so we read
- * balances once here. Never throws — logs and returns on failure.
+ * balances once here.
+ *
+ * Reads the per-user usage that drives the carry only for seats that actually
+ * carry a stray (detected from the balances), so the common no-tier-change path
+ * makes no `/v1/usage/groups` call at all. Never throws — logs and returns on
+ * failure.
  */
 export async function reconcileStackedSeatCreditsForWorkspace({
   workspace,
@@ -485,18 +494,11 @@ export async function reconcileStackedSeatCreditsForWorkspace({
   }
 
   const seatIds = [...currentSeatTypeBySeatId.keys()];
-  const [balancesResult, usageResult] = await Promise.all([
-    listMetronomeSeatBalances({
-      metronomeCustomerId,
-      metronomeContractId,
-      seatIds,
-    }),
-    fetchPerUserAwuUsage({
-      workspaceId,
-      metronomeCustomerId,
-      userIds: seatIds,
-    }),
-  ]);
+  const balancesResult = await listMetronomeSeatBalances({
+    metronomeCustomerId,
+    metronomeContractId,
+    seatIds,
+  });
   if (balancesResult.isErr()) {
     logger.error(
       { workspaceId, err: balancesResult.error },
@@ -504,6 +506,42 @@ export async function reconcileStackedSeatCreditsForWorkspace({
     );
     return;
   }
+
+  // Resolve the per-tier materialized credit ids so we can tell, from the
+  // balances alone, which seats carry a stray credit (a slice for a tier other
+  // than their own). Only those seats can need a correction, so we scope the
+  // per-user usage read (bounded by Metronome's 200-group-value cap) to them —
+  // on the common segment-start path no seat changed tier and this is empty, so
+  // we skip the usage read entirely.
+  const tierMapResult = await buildSeatCreditTierMap({
+    metronomeCustomerId,
+    metronomeContractId,
+    contract,
+    logger,
+  });
+  if (tierMapResult.isErr()) {
+    logger.error(
+      { workspaceId, err: tierMapResult.error },
+      "[StackedSeatCredits] failed to build seat-credit tier map"
+    );
+    return;
+  }
+  const tierByCreditId = tierMapResult.value;
+
+  const straySeatIds = computeSeatIdsWithStrays({
+    seatBalances: balancesResult.value,
+    currentSeatTypeBySeatId,
+    tierByCreditId,
+  });
+  if (straySeatIds.length === 0) {
+    return;
+  }
+
+  const usageResult = await fetchPerUserAwuUsage({
+    workspaceId,
+    metronomeCustomerId,
+    userIds: straySeatIds,
+  });
   if (usageResult.isErr()) {
     logger.error(
       { workspaceId, err: usageResult.error },
@@ -512,14 +550,23 @@ export async function reconcileStackedSeatCreditsForWorkspace({
     return;
   }
 
+  const straySeatTypeBySeatId = new Map<string, MembershipSeatType>();
+  for (const seatId of straySeatIds) {
+    const seatType = currentSeatTypeBySeatId.get(seatId);
+    if (seatType) {
+      straySeatTypeBySeatId.set(seatId, seatType);
+    }
+  }
+
   const result = await correctStackedSeatCreditsFromBalances({
     workspaceId,
     metronomeCustomerId,
     metronomeContractId,
     contract,
     seatBalances: balancesResult.value,
-    currentSeatTypeBySeatId,
+    currentSeatTypeBySeatId: straySeatTypeBySeatId,
     usageBySeatId: usageResult.value,
+    tierByCreditId,
     execute: true,
     logger,
   });

--- a/front/lib/metronome/stacked_seat_credits.test.ts
+++ b/front/lib/metronome/stacked_seat_credits.test.ts
@@ -1,0 +1,113 @@
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import type { TierCredit } from "@app/lib/metronome/stacked_seat_credits";
+import { computeSeatIdsWithStrays } from "@app/lib/metronome/stacked_seat_credits";
+import type { MetronomeSeatBalance } from "@app/lib/metronome/types";
+import type { MembershipSeatType } from "@app/types/memberships";
+import { describe, expect, it } from "vitest";
+
+const AWU = getCreditTypeAwuId();
+const OTHER_CREDIT_TYPE = `${AWU}-not-awu`;
+
+const CREDIT_PRO = "credit-pro";
+const CREDIT_MAX = "credit-max";
+
+function tier(seatType: MembershipSeatType, creditId: string): TierCredit {
+  return {
+    seatType,
+    recurringCreditId: `recurring-${creditId}`,
+    creditId,
+    segmentId: `segment-${creditId}`,
+    allocation: seatType === "max" ? 40_000 : 8_000,
+    adjustmentTimestamp: new Date("2026-06-10T00:00:00.000Z"),
+  };
+}
+
+const TIER_BY_CREDIT_ID = new Map<string, TierCredit>([
+  [CREDIT_PRO, tier("pro", CREDIT_PRO)],
+  [CREDIT_MAX, tier("max", CREDIT_MAX)],
+]);
+
+function seat(
+  seatId: string,
+  credits: Array<{ id: string; balance: number; credit_type_id?: string }>
+): MetronomeSeatBalance {
+  return {
+    seat_id: seatId,
+    balances: [],
+    credits: credits.map((c) => ({
+      id: c.id,
+      balance: c.balance,
+      credit_type_id: c.credit_type_id ?? AWU,
+    })),
+  };
+}
+
+describe("computeSeatIdsWithStrays", () => {
+  it("returns only seats carrying a credit for a tier other than their own", () => {
+    const seatBalances = [
+      // Home credit only — not a stray.
+      seat("home-only", [{ id: CREDIT_MAX, balance: 40_000 }]),
+      // Live stray (pro credit on a max seat).
+      seat("fresh-stray", [
+        { id: CREDIT_MAX, balance: 40_000 },
+        { id: CREDIT_PRO, balance: 8_000 },
+      ]),
+      // Drained stray (balance 0) still counts: its home credit may need a carry.
+      seat("drained-stray", [
+        { id: CREDIT_MAX, balance: 40_000 },
+        { id: CREDIT_PRO, balance: 0 },
+      ]),
+    ];
+    const currentSeatTypeBySeatId = new Map<string, MembershipSeatType>([
+      ["home-only", "max"],
+      ["fresh-stray", "max"],
+      ["drained-stray", "max"],
+    ]);
+
+    expect(
+      computeSeatIdsWithStrays({
+        seatBalances,
+        currentSeatTypeBySeatId,
+        tierByCreditId: TIER_BY_CREDIT_ID,
+      })
+    ).toEqual(["fresh-stray", "drained-stray"]);
+  });
+
+  it("ignores unrecognized credit ids and non-AWU credit types", () => {
+    const seatBalances = [
+      // Excess/pool credit not in the tier map — not a stray.
+      seat("unknown-credit", [{ id: "credit-excess", balance: 100 }]),
+      // A pro-tier credit id but of a non-AWU credit type — ignored.
+      seat("non-awu", [
+        { id: CREDIT_MAX, balance: 40_000 },
+        { id: CREDIT_PRO, balance: 5_000, credit_type_id: OTHER_CREDIT_TYPE },
+      ]),
+    ];
+    const currentSeatTypeBySeatId = new Map<string, MembershipSeatType>([
+      ["unknown-credit", "max"],
+      ["non-awu", "max"],
+    ]);
+
+    expect(
+      computeSeatIdsWithStrays({
+        seatBalances,
+        currentSeatTypeBySeatId,
+        tierByCreditId: TIER_BY_CREDIT_ID,
+      })
+    ).toEqual([]);
+  });
+
+  it("skips seats absent from the current-seat-type map", () => {
+    const seatBalances = [
+      seat("not-tracked", [{ id: CREDIT_PRO, balance: 8_000 }]),
+    ];
+
+    expect(
+      computeSeatIdsWithStrays({
+        seatBalances,
+        currentSeatTypeBySeatId: new Map(),
+        tierByCreditId: TIER_BY_CREDIT_ID,
+      })
+    ).toEqual([]);
+  });
+});

--- a/front/lib/metronome/stacked_seat_credits.ts
+++ b/front/lib/metronome/stacked_seat_credits.ts
@@ -62,7 +62,7 @@ import { Err, Ok } from "@app/types/shared/result";
 
 // A credit-bearing tier's recurring credit, resolved to its materialized credit
 // id + segment for the current period.
-interface TierCredit {
+export interface TierCredit {
   seatType: MembershipSeatType;
   recurringCreditId: string;
   // Materialized credit id for the current segment (matches seat.credits[].id).
@@ -183,6 +183,65 @@ export async function buildSeatCreditTierMap({
   return new Ok(tierByCreditId);
 }
 
+// A seat's balance on one of its recognized seat-credit tiers.
+interface MappedSeatTierCredit {
+  balanceAwu: number;
+  tier: TierCredit;
+}
+
+// Resolve a seat's balance on each of its recognized (AWU) seat-credit tiers.
+// A credit id absent from `tierByCreditId` (excess/pool/unrecognized) or of a
+// non-AWU credit type is dropped.
+function mappedSeatTierCredits(
+  seat: MetronomeSeatBalance,
+  tierByCreditId: Map<string, TierCredit>
+): MappedSeatTierCredit[] {
+  const awuCreditTypeId = getCreditTypeAwuId();
+  return (seat.credits ?? []).flatMap((c) => {
+    if (c.credit_type_id !== awuCreditTypeId) {
+      return [];
+    }
+    const tier = tierByCreditId.get(c.id);
+    return tier ? [{ balanceAwu: c.balance, tier }] : [];
+  });
+}
+
+/**
+ * @cc [owner:tdraier,label:performance;backend] stacked-seat-usage-scoping
+ * The seats whose stacked-credit correction can require per-user usage: those
+ * currently carrying a stray credit slice (a slice for a tier other than the
+ * seat's own), of ANY balance. A seat that never changed tier this period has
+ * no such slice, so the debounced segment-start reconcile can skip the
+ * `/v1/usage/groups` read (bounded by Metronome's 200-value cap) entirely when
+ * this returns empty. Drained (balance 0) strays are included on purpose: the
+ * credit row stays in `credits[]`, and the seat's home credit may still need a
+ * usage-based carry for consumption that leaked onto the drained stray.
+ */
+export function computeSeatIdsWithStrays({
+  seatBalances,
+  currentSeatTypeBySeatId,
+  tierByCreditId,
+}: {
+  seatBalances: MetronomeSeatBalance[];
+  currentSeatTypeBySeatId: Map<string, MembershipSeatType>;
+  tierByCreditId: Map<string, TierCredit>;
+}): string[] {
+  const seatIds: string[] = [];
+  for (const seat of seatBalances) {
+    const homeSeatType = currentSeatTypeBySeatId.get(seat.seat_id);
+    if (!homeSeatType) {
+      continue;
+    }
+    const hasStray = mappedSeatTierCredits(seat, tierByCreditId).some(
+      (m) => m.tier.seatType !== homeSeatType
+    );
+    if (hasStray) {
+      seatIds.push(seat.seat_id);
+    }
+  }
+  return seatIds;
+}
+
 /**
  * Pure detection. For each seat, empty every stray seat credit fully and drive
  * the home credit to `max(0, homeAllocation − usage)`. A credit id absent from
@@ -204,7 +263,6 @@ export function computeStackedSeatCreditAdjustments({
   // home credit to its correct balance; a missing entry is treated as 0 usage.
   usageBySeatId: Map<string, number>;
 }): SeatCreditAdjustment[] {
-  const awuCreditTypeId = getCreditTypeAwuId();
   const adjustments: SeatCreditAdjustment[] = [];
 
   for (const seat of seatBalances) {
@@ -213,14 +271,7 @@ export function computeStackedSeatCreditAdjustments({
       continue;
     }
 
-    // Resolve the seat's balance on each of its recognized seat-credit tiers.
-    const mapped = (seat.credits ?? []).flatMap((c) => {
-      if (c.credit_type_id !== awuCreditTypeId) {
-        return [];
-      }
-      const tier = tierByCreditId.get(c.id);
-      return tier ? [{ balanceAwu: c.balance, tier }] : [];
-    });
+    const mapped = mappedSeatTierCredits(seat, tierByCreditId);
 
     const strays = mapped.filter(
       (m) => m.tier.seatType !== homeSeatType && m.balanceAwu > 0
@@ -420,6 +471,7 @@ export async function correctStackedSeatCreditsFromBalances({
   seatBalances,
   currentSeatTypeBySeatId,
   usageBySeatId,
+  tierByCreditId,
   execute,
   logger,
   pace = NO_PACING,
@@ -431,24 +483,31 @@ export async function correctStackedSeatCreditsFromBalances({
   seatBalances: MetronomeSeatBalance[];
   currentSeatTypeBySeatId: Map<string, MembershipSeatType>;
   usageBySeatId: Map<string, number>;
+  // Prebuilt tier map, reused when the caller already resolved it (e.g. to scope
+  // the usage read). Built here when omitted.
+  tierByCreditId?: Map<string, TierCredit>;
   execute: boolean;
   logger: Logger;
   pace?: PaceFn;
 }): Promise<Result<StackedSeatCreditsSummary, Error>> {
-  const tierMapRes = await buildSeatCreditTierMap({
-    metronomeCustomerId,
-    metronomeContractId,
-    contract,
-    logger,
-    pace,
-  });
-  if (tierMapRes.isErr()) {
-    return new Err(tierMapRes.error);
+  let resolvedTierByCreditId = tierByCreditId;
+  if (!resolvedTierByCreditId) {
+    const tierMapRes = await buildSeatCreditTierMap({
+      metronomeCustomerId,
+      metronomeContractId,
+      contract,
+      logger,
+      pace,
+    });
+    if (tierMapRes.isErr()) {
+      return new Err(tierMapRes.error);
+    }
+    resolvedTierByCreditId = tierMapRes.value;
   }
   const adjustments = computeStackedSeatCreditAdjustments({
     seatBalances,
     currentSeatTypeBySeatId,
-    tierByCreditId: tierMapRes.value,
+    tierByCreditId: resolvedTierByCreditId,
     usageBySeatId,
   });
   const totals = summarizeAdjustments(adjustments);


### PR DESCRIPTION
## Description
`reconcileStackedSeatCreditsForWorkspace` (fired on every `credit.segment.start`) read per-user AWU usage for the whole seat list via `/v1/usage/groups`, even though only seats that changed tier this period can carry a stray credit. It now detects stray-carrying seats from the seat balances first (new `computeSeatIdsWithStrays`), reads usage only for those, and skips the usage call entirely when none exist — the common no-tier-change path. Drained (balance 0) strays are included since their home credit may still need a usage-based carry. The tier map built for detection is passed into `correctStackedSeatCreditsFromBalances` to avoid rebuilding it. The exhaustive backfill script keeps reading usage for all candidate seats.

Stacked on #32312.

## Tests
New `stacked_seat_credits.test.ts` for `computeSeatIdsWithStrays` (home-only excluded; live + drained strays included; unknown/non-AWU credits ignored; untracked seats skipped). All metronome unit tests pass; tsgo + biome clean.

## Risk
Low. Correction behavior is unchanged for seats with strays; only the usage read is scoped. Segment-start timing means fresh strays are detected with a positive balance, and drained strays are still included so carries aren't lost.

## Deploy Plan
Standard.