### PR TITLE
[front] fix: hide skills-only tools from toolset discovery

### DIFF
--- a/front/lib/api/actions/servers/toolsets/tools/index.ts
+++ b/front/lib/api/actions/servers/toolsets/tools/index.ts
@@ -18,6 +18,10 @@ import { Err, Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import assert from "assert";
 
+/**
+ * @cc [owner:aubin-tchoi,label:product] exclude-skills-only-toolsets
+ * The list result MUST NOT include MCP server views restricted to skills.
+ */
 const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
   list: async (_, { auth, runContext }) => {
     assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
@@ -43,6 +47,7 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
         }
       )
     )
+      .filter((mcpServerView) => !mcpServerView.isRestrictedToSkills)
       .map((mcpServerView) => mcpServerView.toJSON())
       .filter(
         (mcpServerView) =>

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -188,10 +188,15 @@ Never explicitly say "I remember" or "based on our previous conversation" - just
 </memory_guidelines>`,
 };
 
+/**
+ * @cc [owner:aubin-tchoi,label:product] exclude-skills-only-toolsets
+ * The available toolsets context MUST NOT include MCP server views restricted to skills.
+ */
 export function buildToolsetsContext(
   availableToolsets: MCPServerViewResource[]
 ): string {
   const toolsetsList = availableToolsets
+    .filter((toolset) => !toolset.isRestrictedToSkills)
     .sort((a, b) => {
       const aView = a.toJSON();
       const bView = b.toJSON();


### PR DESCRIPTION
## Description

Tools marked `isRestrictedToSkills` were still surfaced by the `toolsets__list` tool and in the Dust global agent's available toolsets context, even though `toolsets__enable` rejects them.

This PR filter these views from both lists. This also covers Discover Tools since the logic is shared.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
