### PR TITLE
fix(oauth): preserve static MCP callback provider

### DIFF
--- a/front/lib/api/oauth/providers/mcp.test.ts
+++ b/front/lib/api/oauth/providers/mcp.test.ts
@@ -1,4 +1,5 @@
 import { MCPOAuthProvider } from "@app/lib/api/oauth/providers/mcp";
+import { MCPOAuthStaticOAuthProvider } from "@app/lib/api/oauth/providers/mcp_static";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { OAuthConnectionType } from "@app/types/oauth/lib";
 import { Ok } from "@app/types/shared/result";
@@ -110,4 +111,42 @@ describe("MCPOAuthProvider.getUpdatedExtraConfig", () => {
       true
     );
   });
+});
+
+describe("MCPOAuthProvider.setupUri", () => {
+  it.each([
+    { provider: new MCPOAuthProvider(), expectedProvider: "mcp" },
+    {
+      provider: new MCPOAuthStaticOAuthProvider(),
+      expectedProvider: "mcp_static",
+    },
+  ])(
+    "uses the $expectedProvider callback path",
+    ({ provider, expectedProvider }) => {
+      const connection = makeConnection({
+        client_id: "test-client",
+        authorization_endpoint: "https://example.com/authorize",
+        code_challenge: "test-challenge",
+        scope: "sql offline_access",
+      });
+      connection.provider = provider.provider;
+
+      const authorizationUrl = new URL(
+        provider.setupUri({ connection, useCase: "platform_actions" })
+      );
+      const redirectUri = authorizationUrl.searchParams.get("redirect_uri");
+
+      expect(redirectUri).not.toBeNull();
+      expect(new URL(redirectUri ?? "").pathname).toBe(
+        `/oauth/${expectedProvider}/finalize`
+      );
+      expect(authorizationUrl.searchParams.get("state")).toBe(
+        connection.connection_id
+      );
+      expect(authorizationUrl.searchParams.get("code_challenge")).toBe(
+        "test-challenge"
+      );
+      expect(authorizationUrl.searchParams.get("scope")).toBe("sql offline_access");
+    }
+  );
 });

--- a/front/lib/api/oauth/providers/mcp.test.ts
+++ b/front/lib/api/oauth/providers/mcp.test.ts
@@ -120,33 +120,35 @@ describe("MCPOAuthProvider.setupUri", () => {
       provider: new MCPOAuthStaticOAuthProvider(),
       expectedProvider: "mcp_static",
     },
-  ])(
-    "uses the $expectedProvider callback path",
-    ({ provider, expectedProvider }) => {
-      const connection = makeConnection({
-        client_id: "test-client",
-        authorization_endpoint: "https://example.com/authorize",
-        code_challenge: "test-challenge",
-        scope: "sql offline_access",
-      });
-      connection.provider = provider.provider;
+  ])("uses the $expectedProvider callback path", ({
+    provider,
+    expectedProvider,
+  }) => {
+    const connection = makeConnection({
+      client_id: "test-client",
+      authorization_endpoint: "https://example.com/authorize",
+      code_challenge: "test-challenge",
+      scope: "sql offline_access",
+    });
+    connection.provider = provider.provider;
 
-      const authorizationUrl = new URL(
-        provider.setupUri({ connection, useCase: "platform_actions" })
-      );
-      const redirectUri = authorizationUrl.searchParams.get("redirect_uri");
+    const authorizationUrl = new URL(
+      provider.setupUri({ connection, useCase: "platform_actions" })
+    );
+    const redirectUri = authorizationUrl.searchParams.get("redirect_uri");
 
-      expect(redirectUri).not.toBeNull();
-      expect(new URL(redirectUri ?? "").pathname).toBe(
-        `/oauth/${expectedProvider}/finalize`
-      );
-      expect(authorizationUrl.searchParams.get("state")).toBe(
-        connection.connection_id
-      );
-      expect(authorizationUrl.searchParams.get("code_challenge")).toBe(
-        "test-challenge"
-      );
-      expect(authorizationUrl.searchParams.get("scope")).toBe("sql offline_access");
-    }
-  );
+    expect(redirectUri).not.toBeNull();
+    expect(new URL(redirectUri ?? "").pathname).toBe(
+      `/oauth/${expectedProvider}/finalize`
+    );
+    expect(authorizationUrl.searchParams.get("state")).toBe(
+      connection.connection_id
+    );
+    expect(authorizationUrl.searchParams.get("code_challenge")).toBe(
+      "test-challenge"
+    );
+    expect(authorizationUrl.searchParams.get("scope")).toBe(
+      "sql offline_access"
+    );
+  });
 });

--- a/front/lib/api/oauth/providers/mcp.ts
+++ b/front/lib/api/oauth/providers/mcp.ts
@@ -83,7 +83,7 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
     );
     authUrl.searchParams.set(
       "redirect_uri",
-      finalizeUriForProvider({ provider: "mcp", connection })
+      finalizeUriForProvider({ provider: this.provider, connection })
     );
     authUrl.searchParams.set("state", connection.connection_id);
 


### PR DESCRIPTION
## Description

Fix the static MCP OAuth callback regression introduced in #32204.

`MCPOAuthStaticOAuthProvider` inherits `MCPOAuthProvider.setupUri` and overrides `provider` to `mcp_static`. The callback refactor replaced `this.provider` with the literal `mcp`, causing static OAuth flows to return through `/oauth/mcp/finalize` rather than `/oauth/mcp_static/finalize`.

Restore `this.provider` when calling `finalizeUriForProvider`. Dynamic MCP OAuth retains its existing callback; static OAuth again uses its own provider consistently.

Observed failure sequence: a provider rejects the unregistered `/mcp/` callback; allowing that callback then reaches Dust but fails finalization with `Connection provider mismatch`. The opener also ignores the error message labelled `mcp` while waiting for `mcp_static`, leaving setup pending.

No customer configuration, token migration, callback-host change, or popup behavior change is included.

## Tests
Manually went through the full process and am now able to connect Databricks MCP


## Risk
Fixing existing issue

## Deploy Plan

1. Deploy front

## Review
r? @smb2268 Eng runner fix