### PR TITLE
[front] enh: add skeletons to Spaces tool lists

### DIFF
--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -471,6 +471,7 @@ export const AdminActionsList = ({
           <DataTableSkeleton
             columns={columns}
             SkeletonCell={AdminActionSkeletonCell}
+            rowCount={10}
             rowHeight={64}
           />
         </div>

--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -34,7 +34,15 @@ import type {
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
-import { Chip, cn, DataTable, EmptyCTA, Spinner } from "@dust-tt/sparkle";
+import type { DataTableSkeletonCellProps } from "@dust-tt/sparkle";
+import {
+  Chip,
+  cn,
+  DataTable,
+  DataTableSkeleton,
+  EmptyCTA,
+  LoadingBlock,
+} from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 
@@ -47,6 +55,44 @@ type RowData = {
   spaces: SpaceType[];
   onClick: () => void;
 };
+
+function AdminActionSkeletonCell({
+  columnId,
+  rowIndex,
+}: DataTableSkeletonCellProps) {
+  switch (columnId) {
+    case "name":
+      return (
+        <div className="flex items-center gap-3 py-3">
+          <LoadingBlock className="h-9 w-9 shrink-0 rounded-lg" />
+          <div className="flex h-10 min-w-0 flex-1 flex-col justify-center gap-2">
+            <LoadingBlock
+              className={rowIndex % 2 === 0 ? "h-3 w-28" : "h-3 w-36"}
+            />
+            <LoadingBlock
+              className={rowIndex % 2 === 0 ? "h-3 w-3/4" : "h-3 w-1/2"}
+            />
+          </div>
+        </div>
+      );
+    case "usedBy":
+      return (
+        <div className="flex justify-center">
+          <LoadingBlock className="h-6 w-16 rounded-md" />
+        </div>
+      );
+    case "access":
+      return <LoadingBlock className="h-3 w-20 max-w-full" />;
+    case "account":
+      return <LoadingBlock className="h-3 w-14 max-w-full" />;
+    case "by":
+      return <LoadingBlock className="h-7 w-7 rounded-full" />;
+    case "lastUpdated":
+      return <LoadingBlock className="h-3 w-16 max-w-full" />;
+    default:
+      return null;
+  }
+}
 
 const NameCell = ({ row }: { row: RowData }) => {
   const { mcpServer, mcpServerView, isConnected } = row;
@@ -421,8 +467,12 @@ export const AdminActionsList = ({
         )}
 
       {showLoader && (
-        <div className="mt-16 flex justify-center">
-          <Spinner />
+        <div className="pb-4">
+          <DataTableSkeleton
+            columns={columns}
+            SkeletonCell={AdminActionSkeletonCell}
+            rowHeight={64}
+          />
         </div>
       )}
 

--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -471,7 +471,6 @@ export const AdminActionsList = ({
           <DataTableSkeleton
             columns={columns}
             SkeletonCell={AdminActionSkeletonCell}
-            rowCount={10}
             rowHeight={64}
           />
         </div>

--- a/front/components/spaces/SpaceActionsList.tsx
+++ b/front/components/spaces/SpaceActionsList.tsx
@@ -204,6 +204,7 @@ export const SpaceActionsList = ({
         <DataTableSkeleton
           columns={columns}
           SkeletonCell={SpaceActionSkeletonCell}
+          rowCount={10}
           rowHeight={60}
         />
       </div>

--- a/front/components/spaces/SpaceActionsList.tsx
+++ b/front/components/spaces/SpaceActionsList.tsx
@@ -21,7 +21,8 @@ import { isDevelopment } from "@app/types/shared/env";
 import { isString } from "@app/types/shared/utils/general";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
-import { DataTable, Spinner } from "@dust-tt/sparkle";
+import type { DataTableSkeletonCellProps } from "@dust-tt/sparkle";
+import { DataTable, DataTableSkeleton, LoadingBlock } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import type { ParsedUrlQuery } from "querystring";
 import * as React from "react";
@@ -46,6 +47,31 @@ interface SpaceActionsListProps {
   isAdmin: boolean;
   owner: LightWorkspaceType;
   space: SpaceType;
+}
+
+function SpaceActionSkeletonCell({
+  columnId,
+  rowIndex,
+}: DataTableSkeletonCellProps) {
+  switch (columnId) {
+    case "name":
+      return (
+        <div className="flex items-center gap-2 py-3">
+          <LoadingBlock className="h-9 w-9 shrink-0 rounded-lg" />
+          <LoadingBlock
+            className={rowIndex % 2 === 0 ? "h-4 w-28" : "h-4 w-36"}
+          />
+        </div>
+      );
+    case "description":
+      return (
+        <LoadingBlock
+          className={rowIndex % 2 === 0 ? "h-4 w-3/4" : "h-4 w-1/2"}
+        />
+      );
+    default:
+      return null;
+  }
 }
 
 export const SpaceActionsList = ({
@@ -170,15 +196,19 @@ export const SpaceActionsList = ({
     containerId: ACTION_BUTTONS_CONTAINER_ID,
   });
 
+  const columns = getTableColumns();
+
   if (isMCPServerViewsLoading) {
     return (
-      <div className="mt-8 flex justify-center">
-        <Spinner size="lg" />
+      <div className="pb-4">
+        <DataTableSkeleton
+          columns={columns}
+          SkeletonCell={SpaceActionSkeletonCell}
+          rowHeight={60}
+        />
       </div>
     );
   }
-
-  const columns = getTableColumns();
 
   const isEmpty = rows.length === 0;
 

--- a/front/components/spaces/SpaceActionsList.tsx
+++ b/front/components/spaces/SpaceActionsList.tsx
@@ -204,7 +204,6 @@ export const SpaceActionsList = ({
         <DataTableSkeleton
           columns={columns}
           SkeletonCell={SpaceActionSkeletonCell}
-          rowCount={10}
           rowHeight={60}
         />
       </div>

--- a/sparkle/src/components/DataTableSkeleton.tsx
+++ b/sparkle/src/components/DataTableSkeleton.tsx
@@ -32,7 +32,7 @@ export interface DataTableSkeletonProps<
   columns: SkeletonColumnDef<TData, TValue, TColumnId>[];
   /** Required cell renderer: compose cell skeleton primitives to match each column's content. */
   SkeletonCell: ComponentType<DataTableSkeletonCellProps<NoInfer<TColumnId>>>;
-  /** Number of placeholder rows. Defaults to 5. */
+  /** Number of placeholder rows. Defaults to 10. */
   rowCount?: number;
   /** Row height in pixels; match the loaded table. Defaults to 48. */
   rowHeight?: number;
@@ -53,7 +53,7 @@ export function DataTableSkeleton<
 >({
   columns,
   SkeletonCell,
-  rowCount = 5,
+  rowCount = 10,
   rowHeight = 48,
 }: DataTableSkeletonProps<TData, TValue, TColumnId>) {
   const table = useReactTable({

--- a/sparkle/src/stories/DataTableSkeleton.stories.tsx
+++ b/sparkle/src/stories/DataTableSkeleton.stories.tsx
@@ -144,7 +144,6 @@ const meta: Meta<typeof DataTableSkeleton<MemberRow, string, MemberColumnId>> =
     args: {
       columns,
       SkeletonCell: MemberSkeletonCell,
-      rowCount: 5,
       rowHeight: 48,
     },
     argTypes: {


### PR DESCRIPTION
## Description

The Tools lists in Spaces (the one for the system space and the ones in each space) currently show a spinner while loading.

This PR adds skeleton rows that reuse each table's columns and match its icons, text, and row heights (re-using https://github.com/dust-tt/dust/pull/32310).

Also bumps the default number of rows in the skeleton component, currently too small on most tables that keep the default.

## Tests

- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
