### PR TITLE
[sparkle] add StackOne platform logo

### DIFF
--- a/sparkle/src/logo/platforms/StackOne.tsx
+++ b/sparkle/src/logo/platforms/StackOne.tsx
@@ -1,0 +1,57 @@
+import type { SVGProps } from "react";
+import * as React from "react";
+
+const SvgStackOne = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    fill="none"
+    viewBox="0 0 24 24"
+    {...props}
+  >
+    <g transform="translate(0 5)scale(.12)">
+      <path
+        fill="url(#StackOne_svg__a)"
+        d="M66.666 38.889h66.667V0h-31.845C82.256 0 66.666 0 66.666 20.392z"
+      />
+      <path
+        fill="url(#StackOne_svg__b)"
+        d="M133.333 77.777H66.666v38.889h31.845c19.231 0 34.822 0 34.822-20.392z"
+      />
+      <path
+        fill="#00AF66"
+        d="M133.333 0H66.889 0L0 77.778h66.889V38.896l-.01-1.647C66.762 16.711 83.378 0 103.916 0z"
+      />
+      <path
+        fill="#00AF66"
+        d="M66.666 116.666H133.11 199.999V38.889H133.11v38.882l.01 1.647c.117 20.538-16.499 37.248-37.037 37.248z"
+      />
+    </g>
+    <defs>
+      <linearGradient
+        id="StackOne_svg__a"
+        x1={133.333}
+        x2={66.666}
+        y1={19.444}
+        y2={19.444}
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#00AF66" />
+        <stop offset={1} stopColor="#285C4D" />
+      </linearGradient>
+      <linearGradient
+        id="StackOne_svg__b"
+        x1={66.666}
+        x2={133.333}
+        y1={97.222}
+        y2={97.222}
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#00AF66" />
+        <stop offset={1} stopColor="#285C4D" />
+      </linearGradient>
+    </defs>
+  </svg>
+);
+export default SvgStackOne;

--- a/sparkle/src/logo/platforms/index.ts
+++ b/sparkle/src/logo/platforms/index.ts
@@ -89,6 +89,7 @@ export { default as SlabLogo } from "./Slab";
 export { default as SlackLogo } from "./Slack";
 export { default as SlideLogo } from "./Slide";
 export { default as SnowflakeLogo } from "./Snowflake";
+export { default as StackOneLogo } from "./StackOne";
 export { default as StatuspageLogo } from "./Statuspage";
 export { default as StripeLogo } from "./Stripe";
 export { default as SupabaseLogo } from "./Supabase";

--- a/sparkle/src/logo/platforms/registry.ts
+++ b/sparkle/src/logo/platforms/registry.ts
@@ -90,6 +90,7 @@ import SlabLogo from "./Slab";
 import SlackLogo from "./Slack";
 import SlideLogo from "./Slide";
 import SnowflakeLogo from "./Snowflake";
+import StackOneLogo from "./StackOne";
 import StatuspageLogo from "./Statuspage";
 import StripeLogo from "./Stripe";
 import SupabaseLogo from "./Supabase";
@@ -204,6 +205,7 @@ export const PLATFORM_LOGOS = {
   SlackLogo,
   SlideLogo,
   SnowflakeLogo,
+  StackOneLogo,
   StatuspageLogo,
   StripeLogo,
   SupabaseLogo,

--- a/sparkle/src/logo/src/platforms/StackOne.svg
+++ b/sparkle/src/logo/src/platforms/StackOne.svg
@@ -1,0 +1,18 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g transform="translate(0 5) scale(0.12)">
+<path d="M66.666 38.8889H133.333V0H101.488C82.2562 0 66.666 0 66.666 20.3924V38.8889Z" fill="url(#paint0_linear_stackone)"/>
+<path d="M133.333 77.7773H66.666V116.666H98.5105C117.742 116.666 133.333 116.666 133.333 96.2738V77.7773Z" fill="url(#paint1_linear_stackone)"/>
+<path d="M133.333 0H66.8889H0L3.26502e-06 77.7778H66.8889V38.8959L66.8796 37.2487C66.7622 16.7113 83.3783 0 103.916 0H133.333Z" fill="#00AF66"/>
+<path d="M66.666 116.666H133.11H199.999V38.8887H133.11V77.7705L133.12 79.4177C133.237 99.9552 116.621 116.666 96.0834 116.666H66.666Z" fill="#00AF66"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_stackone" x1="133.333" y1="19.4444" x2="66.666" y2="19.4444" gradientUnits="userSpaceOnUse">
+<stop stop-color="#00AF66"/>
+<stop offset="1" stop-color="#285C4D"/>
+</linearGradient>
+<linearGradient id="paint1_linear_stackone" x1="66.666" y1="97.2218" x2="133.333" y2="97.2218" gradientUnits="userSpaceOnUse">
+<stop stop-color="#00AF66"/>
+<stop offset="1" stop-color="#285C4D"/>
+</linearGradient>
+</defs>
+</svg>


### PR DESCRIPTION


## Description

part 1: Add StackOne as a remote MCP preset. Update sparkle with StackOne logos

## Tests

locally

## Risk

none

## Deploy Plan

sdk only
