### PR TITLE
[front] agent builder: invert the instruction diff shades in dark mode

### DIFF
--- a/front/components/editor/extensions/agent_builder/AgentDiffMarks.ts
+++ b/front/components/editor/extensions/agent_builder/AgentDiffMarks.ts
@@ -19,7 +19,8 @@ export const AdditionMark = Mark.create({
     return [
       "span",
       {
-        class: "addition rounded bg-highlight-200 text-highlight-900",
+        class:
+          "addition text-success-700 bg-success-100 dark:text-success-900 dark:bg-success-200",
       },
       0,
     ];
@@ -45,7 +46,8 @@ export const DeletionMark = Mark.create({
     return [
       "span",
       {
-        class: "deletion rounded bg-warning-200 text-warning-900 line-through",
+        class:
+          "deletion text-warning-600 bg-warning-100 line-through dark:text-warning-900 dark:bg-warning-200",
       },
       0,
     ];

--- a/front/components/editor/extensions/agent_builder/AgentDiffMarks.ts
+++ b/front/components/editor/extensions/agent_builder/AgentDiffMarks.ts
@@ -20,7 +20,7 @@ export const AdditionMark = Mark.create({
       "span",
       {
         class:
-          "addition text-success-700 bg-success-100 dark:text-success-900 dark:bg-success-200",
+          "addition text-success-700 bg-success-100 dark:text-green-100 dark:bg-green-800",
       },
       0,
     ];
@@ -47,7 +47,7 @@ export const DeletionMark = Mark.create({
       "span",
       {
         class:
-          "deletion text-warning-600 bg-warning-100 line-through dark:text-warning-900 dark:bg-warning-200",
+          "deletion text-warning-600 bg-warning-100 line-through dark:text-rose-100 dark:bg-rose-800",
       },
       0,
     ];

--- a/front/components/editor/extensions/agent_builder/AgentDiffMarks.ts
+++ b/front/components/editor/extensions/agent_builder/AgentDiffMarks.ts
@@ -19,7 +19,7 @@ export const AdditionMark = Mark.create({
     return [
       "span",
       {
-        class: "addition text-success-700 bg-success-100",
+        class: "addition rounded bg-highlight-200 text-highlight-900",
       },
       0,
     ];
@@ -45,7 +45,7 @@ export const DeletionMark = Mark.create({
     return [
       "span",
       {
-        class: "deletion text-warning-600 bg-warning-100 line-through",
+        class: "deletion rounded bg-warning-200 text-warning-900 line-through",
       },
       0,
     ];


### PR DESCRIPTION
## Description 
Fixes dust-tt/tasks#9145.

The version comparison diff in the agent builder used the same shades in both themes. In dark mode the marks now follow @pinotalexandre's comment: same green/rose hues, with the 100 shade for text and the 800 shade for the background. Light mode is unchanged.

## Tests

https://pr-32335-merge--app.preview.dust.tt/w/0ec9852c2f/builder/agents/f6f239b44b
vs
https://app.dust.tt/w/0ec9852c2f/builder/agents/f6f239b44b


-> click on the instruction history button from the wysiwyg, in dark mode.