### PR TITLE
feat: add batch update for tool stakes settings

### DIFF
--- a/front-api/routes/w/[wId]/mcp/[serverId]/tools/index.test.ts
+++ b/front-api/routes/w/[wId]/mcp/[serverId]/tools/index.test.ts
@@ -1,0 +1,209 @@
+import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+async function setup(role: MembershipRoleType = "admin") {
+  const { workspace, auth, systemSpace } = await createPrivateApiMockRequest({
+    role,
+  });
+  return { workspace, space: systemSpace, auth };
+}
+
+function batchToolsUrl(wId: string, serverId: string) {
+  return `/api/w/${wId}/mcp/${serverId}/tools`;
+}
+
+describe("PATCH /api/w/:wId/mcp/:serverId/tools (batch update)", () => {
+  it("should batch update multiple tool settings", async () => {
+    const { workspace, auth } = await setup();
+
+    const server = await RemoteMCPServerFactory.create(workspace);
+
+    const response = await honoApp.request(
+      batchToolsUrl(workspace.sId, server.sId),
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tools: [
+            { toolName: "tool1", permission: "low", enabled: true },
+            { toolName: "tool2", permission: "never_ask", enabled: false },
+            { toolName: "tool3", permission: "high", enabled: true },
+          ],
+        }),
+      }
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toHaveProperty("success", true);
+    expect(data).toHaveProperty("updatedCount", 3);
+
+    // Verify the settings were persisted.
+    const metadata = await RemoteMCPServerToolMetadataResource.fetchByServerId(
+      auth,
+      server.sId
+    );
+
+    expect(metadata).toHaveLength(3);
+
+    const tool1 = metadata.find((m) => m.toolName === "tool1");
+    expect(tool1).toBeDefined();
+    expect(tool1?.permission).toBe("low");
+    expect(tool1?.enabled).toBe(true);
+
+    const tool2 = metadata.find((m) => m.toolName === "tool2");
+    expect(tool2).toBeDefined();
+    expect(tool2?.permission).toBe("never_ask");
+    expect(tool2?.enabled).toBe(false);
+
+    const tool3 = metadata.find((m) => m.toolName === "tool3");
+    expect(tool3).toBeDefined();
+    expect(tool3?.permission).toBe("high");
+    expect(tool3?.enabled).toBe(true);
+  });
+
+  it("should update existing tool settings", async () => {
+    const { workspace, auth } = await setup();
+
+    const server = await RemoteMCPServerFactory.create(workspace);
+
+    // Create initial settings.
+    await RemoteMCPServerToolMetadataResource.updateOrCreateSettings(auth, {
+      serverSId: server.sId,
+      toolName: "existingTool",
+      permission: "high",
+      enabled: true,
+    });
+
+    // Batch update should update the existing tool.
+    const response = await honoApp.request(
+      batchToolsUrl(workspace.sId, server.sId),
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tools: [
+            { toolName: "existingTool", permission: "low", enabled: false },
+          ],
+        }),
+      }
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toHaveProperty("success", true);
+    expect(data).toHaveProperty("updatedCount", 1);
+
+    // Verify the settings were updated.
+    const metadata = await RemoteMCPServerToolMetadataResource.fetchByServerId(
+      auth,
+      server.sId
+    );
+
+    expect(metadata).toHaveLength(1);
+    expect(metadata[0].toolName).toBe("existingTool");
+    expect(metadata[0].permission).toBe("low");
+    expect(metadata[0].enabled).toBe(false);
+  });
+
+  it("should return 400 when tools array is empty", async () => {
+    const { workspace } = await setup();
+
+    const server = await RemoteMCPServerFactory.create(workspace);
+
+    const response = await honoApp.request(
+      batchToolsUrl(workspace.sId, server.sId),
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ tools: [] }),
+      }
+    );
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error.message).toContain("Validation error:");
+  });
+
+  it("should return 400 when body is missing tools field", async () => {
+    const { workspace } = await setup();
+
+    const server = await RemoteMCPServerFactory.create(workspace);
+
+    const response = await honoApp.request(
+      batchToolsUrl(workspace.sId, server.sId),
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }
+    );
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error.message).toContain("Validation error:");
+  });
+
+  it("should return 400 when tool has invalid permission", async () => {
+    const { workspace } = await setup();
+
+    const server = await RemoteMCPServerFactory.create(workspace);
+
+    const response = await honoApp.request(
+      batchToolsUrl(workspace.sId, server.sId),
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tools: [{ toolName: "tool1", permission: "invalid", enabled: true }],
+        }),
+      }
+    );
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error.message).toContain("Validation error:");
+  });
+
+  it("should return 401 when user is not admin", async () => {
+    const { workspace } = await setup("user");
+
+    const server = await RemoteMCPServerFactory.create(workspace);
+
+    const response = await honoApp.request(
+      batchToolsUrl(workspace.sId, server.sId),
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tools: [{ toolName: "tool1", permission: "low", enabled: true }],
+        }),
+      }
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("should return 400 for invalid server ID", async () => {
+    const { workspace } = await setup();
+
+    const response = await honoApp.request(
+      batchToolsUrl(workspace.sId, "invalid-server-id"),
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tools: [{ toolName: "tool1", permission: "low", enabled: true }],
+        }),
+      }
+    );
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error.message).toBe("Invalid server ID.");
+  });
+});

