### PR TITLE
Platform-created MCP views name no superuser, flag toggles see their own writes

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1549,18 +1549,6 @@ export class Authenticator {
   }
 
   /**
-   * The user to record as the actor of a write, `editedByUserId` and friends. Those
-   * columns name a member of the workspace. A Dust superuser acting from poke is not
-   * one, so the write is the platform's and carries no user.
-   */
-  attributionUserId(): ModelId | null {
-    if (this._isDustSuperUser) {
-      return null;
-    }
-    return this._user?.id ?? null;
-  }
-
-  /**
    * Poke operator principal (email/name). Prefers the attached Dust user when
    * present; otherwise the Cloudflare Access principal stashed at auth time.
    */

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1549,6 +1549,18 @@ export class Authenticator {
   }
 
   /**
+   * The user to record as the actor of a write, `editedByUserId` and friends. Those
+   * columns name a member of the workspace. A Dust superuser acting from poke is not
+   * one, so the write is the platform's and carries no user.
+   */
+  attributionUserId(): ModelId | null {
+    if (this._isDustSuperUser) {
+      return null;
+    }
+    return this._user?.id ?? null;
+  }
+
+  /**
    * Poke operator principal (email/name). Prefers the attached Dust user when
    * present; otherwise the Cloudflare Access principal stashed at auth time.
    */

--- a/front/lib/resources/feature_flag_resource.ts
+++ b/front/lib/resources/feature_flag_resource.ts
@@ -14,8 +14,8 @@ import { RequestCachedQuery } from "@app/types/shared/utils/request_context";
 import type { LightWorkspaceType, WorkspaceType } from "@app/types/user";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
 
-// Feature flags are a stable snapshot for the request. Mutations become
-// visible on the next request.
+// Feature flags are a stable snapshot for the request. A mutation through this
+// resource refreshes the snapshot, so the same request reads what it just wrote.
 const listForWorkspaceQuery = new RequestCachedQuery<
   ModelId,
   FeatureFlagResource[]
@@ -157,6 +157,7 @@ export class FeatureFlagResource extends BaseResource<FeatureFlagModel> {
         }))
       );
       await FeatureFlagResource.listForWorkspaceCache.invalidate(workspace.id);
+      listForWorkspaceQuery.invalidate(workspace.id);
     }
   }
 
@@ -171,6 +172,7 @@ export class FeatureFlagResource extends BaseResource<FeatureFlagModel> {
       },
     });
     await FeatureFlagResource.listForWorkspaceCache.invalidate(workspace.id);
+    listForWorkspaceQuery.invalidate(workspace.id);
   }
 
   // Deletes every row for one flag name, whatever the workspace, and invalidates the affected

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -48,6 +48,7 @@ import {
   destroyAgentMCPServerConfigurationsForViews,
   destroyMCPServerViewDependencies,
 } from "@app/lib/resources/mcp_server_view_helper";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { RemoteMCPServerHeavyAttributeType } from "@app/lib/resources/remote_mcp_servers_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
@@ -1831,11 +1832,19 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
           .map((v) => [v.internalMCPServerId, v])
       );
 
-      // editedByUserId is only meaningful when a workspace admin triggers the creation
-      // (workspace creation, feature-flag toggle). Just-in-time hydration from a member
-      // read, or a superuser acting from poke, leaves it null: the views are platform-created
-      // and a non-member must never be named as editor, the relocation copies the reference.
-      const editedByUserId = auth.isAdmin() ? auth.attributionUserId() : null;
+      // editedByUserId names a member of the workspace who triggered the creation (workspace
+      // creation, feature-flag toggle). Just-in-time hydration from a member read, or a
+      // superuser acting from poke, leaves it null: the views are platform-created, and a
+      // non-member is never recorded because the relocation copies that reference.
+      const actor = auth.user();
+      const actorMembership =
+        auth.isAdmin() && actor
+          ? await MembershipResource.getActiveMembershipOfUserInWorkspace({
+              user: actor,
+              workspace,
+            })
+          : null;
+      const editedByUserId = actorMembership ? (actor?.id ?? null) : null;
 
       // Unlike MCPServerViewResource.create, this does not clean up regular-space views of
       // the same server when creating the global view. That case is only reachable on a

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -48,7 +48,6 @@ import {
   destroyAgentMCPServerConfigurationsForViews,
   destroyMCPServerViewDependencies,
 } from "@app/lib/resources/mcp_server_view_helper";
-import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { RemoteMCPServerHeavyAttributeType } from "@app/lib/resources/remote_mcp_servers_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
@@ -1832,19 +1831,14 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
           .map((v) => [v.internalMCPServerId, v])
       );
 
-      // editedByUserId names a member of the workspace who triggered the creation (workspace
-      // creation, feature-flag toggle). Just-in-time hydration from a member read, or a
-      // superuser acting from poke, leaves it null: the views are platform-created, and a
-      // non-member is never recorded because the relocation copies that reference.
-      const actor = auth.user();
-      const actorMembership =
-        auth.isAdmin() && actor
-          ? await MembershipResource.getActiveMembershipOfUserInWorkspace({
-              user: actor,
-              workspace,
-            })
+      // editedByUserId is only meaningful when a workspace admin triggers the creation
+      // (workspace creation, feature-flag toggle). A superuser acting from poke is not a
+      // member, and just-in-time hydration from a member read is not an admin action: both
+      // leave it null, the views are platform-created.
+      const editedByUserId =
+        auth.isAdmin() && !auth.isDustSuperUser()
+          ? (auth.user()?.id ?? null)
           : null;
