### PR TITLE
[front] Handle sandbox Unicode database errors

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
@@ -3,9 +3,14 @@ import {
   isSandboxFunctionInvocationTokenPayload,
 } from "@app/lib/api/sandbox/access_tokens";
 import { createSandboxChildAction } from "@app/lib/api/sandbox/create_child_action";
+import {
+  isUnsupportedUnicodeDatabaseError,
+  SANDBOX_UNSUPPORTED_UNICODE_ERROR_MESSAGE,
+} from "@app/lib/api/sandbox/errors";
 import { createSandboxFunctionMCPAction } from "@app/lib/api/sandbox_functions/create_sandbox_function_mcp_action";
 import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { CallMCPToolRequestBodySchema } from "@dust-tt/client";
 import { sandboxApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -61,14 +66,35 @@ app.post(
         });
       }
 
-      const result = await createSandboxFunctionMCPAction(auth, {
-        sandboxFunctionId: claims.sandboxFunctionId,
-        invocationId: claims.invocationId,
-        runtimeSpaceId: claims.spaceId,
-        serverViewId,
-        toolName,
-        rawInputs: toolArgs ?? {},
-      });
+      let result: Awaited<
+        ReturnType<typeof createSandboxFunctionMCPAction>
+      >;
+      try {
+        result = await createSandboxFunctionMCPAction(auth, {
+          sandboxFunctionId: claims.sandboxFunctionId,
+          invocationId: claims.invocationId,
+          runtimeSpaceId: claims.spaceId,
+          serverViewId,
+          toolName,
+          rawInputs: toolArgs ?? {},
+        });
+      } catch (error) {
+        if (!isUnsupportedUnicodeDatabaseError(error)) {
+          throw error;
+        }
+
+        return apiError(
+          ctx,
+          {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: SANDBOX_UNSUPPORTED_UNICODE_ERROR_MESSAGE,
+            },
+          },
+          normalizeError(error)
+        );
+      }
 
       if (result.isErr()) {
         switch (result.error.type) {
@@ -111,16 +137,35 @@ app.post(
       });
     }
 
-    const result = await createSandboxChildAction(auth, {
-      parentActionId: claims.actionId,
-      agentId: claims.aId,
-      agentVersion: claims.aV,
-      conversationId: claims.cId,
-      agentMessageId: claims.mId,
-      serverViewId,
-      toolName,
-      rawInputs: toolArgs ?? {},
-    });
+    let result: Awaited<ReturnType<typeof createSandboxChildAction>>;
+    try {
+      result = await createSandboxChildAction(auth, {
+        parentActionId: claims.actionId,
+        agentId: claims.aId,
+        agentVersion: claims.aV,
+        conversationId: claims.cId,
+        agentMessageId: claims.mId,
+        serverViewId,
+        toolName,
+        rawInputs: toolArgs ?? {},
+      });
+    } catch (error) {
+      if (!isUnsupportedUnicodeDatabaseError(error)) {
+        throw error;
+      }
+
+      return apiError(
+        ctx,
+        {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: SANDBOX_UNSUPPORTED_UNICODE_ERROR_MESSAGE,
+          },
+        },
+        normalizeError(error)
+      );
+    }
 
     if (result.isErr()) {
       logger.error(

--- a/front/lib/api/sandbox/errors.test.ts
+++ b/front/lib/api/sandbox/errors.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { isUnsupportedUnicodeDatabaseError } from "./errors";
+
+describe("isUnsupportedUnicodeDatabaseError", () => {
+  it.each([
+    { code: "22P05" },
+    { original: { code: "22P05" } },
+    { parent: { code: "22P05" } },
+  ])("recognizes a PostgreSQL 22P05 error: %j", (error) => {
+    expect(isUnsupportedUnicodeDatabaseError(error)).toBe(true);
+  });
+
+  it("does not classify unrelated errors", () => {
+    expect(
+      isUnsupportedUnicodeDatabaseError({
+        original: { code: "23505" },
+        message: "duplicate key value violates unique constraint",
+      })
+    ).toBe(false);
+  });
+});

--- a/front/lib/api/sandbox/errors.ts
+++ b/front/lib/api/sandbox/errors.ts
@@ -17,3 +17,34 @@ export function isSandboxNotRunningError(
 ): error is SandboxNotRunningError {
   return error instanceof SandboxNotRunningError;
 }
+
+/** PostgreSQL's invalid Unicode JSON/JSONB payload error code. */
+const POSTGRES_UNSUPPORTED_UNICODE_ERROR_CODE = "22P05";
+
+export const SANDBOX_UNSUPPORTED_UNICODE_ERROR_MESSAGE =
+  "Tool arguments contain unsupported Unicode characters.";
+
+type DatabaseErrorLike = {
+  code?: unknown;
+  original?: { code?: unknown };
+  parent?: { code?: unknown };
+};
+
+/**
+ * Detects the PostgreSQL error raised when a JSON/JSONB value contains an invalid Unicode
+ * escape or a null byte. Sequelize may expose the PostgreSQL code at different nesting levels.
+ */
+export function isUnsupportedUnicodeDatabaseError(
+  error: unknown
+): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const databaseError = error as DatabaseErrorLike;
+  return [
+    databaseError.code,
+    databaseError.original?.code,
+    databaseError.parent?.code,
+  ].includes(POSTGRES_UNSUPPORTED_UNICODE_ERROR_CODE);
+}


### PR DESCRIPTION
## Description

Map PostgreSQL `22P05` Unicode/JSONB errors raised while creating sandbox actions to the existing controlled `400 invalid_request_error` response instead of allowing them to escape as unhandled API `500`s. The original database error remains available in internal API error logs. This covers both conversation sandbox child actions and sandbox function invocations.

## Tests

- Added focused unit coverage for PostgreSQL `22P05` errors exposed at the root, `original`, and `parent` Sequelize error levels.
- `git diff --check` passes locally.
- Full Vitest and TypeScript checks were not run locally because this checkout has no installed `node_modules` or local test runner. Final validation is delegated to PR CI.

## Risk

Low. The change only affects the sandbox action API's handling of this specific PostgreSQL error code. Other unexpected errors continue through the existing unhandled-error path. The input payload is not modified. Rollback is a single front deployment rollback.

## Deploy Plan

Deploy front normally. After deployment, monitor the sandbox action route and the PostgreSQL `22P05` / `unsupported Unicode escape sequence` error rate. Confirm that malformed payloads return controlled `400` responses and no longer produce `Unhandled API Error` entries. Roll back the front deployment if unexpected behavior is observed.