### PR TITLE
feat(front): expose updatedAt and sort archived agents by it

### DIFF
--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -890,6 +890,10 @@
  *         versionCreatedAt:
  *           type: string
  *           nullable: true
+ *         updatedAt:
+ *           type: string
+ *           nullable: true
+ *           description: Timestamp of the last update to this agent configuration row. Used as a stand-in for `archivedAt` when the agent is archived.
  *         versionAuthorId:
  *           type: integer
  *           nullable: true

--- a/front-api/routes/v1/w/[wId]/swagger_schemas.ts
+++ b/front-api/routes/v1/w/[wId]/swagger_schemas.ts
@@ -158,6 +158,11 @@
  *           nullable: true
  *           description: Timestamp of when the version was created
  *           example: "2023-06-15T14:30:00Z"
+ *         updatedAt:
+ *           type: string
+ *           nullable: true
+ *           description: Timestamp of the last update to this agent configuration row. Used as a stand-in for `archivedAt` when the agent is archived.
+ *           example: "2023-06-15T14:30:00Z"
  *         versionAuthorId:
  *           type: string
  *           nullable: true

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -167,6 +167,12 @@ export function ManageAgentsPage() {
       a: LightAgentConfigurationType,
       b: LightAgentConfigurationType
     ) => a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+    // Archived agents are rarely touched again, so `updatedAt` doubles as their archival date;
+    // sorting by name isn't relevant once agents are archived.
+    const byUpdatedAtDesc = (
+      a: LightAgentConfigurationType,
+      b: LightAgentConfigurationType
+    ) => (b.updatedAt ?? "").localeCompare(a.updatedAt ?? "");
     const allAgents: LightAgentConfigurationType[] = agentConfigurations
       .filter(matchesFilters)
       .sort(byName);
@@ -192,7 +198,7 @@ export function ManageAgentsPage() {
       editable_by_me: filteredList(allAgents.filter((a) => a.canEdit)),
       global: filteredList(allAgents.filter((a) => a.scope === "global")),
       archived: filteredList(
-        archivedAgentConfigurations.filter(matchesFilters).sort(byName)
+        archivedAgentConfigurations.filter(matchesFilters).sort(byUpdatedAtDesc)
       ),
     };
   }, [

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1014,6 +1014,7 @@ export async function createAgentConfiguration(
       id: agent.id,
       sId: agent.sId,
       versionCreatedAt: agent.createdAt.toISOString(),
+      updatedAt: agent.updatedAt.toISOString(),
       version: agent.version,
       versionAuthorId: agent.authorId,
       scope: agent.scope,
@@ -1148,6 +1149,12 @@ type ArchiveAgentConfigurationOptions = {
   dangerouslySkipPermissionFiltering?: boolean;
 };
 
+/**
+ * @cc [owner:achilleburah,label:product;backend] archival-bumps-updated-at
+ * Archiving MUST update `AgentConfigurationModel.updatedAt`, since the Archived Agents view uses
+ * it as a stand-in for `archivedAt` (there is no dedicated column). Do not pass `{ silent: true }`
+ * or otherwise suppress the timestamp on the archival update.
+ */
 export async function archiveAgentConfiguration(
   auth: Authenticator,
   agentConfigurationId: string,

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -259,6 +259,7 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
       id: agent.id,
       sId: agent.sId,
       versionCreatedAt: agent.createdAt.toISOString(),
+      updatedAt: agent.updatedAt.toISOString(),
       version: agent.version,
       scope: agent.scope,
       userFavorite: !!favoriteStatePerAgent.get(agent.sId),

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -166,6 +166,9 @@ export type GlobalAgentContext = {
 export const LightAgentConfigurationSchema = z.object({
   id: DbModelIdSchema,
   versionCreatedAt: z.string().nullable(),
+  // Row `updatedAt`, exposed as a stand-in for `archivedAt` since archived agents are rarely
+  // touched again. Undefined for static global agents, which have no backing DB row.
+  updatedAt: z.string().nullable().optional(),
   sId: z.string(),
   version: z.number(),
   versionAuthorId: DbModelIdSchema.nullable(),


### PR DESCRIPTION
## Description

Small hack ahead of the Archived Agents view revamp: since archived agents are rarely touched again, `AgentConfigurationModel.updatedAt` (already bumped on archival) doubles as a stand-in `archivedAt`. This exposes it on `LightAgentConfigurationType` and switches the Archived Agents tab's default sort from alphabetical to `updatedAt` descending, since sorting archived agents by name isn't meaningful.

A real `archivedAt` column (and sorting UI) is left to the view revamp tracked in dust-tt/tasks#10356.

## Tests

- Verified with `tsgo --noEmit` that the modified files typecheck cleanly.
- Manually reasoned through the sort: `byUpdatedAtDesc` falls back to `""` for agents without `updatedAt` (global agents only, which can't be archived), so archived agents always sort correctly.

## Risk

Low. Additive, optional field on a shared response schema (`updatedAt?`), so no existing consumers break. The only behavior change is the default sort order of the Archived Agents tab.

## Deploy Plan

Standard deploy, no migration or feature flag needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)