### PR TITLE
[front] enh: open agent details from automations

### DIFF
--- a/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
@@ -1,3 +1,4 @@
+import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
 import { AdminPageContainer } from "@app/components/layouts/AdminPageContainer";
 import { AutomationsOverview } from "@app/components/workspace/analytics/automations/AutomationsOverview";
 import { AutomationsTriggersTable } from "@app/components/workspace/analytics/automations/AutomationsTriggersTable";
@@ -29,7 +30,8 @@ type AutomationsTab = "triggers" | "slack-workflows";
 
 export function AnalyticsAutomationsPage() {
   const owner = useWorkspace();
-  const { subscription } = useAuth();
+  const { subscription, user } = useAuth();
+  const [agentDetailsId, setAgentDetailsId] = useState<string | null>(null);
   const [period, setPeriod] = useState<ConsumptionPeriodSelection>(
     DEFAULT_CONSUMPTION_PERIOD
   );
@@ -54,6 +56,12 @@ export function AnalyticsAutomationsPage() {
 
   return (
     <AdminPageContainer>
+      <AgentDetailsSheet
+        owner={owner}
+        user={user}
+        agentId={agentDetailsId}
+        onClose={() => setAgentDetailsId(null)}
+      />
       <Page.Vertical align="stretch" gap="xl">
         <Page.Header
           title={
@@ -92,6 +100,7 @@ export function AnalyticsAutomationsPage() {
                 period={period}
                 filter={filter}
                 onFilterChange={setFilter}
+                onAgentClick={setAgentDetailsId}
               />
             </TabsContent>
             <TabsContent value="slack-workflows">
@@ -104,6 +113,7 @@ export function AnalyticsAutomationsPage() {
             period={period}
             filter={filter}
             onFilterChange={setFilter}
+            onAgentClick={setAgentDetailsId}
           />
         )}
       </Page.Vertical>
@@ -116,6 +126,7 @@ interface TriggersSectionProps {
   period: ConsumptionPeriodSelection;
   filter: AutomationsFilter;
   onFilterChange: (filter: AutomationsFilter) => void;
+  onAgentClick: (agentId: string) => void;
 }
 
 function TriggersSection({
@@ -123,6 +134,7 @@ function TriggersSection({
   period,
   filter,
   onFilterChange,
+  onAgentClick,
 }: TriggersSectionProps) {
   return (
     <div className="flex flex-col gap-4">
@@ -132,6 +144,7 @@ function TriggersSection({
         period={period}
         filter={filter}
         onFilterChange={onFilterChange}
+        onAgentClick={onAgentClick}
       />
     </div>
   );

--- a/front/components/workspace/analytics/automations/AutomationsTriggersRowsTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersRowsTable.tsx
@@ -29,6 +29,7 @@ const NO_ROW_SELECTION: RowSelectionState = {};
 
 export type TriggerRowData = AutomationTriggerRow & {
   onClick: () => void;
+  onAgentClick?: () => void;
 };
 
 interface TriggerSkeletonCellProps {

--- a/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
@@ -199,6 +199,7 @@ interface AutomationsTriggersTableProps {
   period: ConsumptionPeriodSelection;
   filter: AutomationsFilter;
   onFilterChange: (next: AutomationsFilter) => void;
+  onAgentClick: (agentId: string) => void;
 }
 
 export function AutomationsTriggersTable({
@@ -206,6 +207,7 @@ export function AutomationsTriggersTable({
   period,
   filter,
   onFilterChange,
+  onAgentClick,
 }: AutomationsTriggersTableProps) {
   const workspaceId = owner.sId;
   const triggersFilter = useMemo(
@@ -466,6 +468,7 @@ export function AutomationsTriggersTable({
           ),
           onSetExecutionMode: (executionMode: TriggerExecutionMode) =>
             void handleSetExecutionMode(trigger, executionMode),
+          onAgentClick: () => onAgentClick(trigger.agent.agentId),
           onClick: () =>
             setExpandedRowId((current) =>
               current === trigger.triggerId ? null : trigger.triggerId
@@ -480,6 +483,7 @@ export function AutomationsTriggersTable({
       executionModeOverrides,
       pendingExecutionModeIds,
       handleSetExecutionMode,
+      onAgentClick,
     ]
   );
 

--- a/front/components/workspace/analytics/automations/automationsTriggerColumns.tsx
+++ b/front/components/workspace/analytics/automations/automationsTriggerColumns.tsx
@@ -19,6 +19,7 @@ import {
   ChevronDown,
   ChevronUp,
   Clock,
+  cn,
   DataTable,
   DropdownMenu,
   DropdownMenuContent,
@@ -106,9 +107,14 @@ export function nameColumn<T extends TriggerRowData>(): ColumnDef<T> {
 
 interface AgentCellProps {
   agent: AutomationTriggerRow["agent"];
+  onClick?: () => void;
 }
 
-function AgentCell({ agent }: AgentCellProps) {
+/**
+ * @cc [owner:aubin-tchoi,label:product] agent-click-does-not-expand-row
+ * When onClick is provided, activating the agent must invoke it without activating the table row.
+ */
+function AgentCell({ agent, onClick }: AgentCellProps) {
   const content = (
     <div className="min-w-0">
       <AvatarNameCell
@@ -119,8 +125,28 @@ function AgentCell({ agent }: AgentCellProps) {
     </div>
   );
 
+  const interactiveContent = onClick ? (
+    <button
+      type="button"
+      className={cn(
+        "inline-flex min-h-11 min-w-11 max-w-full cursor-pointer items-center rounded-sm text-left",
+        "outline-hidden ring-offset-background",
+        "pointer-fine:hover:underline",
+        "focus-visible:ring-2 focus-visible:ring-highlight-300 focus-visible:ring-offset-1"
+      )}
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick();
+      }}
+    >
+      {content}
+    </button>
+  ) : (
+    content
+  );
+
   if (!agent.description) {
-    return content;
+    return interactiveContent;
   }
 
   return (
@@ -142,7 +168,7 @@ function AgentCell({ agent }: AgentCellProps) {
       }
       className="p-3"
       tooltipTriggerAsChild
-      trigger={content}
+      trigger={interactiveContent}
     />
   );
 }
@@ -155,7 +181,10 @@ export function agentColumn<T extends TriggerRowData>(): ColumnDef<T> {
     meta: { className: "w-44", headerAlign: "left" },
     cell: (info) => (
       <DataTable.CellContent className="w-full justify-start">
-        <AgentCell agent={info.row.original.agent} />
+        <AgentCell
+          agent={info.row.original.agent}
+          onClick={info.row.original.onAgentClick}
+        />
       </DataTable.CellContent>
     ),
   };


### PR DESCRIPTION
## Description

This PR makes the agent names on the Automations page open the agent details panel.
This replicates the behavior on the Analytics page.

## Tests

- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
