### PR TITLE
[front] enh: allow sorting API keys by credits

### DIFF
--- a/front/components/workspace/api-keys/APIKeysTable.tsx
+++ b/front/components/workspace/api-keys/APIKeysTable.tsx
@@ -301,7 +301,7 @@ function buildColumns({
       id: "credits",
       accessorKey: "credits",
       header: "Credits",
-      enableSorting: false,
+      enableSorting: true,
       meta: { className: "h-16 w-32", headerAlign: "left" },
       cell: (info) => {
         const { credits, monthlyCap } = info.row.original;
@@ -611,6 +611,16 @@ export function APIKeysTable({
       switch (activeSort.id) {
         case "name":
           comparison = left.name.localeCompare(right.name);
+          break;
+        case "credits":
+          if (left.credits === null || right.credits === null) {
+            return left.credits === right.credits
+              ? 0
+              : left.credits === null
+                ? 1
+                : -1;
+          }
+          comparison = left.credits - right.credits;
           break;
         case "lastUsedAt":
           comparison = (left.lastUsedAt ?? 0) - (right.lastUsedAt ?? 0);


### PR DESCRIPTION
## Description

This PR allows sorting the API Keys table by consumed credits by clicking on the Credits header.
Unavailable values are kept at the bottom.

## Tests

- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
