### PR TITLE
[sparkle] enh: type data table skeleton column IDs

### DIFF
--- a/front/components/members/InvitationsList.tsx
+++ b/front/components/members/InvitationsList.tsx
@@ -8,7 +8,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { sendInvitations } from "@app/lib/invitations";
 import { useWorkspaceInvitations } from "@app/lib/swr/memberships";
 import type { MembershipInvitationType } from "@app/types/membership_invitation";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
 import type { DataTableSkeletonCellProps } from "@dust-tt/sparkle";
@@ -124,7 +124,8 @@ function InvitationSkeletonCell({
     case "initialRole":
       return <ChipCellSkeleton />;
     default:
-      return assertNever(columnId);
+      assertNeverAndIgnore(columnId);
+      return null;
   }
 }
 

--- a/front/components/members/InvitationsList.tsx
+++ b/front/components/members/InvitationsList.tsx
@@ -8,6 +8,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { sendInvitations } from "@app/lib/invitations";
 import { useWorkspaceInvitations } from "@app/lib/swr/memberships";
 import type { MembershipInvitationType } from "@app/types/membership_invitation";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
 import type { DataTableSkeletonCellProps } from "@dust-tt/sparkle";
@@ -21,7 +22,7 @@ import {
   Page,
   TextCellSkeleton,
 } from "@dust-tt/sparkle";
-import type { CellContext } from "@tanstack/react-table";
+import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import type React from "react";
 import { useMemo, useState } from "react";
 
@@ -29,10 +30,12 @@ type RowData = MembershipInvitationType & {
   onClick: () => void;
 };
 
