### PR TITLE
Bump dust-base to 0.8.108 and dsbx to 0.1.58

### DIFF
--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base and sbx bedrock image tags", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.107",
+      tag: "0.8.108",
     });
     expect(getDustBaseImage().baseImage).toEqual({
       type: "docker",
@@ -484,7 +484,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.57/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.58/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,8 +26,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.11.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.107";
-const DSBX_CLI_VERSION = "0.1.57";
+const DUST_BASE_IMAGE_VERSION = "0.8.108";
+const DSBX_CLI_VERSION = "0.1.58";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
 // the stable identity used when creating the workload account.


### PR DESCRIPTION
## Description

Part 3 of 3, split out of #32188. Pins `dust-base` 0.8.108 and dsbx 0.1.58 in the sandbox image registry so sandboxes pick up the CLI from #32348, which talks to the endpoint from #32347.

Kept as a draft until the releases exist.

## Deploy Plan

1. Merge only after the `dsbx-v0.1.58` release workflow has run and `dust-base:0.8.108` is built.
2. Replace sandboxes running older dust-base versions so both conversation and Frame sandboxes receive the new CLI.
