### PR TITLE
Make a sandbox function's Frame non-null

### DIFF
--- a/front/lib/api/frames/publication_storage.test.ts
+++ b/front/lib/api/frames/publication_storage.test.ts
@@ -729,7 +729,7 @@ describe("activateFramePublication", () => {
       inputSchema: functionArtifacts[0].inputSchema,
       outputSchema: functionArtifacts[0].outputSchema,
     });
-    expect(functions[0]?.frame?.sId).toBe(frame.sId);
+    expect(functions[0]?.frame.sId).toBe(frame.sId);
   });
 
   it("rejects a modified function bundle before activation", async () => {

--- a/front/lib/api/sandbox_functions/audit.ts
+++ b/front/lib/api/sandbox_functions/audit.ts
@@ -10,8 +10,7 @@ export function buildSandboxFunctionAuditMetadata(
   invocation: SandboxFunctionInvocationResource
 ): Record<string, string> {
   const { sandboxFunction } = invocation;
-  const frame = sandboxFunction.frame;
-  assert(frame, "Only Frame functions can be invoked.");
+  const { frame } = sandboxFunction;
   assert(
     sandboxFunction.publicationId !== null,
     "Frame functions must belong to a publication."

--- a/front/lib/api/sandbox_functions/frame_share_capability.ts
+++ b/front/lib/api/sandbox_functions/frame_share_capability.ts
@@ -29,12 +29,9 @@ export async function resolveSandboxFunctionWithCapability(
         auth,
         functionIdOrSlug
       );
-    if (sandboxFunction?.frame) {
-      return resolveFrameV2FunctionAccess(auth, sandboxFunction, {
-        allowInactivePublication: allowInactiveFramePublication,
-      });
-    }
-    return null;
+    return resolveFrameV2FunctionAccess(auth, sandboxFunction, {
+      allowInactivePublication: allowInactiveFramePublication,
+    });
   }
 
   return resolveFrameV2FunctionReference(auth, functionIdOrSlug);
@@ -104,12 +101,11 @@ async function resolveFrameV2FunctionAccess(
   sandboxFunction: SandboxFunctionResource | null,
   { allowInactivePublication }: { allowInactivePublication: boolean }
 ): Promise<SandboxFunctionResource | null> {
-  const frame = sandboxFunction?.frame;
-  if (
-    !sandboxFunction ||
-    !frame ||
-    !(await frame.canCurrentUserUseFrame(auth))
-  ) {
+  if (!sandboxFunction) {
+    return null;
+  }
+  const { frame } = sandboxFunction;
+  if (!(await frame.canCurrentUserUseFrame(auth))) {
     return null;
   }
   if (

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -833,7 +833,6 @@ describe("SandboxFunctionInvocationResource", () => {
         frameId: frame.sId,
         frameSourceScope: "pod",
         frameSourceScopeId: space.sId,
-        functionOwnerKind: "frame",
         functionName: sandboxFunction.slug,
         invocationId: invocation.sId,
         publicationId,

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -341,41 +341,35 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
   }
 
   private buildGcsPath(auth: Authenticator): string {
-    const frame = this.sandboxFunction.frame;
-    if (frame) {
-      return `w/${auth.getNonNullableWorkspace().sId}/frames/${frame.sId}/invocations/${this.sId}`;
-    }
-    return `w/${auth.getNonNullableWorkspace().sId}/sandbox_functions/${this.sandboxFunction.sId}/invocations/${this.sId}`;
+    const { frame } = this.sandboxFunction;
+    return `w/${auth.getNonNullableWorkspace().sId}/frames/${frame.sId}/invocations/${this.sId}`;
   }
 
   private observabilityContext(auth?: Authenticator) {
-    const frame = this.sandboxFunction.frame;
-    const sourceConversationId = frame?.useCaseMetadata?.conversationId;
-    const sourceSpaceId = frame?.useCaseMetadata?.spaceId;
+    const { frame } = this.sandboxFunction;
+    const sourceConversationId = frame.useCaseMetadata?.conversationId;
+    const sourceSpaceId = frame.useCaseMetadata?.spaceId;
 
     return {
       ...(auth
         ? { workspaceId: auth.getNonNullableWorkspace().sId }
         : { workspaceModelId: this.workspaceId }),
-      functionOwnerKind: frame ? "frame" : "pod",
       sandboxFunctionId: this.sandboxFunction.sId,
       functionName: this.sandboxFunction.slug,
       invocationId: this.sId,
-      ...(frame
-        ? {
-            frameId: frame.sId,
-            ...(this.sandboxFunction.publicationId
-              ? { publicationId: this.sandboxFunction.publicationId }
-              : {}),
-            frameSourceScope: sourceSpaceId
-              ? "pod"
-              : sourceConversationId
-                ? "conversation"
-                : "unknown",
-            ...(sourceSpaceId || sourceConversationId
-              ? { frameSourceScopeId: sourceSpaceId ?? sourceConversationId }
-              : {}),
-          }
+      frameId: frame.sId,
+      ...(this.sandboxFunction.publicationId
+        ? { publicationId: this.sandboxFunction.publicationId }
+        : {}),
+      // Where the Frame itself lives, not who owns the function: a Frame is created either in a
+      // Pod or from a conversation.
+      frameSourceScope: sourceSpaceId
+        ? "pod"
+        : sourceConversationId
+          ? "conversation"
+          : "unknown",
+      ...(sourceSpaceId || sourceConversationId
+        ? { frameSourceScopeId: sourceSpaceId ?? sourceConversationId }
         : {}),
     };
   }
@@ -620,16 +614,8 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
 
     try {
       const { sandboxFunction } = this;
-      const frame = sandboxFunction.frame;
+      const { frame } = sandboxFunction;
       const publicationId = sandboxFunction.publicationId;
-      if (!frame) {
-        return new Err(
-          new SandboxFunctionInvocationError(
-            "This function is not owned by a Frame: legacy Pod functions can no longer be run.",
-            "frame_runtime_unavailable"
-          )
-        );
-      }
       if (auth.getNonNullableWorkspace().id !== this.workspaceId) {
         return new Err(
           new SandboxFunctionInvocationError(

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -137,10 +137,12 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     this.file = file;
   }
 
-  get frame(): FileResource | null {
-    return this.publicationId !== null && this.file.isFrameV2
-      ? this.file
-      : null;
+  /**
+   * The Frame that owns this function. Non-null by construction: `baseFetch` is the only path
+   * that builds a resource, and it drops any row that does not hydrate into a Frame function.
+   */
+  get frame(): FileResource {
+    return this.file;
   }
 
   get sId(): string {
@@ -299,6 +301,12 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     }
   }
 
+  /**
+   * @cc [owner:davidebbo,label:backend] frame-owned-rows-only
+   * A row MUST NOT be hydrated into a `SandboxFunctionResource` unless it carries a
+   * `publicationId` and its file is a Frames v2 manifest. Callers rely on `frame` and
+   * `publicationId` being present on every resource this returns.
+   */
   private static async baseFetch(
     auth: Authenticator,
     options: ResourceFindOptions<SandboxFunctionModel> = {}
@@ -324,8 +332,8 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     );
     const filesById = new Map(files.map((file) => [file.id, file]));
 
-    // A row we cannot hydrate into a served Frame function is dropped: a legacy Pod function
-    // (no publication), or one whose Frame the caller cannot read.
+    // A row we cannot hydrate into a served Frame function is dropped: one whose Frame the caller
+    // cannot read, or a leftover row from before functions were published against a Frame.
     return sandboxFunctions.flatMap((sandboxFunction) => {
       const blob = sandboxFunction.get();
       const file = filesById.get(blob.fileId);
@@ -634,19 +642,10 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         )
       );
     }
-    const frame = this.frame;
-    if (!frame) {
-      return new Err(
-        new SandboxFunctionInvocationError(
-          "This function is not owned by a Frame: legacy Pod functions can no longer be run.",
-          "frame_runtime_unavailable"
-        )
-      );
-    }
     const authorization = await authorizeSandboxFunctionInvocation(auth, {
       userIdentity: this.userIdentity,
       origin,
-      owner: { kind: "frame", frame },
+      owner: { kind: "frame", frame: this.frame },
     });
     if (!authorization.authorized) {
       return new Err(

--- a/front/temporal/sandbox_functions/activities/run_sandbox_function_tool.ts
+++ b/front/temporal/sandbox_functions/activities/run_sandbox_function_tool.ts
@@ -61,10 +61,8 @@ export async function runSandboxFunctionToolActivity(
 
   // Where files this tool persists belong: the Pod the invoked Frame runs in. Resolved here, once,
   // so the tool paths below stay synchronous.
-  const frame = invocation.sandboxFunction.frame;
-  const frameContext = frame
-    ? await frame.resolveFrameScopedPathContext(auth)
-    : null;
+  const { frame } = invocation.sandboxFunction;
+  const frameContext = await frame.resolveFrameScopedPathContext(auth);
   const pod = frameContext?.spaceId
     ? await SpaceResource.fetchById(auth, frameContext.spaceId)
     : null;


### PR DESCRIPTION
## Description

Follow-up to #32314. Every sandbox function is now owned by a Frame, but the code still acted as if it was optional. So now we can clean all that up.