+type InvitationColumnId = "inviteEmail" | "initialRole";
+
 function InvitationSkeletonCell({
   columnId,
   rowIndex,
-}: DataTableSkeletonCellProps) {
+}: DataTableSkeletonCellProps<InvitationColumnId>) {
   switch (columnId) {
     case "inviteEmail":
       return (
@@ -41,7 +44,7 @@ function InvitationSkeletonCell({
     case "initialRole":
       return <ChipCellSkeleton />;
     default:
-      return null;
+      return assertNever(columnId);
   }
 }
 
@@ -151,7 +154,7 @@ export function InvitationsList({
         className: "w-32",
       },
     },
-  ];
+  ] satisfies (ColumnDef<RowData, string> & { id: InvitationColumnId })[];
 
   return (
     <>

--- a/front/components/members/InvitationsList.tsx
+++ b/front/components/members/InvitationsList.tsx
@@ -30,67 +30,20 @@ type RowData = MembershipInvitationType & {
   onClick: () => void;
 };
 
-type InvitationColumnId = "inviteEmail" | "initialRole";
-
-function InvitationSkeletonCell({
-  columnId,
-  rowIndex,
-}: DataTableSkeletonCellProps<InvitationColumnId>) {
-  switch (columnId) {
-    case "inviteEmail":
-      return (
-        <TextCellSkeleton className={["w-48", "w-56", "w-40"][rowIndex % 3]} />
-      );
-    case "initialRole":
-      return <ChipCellSkeleton />;
-    default:
-      return assertNever(columnId);
-  }
-}
-
-export function InvitationsList({
+function getColumns({
   owner,
-  searchText,
+  sendNotification,
 }: {
   owner: WorkspaceType;
-  searchText?: string;
+  sendNotification: ReturnType<typeof useSendNotification>;
 }) {
-  const { invitations, isInvitationsLoading } = useWorkspaceInvitations(owner, {
-    includeExpired: true,
-  });
-  const [selectedInvite, setSelectedInvite] =
-    useState<MembershipInvitationType | null>(null);
-  const sendNotification = useSendNotification();
-
   // Managers cannot resend invitations targeting the admin role (matches the
   // server-side escalation guard); only admins can.
   const canManageAdminRole = isAdmin(owner);
 
-  const filteredInvitations = useMemo(
-    () =>
-      invitations
-        .sort((a, b) => a.inviteEmail.localeCompare(b.inviteEmail))
-        .filter((i) => i.status === "pending")
-        .filter(
-          (i) =>
-            !searchText ||
-            i.inviteEmail.toLowerCase().includes(searchText.toLowerCase())
-        ),
-    [invitations, searchText]
-  );
-
-  const rows = useMemo(
-    () =>
-      filteredInvitations.map((invitation) => ({
-        ...invitation,
-        onClick: () => setSelectedInvite(invitation),
-      })),
-    [filteredInvitations]
-  );
-
-  const columns = [
+  return [
     {
-      id: "inviteEmail",
+      id: "inviteEmail" as const,
       header: "Invitation Email",
       accessorKey: "inviteEmail",
       cell: (info: CellContext<RowData, string>) => {
@@ -130,7 +83,7 @@ export function InvitationsList({
       },
     },
     {
-      id: "initialRole",
+      id: "initialRole" as const,
       header: "Role",
       accessorFn: (row: RowData) => row.initialRole,
       cell: (info: CellContext<RowData, string>) => {
@@ -154,7 +107,64 @@ export function InvitationsList({
         className: "w-32",
       },
     },
-  ] satisfies (ColumnDef<RowData, string> & { id: InvitationColumnId })[];
+  ] satisfies ColumnDef<RowData, string>[];
+}
+
+type InvitationColumnId = ReturnType<typeof getColumns>[number]["id"];
+
+function InvitationSkeletonCell({
+  columnId,
+  rowIndex,
+}: DataTableSkeletonCellProps<InvitationColumnId>) {
+  switch (columnId) {
+    case "inviteEmail":
+      return (
+        <TextCellSkeleton className={["w-48", "w-56", "w-40"][rowIndex % 3]} />
+      );
+    case "initialRole":
+      return <ChipCellSkeleton />;
+    default:
+      return assertNever(columnId);
+  }
+}
+
+export function InvitationsList({
+  owner,
+  searchText,
+}: {
+  owner: WorkspaceType;
+  searchText?: string;
+}) {
+  const { invitations, isInvitationsLoading } = useWorkspaceInvitations(owner, {
+    includeExpired: true,
+  });
+  const [selectedInvite, setSelectedInvite] =
+    useState<MembershipInvitationType | null>(null);
+  const sendNotification = useSendNotification();
+
+  const filteredInvitations = useMemo(
+    () =>
+      invitations
+        .sort((a, b) => a.inviteEmail.localeCompare(b.inviteEmail))
+        .filter((i) => i.status === "pending")
+        .filter(
+          (i) =>
+            !searchText ||
+            i.inviteEmail.toLowerCase().includes(searchText.toLowerCase())
+        ),
+    [invitations, searchText]
+  );
+
+  const rows = useMemo(
+    () =>
+      filteredInvitations.map((invitation) => ({
+        ...invitation,
+        onClick: () => setSelectedInvite(invitation),
+      })),
+    [filteredInvitations]
+  );
+
+  const columns = getColumns({ owner, sendNotification });
 
   return (
     <>

--- a/front/components/workspace/TopUpsHistoryTable.tsx
+++ b/front/components/workspace/TopUpsHistoryTable.tsx
@@ -1,6 +1,7 @@
 import { formatCredits } from "@app/lib/client/credits";
 import { useAwuTopUpsHistory } from "@app/lib/swr/credits";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { DataTableSkeletonCellProps } from "@dust-tt/sparkle";
 import {
@@ -25,7 +26,11 @@ type TopUpRowData = {
   onClick?: () => void;
 };
 
-function TopUpHistorySkeletonCell({ columnId }: DataTableSkeletonCellProps) {
+type TopUpColumnId = (typeof COLUMNS)[number]["id"];
+
+function TopUpHistorySkeletonCell({
+  columnId,
+}: DataTableSkeletonCellProps<TopUpColumnId>) {
   switch (columnId) {
     case "date":
       return <TextCellSkeleton />;
@@ -36,12 +41,13 @@ function TopUpHistorySkeletonCell({ columnId }: DataTableSkeletonCellProps) {
     case "expiration":
       return <TextCellSkeleton className="ml-auto" />;
     default:
-      return null;
+      return assertNever(columnId);
   }
 }
 
-const COLUMNS: ColumnDef<TopUpRowData, string>[] = [
+const COLUMNS = [
   {
+    id: "date" as const,
     accessorKey: "date",
     header: "Date",
     enableSorting: false,
@@ -49,6 +55,7 @@ const COLUMNS: ColumnDef<TopUpRowData, string>[] = [
     cell: ({ row }) => <span className="text-sm">{row.original.date}</span>,
   },
   {
+    id: "name" as const,
     accessorKey: "name",
     header: "Top-up",
     enableSorting: false,
@@ -56,6 +63,7 @@ const COLUMNS: ColumnDef<TopUpRowData, string>[] = [
     cell: ({ row }) => <span className="text-sm">{row.original.name}</span>,
   },
   {
+    id: "credits" as const,
     accessorKey: "credits",
     header: "Credits",
     enableSorting: false,
@@ -65,6 +73,7 @@ const COLUMNS: ColumnDef<TopUpRowData, string>[] = [
     ),
   },
   {
+    id: "expiration" as const,
     accessorKey: "expiration",
     header: "Expiration",
     enableSorting: false,
@@ -75,7 +84,7 @@ const COLUMNS: ColumnDef<TopUpRowData, string>[] = [
       </span>
     ),
   },
-];
+] satisfies ColumnDef<TopUpRowData, string>[];
 
 export function TopUpsHistoryTable({ owner }: TopUpsHistoryTableProps) {
   const { topUps, isTopUpsHistoryLoading, isTopUpsHistoryError } =

--- a/front/components/workspace/TopUpsHistoryTable.tsx
+++ b/front/components/workspace/TopUpsHistoryTable.tsx
@@ -1,7 +1,7 @@
 import { formatCredits } from "@app/lib/client/credits";
 import { useAwuTopUpsHistory } from "@app/lib/swr/credits";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { DataTableSkeletonCellProps } from "@dust-tt/sparkle";
 import {
@@ -41,7 +41,8 @@ function TopUpHistorySkeletonCell({
     case "expiration":
       return <TextCellSkeleton className="ml-auto" />;
     default:
-      return assertNever(columnId);
+      assertNeverAndIgnore(columnId);
+      return null;
   }
 }
 

--- a/sparkle/src/components/DataTableSkeleton.tsx
+++ b/sparkle/src/components/DataTableSkeleton.tsx
@@ -9,18 +9,29 @@ import {
 } from "@tanstack/react-table";
 import React, { type ComponentType } from "react";
 
-export interface DataTableSkeletonCellProps {
+export interface DataTableSkeletonCellProps<TColumnId extends string = string> {
   /** The column id from the table definition. */
-  columnId: string;
+  columnId: TColumnId;
   /** Zero-based placeholder row index, for varying shapes across rows. */
   rowIndex: number;
 }
 
-export interface DataTableSkeletonProps<TData, TValue = string> {
-  /** Reuse the loaded table columns, including header alignment and width classes. */
-  columns: ColumnDef<TData, TValue>[];
+type SkeletonColumnDef<TData, TValue, TColumnId extends string> = ColumnDef<
+  TData,
+  TValue
+> & { id?: TColumnId } & (string extends TColumnId
+    ? unknown
+    : { id: TColumnId; columns?: never });
+
+export interface DataTableSkeletonProps<
+  TData,
+  TValue = string,
+  TColumnId extends string = string,
+> {
+  /** Reuse the loaded table columns. A column-id union requires explicit ids on flat columns. */
+  columns: SkeletonColumnDef<TData, TValue, TColumnId>[];
   /** Required cell renderer: compose cell skeleton primitives to match each column's content. */
-  SkeletonCell: ComponentType<DataTableSkeletonCellProps>;
+  SkeletonCell: ComponentType<DataTableSkeletonCellProps<NoInfer<TColumnId>>>;
   /** Number of placeholder rows. Defaults to 5. */
   rowCount?: number;
   /** Row height in pixels; match the loaded table. Defaults to 48. */
@@ -32,13 +43,19 @@ export interface DataTableSkeletonProps<TData, TValue = string> {
  * a custom SkeletonCell renderer. Keep that renderer alongside the table's columns
  * and compose TextCellSkeleton, AvatarCellSkeleton, or ChipCellSkeleton to match
  * their contents. Use LoadingBlock for other shapes or more specialized layouts.
+ * Preserve literal column ids with `as const` and `satisfies ColumnDef<...>[]`,
+ * then use `(typeof columns)[number]["id"]` to type an exhaustive cell renderer.
  */
-export function DataTableSkeleton<TData, TValue = string>({
+export function DataTableSkeleton<
+  TData,
+  TValue = string,
+  TColumnId extends string = string,
+>({
   columns,
   SkeletonCell,
   rowCount = 5,
   rowHeight = 48,
-}: DataTableSkeletonProps<TData, TValue>) {
+}: DataTableSkeletonProps<TData, TValue, TColumnId>) {
   const table = useReactTable({
     data: [],
     columns,
@@ -96,7 +113,12 @@ export function DataTableSkeleton<TData, TValue = string>({
                   className={cn("px-2", column.columnDef.meta?.className)}
                   style={{ height: rowHeight }}
                 >
-                  <SkeletonCell columnId={column.id} rowIndex={rowIndex} />
+                  <SkeletonCell
+                    // TanStack widens ids to string. Narrow ids require flat
+                    // columns with explicit ids, which TanStack preserves.
+                    columnId={column.id as TColumnId}
+                    rowIndex={rowIndex}
+                  />
                 </td>
               ))}
             </tr>

--- a/sparkle/src/lib/utils.ts
+++ b/sparkle/src/lib/utils.ts
@@ -6,6 +6,10 @@ export function assertNever(x: never): never {
   throw new Error(`${x} is not of type never. This should never happen.`);
 }
 
+export function assertNeverAndIgnore(_x: never): void {
+  // Intentionally empty.
+}
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }

--- a/sparkle/src/stories/DataTableSkeleton.stories.tsx
+++ b/sparkle/src/stories/DataTableSkeleton.stories.tsx
@@ -8,7 +8,7 @@ import {
   TextCellSkeleton,
 } from "@sparkle/components";
 import type { DataTableSkeletonCellProps } from "@sparkle/components";
-import { assertNever } from "@sparkle/lib/utils";
+import { assertNeverAndIgnore } from "@sparkle/lib/utils";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { ColumnDef } from "@tanstack/react-table";
 import React from "react";
@@ -132,7 +132,8 @@ function MemberSkeletonCell({
     case "usage":
       return <TextCellSkeleton className="ml-auto w-12" />;
     default:
-      return assertNever(columnId);
+      assertNeverAndIgnore(columnId);
+      return null;
   }
 }
 
@@ -166,7 +167,7 @@ type Story = StoryObj<typeof meta>;
  * Reuse the loaded table columns and provide a cell renderer for their contents:
  * circular user avatars, square agent avatars, chip-shaped roles, and right-aligned
  * usage values. Vary text widths with rowIndex for a natural layout.
- * Derive the column-id union from the columns and use assertNever so adding a
+ * Derive the column-id union from the columns and use assertNeverAndIgnore so adding a
  * column requires updating its skeleton.
  * @summary Custom cell placeholders matching user and agent avatars, badges, and text.
  */

--- a/sparkle/src/stories/DataTableSkeleton.stories.tsx
+++ b/sparkle/src/stories/DataTableSkeleton.stories.tsx
@@ -136,27 +136,28 @@ function MemberSkeletonCell({
   }
 }
 
-const meta = {
-  title: "Feedback & Status/DataTableSkeleton",
-  component: DataTableSkeleton<MemberRow, string, MemberColumnId>,
-  args: {
-    columns,
-    SkeletonCell: MemberSkeletonCell,
-    rowCount: 5,
-    rowHeight: 48,
-  },
-  argTypes: {
-    columns: { control: false },
-    SkeletonCell: { control: false },
-    rowCount: { control: { type: "number", min: 1, max: 10 } },
-    rowHeight: { control: { type: "number", min: 48, max: 96 } },
-  },
-  render: (args) => (
-    <div className="w-full max-w-2xl">
-      <DataTableSkeleton {...args} />
-    </div>
-  ),
-} satisfies Meta<typeof DataTableSkeleton<MemberRow, string, MemberColumnId>>;
+const meta: Meta<typeof DataTableSkeleton<MemberRow, string, MemberColumnId>> =
+  {
+    title: "Feedback & Status/DataTableSkeleton",
+    component: DataTableSkeleton,
+    args: {
+      columns,
+      SkeletonCell: MemberSkeletonCell,
+      rowCount: 5,
+      rowHeight: 48,
+    },
+    argTypes: {
+      columns: { control: false },
+      SkeletonCell: { control: false },
+      rowCount: { control: { type: "number", min: 1, max: 10 } },
+      rowHeight: { control: { type: "number", min: 48, max: 96 } },
+    },
+    render: (args) => (
+      <div className="w-full max-w-2xl">
+        <DataTableSkeleton {...args} />
+      </div>
+    ),
+  };
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/sparkle/src/stories/DataTableSkeleton.stories.tsx
+++ b/sparkle/src/stories/DataTableSkeleton.stories.tsx
@@ -8,6 +8,7 @@ import {
   TextCellSkeleton,
 } from "@sparkle/components";
 import type { DataTableSkeletonCellProps } from "@sparkle/components";
+import { assertNever } from "@sparkle/lib/utils";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { ColumnDef } from "@tanstack/react-table";
 import React from "react";
@@ -46,8 +47,9 @@ const members: MemberRow[] = [
   },
 ];
 
-const columns: ColumnDef<MemberRow, string>[] = [
+const columns = [
   {
+    id: "member" as const,
     accessorKey: "member",
     header: "Member",
     meta: { className: "w-[40%]" },
@@ -64,6 +66,7 @@ const columns: ColumnDef<MemberRow, string>[] = [
     ),
   },
   {
+    id: "agent" as const,
     accessorKey: "agent",
     header: "Agent",
     meta: { className: "w-[30%]" },
@@ -75,6 +78,7 @@ const columns: ColumnDef<MemberRow, string>[] = [
     ),
   },
   {
+    id: "role" as const,
     accessorKey: "role",
     header: "Role",
     enableSorting: false,
@@ -88,6 +92,7 @@ const columns: ColumnDef<MemberRow, string>[] = [
     ),
   },
   {
+    id: "usage" as const,
     accessorKey: "usage",
     header: "Usage",
     meta: { className: "w-[10%]", headerAlign: "right" },
@@ -95,12 +100,14 @@ const columns: ColumnDef<MemberRow, string>[] = [
       <div className="text-right text-sm">{row.original.usage}</div>
     ),
   },
-];
+] satisfies ColumnDef<MemberRow, string>[];
+
+type MemberColumnId = (typeof columns)[number]["id"];
 
 function MemberSkeletonCell({
   columnId,
   rowIndex,
-}: DataTableSkeletonCellProps) {
+}: DataTableSkeletonCellProps<MemberColumnId>) {
   switch (columnId) {
     case "member":
       return (
@@ -125,13 +132,13 @@ function MemberSkeletonCell({
     case "usage":
       return <TextCellSkeleton className="ml-auto w-12" />;
     default:
-      return null;
+      return assertNever(columnId);
   }
 }
 
 const meta = {
   title: "Feedback & Status/DataTableSkeleton",
-  component: DataTableSkeleton,
+  component: DataTableSkeleton<MemberRow, string, MemberColumnId>,
   args: {
     columns,
     SkeletonCell: MemberSkeletonCell,
@@ -149,7 +156,7 @@ const meta = {
       <DataTableSkeleton {...args} />
     </div>
   ),
-} satisfies Meta<typeof DataTableSkeleton<MemberRow>>;
+} satisfies Meta<typeof DataTableSkeleton<MemberRow, string, MemberColumnId>>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -158,6 +165,8 @@ type Story = StoryObj<typeof meta>;
  * Reuse the loaded table columns and provide a cell renderer for their contents:
  * circular user avatars, square agent avatars, chip-shaped roles, and right-aligned
  * usage values. Vary text widths with rowIndex for a natural layout.
+ * Derive the column-id union from the columns and use assertNever so adding a
+ * column requires updating its skeleton.
  * @summary Custom cell placeholders matching user and agent avatars, badges, and text.
  */
 export const CustomCells: Story = {};


### PR DESCRIPTION
## Description

Follow-up to #32310, which introduces a composable way to create skeletons for data tables by having the `DataTableSkeleton` component take in input a `SkeletonCell` component that will represent how each cell should have its cell represented during the loading time.

The Skeleton cell component currently receives a plain string column ID to identify each column.

This PR strengthen the typing to enforce that the column IDs passed to this component are the same as the actual columns rendered.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
