### PR TITLE
Make sandbox_functions.publicationId NOT NULL

### DIFF
--- a/front/lib/api/poke/frames.ts
+++ b/front/lib/api/poke/frames.ts
@@ -31,7 +31,6 @@ import type { PokeSandboxType } from "@app/types/poke";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
-import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 export type PokeFrameListItem = {
@@ -302,7 +301,7 @@ export type PokeFrameFunction = {
   // `slug: fn.name`, and Frames have no app prefix to strip.
   slug: string;
   description: string;
-  publicationId: string | null;
+  publicationId: string;
   createdAt: string;
   updatedAt: string;
 };
@@ -355,10 +354,7 @@ export async function getFrameFunctionSource(
     sandboxFunction,
   }: { frame: FileResource; sandboxFunction: SandboxFunctionResource }
 ): Promise<Result<string, FramePublicationError>> {
-  // `publicationId` is non-null for anything resolved as a Frame function: baseFetch drops rows
-  // without one.
   const { publicationId } = sandboxFunction;
-  assert(publicationId, "A Frame function always belongs to a publication.");
 
   return readFramePublicationFunctionBundle(auth, {
     frame,

--- a/front/lib/api/sandbox_functions/audit.ts
+++ b/front/lib/api/sandbox_functions/audit.ts
@@ -1,5 +1,4 @@
 import type { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
-import assert from "assert";
 
 /**
  * Function identifiers for the shared `tool.*` audit events. Function-initiated tool calls reuse
@@ -11,10 +10,6 @@ export function buildSandboxFunctionAuditMetadata(
 ): Record<string, string> {
   const { sandboxFunction } = invocation;
   const { frame } = sandboxFunction;
-  assert(
-    sandboxFunction.publicationId !== null,
-    "Frame functions must belong to a publication."
-  );
 
   return {
     frame_id: frame.sId,

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -661,10 +661,7 @@ export class FileResource extends BaseResource<FileModel> {
     for (;;) {
       const sandboxFunctions = await SandboxFunctionModel.findAll({
         attributes: ["id"],
-        where: {
-          workspaceId: workspaceModelId,
-          publicationId: { [Op.ne]: null },
-        },
+        where: { workspaceId: workspaceModelId },
         limit: FRAME_FUNCTION_DELETE_BATCH_SIZE,
       });
       if (sandboxFunctions.length === 0) {
@@ -691,7 +688,6 @@ export class FileResource extends BaseResource<FileModel> {
       where: {
         workspaceId: workspaceModelId,
         fileId: this.id,
-        publicationId: { [Op.ne]: null },
       },
     });
     await FileResource.deleteFrameFunctionModelIds(

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -358,9 +358,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       functionName: this.sandboxFunction.slug,
       invocationId: this.sId,
       frameId: frame.sId,
-      ...(this.sandboxFunction.publicationId
-        ? { publicationId: this.sandboxFunction.publicationId }
-        : {}),
+      publicationId: this.sandboxFunction.publicationId,
       // Where the Frame itself lives, not who owns the function: a Frame is created either in a
       // Pod or from a conversation.
       frameSourceScope: sourceSpaceId

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -303,9 +303,8 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
   /**
    * @cc [owner:davidebbo,label:backend] frame-owned-rows-only
-   * A row MUST NOT be hydrated into a `SandboxFunctionResource` unless it carries a
-   * `publicationId` and its file is a Frames v2 manifest. Callers rely on `frame` and
-   * `publicationId` being present on every resource this returns.
+   * A row MUST NOT be hydrated into a `SandboxFunctionResource` unless its file is a Frames v2
+   * manifest. Callers rely on `frame` being present on every resource this returns.
    */
   private static async baseFetch(
     auth: Authenticator,
@@ -332,12 +331,11 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     );
     const filesById = new Map(files.map((file) => [file.id, file]));
 
-    // A row we cannot hydrate into a served Frame function is dropped: one whose Frame the caller
-    // cannot read, or a leftover row from before functions were published against a Frame.
+    // A row whose Frame the caller cannot read is dropped.
     return sandboxFunctions.flatMap((sandboxFunction) => {
       const blob = sandboxFunction.get();
       const file = filesById.get(blob.fileId);
-      if (blob.publicationId === null || !file?.isFrameV2) {
+      if (!file?.isFrameV2) {
         return [];
       }
 
@@ -690,9 +688,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       bundleSha256: this.bundleSha256,
       inputSchema: this.inputSchema,
       outputSchema: this.outputSchema,
-      isActivePublication:
-        this.publicationId !== null &&
-        this.publicationId === activePublicationId,
+      isActivePublication: this.publicationId === activePublicationId,
     };
   }
 

--- a/front/lib/resources/storage/models/sandbox_function.ts
+++ b/front/lib/resources/storage/models/sandbox_function.ts
@@ -51,7 +51,7 @@ export class SandboxFunctionModel extends WorkspaceAwareModel<SandboxFunctionMod
   declare updatedAt: CreationOptional<Date>;
 
   declare fileId: ForeignKey<FileModel["id"]>;
-  declare publicationId: string | null;
+  declare publicationId: string;
   declare slug: string;
   declare description: string;
   declare userIdentity: SandboxFunctionUserIdentityPolicy | null;
@@ -102,7 +102,7 @@ SandboxFunctionModel.init(
     },
     publicationId: {
       type: DataTypes.STRING(255),
-      allowNull: true,
+      allowNull: false,
     },
     slug: {
       type: DataTypes.STRING(255),

--- a/front/migrations/post-deploy/20260911140000_sandbox_functions_publication_id_not_null.sql
+++ b/front/migrations/post-deploy/20260911140000_sandbox_functions_publication_id_not_null.sql
@@ -1,0 +1,17 @@
+/*
+Post-deploy: make `sandbox_functions."publicationId"` NOT NULL.
+
+Every function row belongs to a Frame publication — `createForFramePublication` is the only writer
+and always sets one. The column was nullable for Pod functions, which no longer exist; production
+holds no row without a publication (10,972 rows US, 25 EU, zero NULL in either).
+
+`SET NOT NULL` scans the table under an ACCESS EXCLUSIVE lock. At this size that is a few
+milliseconds, well inside the statement timeout below.
+*/
+
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_functions" ALTER COLUMN "publicationId" SET NOT NULL;


### PR DESCRIPTION
## Description

Follow-up to #32327, now merged; this branch has been rebased onto `main`.

`createForFramePublication` is the only writer of `sandbox_functions` and always sets a publication id. The column was nullable only for Pod functions, which no longer exist. Production holds no row without one: 10,972 rows in US, 25 in EU, zero NULL in either.

With the column tightened, everything that only existed to handle the null case goes: the `publicationId === null` half of the `baseFetch` filter, the `Op.ne: null` filters on the Frame function deletes in `FileResource`, the conditional `publicationId` in the invocation log context, the `publicationId !== null` guard in `isActivePublication`, and the asserts in the audit metadata builder and the Poke bundle reader (both of which were restating the same invariant in prose). `PokeFrameFunction.publicationId` becomes non-null accordingly.

## Tests

No behavior change, so no new tests — the type system carries this one. Ran 219 front tests (`sandbox_function_*`, `file_resource`, `lib/api/frames`, `temporal/sandbox_functions`) and 199 front-api tests (sandbox, frames and poke routes) against a local DB with the migration applied. `tsgo --noEmit` clean in both `front` and `front-api`.

## Risk

Low. `SET NOT NULL` fails loudly rather than corrupting anything if a NULL row appeared between now and the migration, and the writer cannot produce one.

The two `Op.ne: null` filters that were dropped were selecting Frame functions out of a set that no longer contains anything else, so the query results are unchanged.

Not rollback-safe in the schema sense (a new forward migration would be needed to re-widen), but the code change alone reverts cleanly.

## Deploy Plan

Standard post-deploy migration: ship the code, then run `migrations/post-deploy/20260911140000_sandbox_functions_publication_id_not_null.sql` in both regions.

