### PR TITLE
[front] Stop querying the ToolInvocations Metronome metric

### DIFF
--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -11,7 +11,6 @@ export const MODEL_COST_MICRO_USD_PER_AWU_CREDIT = 8_500;
 // Metrics
 const DEV_METRIC_LLM_PROVIDER_COST_PROGRAMMATIC =
   "e02846b3-956c-48bc-9fd1-162061aed624";
-const DEV_METRIC_TOOL_INVOCATIONS_V2 = "0a35a534-0d1c-4ed5-8177-358d9dff71a5";
 const DEV_METRIC_LLM_PROVIDER_COST_AWU_V2 =
   "a6abefc5-d749-4757-a139-336b53c837f5";
 
@@ -37,7 +36,6 @@ const DEV_PRODUCT_PLATFORM_FEE = "11e635e1-0fb9-44e1-9499-690d5ee27ace";
 // Metrics
 const PROD_METRIC_LLM_PROVIDER_COST_PROGRAMMATIC =
   "3ad68bfb-7a59-49ad-b29e-54700fa0e6fa";
-const PROD_METRIC_TOOL_INVOCATIONS_V2 = "f32cc30e-c52f-4dc0-bde0-cef343bdc6d3";
 const PROD_METRIC_LLM_PROVIDER_COST_AWU_V2 =
   "ffb1ecce-6c2b-4f16-add1-5da81baec0a7";
 
@@ -263,8 +261,6 @@ export const getMetricLlmProviderCostProgrammaticId = () =>
     DEV_METRIC_LLM_PROVIDER_COST_PROGRAMMATIC,
     PROD_METRIC_LLM_PROVIDER_COST_PROGRAMMATIC
   );
-export const getMetricToolInvocationsId = () =>
-  devOrProd(DEV_METRIC_TOOL_INVOCATIONS_V2, PROD_METRIC_TOOL_INVOCATIONS_V2);
 export const getMetricLlmProviderCostAwuId = () =>
   devOrProd(
     DEV_METRIC_LLM_PROVIDER_COST_AWU_V2,

--- a/front/lib/metronome/per_api_key_usage.ts
+++ b/front/lib/metronome/per_api_key_usage.ts
@@ -1,13 +1,6 @@
 import { listMetronomeUsageWithGroups } from "@app/lib/metronome/client";
-import {
-  getMetricLlmProviderCostAwuId,
-  getMetricToolInvocationsId,
-} from "@app/lib/metronome/constants";
+import { getMetricLlmProviderCostAwuId } from "@app/lib/metronome/constants";
 import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
-import {
-  isToolCostCategory,
-  TOOL_COST_CATEGORY_AWU_WEIGHTS,
-} from "@app/lib/metronome/events";
 import { buildUsageQuerySegments } from "@app/lib/metronome/per_user_usage";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Result } from "@app/types/shared/result";
