### PR TITLE
[LLM] Repoint Kimi K2.6 agents to K3 and gate K3 behind the Fireworks flag

### DIFF
--- a/.claude/skills/dust-llm/SKILL.md
+++ b/.claude/skills/dust-llm/SKILL.md
@@ -71,7 +71,7 @@ Pick the newest sibling (e.g. for "Gemini 3.6 Flash" the sibling is "Gemini 3.5 
 
 | File | What to add |
 |------|-------------|
-| `front/types/assistant/models/{provider}.ts` | `X_MODEL_ID` const + `X_MODEL_CONFIG`. **Set `isLatest: false` on the previous model in the same family** and drop "latest" from its description. |
+| `front/types/assistant/models/{provider}.ts` | `X_MODEL_ID` const + `X_MODEL_CONFIG`. **Set `isLatest: false` on the previous model in the same family** and drop "latest" from its description. **Carry over the predecessor's `availableIfOneOf` / `unavailableIfOneOf`** (see below). |
 | `front/types/assistant/models/models.ts` | Add id to `STATIC_MODEL_IDS` and config to `SUPPORTED_MODEL_CONFIGS` (imports in both alpha blocks). |
 | `front/types/assistant/models/auto.ts` | If the model should participate in `auto`/`auto_fast`/`auto_complex` routing, add a `ModelStreamCandidate`. |
 | `front/lib/model_constructors/types/models.ts` | Add `export const X = "model-id"` and include it in the `MODELS` array (this is the `model_constructors` id type). |
@@ -85,6 +85,22 @@ Adding the id to `STATIC_MODEL_IDS` makes these fail to compile until updated:
 | `front/lib/api/assistant/token_pricing/global.ts` | `CURRENT_MODEL_PRICING` entry (input/output/`cache_read_input_tokens` per 1M) + doc URL comment. |
 | `front/types/assistant/models/static_model_reasoning_efforts.ts` | `{ none, light, medium, high }` support map (`satisfies Record<StaticModelIdType, ReasoningEffortSupport>`). **Must match the config's `supportedReasoningEfforts`** (enforced by `model_tiers.test.ts`). |
 | `front/types/assistant/models/model_tiers.ts` | `STATIC_MODEL_TIERS` entry mapping each supported effort → tier name. |
+
+> **Gating is inherited, and lives in two unlinked places.** A new version of a gated model
+> stays gated — being newer is not a reason to release it. Copy the predecessor's
+> `availableIfOneOf` / `unavailableIfOneOf` onto the new `X_MODEL_CONFIG` (gates the picker,
+> via `isModelAvailable`) **and** declare the same flag on every endpoint you add (gates the
+> router, via `isEndpointAvailable`):
+>
+> ```ts
+> static readonly endpointFilter = {
+>   featureFlags: { contains: "fireworks_new_model_feature" as const },
+> };
+> ```
+>
+> Half-gating fails silently either way: hidden but reachable, or pickable but unroutable —
+> and `resolveModel` swaps in a fallback model instead of erroring. Releasing a gated family
+> is a separate, deliberate change.
 
 ### C. `model_constructors` — the endpoint classes (stream)
 

--- a/front/lib/llms/stream/endpoints/moonshot_ai_kimi_k2_dot_six_global_fireworks.ts
+++ b/front/lib/llms/stream/endpoints/moonshot_ai_kimi_k2_dot_six_global_fireworks.ts
@@ -5,7 +5,11 @@ import { MoonshotAiKimiK2Dot6GlobalFireworksStream } from "@app/lib/model_constr
 export class DustMoonshotAiKimiK2Dot6GlobalFireworksStream extends WithDustMoonshotAiKimiK2Dot6Config(
   MoonshotAiKimiK2Dot6GlobalFireworksStream
 ) {
-  static readonly endpointFilter = {};
+  // Mirrors `availableIfOneOf` on FIREWORKS_KIMI_K2P6_MODEL_CONFIG: the legacy
+  // config gates the model picker, this gates the router.
+  static readonly endpointFilter = {
+    featureFlags: { contains: "fireworks_new_model_feature" as const },
+  };
 }
 
 defineDustStreamEndpoint(DustMoonshotAiKimiK2Dot6GlobalFireworksStream);

--- a/front/lib/llms/stream/endpoints/moonshot_ai_kimi_k3_global_fireworks.ts
+++ b/front/lib/llms/stream/endpoints/moonshot_ai_kimi_k3_global_fireworks.ts
@@ -5,7 +5,11 @@ import { MoonshotAiKimiK3GlobalFireworksStream } from "@app/lib/model_constructo
 export class DustMoonshotAiKimiK3GlobalFireworksStream extends WithDustMoonshotAiKimiK3Config(
   MoonshotAiKimiK3GlobalFireworksStream
 ) {
-  static readonly endpointFilter = {};
+  // Mirrors `availableIfOneOf` on FIREWORKS_KIMI_K3_MODEL_CONFIG: the legacy
+  // config gates the model picker, this gates the router.
+  static readonly endpointFilter = {
+    featureFlags: { contains: "fireworks_new_model_feature" as const },
+  };
 }
 
 defineDustStreamEndpoint(DustMoonshotAiKimiK3GlobalFireworksStream);

--- a/front/migrations/20260911_migrate_kimi_k2p6_to_kimi_k3.ts
+++ b/front/migrations/20260911_migrate_kimi_k2p6_to_kimi_k3.ts
@@ -1,0 +1,99 @@
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { makeScript } from "@app/scripts/helpers";
+
+// Fireworks decommissions the `kimi-k2p6` serverless endpoint on 2026-09-25
+// (announced by email), so every agent still pointing at it will fail on each
+// run after that date. Kimi K3 is the Moonshot-named successor.
+//
+// Both model ids are hardcoded on purpose so this migration is a frozen
+// snapshot: it keeps working once the K2.6 config is removed from the codebase,
+// and won't silently change target if the "latest Kimi model" pointer moves.
+const FROM_MODEL_ID = "accounts/fireworks/models/kimi-k2p6";
+const TO_MODEL_ID = "accounts/fireworks/models/kimi-k3";
+
+// K2.6 thinking is binary (on/off), so none/light/medium/high all collapsed to
+// "thinking on or off" — there is no graded behavior to preserve here, unlike
+// the GLM-5.2 -> GLM-5.3 migration.
+//
+// What we must preserve is *runnability*. K2.6 is `balanced` at every effort
+// (model_tiers.ts), while K3 is `balanced` at `light` and `premium` at
+// medium/high. `checkModelTierAccess` denies a run whose tier is above the
+// member's cap, so mapping to medium/high would break every agent in a
+// workspace without premium access — and cost 4x input / 4.7x output
+// ($0.95/$4.00 -> $3.75/$18.75 per 1M) for the ones that still run.
+//
+// `light` also absorbs the stored `none` rows: K3 has no `none` (it always
+// thinks), and `resolveModel` would fall back to its `defaultReasoningEffort`,
+// which is `light` anyway. Setting it explicitly keeps the stored value honest.
+const TO_REASONING_EFFORT = "light";
+
+// `active` rows only, so version history keeps showing the model each version
+// actually ran on. Known gap: `restoreAgentConfiguration` un-archives the
+// latest row in place rather than writing a new version
+// (lib/api/assistant/configuration/agent.ts), so an agent deleted before this
+// migration and restored after 2026-09-25 comes back on a model Fireworks no
+// longer serves. Re-run this script (dropping the status filter) if that shows
+// up in support.
+const AgentConfigurationModelWithBypass: ModelStaticWorkspaceAware<AgentConfigurationModel> =
+  AgentConfigurationModel;
+
+makeScript({}, async ({ execute }, logger) => {
+  const agents = await AgentConfigurationModelWithBypass.findAll({
+    where: {
+      modelId: FROM_MODEL_ID,
+      status: "active",
+    },
+    // WORKSPACE_ISOLATION_BYPASS: Migration runs across all workspaces.
+    // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+    dangerouslyBypassWorkspaceIsolationSecurity: true,
+  });
+
+  const countByReasoningEffort = agents.reduce<Record<string, number>>(
+    (acc, agent) => {
+      const effort = agent.reasoningEffort ?? "null";
+      acc[effort] = (acc[effort] ?? 0) + 1;
+      return acc;
+    },
+    {}
+  );
+
+  logger.info(
+    {
+      count: agents.length,
+      countByReasoningEffort,
+      from: FROM_MODEL_ID,
+      to: TO_MODEL_ID,
+      reasoningEffort: TO_REASONING_EFFORT,
+    },
+    `Found ${agents.length} agent configurations on ${FROM_MODEL_ID}, migrating to ${TO_MODEL_ID}.`
+  );
+
+  for (const agent of agents) {
+    logger.info(
+      {
+        sId: agent.sId,
+        version: agent.version,
+        workspaceId: agent.workspaceId,
+        fromReasoningEffort: agent.reasoningEffort,
+      },
+      `Migrating agent ${agent.sId} (version ${agent.version}) from ${FROM_MODEL_ID} to ${TO_MODEL_ID}.`
+    );
+  }
+
+  if (execute && agents.length > 0) {
+    // Single batched UPDATE instead of one query per row
+    // (batch-database-queries). Scoped to the exact ids gathered above, so no
+    // workspace isolation bypass is needed (the cross-workspace scan happened
+    // in the findAll).
+    await AgentConfigurationModelWithBypass.update(
+      {
+        modelId: TO_MODEL_ID,
+        reasoningEffort: TO_REASONING_EFFORT,
+      },
+      { where: { id: agents.map((agent) => agent.id) } }
+    );
+  }
+
+  logger.info("Migration complete.");
+});

--- a/front/types/assistant/models/fireworks.ts
+++ b/front/types/assistant/models/fireworks.ts
@@ -364,6 +364,12 @@ export const FIREWORKS_KIMI_K3_MODEL_CONFIG: ModelConfigurationType = {
   useNativeLightReasoning: true,
   supportsResponseFormat: true,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  // Gated like the rest of the Fireworks fleet, and like the K2.6 it replaces:
+  // at $3.75/$18.75 per 1M it sits in the `premium` tier at medium/high, so it
+  // is opened per workspace rather than to everyone.
+  availableIfOneOf: {
+    featureFlag: "fireworks_new_model_feature",
+  },
   regionalAvailability: {
     "us-central1": true,
     "europe-west1": false,


### PR DESCRIPTION
## Description

Adds the repoint script for the Kimi K2.6 serverless endpoint Fireworks decommissions on 2026-09-25, and gates Kimi K3 behind `fireworks_new_model_feature` in both the model config and the router endpoint filter — K3 was the only Fireworks model besides GLM-5.3 left ungated, and K2.6 was gated in its config but not in its endpoint filter.

## Tests

`npm run test -- lib/model_constructors/providers/fireworks/models/kimi_k3.test.ts lib/assistant.test.ts types/assistant/models/model_tiers.test.ts` (57 passing). The migration is dry-run by default — run it without `--execute` first to see the per-effort counts.

## Risk

Workspaces without `fireworks_new_model_feature` that already have agents on K3 lose it: new messages silently resolve to another preferred large model, and any agent message whose resolution was persisted as K3 before the deploy fails with `AgentLoopDataModelNotFoundError` when it runs after. Check for K3 agents outside flagged workspaces before merging; migrated K2.6 agents are unaffected since K2.6 was already flag-gated.

## Deploy Plan

- Standard deploy, no schema migration needed
- Deploy `main` on `front`
- On Prodbox (US then EU), dry-run first: `npx tsx migrations/20260911_migrate_kimi_k2p6_to_kimi_k3.ts`
- Review the logged `countByReasoningEffort`, then re-run with `--execute`