-      const editedByUserId = actorMembership ? (actor?.id ?? null) : null;
 
       // Unlike MCPServerViewResource.create, this does not clean up regular-space views of
       // the same server when creating the global view. That case is only reachable on a

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -1831,10 +1831,11 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
           .map((v) => [v.internalMCPServerId, v])
       );
 
-      // editedByUserId is only meaningful when an admin triggers the creation (workspace
-      // creation, feature-flag toggle); just-in-time hydration from a member read leaves it
-      // null, the views are platform-created.
-      const editedByUserId = auth.isAdmin() ? (auth.user()?.id ?? null) : null;
+      // editedByUserId is only meaningful when a workspace admin triggers the creation
+      // (workspace creation, feature-flag toggle). Just-in-time hydration from a member
+      // read, or a superuser acting from poke, leaves it null: the views are platform-created
+      // and a non-member must never be named as editor, the relocation copies the reference.
+      const editedByUserId = auth.isAdmin() ? auth.attributionUserId() : null;
 
       // Unlike MCPServerViewResource.create, this does not clean up regular-space views of
       // the same server when creating the global view. That case is only reachable on a

--- a/front/types/shared/utils/request_context.test.ts
+++ b/front/types/shared/utils/request_context.test.ts
@@ -34,6 +34,22 @@ describe("RequestCachedQuery", () => {
     await expect(query.get("key", load)).resolves.toEqual({ load: 2 });
   });
 
+  it("reloads after invalidate within the same request", async () => {
+    const query = new RequestCachedQuery<string, number>();
+    let loadCount = 0;
+    const load = async () => ++loadCount;
+    const queryCache = new RequestQueryCache();
+
+    setRequestStorageResolver(() => ({ queryCache, requestContext }));
+
+    await expect(query.get("key", load)).resolves.toBe(1);
+    await expect(query.get("key", load)).resolves.toBe(1);
+
+    query.invalidate("key");
+    await expect(query.get("key", load)).resolves.toBe(2);
+    await expect(query.get("other", load)).resolves.toBe(3);
+  });
+
   it("does not cache when no request storage adapter is installed", async () => {
     const query = new RequestCachedQuery<string, number>();
     let loadCount = 0;

--- a/front/types/shared/utils/request_context.ts
+++ b/front/types/shared/utils/request_context.ts
@@ -36,6 +36,11 @@ export class RequestCachedQuery<Key, Value> {
     const cache = getRequestStorage()?.queryCache;
     return cache ? cache.get(this, key, query) : query();
   }
+
+  /** Forgets the memoized value for one key, so the next read in this request reloads. */
+  invalidate(key: Key): void {
+    getRequestStorage()?.queryCache.invalidate(this, key);
+  }
 }
 
 export class RequestQueryCache {
@@ -65,6 +70,13 @@ export class RequestQueryCache {
     const value = load();
     values.set(key, value);
     return value;
+  }
+
+  invalidate<Key, Value>(
+    query: RequestCachedQuery<Key, Value>,
+    key: Key
+  ): void {
+    this.valuesByQuery.get(query.cacheId)?.delete(key);
   }
 }
 


### PR DESCRIPTION
## Description

Two things about the Toggle Feature Flag plugin came out of a relocation failure, and both are wrong in a way nobody sees.

The plugin does not create the MCP server views it reports creating. Feature flags are a per-request snapshot: the plugin reads them to compute what to add, enables the flags, then asks for the views of every auto server the flags unlock. That read gets the stale snapshot, finds nothing new, and the plugin prints "created 0 views". The views appear later, created just in time by the first request that lists them, and stamped with that request's user. On a customer workspace that first request came from a superuser browsing it in poke, so the views were signed by an employee who is not a member of the workspace, and the relocation choked on that reference.

Two fixes. The flag resource owns the snapshot, so its mutators now refresh it: `enableMany` and `disableMany` evict the request entry along with the shared cache, and the plugin sees what it just wrote and creates the views itself, as intended. And attribution is a member's business: the auto view creation records the acting user only for a workspace admin who is not a Dust superuser, and null otherwise. A superuser acting from poke has the admin role forced on and is not a member, so nothing is recorded for them. Platform-created rows never name someone who is not in the workspace.

## Tests

The request cache gains an `invalidate` and a unit test covering it, the file's three tests pass. `tsc` is clean on the touched files and biome passes. The plugin behaviour is checked by hand after deploy: toggle a flag that unlocks an auto server on a test workspace, the plugin output should read "created 2 views" and the rows should carry a null `editedByUserId`.

## Risk

Poke and one write path in the MCP server view resource. The request cache change only affects readers in the same request as a flag mutation, who now see the new value, which is the behaviour every caller assumed anyway.

## Deploy Plan

Merge and deploy front to all cells.