@@ -63,13 +56,11 @@ function fetchSegmentedUsage({
  * `user_id` (both are billable-metric group keys on the AWU products).
  *
  * Scoped to `keyNames` via an `api_key_name` `group_filters`: an unfiltered
- * query is capped server-side and silently omits groups. The AWU products only
- * expose `[api_key_name]` and `[api_key_name, tool_category]` as compound group
- * keys (no `usage_type` dimension), so — unlike the per-user query — free usage
- * can't be split out here. We count total per-name spend, which matches what
- * the per-name Metronome cap alert measures. AI Usage is already AWU spend
- * (cost_awu, priced 1:1); Tool Usage is an invocation count weighted by the
- * per-category AWU price.
+ * query is capped server-side and silently omits groups. We count total per-name
+ * spend, which matches what the per-name Metronome cap alert measures. The value
+ * is already AWU spend (cost_awu, priced 1:1) — tool-invocation cost is now
+ * folded into that aggregated metric (#31569), so the ToolInvocations metric is
+ * no longer queried.
  */
 export async function fetchPerApiKeyAwuUsage({
   workspaceId,
@@ -101,32 +92,20 @@ export async function fetchPerApiKeyAwuUsage({
     return new Ok(new Map());
   }
 
-  const [aiResult, toolResult] = await Promise.all([
-    fetchSegmentedUsage({
-      segments,
-      metronomeCustomerId,
-      billableMetricId: getMetricLlmProviderCostAwuId(),
-      groupKey: [API_KEY_NAME_GROUP_KEY],
-      keyNames,
-    }),
-    fetchSegmentedUsage({
-      segments,
-      metronomeCustomerId,
-      billableMetricId: getMetricToolInvocationsId(),
-      groupKey: [API_KEY_NAME_GROUP_KEY, "tool_category"],
-      keyNames,
-    }),
-  ]);
+  const aiResult = await fetchSegmentedUsage({
+    segments,
+    metronomeCustomerId,
+    billableMetricId: getMetricLlmProviderCostAwuId(),
+    groupKey: [API_KEY_NAME_GROUP_KEY],
+    keyNames,
+  });
   if (aiResult.isErr()) {
     return new Err(aiResult.error);
-  }
-  if (toolResult.isErr()) {
-    return new Err(toolResult.error);
   }
 
   const perKey = new Map<string, number>();
 
-  // AI usage: the value is already AWU spend (cost_awu, priced 1:1).
+  // The value is already AWU spend (cost_awu, priced 1:1).
   for (const entry of aiResult.value) {
     const keyName = entry.group?.[API_KEY_NAME_GROUP_KEY];
     if (
@@ -138,25 +117,6 @@ export async function fetchPerApiKeyAwuUsage({
       continue;
     }
     perKey.set(keyName, (perKey.get(keyName) ?? 0) + entry.value);
-  }
-
-  // Tool usage: the value is an invocation count — weight it by the
-  // per-category AWU price to convert it into AWU spend.
-  for (const entry of toolResult.value) {
-    const keyName = entry.group?.[API_KEY_NAME_GROUP_KEY];
-    const category = entry.group?.["tool_category"];
-    if (
-      !keyName ||
-      entry.value === null ||
-      new Date(entry.startingOn).getTime() < cycleStartMs ||
-      new Date(entry.startingOn).getTime() >= cycleEndMs ||
-      !category ||
-      !isToolCostCategory(category)
-    ) {
-      continue;
-    }
-    const awuSpent = entry.value * TOOL_COST_CATEGORY_AWU_WEIGHTS[category];
-    perKey.set(keyName, (perKey.get(keyName) ?? 0) + awuSpent);
   }
 
   return new Ok(perKey);

--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -6,15 +6,10 @@ import {
 } from "@app/lib/metronome/client";
 import {
   getMetricLlmProviderCostAwuId,
-  getMetricToolInvocationsId,
   USAGE_TYPE_FREE,
   USAGE_TYPE_GROUP_KEY,
 } from "@app/lib/metronome/constants";
 import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
-import {
-  isToolCostCategory,
-  TOOL_COST_CATEGORY_AWU_WEIGHTS,
-} from "@app/lib/metronome/events";
 import type { MetronomeUsageWithGroupsResponse } from "@app/lib/metronome/types";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Result } from "@app/types/shared/result";
@@ -286,27 +281,17 @@ export async function fetchPerUserAwuUsageRows({
     return new Ok([]);
   }
 
-  const [aiResult, toolResult] = await Promise.all([
-    fetchSegmentedUsage({
-      segments,
-      metronomeCustomerId,
-      billableMetricId: getMetricLlmProviderCostAwuId(),
-      groupKey: ["user_id", USAGE_TYPE_GROUP_KEY],
-      userIds,
-    }),
-    fetchSegmentedUsage({
-      segments,
-      metronomeCustomerId,
-      billableMetricId: getMetricToolInvocationsId(),
-      groupKey: ["user_id", USAGE_TYPE_GROUP_KEY, "tool_category"],
-      userIds,
-    }),
-  ]);
+  // Tool-invocation cost is now folded into the aggregated cost_awu metric
+  // (#31569), so we no longer query the ToolInvocations metric.
+  const aiResult = await fetchSegmentedUsage({
+    segments,
+    metronomeCustomerId,
+    billableMetricId: getMetricLlmProviderCostAwuId(),
+    groupKey: ["user_id", USAGE_TYPE_GROUP_KEY],
+    userIds,
+  });
   if (aiResult.isErr()) {
     return new Err(aiResult.error);
-  }
-  if (toolResult.isErr()) {
-    return new Err(toolResult.error);
   }
 
   const isBilledBucket = (entry: MetronomeUsageWithGroupsResponse): boolean => {
@@ -336,34 +321,6 @@ export async function fetchPerUserAwuUsageRows({
       value: entry.value,
       awuWeight: 1,
       awuCredits: entry.value,
-    });
-  }
-
-  // Tool usage: the value is an invocation count — weight it by the
-  // per-category AWU price to convert it into AWU spend.
-  for (const entry of toolResult.value) {
-    const userId = entry.group?.["user_id"];
-    const category = entry.group?.["tool_category"];
-    if (
-      !userId ||
-      entry.value === null ||
-      !isBilledBucket(entry) ||
-      !category ||
-      !isToolCostCategory(category)
-    ) {
-      continue;
-    }
-    const awuWeight = TOOL_COST_CATEGORY_AWU_WEIGHTS[category];
-    rows.push({
-      userId,
-      metric: "tool_invocations",
-      usageType: entry.group?.[USAGE_TYPE_GROUP_KEY] ?? "",
-      toolCategory: category,
-      startingOn: entry.startingOn,
-      endingBefore: entry.endingBefore,
-      value: entry.value,
-      awuWeight,
-      awuCredits: entry.value * awuWeight,
     });
   }
 

--- a/front/lib/metronome/programmatic_awu_usage.ts
+++ b/front/lib/metronome/programmatic_awu_usage.ts
@@ -6,15 +6,10 @@ import {
 } from "@app/lib/metronome/client";
 import {
   getMetricLlmProviderCostAwuId,
-  getMetricToolInvocationsId,
   USAGE_TYPE_GROUP_KEY,
   USAGE_TYPE_PROGRAMMATIC,
 } from "@app/lib/metronome/constants";
 import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
-import {
-  isToolCostCategory,
-  TOOL_COST_CATEGORY_AWU_WEIGHTS,
-} from "@app/lib/metronome/events";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -81,17 +76,15 @@ export async function getRemainingProgrammaticUsageFromMetronome(
  * floored period start (at HOUR granularity when the period itself does not
  * start at midnight) and drop pre-period buckets in code.
  *
- * AWU spend has two sources, both priced in the AWU credit type:
- *   - AI Usage: the `cost_awu` metric, priced 1 AWU per unit.
- *   - Tool Usage: an invocation count, weighted per category (basic ×1,
- *     advanced ×3).
+ * AWU spend is read from the `cost_awu` metric (priced 1 AWU per unit).
+ * Tool-invocation cost is now folded into that aggregated metric (#31569), so
+ * the ToolInvocations metric is no longer queried.
  *
- * We group by `usage_type` (plus `tool_category` for tools) and keep only the
- * `programmatic` buckets in code rather than filtering the query on
- * `usage_type`: filtered queries make Metronome under-aggregate some buckets
- * (see per_user_usage.ts). Unlike the per-user query, grouping only by
- * `usage_type` has a handful of groups, so the unfiltered query is not at
- * risk of being capped server-side.
+ * We group by `usage_type` and keep only the `programmatic` buckets in code
+ * rather than filtering the query on `usage_type`: filtered queries make
+ * Metronome under-aggregate some buckets (see per_user_usage.ts). Unlike the
+ * per-user query, grouping only by `usage_type` has a handful of groups, so the
+ * unfiltered query is not at risk of being capped server-side.
  */
 export async function fetchProgrammaticAwuSpend({
   workspaceId,
@@ -117,34 +110,21 @@ export async function fetchProgrammaticAwuSpend({
   const windowSize =
     cycleStartMs === floorToMidnightUTC(cycleStart).getTime() ? "DAY" : "HOUR";
 
-  const [aiResult, toolResult] = await Promise.all([
-    listMetronomeUsageWithGroups({
-      customerId: metronomeCustomerId,
-      billableMetricId: getMetricLlmProviderCostAwuId(),
-      startingOn,
-      endingBefore,
-      windowSize,
-      groupKey: [USAGE_TYPE_GROUP_KEY],
-    }),
-    listMetronomeUsageWithGroups({
-      customerId: metronomeCustomerId,
-      billableMetricId: getMetricToolInvocationsId(),
-      startingOn,
-      endingBefore,
-      windowSize,
-      groupKey: [USAGE_TYPE_GROUP_KEY, "tool_category"],
-    }),
-  ]);
+  const aiResult = await listMetronomeUsageWithGroups({
+    customerId: metronomeCustomerId,
+    billableMetricId: getMetricLlmProviderCostAwuId(),
+    startingOn,
+    endingBefore,
+    windowSize,
+    groupKey: [USAGE_TYPE_GROUP_KEY],
+  });
   if (aiResult.isErr()) {
     return new Err(aiResult.error);
-  }
-  if (toolResult.isErr()) {
-    return new Err(toolResult.error);
   }
 
   let spentAwuCredits = 0;
 
-  // AI usage: the value is already AWU spend (cost_awu, priced 1:1).
+  // The value is already AWU spend (cost_awu, priced 1:1).
   for (const entry of aiResult.value) {
     if (
       entry.value === null ||
@@ -154,22 +134,6 @@ export async function fetchProgrammaticAwuSpend({
       continue;
     }
     spentAwuCredits += entry.value;
-  }
-
-  // Tool usage: the value is an invocation count — weight it by the
-  // per-category AWU price to convert it into AWU spend.
-  for (const entry of toolResult.value) {
-    const category = entry.group?.["tool_category"];
-    if (
-      entry.value === null ||
-      entry.group?.[USAGE_TYPE_GROUP_KEY] !== USAGE_TYPE_PROGRAMMATIC ||
-      new Date(entry.startingOn).getTime() < cycleStartMs ||
-      !category ||
-      !isToolCostCategory(category)
-    ) {
-      continue;
-    }
-    spentAwuCredits += entry.value * TOOL_COST_CATEGORY_AWU_WEIGHTS[category];
   }
 
   return new Ok(spentAwuCredits);

--- a/front/lib/metronome/setup_new_pricing.ts
+++ b/front/lib/metronome/setup_new_pricing.ts
@@ -152,10 +152,10 @@ export const NEW_METRICS: MetricDef[] = [
   // grouping unrelated to any single user/key, so it needs its own compound
   // key rather than piggybacking on the user_id/api_key_name ones. Bare
   // `[api_key_name(, tool_category)]` (no usage_type) is also kept so
-  // per_api_key_usage.ts's existing query — which still targets whichever
-  // metric ID `getMetricToolInvocationsId()`/`getMetricLlmProviderCostAwuId()`
-  // resolve to per environment (the live billing metrics in prod today, v2
-  // only once repointed) — keeps working unchanged against either shape.
+  // per_api_key_usage.ts's existing query — which targets whichever metric ID
+  // `getMetricLlmProviderCostAwuId()` resolves to per environment (the live
+  // billing metric in prod today, v2 only once repointed) — keeps working
+  // unchanged against either shape.
   // `[agent_id, usage_type(, tool_category)]` is reserved now, unused today,
   // for a possible future agent_id-filtered spend alert (same compound-key
   // requirement as the api_key_name alert above). Once v2 goes live in prod

--- a/front/scripts/debug_user_awu_spend.ts
+++ b/front/scripts/debug_user_awu_spend.ts
@@ -7,9 +7,8 @@
  * Read-only: ignores --execute. Dumps:
  *   - contract.starting_at and the current billing period bounds
  *   - the user's live seat AWU balance (balance + starting_balance)
- *   - per-hour usage buckets for the user (cost_awu + tool invocations), split
- *     by usage_type, flagging buckets trimmed because they precede the period
- *     start, and weighting tool invocations into AWU
+ *   - per-hour cost_awu usage buckets for the user, split by usage_type,
+ *     flagging buckets trimmed because they precede the period start
  *   - the canonical Consumed from fetchPerUserAwuUsage, and the comparison with
  *     the seat ledger (starting_balance - balance)
  *
@@ -24,16 +23,11 @@ import {
 import {
   getCreditTypeAwuId,
   getMetricLlmProviderCostAwuId,
-  getMetricToolInvocationsId,
   USAGE_TYPE_GROUP_KEY,
   USAGE_TYPE_PROGRAMMATIC,
   USAGE_TYPE_USER,
 } from "@app/lib/metronome/constants";
 import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
-import {
-  isToolCostCategory,
-  TOOL_COST_CATEGORY_AWU_WEIGHTS,
-} from "@app/lib/metronome/events";
 import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -135,34 +129,17 @@ makeScript(
       new Date(Math.min(cycleEnd.getTime(), Date.now()))
     ).toISOString();
 
-    const [aiResult, toolResult] = await Promise.all([
-      listMetronomeUsageWithGroups({
-        customerId: metronomeCustomerId,
-        billableMetricId: getMetricLlmProviderCostAwuId(),
-        startingOn,
-        endingBefore,
-        windowSize: "HOUR",
-        groupKey: ["user_id", USAGE_TYPE_GROUP_KEY],
-        groupFilters: { user_id: [userId] },
-      }),
-      listMetronomeUsageWithGroups({
-        customerId: metronomeCustomerId,
-        billableMetricId: getMetricToolInvocationsId(),
-        startingOn,
-        endingBefore,
-        windowSize: "HOUR",
-        groupKey: ["user_id", USAGE_TYPE_GROUP_KEY, "tool_category"],
-        groupFilters: { user_id: [userId] },
-      }),
-    ]);
-    if (aiResult.isErr() || toolResult.isErr()) {
-      logger.error(
-        {
-          aiErr: aiResult.isErr() ? aiResult.error : null,
-          toolErr: toolResult.isErr() ? toolResult.error : null,
-        },
-        "Failed to read usage"
-      );
+    const aiResult = await listMetronomeUsageWithGroups({
+      customerId: metronomeCustomerId,
+      billableMetricId: getMetricLlmProviderCostAwuId(),
+      startingOn,
+      endingBefore,
+      windowSize: "HOUR",
+      groupKey: ["user_id", USAGE_TYPE_GROUP_KEY],
+      groupFilters: { user_id: [userId] },
+    });
+    if (aiResult.isErr()) {
+      logger.error({ aiErr: aiResult.error }, "Failed to read usage");
       return;
     }
 
@@ -193,40 +170,6 @@ makeScript(
       }
     }
 
-    let toolPaid = 0;
-    let toolFree = 0;
-    let toolTrimmed = 0;
-    for (const e of toolResult.value) {
-      const category = e.group?.["tool_category"];
-      if (e.value === null || !category || !isToolCostCategory(category)) {
-        continue;
-      }
-      const awuSpent = e.value * TOOL_COST_CATEGORY_AWU_WEIGHTS[category];
-      const tsMs = new Date(e.startingOn).getTime();
-      const usageType = e.group?.[USAGE_TYPE_GROUP_KEY] ?? "?";
-      const trimmed = tsMs < cycleStartMs;
-      if (trimmed) {
-        toolTrimmed += awuSpent;
-      } else if (usageType === "free") {
-        toolFree += awuSpent;
-      } else {
-        toolPaid += awuSpent;
-      }
-      if (awuSpent !== 0) {
-        logger.info(
-          {
-            startingOn: e.startingOn,
-            usageType,
-            category,
-            count: e.value,
-            awu: awuSpent,
-            trimmed,
-          },
-          "[debug] Tool hourly bucket"
-        );
-      }
-    }
-
     // --- Canonical query replica -------------------------------------------
     // Reproduce fetchPerUserAwuUsage's EXACT queries (usage_type filter, no
     // user_id filter; same windowSize logic) and sum for THIS user, to see
@@ -236,26 +179,15 @@ makeScript(
         ? "DAY"
         : "HOUR";
     const paidUsageTypes = [USAGE_TYPE_USER, USAGE_TYPE_PROGRAMMATIC];
-    const [aiPaid, toolPaidRes] = await Promise.all([
-      listMetronomeUsageWithGroups({
-        customerId: metronomeCustomerId,
-        billableMetricId: getMetricLlmProviderCostAwuId(),
-        startingOn,
-        endingBefore,
-        windowSize: windowSizeUsed,
-        groupKey: ["user_id", USAGE_TYPE_GROUP_KEY],
-        groupFilters: { [USAGE_TYPE_GROUP_KEY]: paidUsageTypes },
-      }),
-      listMetronomeUsageWithGroups({
-        customerId: metronomeCustomerId,
-        billableMetricId: getMetricToolInvocationsId(),
-        startingOn,
-        endingBefore,
-        windowSize: windowSizeUsed,
-        groupKey: ["user_id", USAGE_TYPE_GROUP_KEY, "tool_category"],
-        groupFilters: { [USAGE_TYPE_GROUP_KEY]: paidUsageTypes },
-      }),
-    ]);
+    const aiPaid = await listMetronomeUsageWithGroups({
+      customerId: metronomeCustomerId,
+      billableMetricId: getMetricLlmProviderCostAwuId(),
+      startingOn,
+      endingBefore,
+      windowSize: windowSizeUsed,
+      groupKey: ["user_id", USAGE_TYPE_GROUP_KEY],
+      groupFilters: { [USAGE_TYPE_GROUP_KEY]: paidUsageTypes },
+    });
     let canonLlm = 0;
     let canonLlmTrimmed = 0;
     if (aiPaid.isOk()) {
@@ -270,30 +202,12 @@ makeScript(
         }
       }
     }
-    let canonTool = 0;
-    if (toolPaidRes.isOk()) {
-      for (const e of toolPaidRes.value) {
-        const category = e.group?.["tool_category"];
-        if (
-          e.group?.["user_id"] !== userId ||
-          e.value === null ||
-          !category ||
-          !isToolCostCategory(category) ||
-          new Date(e.startingOn).getTime() < cycleStartMs
-        ) {
-          continue;
-        }
-        canonTool += e.value * TOOL_COST_CATEGORY_AWU_WEIGHTS[category];
-      }
-    }
     logger.info(
       {
         windowSizeUsed,
         canonicalQueryLlm: canonLlm,
-        canonicalQueryTool: canonTool,
-        canonicalQueryTotal: canonLlm + canonTool,
         canonicalQueryLlmTrimmed: canonLlmTrimmed,
-        userIdFilterTotal: llmPaid + toolPaid,
+        userIdFilterTotal: llmPaid,
       },
       "[debug] Canonical query (usage_type filter) vs user_id-filter query"
     );
@@ -345,28 +259,16 @@ makeScript(
 
     // --- Fix candidate: same metrics & group keys, NO usage_type filter ----
     // (drop free in code). Logs row counts to detect truncation/empty results.
-    const [aiFix, toolFix] = await Promise.all([
-      listMetronomeUsageWithGroups({
-        customerId: metronomeCustomerId,
-        billableMetricId: getMetricLlmProviderCostAwuId(),
-        startingOn,
-        endingBefore,
-        windowSize: windowSizeUsed,
-        groupKey: ["user_id", USAGE_TYPE_GROUP_KEY],
-      }),
-      listMetronomeUsageWithGroups({
-        customerId: metronomeCustomerId,
-        billableMetricId: getMetricToolInvocationsId(),
-        startingOn,
-        endingBefore,
-        windowSize: windowSizeUsed,
-        groupKey: ["user_id", USAGE_TYPE_GROUP_KEY, "tool_category"],
-      }),
-    ]);
+    const aiFix = await listMetronomeUsageWithGroups({
+      customerId: metronomeCustomerId,
+      billableMetricId: getMetricLlmProviderCostAwuId(),
+      startingOn,
+      endingBefore,
+      windowSize: windowSizeUsed,
+      groupKey: ["user_id", USAGE_TYPE_GROUP_KEY],
+    });
     let fixLlm = 0;
-    let fixTool = 0;
     let fixLlmRows = 0;
-    let fixToolRows = 0;
     if (aiFix.isOk()) {
       for (const e of aiFix.value) {
         fixLlmRows++;
@@ -381,34 +283,12 @@ makeScript(
         fixLlm += e.value;
       }
     }
-    if (toolFix.isOk()) {
-      for (const e of toolFix.value) {
-        fixToolRows++;
-        const category = e.group?.["tool_category"];
-        if (
-          e.group?.["user_id"] !== userId ||
-          e.value === null ||
-          e.group?.[USAGE_TYPE_GROUP_KEY] === "free" ||
-          !category ||
-          !isToolCostCategory(category) ||
-          new Date(e.startingOn).getTime() < cycleStartMs
-        ) {
-          continue;
-        }
-        fixTool += e.value * TOOL_COST_CATEGORY_AWU_WEIGHTS[category];
-      }
-    }
     logger.info(
       {
         aiFixOk: aiFix.isOk(),
-        toolFixOk: toolFix.isOk(),
         aiFixErr: aiFix.isErr() ? aiFix.error.message : null,
-        toolFixErr: toolFix.isErr() ? toolFix.error.message : null,
         fixLlmRowsTotal: fixLlmRows,
-        fixToolRowsTotal: fixToolRows,
         fixLlm,
-        fixTool,
-        fixTotal: fixLlm + fixTool,
         seatLedgerConsumedAwu: seatConsumed,
       },
       "[debug] Fix candidate (remove usage_type filter, drop free in code) vs seat"
@@ -426,15 +306,12 @@ makeScript(
 
     logger.info(
       {
-        paidConsumedRecomputed: llmPaid + toolPaid,
+        paidConsumedRecomputed: llmPaid,
         canonicalConsumed,
         breakdown: {
           llmPaid,
-          toolPaid,
           llmFree,
-          toolFree,
           llmTrimmedPreStart: llmTrimmed,
-          toolTrimmedPreStart: toolTrimmed,
         },
         seatLedgerConsumedAwu: seatConsumed,
         consumedMinusSeatLedger:


### PR DESCRIPTION
## Description
Since #31569 the aggregated `cost_awu` usage event already includes tool-invocation cost, and the separate `ToolInvocations` count events are no longer emitted. This:
- drops the second (`ToolInvocations`, grouped by `tool_category`) query from the per-user, per-api-key and programmatic AWU usage helpers — AWU spend now comes solely from `cost_awu`;
- removes the now-unused `getMetricToolInvocationsId` getter and `DEV/PROD_METRIC_TOOL_INVOCATIONS_V2` constants;
- strips the tool paths from the `debug_user_awu_spend` script (the getter's last consumer).

The `Tool Invocations` billable-metric *definition* in the setup script is left in place.

**⚠️ Draft — do not merge before 2026-10-06** (34 days after #31569 merged 2026-09-02). A billing period straddling the 2026-09-02 cutoff still holds its pre-cutoff tool cost only in the `ToolInvocations` metric, and the read code currently sums both paths; merging earlier would undercount AWU for the in-progress period. Once the September cycle fully rolls off, the `ToolInvocations` query returns zero and removing it is a no-op.

## Tests
Type-check + existing metronome unit tests pass (346). No behavioral test change (affected helpers had no fetch-level tests; segment-builder tests unaffected).

## Risk
Low once the merge date is respected. Before 2026-10-06 it would undercount AWU for straddling periods — hence draft. Easily reverted.

## Deploy Plan
Standard, after 2026-10-06.