--- a/front-api/routes/w/[wId]/mcp/[serverId]/tools/index.ts
+++ b/front-api/routes/w/[wId]/mcp/[serverId]/tools/index.ts
@@ -1,9 +1,73 @@
+import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
+import type { BatchUpdateMCPToolSettingsResponseBody } from "@app/lib/api/mcp";
+import { BatchUpdateMCPToolSettingsBodySchema } from "@app/lib/api/mcp_schemas";
+import { DustError } from "@app/lib/error";
+import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsUser } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 import tool from "./[toolName]";
 
+const ParamsSchema = z.object({
+  serverId: z.string(),
+});
+
 // Mounted under /api/w/:wId/mcp/:serverId/tools.
 const app = workspaceApp();
+
+/** @ignoreswagger */
+app.patch(
+  "/",
+  validate("param", ParamsSchema),
+  ensureIsUser(),
+  validate("json", BatchUpdateMCPToolSettingsBodySchema),
+  async (ctx): HandlerResult<BatchUpdateMCPToolSettingsResponseBody> => {
+    const auth = ctx.get("auth");
+    const { serverId } = ctx.req.valid("param");
+
+    try {
+      getServerTypeAndIdFromSId(serverId);
+    } catch {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid server ID.",
+        },
+      });
+    }
+
+    const { tools } = ctx.req.valid("json");
+
+    try {
+      const updatedTools =
+        await RemoteMCPServerToolMetadataResource.batchUpdateOrCreateSettings(
+          auth,
+          {
+            serverSId: serverId,
+            tools,
+          }
+        );
+
+      return ctx.json({ success: true, updatedCount: updatedTools.length });
+    } catch (error) {
+      if (error instanceof DustError && error.code === "unauthorized") {
+        return apiError(ctx, {
+          status_code: 401,
+          api_error: {
+            type: "not_authenticated",
+            message: error.message,
+          },
+        });
+      }
+      throw error;
+    }
+  }
+);
 
 app.route("/:toolName", tool);
 

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -210,26 +210,26 @@ export function MCPServerDetails({
       permission: string;
     }>
   ) => {
-    for (const change of toolChanges) {
-      const response = await clientFetch(
-        `/api/w/${owner.sId}/mcp/${mcpServerView?.server.sId}/tools/${change.toolName}`,
-        {
-          method: "PATCH",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
+    // Use batch endpoint for efficiency when updating multiple tools.
+    const response = await clientFetch(
+      `/api/w/${owner.sId}/mcp/${mcpServerView?.server.sId}/tools`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          tools: toolChanges.map((change) => ({
+            toolName: change.toolName,
             permission: change.permission,
             enabled: change.enabled,
-          }),
-        }
-      );
-      if (!response.ok) {
-        const body = await response.json();
-        throw new Error(
-          body.error?.message ?? "Failed to update tool settings"
-        );
+          })),
+        }),
       }
+    );
+    if (!response.ok) {
+      const body = await response.json();
+      throw new Error(body.error?.message ?? "Failed to update tool settings");
     }
   };
 

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -27,7 +27,7 @@ import {
   DropdownMenuTrigger,
   InfoCircle,
 } from "@dust-tt/sparkle";
-import { memo } from "react";
+import { memo, useCallback } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 
 interface ToolsListProps {
@@ -70,13 +70,6 @@ function ToolItem({
     });
   };
 
