### PR TITLE
[front] fix: prevent automation pool column clipping

### DIFF
--- a/front/components/workspace/analytics/automations/automationsTriggerColumns.tsx
+++ b/front/components/workspace/analytics/automations/automationsTriggerColumns.tsx
@@ -269,7 +269,7 @@ export function poolColumn<
     id: "pool",
     header: "Pool",
     enableSorting: false,
-    meta: { className: "w-28" },
+    meta: { className: "w-32" },
     cell: (info) => (
       <DataTable.CellContent className="w-full justify-start">
         <PoolCell row={info.row.original} />

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -453,7 +453,7 @@ function buildColumns({
       id: "vsPrev",
       header: "vs prev",
       enableSorting: false,
-      meta: { className: "w-16", sizeRatio: 18, headerAlign: "right" },
+      meta: { className: "w-28", sizeRatio: 18, headerAlign: "right" },
       cell: (info) => (
         <VsPrevCell
           credits={info.row.original.credits}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -453,7 +453,7 @@ function buildColumns({
       id: "vsPrev",
       header: "vs prev",
       enableSorting: false,
-      meta: { className: "w-28", sizeRatio: 18, headerAlign: "right" },
+      meta: { className: "w-24", sizeRatio: 18, headerAlign: "right" },
       cell: (info) => (
         <VsPrevCell
           credits={info.row.original.credits}


### PR DESCRIPTION
## Description

The automations Pool column clips the pool (workspace or user pool) selector because its 112 px width leaves only 96 px after cell padding.

<img width="1094" height="214" alt="Screenshot 2026-09-11 at 3 38 30 PM" src="https://github.com/user-attachments/assets/464b1f63-b29d-4043-89bf-5d5890346f00" />

This PR increases the column width to 128 px so the label and dropdown chevron fit in both workspace and personal automations tables.

Same for the Vs prev column in the attribution table, which can clip if there are 4 digits or more.

## Tests

- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
