### PR TITLE
LLM models: revert flag gating for Kimi 3

### DIFF
--- a/front/lib/llms/stream/endpoints/moonshot_ai_kimi_k3_global_fireworks.ts
+++ b/front/lib/llms/stream/endpoints/moonshot_ai_kimi_k3_global_fireworks.ts
@@ -5,11 +5,7 @@ import { MoonshotAiKimiK3GlobalFireworksStream } from "@app/lib/model_constructo
 export class DustMoonshotAiKimiK3GlobalFireworksStream extends WithDustMoonshotAiKimiK3Config(
   MoonshotAiKimiK3GlobalFireworksStream
 ) {
-  // Mirrors `availableIfOneOf` on FIREWORKS_KIMI_K3_MODEL_CONFIG: the legacy
-  // config gates the model picker, this gates the router.
-  static readonly endpointFilter = {
-    featureFlags: { contains: "fireworks_new_model_feature" as const },
-  };
+  static readonly endpointFilter = {};
 }
 
 defineDustStreamEndpoint(DustMoonshotAiKimiK3GlobalFireworksStream);

--- a/front/types/assistant/models/fireworks.ts
+++ b/front/types/assistant/models/fireworks.ts
@@ -364,12 +364,6 @@ export const FIREWORKS_KIMI_K3_MODEL_CONFIG: ModelConfigurationType = {
   useNativeLightReasoning: true,
   supportsResponseFormat: true,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
-  // Gated like the rest of the Fireworks fleet, and like the K2.6 it replaces:
-  // at $3.75/$18.75 per 1M it sits in the `premium` tier at medium/high, so it
-  // is opened per workspace rather than to everyone.
-  availableIfOneOf: {
-    featureFlag: "fireworks_new_model_feature",
-  },
   regionalAvailability: {
     "us-central1": true,
     "europe-west1": false,


### PR DESCRIPTION
## Description

revert flag part of https://github.com/dust-tt/dust/pull/32345
model was not previously flag gated and many agents are using in workspaces without the flag.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://app.notion.com/p/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

expose Kimi 3 to everybody, as it was before previous PR

## Deploy Plan

deploy front
