### PR TITLE
Relocation exports every user the workspace references

### DIFF
--- a/front/temporal/relocation/activities/source_region/front/sql.ts
+++ b/front/temporal/relocation/activities/source_region/front/sql.ts
@@ -21,6 +21,7 @@ import {
 } from "@app/temporal/relocation/lib/file_storage/relocation";
 import { generateParameterizedInsertStatements } from "@app/temporal/relocation/lib/sql/insert";
 import { getTopologicalOrder } from "@app/temporal/relocation/lib/sql/schema/dependencies";
+import { getWorkspaceReferencedUserIds } from "@app/temporal/relocation/lib/sql/schema/introspection";
 import type { CellType } from "@app/types/cell";
 import type { ModelId } from "@app/types/shared/model_id";
 import assert from "assert";
@@ -59,11 +60,28 @@ export async function readCoreEntitiesFromSourceRegion({
     workspace: renderLightWorkspaceType({ workspace }),
   });
 
-  // Fetch all associated users of the workspace.
+  // Every user the workspace's rows point at, members included. The destination maps
+  // each of them to its own user by workOSUserId, or creates them, so no foreign key
+  // is left dangling by a reference to someone who is not a member.
+  const memberUserIds = memberships.map((m) => m.userId);
+  const referencedUserIds = await getWorkspaceReferencedUserIds(
+    frontSequelize,
+    {
+      workspaceId: workspace.id,
+    }
+  );
+  const userIds = [...new Set([...memberUserIds, ...referencedUserIds])];
+  localLogger.info(
+    {
+      memberCount: memberUserIds.length,
+      referencedOnlyCount: userIds.length - memberUserIds.length,
+    },
+    "[SQL Core Entities] Users to relocate."
+  );
   const users = await UserModel.findAll({
     where: {
       id: {
-        [Op.in]: memberships.map((m) => m.userId),
+        [Op.in]: userIds,
       },
     },
     // We need the raw SQL.

--- a/front/temporal/relocation/lib/sql/schema/introspection.ts
+++ b/front/temporal/relocation/lib/sql/schema/introspection.ts
@@ -1,4 +1,5 @@
 import logger from "@app/logger/logger";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Sequelize } from "sequelize";
 import { QueryTypes } from "sequelize";
 
@@ -83,4 +84,40 @@ export async function getUserReferencingColumns(
   );
 
   return result;
+}
+
+/**
+ * Every user id the workspace's rows point at, through the columns that reference
+ * users.id, whatever the table. Members are only part of it: a superuser acting from
+ * poke, a former member whose membership row is gone, an editor from another workspace
+ * all leave references the relocation has to carry.
+ */
+export async function getWorkspaceReferencedUserIds(
+  client: Sequelize,
+  { workspaceId }: { workspaceId: ModelId }
+): Promise<ModelId[]> {
+  const [userColumnsByTable, workspaceTables] = await Promise.all([
+    getUserReferencingColumns(client),
+    getTablesWithColumn(client, { columnName: "workspaceId" }),
+  ]);
+  const workspaceTableSet = new Set(workspaceTables);
+
+  const userIds = new Set<ModelId>();
+  for (const [table, columns] of Object.entries(userColumnsByTable)) {
+    if (!workspaceTableSet.has(table)) {
+      continue;
+    }
+    for (const column of columns) {
+      // Identifiers come from information_schema, not from user input.
+      const rows = await client.query<{ id: ModelId }>(
+        `SELECT DISTINCT "${column}" AS id FROM "${table}" WHERE "workspaceId" = :workspaceId AND "${column}" IS NOT NULL`,
+        { replacements: { workspaceId }, type: QueryTypes.SELECT }
+      );
+      for (const { id } of rows) {
+        userIds.add(id);
+      }
+    }
+  }
+
+  return [...userIds];
 }


### PR DESCRIPTION
## Description

A relocation ships the workspace's users by listing its memberships, then copies every other table row by row, rewriting `userId` columns through a mapping built from that same list. Anyone the rows point at who is not a member is invisible to both: a Dust superuser who created MCP server views from poke, a former member whose membership row is gone, an editor from another workspace. Their source id is copied as is, it does not exist in the destination, and the foreign key rejects the chunk. That is what stopped today's relocation, on `mcp_server_views.editedByUserId`, and needed a hand-patched mapping file to finish.

After this PR the source exports every user the workspace's rows reference. The destination already knows which columns point at `users.id`, it introspects the foreign keys to rewrite them, so the source runs the same introspection over the workspace-scoped tables, collects the distinct ids in those columns, and adds them to the members. The destination then maps each of them to its own user by `workOSUserId`, or inserts them, and no reference is left dangling. There is no list to maintain: a new column with a foreign key to users is covered the day it is added. User metadata still follows members only, that is per-user configuration and belongs to the people who use the workspace.

## Tests

`tsc` is clean on the touched files and biome passes. The introspection helper is the same query family the destination already runs in production, and the new step is one `SELECT DISTINCT` per user-referencing column of a workspace-scoped table, a few dozen small indexed queries at relocation start. The proof is the next relocation: the log line now says how many users were exported beyond the members, and a workspace touched from poke by a non-member relocates without a mapping patch.

## Risk

Relocation only, source side. It exports more users than before, never fewer, and the destination path is unchanged. A user exported this way who is absent from the destination is inserted with the source row, which is what a member gets today.

## Deploy Plan

Merge and deploy front to all cells, the relocation worker ships with it. No relocation is in flight.
