### PR TITLE
Add daily file viewer history

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -93,6 +93,7 @@ import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_sour
 import { FileSystemBlobCleanupModel } from "@app/lib/resources/storage/models/file_system_blob_cleanup";
 import { FileSystemMutationModel } from "@app/lib/resources/storage/models/file_system_mutation";
 import { FileSystemNodeModel } from "@app/lib/resources/storage/models/file_system_node";
+import { FileViewerDailyModel } from "@app/lib/resources/storage/models/file_viewer_daily";
 import {
   AuthorizedFileAccessModel,
   ExternalViewerSessionModel,
@@ -185,6 +186,7 @@ export function loadAllModels() {
     // FileSystemNodeModel first: files references it through fileSystemNodeId.
     FileSystemNodeModel,
     FileModel,
+    FileViewerDailyModel,
     FileSystemMutationModel,
     FileSystemBlobCleanupModel,
     SandboxFunctionModel,

--- a/front/lib/resources/storage/models/file_viewer_daily.ts
+++ b/front/lib/resources/storage/models/file_viewer_daily.ts
@@ -9,9 +9,8 @@ import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspa
 
 /**
  * @cc [owner:flvndvd,label:backend;concurrency] file-owned-viewer-history
- * Deleting a file MUST atomically remove its daily observations, including when
- * a concurrent reader records a view or an older server deletes the parent.
- * These rows own no external assets, so the file foreign key deliberately cascades.
+ * File and workspace foreign keys MUST restrict deletion while viewer rows remain.
+ * Cleanup MUST explicitly remove viewer rows before deleting their file or workspace.
  */
 export class FileViewerDailyModel extends WorkspaceAwareModel<FileViewerDailyModel> {
   declare createdAt: CreationOptional<Date>;
@@ -52,7 +51,7 @@ FileViewerDailyModel.init(
 
 FileModel.hasMany(FileViewerDailyModel, {
   foreignKey: { name: "fileId", allowNull: false },
-  onDelete: "CASCADE",
+  onDelete: "RESTRICT",
 });
 FileViewerDailyModel.belongsTo(FileModel, {
   foreignKey: { name: "fileId", allowNull: false },

--- a/front/lib/resources/storage/models/file_viewer_daily.ts
+++ b/front/lib/resources/storage/models/file_viewer_daily.ts
@@ -1,0 +1,59 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import type {
+  CreationOptional,
+  ForeignKey,
+} from "@app/lib/resources/storage/data_types";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
+import { FileModel } from "@app/lib/resources/storage/models/files";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+
+/**
+ * @cc [owner:flvndvd,label:backend;concurrency] file-owned-viewer-history
+ * Deleting a file MUST atomically remove its daily observations, including when
+ * a concurrent reader records a view or an older server deletes the parent.
+ * These rows own no external assets, so the file foreign key deliberately cascades.
+ */
+export class FileViewerDailyModel extends WorkspaceAwareModel<FileViewerDailyModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare fileId: ForeignKey<FileModel["id"]>;
+  declare email: string;
+  declare viewedOn: string;
+  declare firstViewedAt: Date;
+  declare lastViewedAt: Date;
+}
+
+FileViewerDailyModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    email: { type: DataTypes.STRING(255), allowNull: false },
+    viewedOn: { type: DataTypes.DATEONLY, allowNull: false },
+    firstViewedAt: { type: DataTypes.DATE, allowNull: false },
+    lastViewedAt: { type: DataTypes.DATE, allowNull: false },
+  },
+  {
+    modelName: "file_viewer_daily",
+    sequelize: frontSequelize,
+    indexes: [
+      { fields: ["workspaceId", "fileId", "email", "viewedOn"], unique: true },
+      { fields: ["fileId"], concurrently: true },
+    ],
+  }
+);
+
+FileModel.hasMany(FileViewerDailyModel, {
+  foreignKey: { name: "fileId", allowNull: false },
+  onDelete: "CASCADE",
+});
+FileViewerDailyModel.belongsTo(FileModel, {
+  foreignKey: { name: "fileId", allowNull: false },
+});

--- a/front/migrations/pre-deploy/20260911155553_file_viewer_daily.sql
+++ b/front/migrations/pre-deploy/20260911155553_file_viewer_daily.sql
@@ -69,7 +69,7 @@ Statement 112
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."file_viewer_dailies" ADD CONSTRAINT "file_viewer_dailies_fileId_fkey" FOREIGN KEY ("fileId") REFERENCES files(id) ON UPDATE CASCADE ON DELETE CASCADE NOT VALID;
+ALTER TABLE "public"."file_viewer_dailies" ADD CONSTRAINT "file_viewer_dailies_fileId_fkey" FOREIGN KEY ("fileId") REFERENCES files(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
 
 /*
 Statement 113

--- a/front/migrations/pre-deploy/20260911155553_file_viewer_daily.sql
+++ b/front/migrations/pre-deploy/20260911155553_file_viewer_daily.sql
@@ -1,0 +1,93 @@
+-- Generated with migration:generate:pre-deploy; scoped to this model change.
+
+/*
+Statement 7
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE SEQUENCE "public"."file_viewer_dailies_id_seq"
+	AS bigint
+	INCREMENT BY 1
+	MINVALUE 1 MAXVALUE 9223372036854775807
+	START WITH 1 CACHE 1 NO CYCLE
+;
+
+/*
+Statement 36
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE TABLE "public"."file_viewer_dailies" (
+	"createdAt" timestamp with time zone NOT NULL,
+	"updatedAt" timestamp with time zone NOT NULL,
+	"firstViewedAt" timestamp with time zone NOT NULL,
+	"lastViewedAt" timestamp with time zone NOT NULL,
+	"workspaceId" bigint NOT NULL,
+	"id" bigint DEFAULT nextval('file_viewer_dailies_id_seq'::regclass) NOT NULL,
+	"fileId" bigint NOT NULL,
+	"viewedOn" date NOT NULL,
+	"email" character varying(255) COLLATE "pg_catalog"."default" NOT NULL
+);
+
+/*
+Statement 37
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY file_viewer_dailies_pkey ON public.file_viewer_dailies USING btree (id);
+
+/*
+Statement 38
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."file_viewer_dailies" ADD CONSTRAINT "file_viewer_dailies_pkey" PRIMARY KEY USING INDEX "file_viewer_dailies_pkey";
+
+/*
+Statement 39
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY file_viewer_dailies_file_id ON public.file_viewer_dailies USING btree ("fileId");
+
+/*
+Statement 40
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY file_viewer_dailies_workspace_id_file_id_email_viewed_on ON public.file_viewer_dailies USING btree ("workspaceId", "fileId", email, "viewedOn");
+
+/*
+Statement 41
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER SEQUENCE "public"."file_viewer_dailies_id_seq" OWNED BY "public"."file_viewer_dailies"."id";
+
+/*
+Statement 112
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."file_viewer_dailies" ADD CONSTRAINT "file_viewer_dailies_fileId_fkey" FOREIGN KEY ("fileId") REFERENCES files(id) ON UPDATE CASCADE ON DELETE CASCADE NOT VALID;
+
+/*
+Statement 113
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."file_viewer_dailies" VALIDATE CONSTRAINT "file_viewer_dailies_fileId_fkey";
+
+/*
+Statement 188
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."file_viewer_dailies" ADD CONSTRAINT "file_viewer_dailies_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES workspaces(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 189
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."file_viewer_dailies" VALIDATE CONSTRAINT "file_viewer_dailies_workspaceId_fkey";


### PR DESCRIPTION
## Description

Since we released frame sharing with external email addresses, people have consistently asked for domain support. Sharing with `david.co` brings back an early data-model decision: we store viewer activity on the access grant itself.

That worked when one grant represented one email address. With a domain grant, Alice and Bob share the same access rule, but we still want to know who opened the file and how often each person returned.

This first PR starts separating grants from analytics with a file-level viewer history table. It stores first and last view timestamps per email and day, which lets us derive each person's first and last recorded views and days viewed. Daily rows retain useful frequency without storing every opening, and file ownership keeps history independent of grant changes.

Both foreign keys restrict deletion. File ID updates are restricted, while workspace ID updates keep the existing cascade behavior. Follow-up PRs will wire up recording, explicit cleanup, domain access and the sharing UI.

## Tests

Applied the migration to a disposable local database and verified daily uniqueness, separate viewers and days, restricted file ID updates, cascading workspace ID updates, and that file deletion requires explicit viewer cleanup. Formatting passes. Local typechecking reports the same dependency errors on main.

## Risk

Low. The new table is unused, and the migration leaves existing constraints unchanged. Application rollback can leave the table in place.

## Deploy Plan

Run the pre-deploy migration before deploying.