-  const toolPermissionLabel: Record<MCPToolStakeLevelType, string> = {
-    high: "High (always ask for confirmation)",
-    medium: "Medium (allows input-scoped confirmation save)",
-    low: "Low (allows user-global confirmation save)",
-    never_ask: "Never ask (automatic execution)",
-  };
-
   return (
     <div className="flex flex-col gap-1 pb-2">
       <div className="flex items-center gap-2">
@@ -108,7 +101,7 @@ function ToolItem({
               >
                 <Button
                   variant="outline"
-                  label={toolPermissionLabel[toolPermission]}
+                  label={STAKE_LEVEL_LABELS[toolPermission]}
                   isSelect
                 />
               </DropdownMenuTrigger>
@@ -117,7 +110,7 @@ function ToolItem({
                   <DropdownMenuItem
                     key={permission}
                     onClick={() => handlePermissionChange(permission)}
-                    label={toolPermissionLabel[permission]}
+                    label={STAKE_LEVEL_LABELS[permission]}
                     disabled={!toolEnabled}
                   />
                 ))}
@@ -153,6 +146,20 @@ function getDefaultToolSettings({
 
 const noop = () => {};
 
+const STAKE_LEVEL_LABELS: Record<MCPToolStakeLevelType, string> = {
+  high: "High (always ask for confirmation)",
+  medium: "Medium (allows input-scoped confirmation save)",
+  low: "Low (allows user-global confirmation save)",
+  never_ask: "Never ask (automatic execution)",
+};
+
+const STAKE_LEVEL_SHORT_LABELS: Record<MCPToolStakeLevelType, string> = {
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+  never_ask: "Never ask",
+};
+
 // We disable buttons for agent builder view because it would feel like
 // you can configure per agent
 export const ToolsList = memo(
@@ -172,9 +179,79 @@ export const ToolsList = memo(
       )
     );
 
+    // Handler to set all tools to a specific stake level.
+    const handleSetAllStakeLevel = useCallback(
+      (permission: MCPToolStakeLevelType) => {
+        if (!tools || disableUpdates) {
+          return;
+        }
+        for (const tool of tools) {
+          const fieldName =
+            `toolSettings.${encodeMCPToolNameForForm(tool.name)}` as const;
+          const currentSettings = formContext.getValues(fieldName);
+          const defaultSettings = getDefaultToolSettings({
+            tool,
+            toolMetadataByName,
+            mcpServerView,
+          });
+          const settings = currentSettings ?? defaultSettings;
+          // Only update if the tool supports this stake level.
+          const supportsLevel =
+            permission !== "medium" ||
+            canToolUseMediumStakeLevel(mcpServerView.server, tool.name);
+          if (supportsLevel) {
+            formContext.setValue(
+              fieldName,
+              { ...settings, permission },
+              { shouldDirty: true }
+            );
+          }
+        }
+      },
+      [tools, disableUpdates, formContext, toolMetadataByName, mcpServerView]
+    );
+
+    // Handler to enable/disable all tools at once.
+    const handleSetAllEnabled = useCallback(
+      (enabled: boolean) => {
+        if (!tools || disableUpdates) {
+          return;
+        }
+        for (const tool of tools) {
+          const fieldName =
+            `toolSettings.${encodeMCPToolNameForForm(tool.name)}` as const;
+          const currentSettings = formContext.getValues(fieldName);
+          const defaultSettings = getDefaultToolSettings({
+            tool,
+            toolMetadataByName,
+            mcpServerView,
+          });
+          const settings = currentSettings ?? defaultSettings;
+          formContext.setValue(
+            fieldName,
+            { ...settings, enabled },
+            { shouldDirty: true }
+          );
+        }
+      },
+      [tools, disableUpdates, formContext, toolMetadataByName, mcpServerView]
+    );
+
     if (!tools || tools.length === 0) {
       return null;
     }
+
+    // Only show batch controls when there are multiple tools.
+    const showBatchControls = mayUpdate && tools.length > 1;
+
+    // Available stake levels for batch update (exclude medium if no tool supports it).
+    const batchStakeLevels = MCP_TOOL_STAKE_LEVELS.filter(
+      (stakeLevel) =>
+        stakeLevel !== "medium" ||
+        tools.some((tool) =>
+          canToolUseMediumStakeLevel(mcpServerView.server, tool.name)
+        )
+    );
 
     return (
       <Collapsible defaultOpen={tools.length <= 5}>
@@ -207,6 +284,53 @@ export const ToolsList = memo(
                 </li>
               </ul>
             </ContentMessage>
+
+            {showBatchControls && (
+              <div className="mb-4 flex items-center gap-2">
+                <span className="text-sm text-muted-foreground">
+                  Batch actions:
+                </span>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      label="Set all stakes to..."
+                      isSelect
+                    />
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent>
+                    {batchStakeLevels.map((level) => (
+                      <DropdownMenuItem
+                        key={level}
+                        onClick={() => handleSetAllStakeLevel(level)}
+                        label={STAKE_LEVEL_SHORT_LABELS[level]}
+                      />
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      label="Toggle all..."
+                      isSelect
+                    />
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent>
+                    <DropdownMenuItem
+                      onClick={() => handleSetAllEnabled(true)}
+                      label="Enable all"
+                    />
+                    <DropdownMenuItem
+                      onClick={() => handleSetAllEnabled(false)}
+                      label="Disable all"
+                    />
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            )}
 
             <div className="flex flex-col gap-4">
               {tools.map((tool) => {

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -19,6 +19,7 @@ import {
 } from "@app/lib/actions/types/guards";
 import type { MCPServersUsage } from "@app/lib/api/agent_actions";
 import type {
+  BatchUpdateMCPToolSettingsBodySchema,
   PatchMCPServerBodySchema,
   PostRequestActionsAccessBodySchema,
   UpdateMCPToolSettingsBodySchema,
@@ -286,6 +287,15 @@ export type PatchMCPServerToolsPermissionsResponseBody = {
   success: boolean;
 };
 
+export type BatchUpdateMCPToolSettingsResponseBody = {
+  success: boolean;
+  updatedCount: number;
+};
+
 export type UpdateMCPToolSettingsBodyType = z.infer<
   typeof UpdateMCPToolSettingsBodySchema
+>;
+
+export type BatchUpdateMCPToolSettingsBodyType = z.infer<
+  typeof BatchUpdateMCPToolSettingsBodySchema
 >;

--- a/front/lib/api/mcp_schemas.ts
+++ b/front/lib/api/mcp_schemas.ts
@@ -125,3 +125,17 @@ export const UpdateMCPToolSettingsBodySchema = z
       message: "At least one of 'permission' or 'enabled' must be provided.",
     }
   );
+
+// Schema for individual tool settings in batch update.
+const BatchToolSettingSchema = z.object({
+  toolName: z.string().min(1, "Tool name is required."),
+  permission: z.enum(MCP_TOOL_STAKE_LEVELS),
+  enabled: z.boolean(),
+});
+
+// Schema for batch updating multiple tool settings at once.
+export const BatchUpdateMCPToolSettingsBodySchema = z.object({
+  tools: z
+    .array(BatchToolSettingSchema)
+    .min(1, "At least one tool is required."),
+});

--- a/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
+++ b/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
@@ -138,6 +138,54 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
     return new this(this.model, toolMetadata.get());
   }
 
+  static async batchUpdateOrCreateSettings(
+    auth: Authenticator,
+    {
+      serverSId,
+      tools,
+    }: {
+      serverSId: string;
+      tools: Array<{
+        toolName: string;
+        permission: MCPToolStakeLevelType;
+        enabled: boolean;
+      }>;
+    }
+  ): Promise<RemoteMCPServerToolMetadataResource[]> {
+    const canAdministrate =
+      await SpaceResource.canAdministrateSystemSpace(auth);
+
+    if (!canAdministrate) {
+      throw new DustError(
+        "unauthorized",
+        "The user is not authorized to update tool metadata"
+      );
+    }
+
+    const { serverType, id: serverId } = getServerTypeAndIdFromSId(serverSId);
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const results: RemoteMCPServerToolMetadataResource[] = [];
+
+    // Use upsert for each tool. The model has two separate unique indexes
+    // (for remote vs internal servers), so bulkCreate with updateOnDuplicate
+    // doesn't work cleanly. Upsert handles the conflict detection correctly.
+    for (const tool of tools) {
+      const [toolMetadata] = await this.model.upsert({
+        ...(serverType === "remote"
+          ? { remoteMCPServerId: serverId }
+          : { internalMCPServerId: serverSId }),
+        toolName: tool.toolName,
+        permission: tool.permission,
+        enabled: tool.enabled,
+        workspaceId,
+      });
+      results.push(new this(this.model, toolMetadata.get()));
+    }
+
+    return results;
+  }
+
   // Deletes tool metadata for tools that are not in the list
   static async deleteStaleTools(
     auth: Authenticator,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR adds batch-update functionality for tool stakes settings in MCP servers, making it practical to configure tools in bulk for MCPs with many tools (50+).

## Changes

### Backend
- **New batch endpoint**: `PATCH /api/w/:wId/mcp/:serverId/tools` accepts an array of tool settings to update multiple tools in a single request
- **New schema**: `BatchUpdateMCPToolSettingsBodySchema` for validating batch requests
- **New resource method**: `batchUpdateOrCreateSettings` on `RemoteMCPServerToolMetadataResource` for efficient batch updates
- **Updated form submission**: `MCPServerDetails` now uses the batch endpoint instead of sending individual requests for each tool change

### Frontend
- **Batch actions UI**: When there are 2+ tools, the ToolsList component now displays "Set all stakes to..." and "Toggle all..." dropdowns
- **Set all stakes to...**: Allows setting all tool stake levels to High, Medium (if applicable), Low, or Never ask in one click
- **Toggle all...**: Enables or disables all tools at once

## Testing
- Added 7 comprehensive tests for the new batch endpoint covering:
  - Successful batch updates
  - Updating existing tool settings
  - Validation errors (empty array, missing fields, invalid permission)
  - Authorization (non-admin users)
  - Invalid server IDs

All MCP tests pass (72 tests total).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1789141259968539?thread_ts=1789141259.968539&cid=C050A0S2Z7F)

<div><a href="https://cursor.com/agents/bc-b468b1d7-59c9-574d-bd1c-1c0879248303?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b468b1d7-59c9-574d-bd1c-1c0879248303&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

