### PR TITLE
fix: preserve custom MCP server view names

### DIFF
--- a/front/lib/actions/mcp_helper.test.ts
+++ b/front/lib/actions/mcp_helper.test.ts
@@ -1,0 +1,28 @@
+import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import { describe, expect, it } from "vitest";
+
+describe("getMcpServerViewDisplayName", () => {
+  it("preserves custom MCP server view names", () => {
+    expect(
+      getMcpServerViewDisplayName({
+        name: "PostHog Read Only",
+        server: {
+          sId: "remote_mcp_server_123",
+          name: "post_hog",
+        },
+      })
+    ).toBe("PostHog Read Only");
+  });
+
+  it("formats the server name when no custom view name is set", () => {
+    expect(
+      getMcpServerViewDisplayName({
+        name: null,
+        server: {
+          sId: "remote_mcp_server_123",
+          name: "github_mcp",
+        },
+      })
+    ).toBe("GitHub MCP");
+  });
+});

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -197,7 +197,7 @@ export function getMcpServerViewDisplayName(
     | MCPServerConfigurationType
 ) {
   if (view.name) {
-    return asDisplayName(view.name);
+    return view.name;
   }
   return getMcpServerDisplayName(view.server, action);
 }


### PR DESCRIPTION
## Description

Preserve user-defined MCP server view names exactly as entered instead of passing them through Dust's generic display-name formatter. This fixes labels such as `PostHog Read Only` rendering as `Post hog read only` and `Official GitHub MCP` rendering as `Official git hub MCP`.

The fallback path for server-provided names continues to use the existing formatter.

## Tests

Added regression coverage for preserving custom names and formatting server-provided fallback names in `front/lib/actions/mcp_helper.test.ts`.
<img width="486" height="201" alt="Screenshot 2026-09-11 at 2 45 42 PM" src="https://github.com/user-attachments/assets/0590c43e-0b0c-4d3b-9cb0-ba8a19fbbde7" />

## Risk

Low. This is a frontend display-only change. Stored names, MCP tool identifiers, and execution behavior are unchanged.

## Deploy Plan

Deploy front.