### PR TITLE
ops: Archive raw Claap recordings to Google Drive via Pipedream

### DIFF
--- a/x/claap-drive-archive/.env.example
+++ b/x/claap-drive-archive/.env.example
@@ -1,0 +1,16 @@
+# Claap workspace API key (X-Claap-Key). Create it in Claap admin.
+CLAAP_API_KEY=cla_xxxxx
+
+# Shared with the Pipedream HTTP trigger. Same value as X-Claap-Webhook-Secret.
+CLAAP_WEBHOOK_SECRET=
+
+# Google Drive folder that owns per-user subfolders. Prefer a Shared Drive.
+GOOGLE_DRIVE_ROOT_FOLDER_ID=
+
+# Optional. Used by the local backfill CLI via Application Default Credentials
+# or a service account JSON path.
+# GOOGLE_APPLICATION_CREDENTIALS=./service-account.json
+
+# Optional video archive. Default is off: transcript + raw JSON only.
+UPLOAD_VIDEO=false
+MAX_VIDEO_BYTES=209715200

--- a/x/claap-drive-archive/.gitignore
+++ b/x/claap-drive-archive/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.env
+.env.local
+*.json.key
+service-account.json

--- a/x/claap-drive-archive/README.md
+++ b/x/claap-drive-archive/README.md
@@ -1,0 +1,106 @@
+# Claap → Google Drive archive
+
+Internal ops automation. **Not part of the Dust product.**
+
+It copies every Claap recording's *raw* data into a company Google Drive folder,
+one subfolder per recorder, with no AI notes or generated summaries.
+
+Host this on **Pipedream**. The TypeScript here is the testable source of truth
+plus a local backfill CLI. The files in `pipedream/` are what you paste into
+Pipedream workflows.
+
+## Why Pipedream
+
+Claap webhooks are created in the Claap UI (not via API) and must return HTTP
+200 within 5 seconds. Pipedream gives us:
+
+- a public HTTPS endpoint for `recording_added` / `recording_updated`
+- a secrets vault for the Claap API key and webhook secret
+- a first-party Google Drive OAuth connection
+- retries and run logs
+- a scheduled backfill so a failed run does not lose recordings
+
+Keep the archive off personal Drives. Use a **Shared Drive** owned by the
+workspace, connected with a dedicated Google account (for example
+`claap-archive@dust.tt`).
+
+## What gets stored
+
+```
+<Shared Drive>/Claap Recordings/
+  ilias@dust.tt/
+    2026-09-12_Discovery-call-with-Acme-Q3_rec_abc123.md
+    2026-09-12_Discovery-call-with-Acme-Q3_rec_abc123.json
+  iris@dust.tt/
+    ...
+```
+
+The markdown file is the durable document: YAML metadata (who recorded, who
+attended, source, deal, Claap URL) and the **word-for-word transcript**. See
+`examples/sample-archive.md`.
+
+The JSON file is the untouched Claap recording + transcript payload.
+
+Video upload is **off by default**. Claap video URLs expire in 24 hours and
+meeting files are large. Turn it on in the Pipedream props if you want `.mp4`
+files next to the transcript. Private Claap recordings never appear on the
+webhook.
+
+## Deploy on Pipedream
+
+### 1. Drive folder
+
+1. Create a Shared Drive folder named `Claap Recordings`.
+2. Copy the folder ID from the URL (`https://drive.google.com/drive/folders/<ID>`).
+
+### 2. Webhook workflow
+
+1. Create a Pipedream workflow with trigger **HTTP / Webhook Requests**.
+2. Set the HTTP response to **Return a custom response from your workflow**.
+3. Add a Node.js code step and paste `pipedream/webhook-archive.js`.
+4. Connect a Google Drive account that can write to the Shared Drive.
+5. Fill in:
+   - Claap API key (`cla_…`)
+   - Claap webhook secret (you choose this; Claap sends it back as `X-Claap-Webhook-Secret`)
+   - root folder ID
+6. Deploy and copy the workflow URL.
+
+### 3. Claap webhook
+
+In Claap admin → Webhooks, create a webhook:
+
+- events: `recording_added`, `recording_updated`
+- destination: the Pipedream URL
+- secret: the same value as the workflow prop
+
+### 4. Backfill workflow
+
+Create a second workflow with a **Schedule** trigger (every hour or daily).
+Paste `pipedream/scheduled-backfill.js`. Use the same Drive connection, API key,
+and folder ID. Default lookback is 48 hours. Safe to rerun: files upsert by
+`claapRecordingId`.
+
+## Local backfill
+
+For a one-off historical import, or to test without Pipedream:
+
+```bash
+cd x/claap-drive-archive
+cp .env.example .env   # fill in keys
+gcloud auth application-default login   # or set GOOGLE_APPLICATION_CREDENTIALS
+npm test
+npm run backfill -- --days=30
+```
+
+## Security
+
+- Store `CLAAP_API_KEY` and the webhook secret only in Pipedream / `.env` (gitignored).
+- Restrict the Drive folder to the people who should see call corpus data.
+- The markdown archive does not include Claap AI fields, outlines, or takeaways.
+  Those stay in the JSON dump if you need them later.
+
+## Moving this out of dust-tt
+
+This folder is only parked under `x/` so the logic can be reviewed and tested.
+It can be copied into a private ops repo at any time. Nothing here is imported
+by `front`, `front-api`, or any Dust runtime.

--- a/x/claap-drive-archive/examples/sample-archive.md
+++ b/x/claap-drive-archive/examples/sample-archive.md
@@ -1,0 +1,38 @@
+---
+claap_id: rec_abc123
+title: "Discovery call with Acme / Q3"
+created_at: "2026-09-12T15:04:05.000Z"
+date: 2026-09-12
+duration_seconds: 1842
+source: GoogleMeet
+meeting_type: external
+conference_url: "https://meet.google.com/aaa-bbbb-cccc"
+meeting_starting_at: "2026-09-12T14:30:00.000Z"
+meeting_ending_at: "2026-09-12T15:00:00.000Z"
+recorder_name: "Ilias Bettaieb"
+recorder_email: ilias@dust.tt
+recorder_attended: true
+participants:
+  - name: "Jane Doe"
+    email: jane@acme.com
+    attended: true
+  - name: "Ilias Bettaieb"
+    email: ilias@dust.tt
+    attended: true
+companies:
+  - Acme
+deal: "Acme — Enterprise"
+crm: hubspot
+channel: External
+labels:
+  - customer
+workspace: Dust
+claap_url: "https://app.claap.io/dust/discovery-call-with-acme-rec_abc123"
+transcript_only: false
+video_available: true
+---
+
+# Transcript
+
+[00:02:16] speaker_1: Hello there!
+[00:02:18] speaker_2: Thanks for joining.

--- a/x/claap-drive-archive/package-lock.json
+++ b/x/claap-drive-archive/package-lock.json
@@ -1,0 +1,1154 @@
+{
+  "name": "claap-drive-archive",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "claap-drive-archive",
+      "version": "0.1.0",
+      "dependencies": {
+        "googleapis": "^144.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.13.10",
+        "tsx": "^4.19.3",
+        "typescript": "^5.8.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.2.tgz",
+      "integrity": "sha512-xlvWf4Vs9n1PEVYwP1n4vvG07M6y8WgvJ2t0vbrWTmijsIHp1cS+uJ2kMIRdY3nHZK0nCYKrPeD171+SzF4/zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "144.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-144.0.0.tgz",
+      "integrity": "sha512-ELcWOXtJxjPX4vsKMh+7V+jZvgPwYMlEhQFiu2sa9Qmt5veX8nwXPksOWGGN6Zk4xCiLygUyaz7xGtcMO+Onxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.13",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.13.tgz",
+      "integrity": "sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/x/claap-drive-archive/package.json
+++ b/x/claap-drive-archive/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "claap-drive-archive",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Internal ops: archive raw Claap recordings to Google Drive. Hosted on Pipedream, not part of the Dust product.",
+  "type": "module",
+  "scripts": {
+    "test": "tsx --test tests/*.test.ts",
+    "typecheck": "tsc --noEmit",
+    "backfill": "tsx scripts/backfill.ts"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "googleapis": "^144.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.10",
+    "tsx": "^4.19.3",
+    "typescript": "^5.8.2"
+  }
+}

--- a/x/claap-drive-archive/pipedream/README.md
+++ b/x/claap-drive-archive/pipedream/README.md
@@ -1,0 +1,51 @@
+# Pipedream setup
+
+Two workflows. Same Google Drive connection and Claap API key.
+
+## Workflow A — live archive
+
+1. New workflow → trigger **New HTTP / Webhook Requests**.
+2. In the trigger:
+   - HTTP Response: **Return a custom response from your workflow**
+   - leave auth on the workflow (the code checks `X-Claap-Webhook-Secret`)
+3. Add step → **Run Node.js code**.
+4. Replace the stub with the contents of `webhook-archive.js`.
+5. Connect Google Drive (grant Drive file access).
+6. Set props:
+   - `claapApiKey`
+   - `claapWebhookSecret`
+   - `rootFolderId`
+   - `uploadVideo` = false unless you explicitly want mp4s
+7. Deploy. Copy the endpoint URL into Claap → Webhooks.
+
+Claap must get HTTP 200 within 5 seconds. The step acknowledges first, then
+writes to Drive. If a write fails, workflow B repairs it.
+
+## Workflow B — catch-up
+
+1. New workflow → trigger **Schedule** → every 1 hour (or daily).
+2. Add a Node.js step and paste `scheduled-backfill.js`.
+3. Reuse the same Drive account, API key, and folder ID.
+4. `lookbackHours` defaults to 48.
+
+## Test without a real meeting
+
+Use Claap `POST /v1/webhooks/{webhookId}/trigger` with:
+
+```json
+{ "type": "recording_added", "recordingId": "<existing recording id>" }
+```
+
+Or send a Pipedream test event whose body is:
+
+```json
+{
+  "eventId": "test",
+  "event": {
+    "type": "recording_added",
+    "recording": { "id": "<existing recording id>" }
+  }
+}
+```
+
+Include header `X-Claap-Webhook-Secret: <your secret>`.

--- a/x/claap-drive-archive/pipedream/scheduled-backfill.js
+++ b/x/claap-drive-archive/pipedream/scheduled-backfill.js
@@ -1,0 +1,269 @@
+import { google } from "googleapis";
+
+const CLAAP_API = "https://api.claap.io";
+const FOLDER_MIME = "application/vnd.google-apps.folder";
+
+function yamlScalar(value) {
+  if (value === null || value === undefined) {
+    return "null";
+  }
+  if (typeof value === "boolean" || typeof value === "number") {
+    return String(value);
+  }
+  if (
+    value === "" ||
+    value === "true" ||
+    value === "false" ||
+    value === "null" ||
+    /[:#\n\r"'{}[\]&*?|<>=!%`,]/.test(value) ||
+    /\s/.test(value) ||
+    /^-/.test(value)
+  ) {
+    return JSON.stringify(value);
+  }
+  return value;
+}
+
+function sanitizeFilenamePart(value) {
+  const cleaned = value
+    .normalize("NFKD")
+    .replace(/[\u0000-\u001f]/g, "")
+    .replace(/[\\/:*?"<>|]/g, "-")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  return cleaned.length > 0 ? cleaned : "untitled";
+}
+
+function formatTimestamp(seconds) {
+  const total = Math.max(0, Math.floor(Number(seconds) || 0));
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const rest = total % 60;
+  return [hours, minutes, rest].map((part) => String(part).padStart(2, "0")).join(":");
+}
+
+function escapeDriveQuery(value) {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
+function personLines(person, indent = "  ") {
+  const lines = [`${indent}- name: ${yamlScalar(person?.name ?? "")}`];
+  if (person?.email) {
+    lines.push(`${indent}  email: ${yamlScalar(person.email)}`);
+  }
+  lines.push(`${indent}  attended: ${yamlScalar(Boolean(person?.attended))}`);
+  return lines;
+}
+
+function buildMarkdown(recording, transcript) {
+  const participants = recording.meeting?.participants ?? [];
+  const companies = recording.companies ?? [];
+  const labels = recording.labels ?? [];
+  const date = String(recording.createdAt || "").slice(0, 10);
+  const frontmatter = [
+    `claap_id: ${yamlScalar(recording.id)}`,
+    `title: ${yamlScalar(recording.title ?? "")}`,
+    `created_at: ${yamlScalar(recording.createdAt)}`,
+    `date: ${yamlScalar(date)}`,
+    `duration_seconds: ${yamlScalar(recording.durationSeconds ?? null)}`,
+    `source: ${yamlScalar(recording.source ?? null)}`,
+    `meeting_type: ${yamlScalar(recording.meeting?.type ?? null)}`,
+    `conference_url: ${yamlScalar(recording.meeting?.conferenceUrl ?? null)}`,
+    `meeting_starting_at: ${yamlScalar(recording.meeting?.startingAt ?? null)}`,
+    `meeting_ending_at: ${yamlScalar(recording.meeting?.endingAt ?? null)}`,
+    `recorder_name: ${yamlScalar(recording.recorder?.name ?? "")}`,
+    `recorder_email: ${yamlScalar(recording.recorder?.email ?? "")}`,
+    `recorder_attended: ${yamlScalar(Boolean(recording.recorder?.attended))}`,
+    "participants:",
+    ...(participants.length ? participants.flatMap((person) => personLines(person)) : ["  []"]),
+    "companies:",
+    ...(companies.length ? companies.map((company) => `  - ${yamlScalar(company.name)}`) : ["  []"]),
+    `deal: ${yamlScalar(recording.deal?.name ?? recording.deal?.id ?? null)}`,
+    `crm: ${yamlScalar(recording.crmInfo?.crm ?? null)}`,
+    `channel: ${yamlScalar(recording.channel?.name ?? null)}`,
+    "labels:",
+    ...(labels.length ? labels.map((label) => `  - ${yamlScalar(label)}`) : ["  []"]),
+    `workspace: ${yamlScalar(recording.workspace?.name ?? "")}`,
+    `claap_url: ${yamlScalar(recording.url)}`,
+    `transcript_only: ${yamlScalar(Boolean(recording.transcriptOnly))}`,
+    `video_available: ${yamlScalar(Boolean(recording.video?.url) && !recording.transcriptOnly)}`,
+  ];
+  const body =
+    transcript?.segments?.length > 0
+      ? transcript.segments
+          .map((segment) => {
+            const speaker = segment.speaker?.trim() || "unknown";
+            return `[${formatTimestamp(segment.startedAt)}] ${speaker}: ${String(segment.text || "").trim()}`;
+          })
+          .join("\n")
+      : "_No transcript was available for this recording._";
+  return `---\n${frontmatter.join("\n")}\n---\n\n# Transcript\n\n${body}\n`;
+}
+
+function archiveBaseName(recording) {
+  const date = String(recording.createdAt || "").slice(0, 10);
+  const title = sanitizeFilenamePart(recording.title || "untitled").slice(0, 80);
+  return `${date}_${title}_${recording.id}`;
+}
+
+async function claapGet(apiKey, path) {
+  const res = await fetch(`${CLAAP_API}/${path}`, {
+    headers: { Accept: "application/json", "X-Claap-Key": apiKey },
+  });
+  if (!res.ok) {
+    throw new Error(`Claap ${res.status} ${path}: ${await res.text()}`);
+  }
+  return res.json();
+}
+
+function driveClient(accessToken) {
+  const auth = new google.auth.OAuth2();
+  auth.setCredentials({ access_token: accessToken });
+  return google.drive({ version: "v3", auth });
+}
+
+async function findFile(drive, query) {
+  const response = await drive.files.list({
+    q: query,
+    fields: "files(id,name)",
+    pageSize: 1,
+    includeItemsFromAllDrives: true,
+    supportsAllDrives: true,
+  });
+  return response.data.files?.[0] ?? null;
+}
+
+async function ensureFolder(drive, parentId, name) {
+  const existing = await findFile(
+    drive,
+    `mimeType = '${FOLDER_MIME}' and name = '${escapeDriveQuery(name)}' and '${escapeDriveQuery(parentId)}' in parents and trashed = false`
+  );
+  if (existing?.id) {
+    return existing.id;
+  }
+  const created = await drive.files.create({
+    requestBody: { name, mimeType: FOLDER_MIME, parents: [parentId] },
+    fields: "id",
+    supportsAllDrives: true,
+  });
+  return created.data.id;
+}
+
+async function upsertFile(drive, { parentId, name, mimeType, content, kind, recordingId }) {
+  const existing = await findFile(
+    drive,
+    `appProperties has { key='claapRecordingId' and value='${escapeDriveQuery(recordingId)}' } and appProperties has { key='kind' and value='${escapeDriveQuery(kind)}' } and '${escapeDriveQuery(parentId)}' in parents and trashed = false`
+  );
+  const media = { mimeType, body: content };
+  const requestBody = { name, appProperties: { claapRecordingId: recordingId, kind } };
+  if (existing?.id) {
+    return (
+      await drive.files.update({
+        fileId: existing.id,
+        requestBody,
+        media,
+        fields: "id",
+        supportsAllDrives: true,
+      })
+    ).data;
+  }
+  return (
+    await drive.files.create({
+      requestBody: { ...requestBody, mimeType, parents: [parentId] },
+      media,
+      fields: "id",
+      supportsAllDrives: true,
+    })
+  ).data;
+}
+
+async function archiveOne(apiKey, drive, recordingId, rootFolderId) {
+  const recording = (await claapGet(apiKey, `v1/recordings/${encodeURIComponent(recordingId)}`))
+    .result.recording;
+  if (recording.state !== "Ready") {
+    return { status: "skipped", recordingId, reason: recording.state };
+  }
+  let transcript = null;
+  try {
+    transcript = (
+      await claapGet(apiKey, `v1/recordings/${encodeURIComponent(recordingId)}/transcript?format=json`)
+    ).result.transcript;
+  } catch (error) {
+    console.warn(`Transcript missing for ${recordingId}`, error);
+  }
+  const folderId = await ensureFolder(
+    drive,
+    rootFolderId,
+    sanitizeFilenamePart(recording.recorder?.email?.toLowerCase() || "_unknown")
+  );
+  const baseName = archiveBaseName(recording);
+  await upsertFile(drive, {
+    parentId: folderId,
+    name: `${baseName}.md`,
+    mimeType: "text/markdown",
+    content: buildMarkdown(recording, transcript),
+    kind: "transcript",
+    recordingId,
+  });
+  await upsertFile(drive, {
+    parentId: folderId,
+    name: `${baseName}.json`,
+    mimeType: "application/json",
+    content: `${JSON.stringify({ archivedAt: new Date().toISOString(), recording, transcript }, null, 2)}\n`,
+    kind: "raw",
+    recordingId,
+  });
+  return { status: "archived", recordingId, folderId };
+}
+
+export default defineComponent({
+  name: "Backfill Claap recordings to Google Drive",
+  description: "Re-archives recent Claap recordings. Safe to rerun; files upsert by recording id.",
+  props: {
+    googleDrive: {
+      type: "app",
+      app: "google_drive",
+    },
+    claapApiKey: {
+      type: "string",
+      label: "Claap API key",
+      secret: true,
+    },
+    rootFolderId: {
+      type: "string",
+      label: "Google Drive root folder ID",
+    },
+    lookbackHours: {
+      type: "integer",
+      label: "Lookback hours",
+      default: 48,
+    },
+  },
+  async run({ $ }) {
+    const createdAfter = new Date(Date.now() - this.lookbackHours * 60 * 60 * 1000).toISOString();
+    const drive = driveClient(this.googleDrive.$auth.oauth_access_token);
+    const results = [];
+    let cursor;
+
+    do {
+      const params = new URLSearchParams({
+        createdAfter,
+        limit: "50",
+        sort: "created_asc",
+      });
+      if (cursor) {
+        params.set("cursor", cursor);
+      }
+      const page = await claapGet(this.claapApiKey, `v1/recordings?${params.toString()}`);
+      for (const recording of page.result.recordings) {
+        results.push(await archiveOne(this.claapApiKey, drive, recording.id, this.rootFolderId));
+      }
+      cursor = page.result.pagination?.nextCursor;
+    } while (cursor);
+
+    const archived = results.filter((result) => result.status === "archived").length;
+    $.export("summary", `Archived ${archived} / ${results.length} recordings since ${createdAfter}`);
+    return { createdAfter, archived, results };
+  },
+});

--- a/x/claap-drive-archive/pipedream/webhook-archive.js
+++ b/x/claap-drive-archive/pipedream/webhook-archive.js
@@ -1,0 +1,330 @@
+import { timingSafeEqual } from "crypto";
+import { google } from "googleapis";
+
+const CLAAP_API = "https://api.claap.io";
+const FOLDER_MIME = "application/vnd.google-apps.folder";
+
+function yamlScalar(value) {
+  if (value === null || value === undefined) {
+    return "null";
+  }
+  if (typeof value === "boolean" || typeof value === "number") {
+    return String(value);
+  }
+  if (
+    value === "" ||
+    value === "true" ||
+    value === "false" ||
+    value === "null" ||
+    /[:#\n\r"'{}[\]&*?|<>=!%`,]/.test(value) ||
+    /\s/.test(value) ||
+    /^-/.test(value)
+  ) {
+    return JSON.stringify(value);
+  }
+  return value;
+}
+
+function sanitizeFilenamePart(value) {
+  const cleaned = value
+    .normalize("NFKD")
+    .replace(/[\u0000-\u001f]/g, "")
+    .replace(/[\\/:*?"<>|]/g, "-")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  return cleaned.length > 0 ? cleaned : "untitled";
+}
+
+function formatTimestamp(seconds) {
+  const total = Math.max(0, Math.floor(Number(seconds) || 0));
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const rest = total % 60;
+  return [hours, minutes, rest].map((part) => String(part).padStart(2, "0")).join(":");
+}
+
+function escapeDriveQuery(value) {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
+function verifySecret(provided, expected) {
+  if (!expected || !provided) {
+    return false;
+  }
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+function extractRecordingId(body) {
+  return body?.event?.recording?.id || body?.recording?.id || body?.recordingId || null;
+}
+
+function personLines(person, indent = "  ") {
+  const lines = [`${indent}- name: ${yamlScalar(person?.name ?? "")}`];
+  if (person?.email) {
+    lines.push(`${indent}  email: ${yamlScalar(person.email)}`);
+  }
+  lines.push(`${indent}  attended: ${yamlScalar(Boolean(person?.attended))}`);
+  return lines;
+}
+
+function buildMarkdown(recording, transcript) {
+  const participants = recording.meeting?.participants ?? [];
+  const companies = recording.companies ?? [];
+  const labels = recording.labels ?? [];
+  const date = String(recording.createdAt || "").slice(0, 10);
+  const frontmatter = [
+    `claap_id: ${yamlScalar(recording.id)}`,
+    `title: ${yamlScalar(recording.title ?? "")}`,
+    `created_at: ${yamlScalar(recording.createdAt)}`,
+    `date: ${yamlScalar(date)}`,
+    `duration_seconds: ${yamlScalar(recording.durationSeconds ?? null)}`,
+    `source: ${yamlScalar(recording.source ?? null)}`,
+    `meeting_type: ${yamlScalar(recording.meeting?.type ?? null)}`,
+    `conference_url: ${yamlScalar(recording.meeting?.conferenceUrl ?? null)}`,
+    `meeting_starting_at: ${yamlScalar(recording.meeting?.startingAt ?? null)}`,
+    `meeting_ending_at: ${yamlScalar(recording.meeting?.endingAt ?? null)}`,
+    `recorder_name: ${yamlScalar(recording.recorder?.name ?? "")}`,
+    `recorder_email: ${yamlScalar(recording.recorder?.email ?? "")}`,
+    `recorder_attended: ${yamlScalar(Boolean(recording.recorder?.attended))}`,
+    "participants:",
+    ...(participants.length ? participants.flatMap((person) => personLines(person)) : ["  []"]),
+    "companies:",
+    ...(companies.length ? companies.map((company) => `  - ${yamlScalar(company.name)}`) : ["  []"]),
+    `deal: ${yamlScalar(recording.deal?.name ?? recording.deal?.id ?? null)}`,
+    `crm: ${yamlScalar(recording.crmInfo?.crm ?? null)}`,
+    `channel: ${yamlScalar(recording.channel?.name ?? null)}`,
+    "labels:",
+    ...(labels.length ? labels.map((label) => `  - ${yamlScalar(label)}`) : ["  []"]),
+    `workspace: ${yamlScalar(recording.workspace?.name ?? "")}`,
+    `claap_url: ${yamlScalar(recording.url)}`,
+    `transcript_only: ${yamlScalar(Boolean(recording.transcriptOnly))}`,
+    `video_available: ${yamlScalar(Boolean(recording.video?.url) && !recording.transcriptOnly)}`,
+  ];
+
+  const body =
+    transcript?.segments?.length > 0
+      ? transcript.segments
+          .map((segment) => {
+            const speaker = segment.speaker?.trim() || "unknown";
+            return `[${formatTimestamp(segment.startedAt)}] ${speaker}: ${String(segment.text || "").trim()}`;
+          })
+          .join("\n")
+      : "_No transcript was available for this recording._";
+
+  return `---\n${frontmatter.join("\n")}\n---\n\n# Transcript\n\n${body}\n`;
+}
+
+function archiveBaseName(recording) {
+  const date = String(recording.createdAt || "").slice(0, 10);
+  const title = sanitizeFilenamePart(recording.title || "untitled").slice(0, 80);
+  return `${date}_${title}_${recording.id}`;
+}
+
+async function claapGet(apiKey, path) {
+  const response = await fetch(`${CLAAP_API}/${path}`, {
+    headers: {
+      Accept: "application/json",
+      "X-Claap-Key": apiKey,
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Claap ${response.status} ${path}: ${await response.text()}`);
+  }
+  return response.json();
+}
+
+function driveClient(accessToken) {
+  const auth = new google.auth.OAuth2();
+  auth.setCredentials({ access_token: accessToken });
+  return google.drive({ version: "v3", auth });
+}
+
+async function findFile(drive, query) {
+  const response = await drive.files.list({
+    q: query,
+    fields: "files(id,name,webViewLink)",
+    pageSize: 1,
+    includeItemsFromAllDrives: true,
+    supportsAllDrives: true,
+  });
+  return response.data.files?.[0] ?? null;
+}
+
+async function ensureFolder(drive, parentId, name) {
+  const existing = await findFile(
+    drive,
+    `mimeType = '${FOLDER_MIME}' and name = '${escapeDriveQuery(name)}' and '${escapeDriveQuery(parentId)}' in parents and trashed = false`
+  );
+  if (existing?.id) {
+    return existing.id;
+  }
+  const created = await drive.files.create({
+    requestBody: {
+      name,
+      mimeType: FOLDER_MIME,
+      parents: [parentId],
+    },
+    fields: "id",
+    supportsAllDrives: true,
+  });
+  return created.data.id;
+}
+
+async function upsertFile(drive, { parentId, name, mimeType, content, kind, recordingId }) {
+  const existing = await findFile(
+    drive,
+    `appProperties has { key='claapRecordingId' and value='${escapeDriveQuery(recordingId)}' } and appProperties has { key='kind' and value='${escapeDriveQuery(kind)}' } and '${escapeDriveQuery(parentId)}' in parents and trashed = false`
+  );
+  const media = { mimeType, body: content };
+  const requestBody = { name, appProperties: { claapRecordingId: recordingId, kind } };
+  if (existing?.id) {
+    const updated = await drive.files.update({
+      fileId: existing.id,
+      requestBody,
+      media,
+      fields: "id,webViewLink",
+      supportsAllDrives: true,
+    });
+    return updated.data;
+  }
+  const created = await drive.files.create({
+    requestBody: { ...requestBody, mimeType, parents: [parentId] },
+    media,
+    fields: "id,webViewLink",
+    supportsAllDrives: true,
+  });
+  return created.data;
+}
+
+export default defineComponent({
+  name: "Archive Claap recording to Google Drive",
+  description:
+    "Stores raw Claap transcript + metadata JSON in a per-user Google Drive folder. Does not write AI notes.",
+  props: {
+    googleDrive: {
+      type: "app",
+      app: "google_drive",
+    },
+    claapApiKey: {
+      type: "string",
+      label: "Claap API key",
+      secret: true,
+    },
+    claapWebhookSecret: {
+      type: "string",
+      label: "Claap webhook secret",
+      secret: true,
+    },
+    rootFolderId: {
+      type: "string",
+      label: "Google Drive root folder ID",
+      description: "Shared Drive folder that will contain one subfolder per recorder email.",
+    },
+    uploadVideo: {
+      type: "boolean",
+      label: "Upload video files",
+      default: false,
+    },
+    maxVideoBytes: {
+      type: "integer",
+      label: "Max video size in bytes",
+      default: 209715200,
+    },
+  },
+  async run({ steps, $ }) {
+    const headers = steps.trigger.event.headers || {};
+    const providedSecret = headers["x-claap-webhook-secret"];
+    if (!verifySecret(providedSecret, this.claapWebhookSecret)) {
+      await $.respond({
+        status: 401,
+        body: { ok: false, error: "invalid webhook secret" },
+      });
+      return { skipped: true, reason: "invalid webhook secret" };
+    }
+
+    const recordingId = extractRecordingId(steps.trigger.event.body);
+    if (!recordingId) {
+      await $.respond({
+        status: 400,
+        body: { ok: false, error: "missing recording id" },
+      });
+      return { skipped: true, reason: "missing recording id" };
+    }
+
+    // Claap requires HTTP 200 within 5 seconds. Ack first; Drive writes are idempotent
+    // and the scheduled backfill workflow catches failures.
+    await $.respond({
+      status: 200,
+      body: { ok: true, recordingId },
+    });
+
+    const recording = (await claapGet(this.claapApiKey, `v1/recordings/${encodeURIComponent(recordingId)}`))
+      .result.recording;
+    if (recording.state !== "Ready") {
+      return { skipped: true, recordingId, reason: `state ${recording.state}` };
+    }
+
+    let transcript = null;
+    try {
+      transcript = (
+        await claapGet(
+          this.claapApiKey,
+          `v1/recordings/${encodeURIComponent(recordingId)}/transcript?format=json`
+        )
+      ).result.transcript;
+    } catch (error) {
+      console.warn("Transcript fetch failed; writing metadata only", error);
+    }
+
+    const drive = driveClient(this.googleDrive.$auth.oauth_access_token);
+    const recorderFolder = sanitizeFilenamePart(recording.recorder?.email?.toLowerCase() || "_unknown");
+    const folderId = await ensureFolder(drive, this.rootFolderId, recorderFolder);
+    const baseName = archiveBaseName(recording);
+
+    const markdownFile = await upsertFile(drive, {
+      parentId: folderId,
+      name: `${baseName}.md`,
+      mimeType: "text/markdown",
+      content: buildMarkdown(recording, transcript),
+      kind: "transcript",
+      recordingId,
+    });
+    const jsonFile = await upsertFile(drive, {
+      parentId: folderId,
+      name: `${baseName}.json`,
+      mimeType: "application/json",
+      content: `${JSON.stringify({ archivedAt: new Date().toISOString(), recording, transcript }, null, 2)}\n`,
+      kind: "raw",
+      recordingId,
+    });
+
+    let videoFile = null;
+    if (this.uploadVideo && recording.video?.url && !recording.transcriptOnly) {
+      const videoResponse = await fetch(recording.video.url);
+      if (videoResponse.ok) {
+        const bytes = Buffer.from(await videoResponse.arrayBuffer());
+        if (bytes.byteLength > 0 && bytes.byteLength <= this.maxVideoBytes) {
+          videoFile = await upsertFile(drive, {
+            parentId: folderId,
+            name: `${baseName}.mp4`,
+            mimeType: videoResponse.headers.get("content-type") || "video/mp4",
+            content: bytes,
+            kind: "video",
+            recordingId,
+          });
+        }
+      }
+    }
+
+    return {
+      recordingId,
+      folderId,
+      markdownFile,
+      jsonFile,
+      videoFile,
+    };
+  },
+});

--- a/x/claap-drive-archive/scripts/backfill.ts
+++ b/x/claap-drive-archive/scripts/backfill.ts
@@ -1,0 +1,66 @@
+import { archiveRecordingsSince } from "../src/archive.ts";
+import { createClaapClient } from "../src/claap.ts";
+import { createGoogleDrivePortFromAdc } from "../src/google_drive.ts";
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable ${name}`);
+  }
+  return value;
+}
+
+function parseArgs(argv: string[]): { createdAfter: string } {
+  const createdAfterFlag = argv.find((arg) => arg.startsWith("--created-after="));
+  if (createdAfterFlag) {
+    return { createdAfter: createdAfterFlag.slice("--created-after=".length) };
+  }
+
+  const daysFlag = argv.find((arg) => arg.startsWith("--days="));
+  const days = daysFlag ? Number(daysFlag.slice("--days=".length)) : 2;
+  if (!Number.isFinite(days) || days <= 0) {
+    throw new Error("`--days` must be a positive number");
+  }
+  const createdAfter = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+  return { createdAfter };
+}
+
+async function fetchVideo(url: string) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Video download failed: ${response.status}`);
+  }
+  const body = Buffer.from(await response.arrayBuffer());
+  return {
+    body,
+    mimeType: response.headers.get("content-type") ?? "video/mp4",
+    byteLength: body.byteLength,
+  };
+}
+
+async function main() {
+  const { createdAfter } = parseArgs(process.argv.slice(2));
+  const claap = createClaapClient(requiredEnv("CLAAP_API_KEY"));
+  const drive = createGoogleDrivePortFromAdc();
+  const uploadVideo = process.env.UPLOAD_VIDEO === "true";
+
+  const results = await archiveRecordingsSince({
+    claap,
+    drive,
+    createdAfter,
+    options: {
+      rootFolderId: requiredEnv("GOOGLE_DRIVE_ROOT_FOLDER_ID"),
+      uploadVideo,
+      maxVideoBytes: Number(process.env.MAX_VIDEO_BYTES ?? 209715200),
+      fetchVideo: uploadVideo ? fetchVideo : undefined,
+    },
+  });
+
+  const archived = results.filter((result) => result.status === "archived").length;
+  const skipped = results.length - archived;
+  console.log(
+    JSON.stringify({ createdAfter, archived, skipped, results }, null, 2)
+  );
+}
+
+await main();

--- a/x/claap-drive-archive/src/archive.ts
+++ b/x/claap-drive-archive/src/archive.ts
@@ -1,0 +1,162 @@
+import { buildArchiveJson, buildArchiveMarkdown } from "./document.ts";
+import {
+  archiveBaseName,
+  recorderFolderName,
+  videoExtension,
+} from "./filenames.ts";
+import type {
+  ArchiveOptions,
+  ArchiveResult,
+  ClaapPort,
+  ClaapRecording,
+  ClaapTranscript,
+  DrivePort,
+} from "./types.ts";
+
+const DEFAULT_VIDEO_MIME = "video/mp4";
+
+async function loadTranscript(
+  claap: ClaapPort,
+  recording: ClaapRecording
+): Promise<ClaapTranscript | null> {
+  try {
+    return await claap.getTranscript(recording.id);
+  } catch (error) {
+    if (recording.transcripts && recording.transcripts.length > 0) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function maybeUploadVideo(input: {
+  drive: DrivePort;
+  folderId: string;
+  recording: ClaapRecording;
+  baseName: string;
+  options: ArchiveOptions;
+}): Promise<string | undefined> {
+  const { drive, folderId, recording, baseName, options } = input;
+  if (!options.uploadVideo || recording.transcriptOnly || !recording.video?.url) {
+    return undefined;
+  }
+  if (!options.fetchVideo) {
+    throw new Error("uploadVideo is enabled but no fetchVideo implementation was provided");
+  }
+
+  const video = await options.fetchVideo(recording.video.url);
+  if (video.byteLength === 0) {
+    return undefined;
+  }
+  if (video.byteLength > options.maxVideoBytes) {
+    return undefined;
+  }
+
+  const mimeType = video.mimeType || DEFAULT_VIDEO_MIME;
+  const file = await drive.upsertMedia({
+    parentId: folderId,
+    name: `${baseName}.${videoExtension(mimeType)}`,
+    mimeType,
+    body: video.body,
+    appProperties: {
+      claapRecordingId: recording.id,
+      kind: "video",
+    },
+  });
+  return file.id;
+}
+
+export async function archiveRecording(input: {
+  claap: ClaapPort;
+  drive: DrivePort;
+  recordingId: string;
+  options: ArchiveOptions;
+}): Promise<ArchiveResult> {
+  const recording = await input.claap.getRecording(input.recordingId);
+  if (recording.state !== "Ready") {
+    return {
+      status: "skipped",
+      recordingId: recording.id,
+      reason: `recording state is ${recording.state}`,
+    };
+  }
+
+  const transcript = await loadTranscript(input.claap, recording);
+  const markdown = buildArchiveMarkdown({ recording, transcript });
+  const json = buildArchiveJson({ recording, transcript });
+  const folderId = await input.drive.ensureFolder(
+    input.options.rootFolderId,
+    recorderFolderName(recording)
+  );
+  const baseName = archiveBaseName(recording);
+
+  const markdownFile = await input.drive.upsertFile({
+    parentId: folderId,
+    name: `${baseName}.md`,
+    mimeType: "text/markdown",
+    content: markdown,
+    appProperties: {
+      claapRecordingId: recording.id,
+      kind: "transcript",
+    },
+  });
+
+  const jsonFile = await input.drive.upsertFile({
+    parentId: folderId,
+    name: `${baseName}.json`,
+    mimeType: "application/json",
+    content: json,
+    appProperties: {
+      claapRecordingId: recording.id,
+      kind: "raw",
+    },
+  });
+
+  const videoFileId = await maybeUploadVideo({
+    drive: input.drive,
+    folderId,
+    recording,
+    baseName,
+    options: input.options,
+  });
+
+  return {
+    status: "archived",
+    recordingId: recording.id,
+    folderId,
+    markdownFileId: markdownFile.id,
+    jsonFileId: jsonFile.id,
+    videoFileId,
+  };
+}
+
+export async function archiveRecordingsSince(input: {
+  claap: ClaapPort;
+  drive: DrivePort;
+  createdAfter: string;
+  options: ArchiveOptions;
+}): Promise<ArchiveResult[]> {
+  const results: ArchiveResult[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const page = await input.claap.listRecordings({
+      createdAfter: input.createdAfter,
+      cursor,
+      limit: 50,
+    });
+    for (const recording of page.recordings) {
+      results.push(
+        await archiveRecording({
+          claap: input.claap,
+          drive: input.drive,
+          recordingId: recording.id,
+          options: input.options,
+        })
+      );
+    }
+    cursor = page.nextCursor;
+  } while (cursor);
+
+  return results;
+}

--- a/x/claap-drive-archive/src/claap.ts
+++ b/x/claap-drive-archive/src/claap.ts
@@ -1,0 +1,82 @@
+import type { ClaapPort, ClaapRecording, ClaapTranscript } from "./types.ts";
+
+const DEFAULT_BASE_URL = "https://api.claap.io";
+
+type ClaapEnvelope<T> = { result: T };
+
+async function readError(response: Response): Promise<string> {
+  const text = await response.text();
+  return text.slice(0, 500) || response.statusText;
+}
+
+export function createClaapClient(
+  apiKey: string,
+  baseUrl = DEFAULT_BASE_URL
+): ClaapPort {
+  async function request<T>(
+    path: string,
+    searchParams?: Record<string, string | number | undefined>
+  ): Promise<T> {
+    const url = new URL(path, `${baseUrl.replace(/\/$/, "")}/`);
+    if (searchParams) {
+      for (const [key, value] of Object.entries(searchParams)) {
+        if (value !== undefined && value !== "") {
+          url.searchParams.set(key, String(value));
+        }
+      }
+    }
+
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+        "X-Claap-Key": apiKey,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Claap ${response.status} ${url.pathname}: ${await readError(response)}`
+      );
+    }
+
+    return (await response.json()) as T;
+  }
+
+  return {
+    async getRecording(recordingId) {
+      const payload = await request<ClaapEnvelope<{ recording: ClaapRecording }>>(
+        `v1/recordings/${encodeURIComponent(recordingId)}`
+      );
+      return payload.result.recording;
+    },
+
+    async getTranscript(recordingId) {
+      const payload = await request<
+        ClaapEnvelope<{ transcript: ClaapTranscript }>
+      >(`v1/recordings/${encodeURIComponent(recordingId)}/transcript`, {
+        format: "json",
+      });
+      return payload.result.transcript;
+    },
+
+    async listRecordings(params = {}) {
+      const payload = await request<
+        ClaapEnvelope<{
+          recordings: ClaapRecording[];
+          pagination: { nextCursor?: string; totalCount: number };
+        }>
+      >("v1/recordings", {
+        createdAfter: params.createdAfter,
+        createdBefore: params.createdBefore,
+        cursor: params.cursor,
+        limit: params.limit ?? 50,
+        recorderEmail: params.recorderEmail,
+        sort: "created_asc",
+      });
+      return {
+        recordings: payload.result.recordings,
+        nextCursor: payload.result.pagination.nextCursor,
+      };
+    },
+  };
+}

--- a/x/claap-drive-archive/src/document.ts
+++ b/x/claap-drive-archive/src/document.ts
@@ -1,0 +1,112 @@
+import { archiveDatePrefix } from "./filenames.ts";
+import type { ClaapPerson, ClaapRecording, ClaapTranscript } from "./types.ts";
+import { yamlScalar } from "./yaml.ts";
+
+function formatTimestamp(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return "00:00:00";
+  }
+  const total = Math.floor(seconds);
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const rest = total % 60;
+  return [hours, minutes, rest].map((part) => String(part).padStart(2, "0")).join(":");
+}
+
+function personLine(person: ClaapPerson, indent = "  "): string[] {
+  const lines = [`${indent}- name: ${yamlScalar(person.name ?? "")}`];
+  if (person.email) {
+    lines.push(`${indent}  email: ${yamlScalar(person.email)}`);
+  }
+  lines.push(`${indent}  attended: ${yamlScalar(person.attended)}`);
+  return lines;
+}
+
+export function buildFrontmatter(recording: ClaapRecording): string {
+  const participants = recording.meeting?.participants ?? [];
+  const companies = recording.companies ?? [];
+  const labels = recording.labels ?? [];
+
+  const lines = [
+    `claap_id: ${yamlScalar(recording.id)}`,
+    `title: ${yamlScalar(recording.title ?? "")}`,
+    `created_at: ${yamlScalar(recording.createdAt)}`,
+    `date: ${yamlScalar(archiveDatePrefix(recording.createdAt))}`,
+    `duration_seconds: ${yamlScalar(recording.durationSeconds ?? null)}`,
+    `source: ${yamlScalar(recording.source ?? null)}`,
+    `meeting_type: ${yamlScalar(recording.meeting?.type ?? null)}`,
+    `conference_url: ${yamlScalar(recording.meeting?.conferenceUrl ?? null)}`,
+    `meeting_starting_at: ${yamlScalar(recording.meeting?.startingAt ?? null)}`,
+    `meeting_ending_at: ${yamlScalar(recording.meeting?.endingAt ?? null)}`,
+    `recorder_name: ${yamlScalar(recording.recorder.name)}`,
+    `recorder_email: ${yamlScalar(recording.recorder.email)}`,
+    `recorder_attended: ${yamlScalar(recording.recorder.attended)}`,
+    "participants:",
+    ...(participants.length > 0
+      ? participants.flatMap((person) => personLine(person))
+      : ["  []"]),
+    "companies:",
+    ...(companies.length > 0
+      ? companies.map((company) => `  - ${yamlScalar(company.name)}`)
+      : ["  []"]),
+    `deal: ${yamlScalar(recording.deal?.name ?? recording.deal?.id ?? null)}`,
+    `crm: ${yamlScalar(recording.crmInfo?.crm ?? null)}`,
+    `channel: ${yamlScalar(recording.channel?.name ?? null)}`,
+    "labels:",
+    ...(labels.length > 0
+      ? labels.map((label) => `  - ${yamlScalar(label)}`)
+      : ["  []"]),
+    `workspace: ${yamlScalar(recording.workspace.name)}`,
+    `claap_url: ${yamlScalar(recording.url)}`,
+    `transcript_only: ${yamlScalar(Boolean(recording.transcriptOnly))}`,
+    `video_available: ${yamlScalar(Boolean(recording.video?.url) && !recording.transcriptOnly)}`,
+  ];
+
+  return `---\n${lines.join("\n")}\n---\n`;
+}
+
+export function formatTranscript(
+  transcript: ClaapTranscript | null,
+  fallbackText?: string | null
+): string {
+  if (transcript && transcript.segments.length > 0) {
+    return transcript.segments
+      .map((segment) => {
+        const speaker = segment.speaker?.trim() || "unknown";
+        const text = segment.text.trim();
+        return `[${formatTimestamp(segment.startedAt)}] ${speaker}: ${text}`;
+      })
+      .join("\n");
+  }
+
+  if (fallbackText?.trim()) {
+    return fallbackText.trim();
+  }
+
+  return "_No transcript was available for this recording._";
+}
+
+export function buildArchiveMarkdown(input: {
+  recording: ClaapRecording;
+  transcript: ClaapTranscript | null;
+  fallbackText?: string | null;
+}): string {
+  const frontmatter = buildFrontmatter(input.recording);
+  const transcript = formatTranscript(input.transcript, input.fallbackText);
+  return `${frontmatter}\n# Transcript\n\n${transcript}\n`;
+}
+
+export function buildArchiveJson(input: {
+  recording: ClaapRecording;
+  transcript: ClaapTranscript | null;
+}): string {
+  return `${JSON.stringify(
+    {
+      archivedAt: new Date().toISOString(),
+      recording: input.recording,
+      transcript: input.transcript,
+    },
+    null,
+    2
+  )}\n`;
+}

--- a/x/claap-drive-archive/src/filenames.ts
+++ b/x/claap-drive-archive/src/filenames.ts
@@ -1,0 +1,53 @@
+import type { ClaapRecording } from "./types.ts";
+
+const MAX_TITLE_LENGTH = 80;
+
+export function sanitizeFilenamePart(value: string): string {
+  const cleaned = value
+    .normalize("NFKD")
+    .replace(/[\u0000-\u001f]/g, "")
+    .replace(/[\\/:*?"<>|]/g, "-")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+
+  return cleaned.length > 0 ? cleaned : "untitled";
+}
+
+export function recorderFolderName(recording: ClaapRecording): string {
+  const email = recording.recorder.email?.trim().toLowerCase();
+  if (!email) {
+    return "_unknown";
+  }
+  return sanitizeFilenamePart(email);
+}
+
+export function archiveDatePrefix(createdAt: string): string {
+  const match = /^(\d{4}-\d{2}-\d{2})/.exec(createdAt);
+  if (match) {
+    return match[1];
+  }
+  return new Date(createdAt).toISOString().slice(0, 10);
+}
+
+export function archiveBaseName(recording: ClaapRecording): string {
+  const date = archiveDatePrefix(recording.createdAt);
+  const title = sanitizeFilenamePart(recording.title ?? "untitled").slice(
+    0,
+    MAX_TITLE_LENGTH
+  );
+  return `${date}_${title}_${recording.id}`;
+}
+
+export function videoExtension(mimeType: string): string {
+  if (mimeType.includes("quicktime") || mimeType.includes("mp4")) {
+    return "mp4";
+  }
+  if (mimeType.includes("webm")) {
+    return "webm";
+  }
+  if (mimeType.includes("mpeg")) {
+    return "mpeg";
+  }
+  return "mp4";
+}

--- a/x/claap-drive-archive/src/google_drive.ts
+++ b/x/claap-drive-archive/src/google_drive.ts
@@ -1,0 +1,143 @@
+import { google, type drive_v3 } from "googleapis";
+
+import type { DrivePort } from "./types.ts";
+
+const FOLDER_MIME = "application/vnd.google-apps.folder";
+
+function driveQueryEscape(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
+export function createGoogleDrivePort(input: {
+  drive?: drive_v3.Drive;
+  accessToken?: string;
+}): DrivePort {
+  let drive = input.drive;
+  if (!drive && input.accessToken) {
+    const auth = new google.auth.OAuth2();
+    auth.setCredentials({ access_token: input.accessToken });
+    drive = google.drive({ version: "v3", auth });
+  }
+  if (!drive) {
+    throw new Error("Google Drive client requires drive or accessToken");
+  }
+  const driveClient = drive;
+
+  async function findFile(query: string): Promise<drive_v3.Schema$File | null> {
+    const response = await driveClient.files.list({
+      q: query,
+      fields: "files(id,name,webViewLink)",
+      pageSize: 1,
+      includeItemsFromAllDrives: true,
+      supportsAllDrives: true,
+    });
+    return response.data.files?.[0] ?? null;
+  }
+
+  return {
+    async ensureFolder(parentId, name) {
+      const existing = await findFile(
+        `mimeType = '${FOLDER_MIME}' and name = '${driveQueryEscape(name)}' and '${driveQueryEscape(parentId)}' in parents and trashed = false`
+      );
+      if (existing?.id) {
+        return existing.id;
+      }
+
+      const created = await driveClient.files.create({
+        requestBody: {
+          name,
+          mimeType: FOLDER_MIME,
+          parents: [parentId],
+        },
+        fields: "id",
+        supportsAllDrives: true,
+      });
+      if (!created.data.id) {
+        throw new Error(`Failed to create Drive folder ${name}`);
+      }
+      return created.data.id;
+    },
+
+    async upsertFile({ parentId, name, mimeType, content, appProperties }) {
+      const recordingId = appProperties.claapRecordingId;
+      const kind = appProperties.kind;
+      const existing = recordingId
+        ? await findFile(
+            `appProperties has { key='claapRecordingId' and value='${driveQueryEscape(recordingId)}' } and appProperties has { key='kind' and value='${driveQueryEscape(kind)}' } and '${driveQueryEscape(parentId)}' in parents and trashed = false`
+          )
+        : null;
+
+      const media = {
+        mimeType,
+        body: typeof content === "string" ? content : content,
+      };
+
+      if (existing?.id) {
+        const updated = await driveClient.files.update({
+          fileId: existing.id,
+          requestBody: { name, appProperties },
+          media,
+          fields: "id,name,webViewLink",
+          supportsAllDrives: true,
+        });
+        return {
+          id: updated.data.id ?? existing.id,
+          name: updated.data.name ?? name,
+          webViewLink: updated.data.webViewLink ?? undefined,
+        };
+      }
+
+      const created = await driveClient.files.create({
+        requestBody: {
+          name,
+          mimeType,
+          parents: [parentId],
+          appProperties,
+        },
+        media,
+        fields: "id,name,webViewLink",
+        supportsAllDrives: true,
+      });
+      if (!created.data.id) {
+        throw new Error(`Failed to create Drive file ${name}`);
+      }
+      return {
+        id: created.data.id,
+        name: created.data.name ?? name,
+        webViewLink: created.data.webViewLink ?? undefined,
+      };
+    },
+
+    async upsertMedia({ parentId, name, mimeType, body, appProperties }) {
+      return this.upsertFile({
+        parentId,
+        name,
+        mimeType,
+        content: typeof body === "object" && Buffer.isBuffer(body) ? body : await streamToBuffer(body),
+        appProperties,
+      });
+    },
+  };
+}
+
+async function streamToBuffer(
+  body: NodeJS.ReadableStream | Buffer
+): Promise<Buffer> {
+  if (Buffer.isBuffer(body)) {
+    return body;
+  }
+  const chunks: Buffer[] = [];
+  for await (const chunk of body) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+export function createGoogleDrivePortFromAdc(): DrivePort {
+  const auth = new google.auth.GoogleAuth({
+    scopes: ["https://www.googleapis.com/auth/drive"],
+  });
+  return createGoogleDrivePort({
+    drive: google.drive({ version: "v3", auth }),
+  });
+}

--- a/x/claap-drive-archive/src/index.ts
+++ b/x/claap-drive-archive/src/index.ts
@@ -1,0 +1,22 @@
+export { archiveRecording, archiveRecordingsSince } from "./archive.ts";
+export { createClaapClient } from "./claap.ts";
+export {
+  buildArchiveJson,
+  buildArchiveMarkdown,
+  buildFrontmatter,
+  formatTranscript,
+} from "./document.ts";
+export { archiveBaseName, recorderFolderName } from "./filenames.ts";
+export { createGoogleDrivePort, createGoogleDrivePortFromAdc } from "./google_drive.ts";
+export {
+  extractRecordingId,
+  isClaapWebhookEvent,
+  verifyClaapWebhookSecret,
+} from "./webhook.ts";
+export type {
+  ArchiveOptions,
+  ArchiveResult,
+  ClaapPort,
+  ClaapRecording,
+  DrivePort,
+} from "./types.ts";

--- a/x/claap-drive-archive/src/types.ts
+++ b/x/claap-drive-archive/src/types.ts
@@ -1,0 +1,128 @@
+export type ClaapPerson = {
+  attended: boolean;
+  email?: string;
+  id?: string;
+  name?: string;
+};
+
+export type ClaapTranscriptSegment = {
+  startedAt: number;
+  endedAt: number;
+  speaker?: string;
+  text: string;
+  languageCode?: string;
+};
+
+export type ClaapTranscript = {
+  languageCode?: string;
+  segments: ClaapTranscriptSegment[];
+};
+
+export type ClaapRecordingState = "Empty" | "Uploaded" | "Ready" | "Failed";
+
+export type ClaapRecording = {
+  id: string;
+  state: ClaapRecordingState;
+  title?: string;
+  createdAt: string;
+  durationSeconds?: number;
+  source?: string;
+  url: string;
+  transcriptOnly?: boolean;
+  labels?: string[];
+  recorder: ClaapPerson & { email: string; id: string; name: string };
+  channel?: { id: string; name: string };
+  workspace: { id: string; name: string };
+  meeting?: {
+    conferenceUrl?: string;
+    startingAt: string;
+    endingAt: string;
+    type: "internal" | "external";
+    participants: ClaapPerson[];
+  };
+  companies?: { id: string; name: string }[];
+  deal?: { id: string; name?: string };
+  crmInfo?: { crm: string; deal?: { id: string } };
+  video?: { url?: string };
+  transcripts?: Array<{
+    isActive?: boolean;
+    isTranscript?: boolean;
+    langIso2?: string;
+    textUrl: string;
+    url: string;
+  }>;
+  actionItems?: unknown;
+  aiFields?: unknown;
+  analytics?: unknown;
+  keyTakeaways?: unknown;
+  outlines?: unknown;
+};
+
+export type ClaapWebhookEvent = {
+  eventId: string;
+  event: {
+    type: "recording_added" | "recording_updated";
+    recording: ClaapRecording;
+  };
+};
+
+export type ArchiveResult =
+  | {
+      status: "archived";
+      recordingId: string;
+      folderId: string;
+      markdownFileId: string;
+      jsonFileId: string;
+      videoFileId?: string;
+    }
+  | { status: "skipped"; recordingId?: string; reason: string };
+
+export type DriveFile = {
+  id: string;
+  name?: string;
+  webViewLink?: string;
+};
+
+export type DrivePort = {
+  ensureFolder(parentId: string, name: string): Promise<string>;
+  upsertFile(input: {
+    parentId: string;
+    name: string;
+    mimeType: string;
+    content: Buffer | string;
+    appProperties: Record<string, string>;
+  }): Promise<DriveFile>;
+  upsertMedia(input: {
+    parentId: string;
+    name: string;
+    mimeType: string;
+    body: NodeJS.ReadableStream | Buffer;
+    appProperties: Record<string, string>;
+  }): Promise<DriveFile>;
+};
+
+export type ClaapPort = {
+  getRecording(recordingId: string): Promise<ClaapRecording>;
+  getTranscript(recordingId: string): Promise<ClaapTranscript>;
+  listRecordings(params?: {
+    createdAfter?: string;
+    createdBefore?: string;
+    cursor?: string;
+    limit?: number;
+    recorderEmail?: string;
+  }): Promise<{
+    recordings: ClaapRecording[];
+    nextCursor?: string;
+  }>;
+};
+
+export type ArchiveOptions = {
+  rootFolderId: string;
+  uploadVideo: boolean;
+  maxVideoBytes: number;
+  fetchVideo?: (url: string) => Promise<{
+    body: Buffer;
+    mimeType: string;
+    byteLength: number;
+  }>;
+};

--- a/x/claap-drive-archive/src/webhook.ts
+++ b/x/claap-drive-archive/src/webhook.ts
@@ -1,0 +1,68 @@
+import { timingSafeEqual } from "node:crypto";
+
+import type { ClaapRecording, ClaapWebhookEvent } from "./types.ts";
+
+function headerValue(
+  headers: Record<string, string | string[] | undefined>,
+  name: string
+): string | undefined {
+  const direct = headers[name] ?? headers[name.toLowerCase()];
+  if (Array.isArray(direct)) {
+    return direct[0];
+  }
+  return direct;
+}
+
+export function verifyClaapWebhookSecret(
+  headers: Record<string, string | string[] | undefined>,
+  expectedSecret: string
+): boolean {
+  if (!expectedSecret) {
+    return false;
+  }
+  const provided = headerValue(headers, "x-claap-webhook-secret");
+  if (!provided) {
+    return false;
+  }
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expectedSecret);
+  if (a.length !== b.length) {
+    return false;
+  }
+  return timingSafeEqual(a, b);
+}
+
+export function isClaapWebhookEvent(value: unknown): value is ClaapWebhookEvent {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const event = (value as { event?: unknown }).event;
+  if (!event || typeof event !== "object") {
+    return false;
+  }
+  const type = (event as { type?: unknown }).type;
+  const recording = (event as { recording?: unknown }).recording;
+  return (
+    (type === "recording_added" || type === "recording_updated") &&
+    Boolean(recording) &&
+    typeof recording === "object" &&
+    typeof (recording as { id?: unknown }).id === "string"
+  );
+}
+
+export function extractRecordingId(body: unknown): string | null {
+  if (isClaapWebhookEvent(body)) {
+    return body.event.recording.id;
+  }
+  if (body && typeof body === "object") {
+    const recording = (body as { recording?: ClaapRecording }).recording;
+    if (recording && typeof recording.id === "string") {
+      return recording.id;
+    }
+    const id = (body as { recordingId?: unknown }).recordingId;
+    if (typeof id === "string") {
+      return id;
+    }
+  }
+  return null;
+}

--- a/x/claap-drive-archive/src/yaml.ts
+++ b/x/claap-drive-archive/src/yaml.ts
@@ -1,0 +1,28 @@
+function needsQuotes(value: string): boolean {
+  return (
+    value === "" ||
+    value === "true" ||
+    value === "false" ||
+    value === "null" ||
+    /[:#\n\r"'{}[\]&*?|<>=!%`,]/.test(value) ||
+    /\s/.test(value) ||
+    /^-/.test(value)
+  );
+}
+
+export function yamlScalar(value: string | number | boolean | null | undefined): string {
+  if (value === null || value === undefined) {
+    return "null";
+  }
+  if (typeof value === "boolean" || typeof value === "number") {
+    return String(value);
+  }
+  if (needsQuotes(value)) {
+    return JSON.stringify(value);
+  }
+  return value;
+}
+
+export function yamlBlock(lines: string[]): string {
+  return `${lines.join("\n")}\n`;
+}

--- a/x/claap-drive-archive/tests/archive.test.ts
+++ b/x/claap-drive-archive/tests/archive.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { archiveRecording, archiveRecordingsSince } from "../src/archive.ts";
+import type { ClaapPort, ClaapRecording, DrivePort } from "../src/types.ts";
+import { makeRecording, makeTranscript } from "./fixtures.ts";
+
+function createMocks(recordings: ClaapRecording[]) {
+  const folders = new Map<string, string>();
+  const files: Array<{
+    parentId: string;
+    name: string;
+    mimeType: string;
+    content: string;
+    appProperties: Record<string, string>;
+  }> = [];
+
+  const claap: ClaapPort = {
+    async getRecording(recordingId) {
+      const recording = recordings.find((item) => item.id === recordingId);
+      if (!recording) {
+        throw new Error(`missing recording ${recordingId}`);
+      }
+      return recording;
+    },
+    async getTranscript() {
+      return makeTranscript();
+    },
+    async listRecordings() {
+      return { recordings };
+    },
+  };
+
+  const drive: DrivePort = {
+    async ensureFolder(parentId, name) {
+      const key = `${parentId}/${name}`;
+      const existing = folders.get(key);
+      if (existing) {
+        return existing;
+      }
+      const id = `folder_${folders.size + 1}`;
+      folders.set(key, id);
+      return id;
+    },
+    async upsertFile(input) {
+      const content = typeof input.content === "string" ? input.content : input.content.toString("utf8");
+      const existing = files.findIndex(
+        (file) =>
+          file.appProperties.claapRecordingId === input.appProperties.claapRecordingId &&
+          file.appProperties.kind === input.appProperties.kind
+      );
+      const stored = {
+        parentId: input.parentId,
+        name: input.name,
+        mimeType: input.mimeType,
+        content,
+        appProperties: input.appProperties,
+      };
+      if (existing >= 0) {
+        files[existing] = stored;
+        return { id: `file_${existing + 1}` };
+      }
+      files.push(stored);
+      return { id: `file_${files.length}` };
+    },
+    async upsertMedia(input) {
+      return this.upsertFile({
+        ...input,
+        content: Buffer.isBuffer(input.body) ? input.body : Buffer.from("video"),
+      });
+    },
+  };
+
+  return { claap, drive, files, folders };
+}
+
+describe("archiveRecording", () => {
+  it("writes markdown and json under the recorder folder", async () => {
+    const recording = makeRecording();
+    const { claap, drive, files, folders } = createMocks([recording]);
+
+    const result = await archiveRecording({
+      claap,
+      drive,
+      recordingId: recording.id,
+      options: {
+        rootFolderId: "root",
+        uploadVideo: false,
+        maxVideoBytes: 1,
+      },
+    });
+
+    assert.equal(result.status, "archived");
+    assert.equal(folders.get("root/ilias@dust.tt"), "folder_1");
+    assert.equal(files.length, 2);
+    assert.equal(files[0]?.name.endsWith(".md"), true);
+    assert.equal(files[1]?.name.endsWith(".json"), true);
+    assert.match(files[0]?.content ?? "", /# Transcript/);
+    assert.doesNotMatch(files[0]?.content ?? "", /MEDICC/);
+    assert.match(files[1]?.content ?? "", /"id": "rec_abc123"/);
+  });
+
+  it("skips recordings that are not ready", async () => {
+    const recording = makeRecording({ state: "Uploaded" });
+    const { claap, drive, files } = createMocks([recording]);
+
+    const result = await archiveRecording({
+      claap,
+      drive,
+      recordingId: recording.id,
+      options: { rootFolderId: "root", uploadVideo: false, maxVideoBytes: 1 },
+    });
+
+    assert.deepEqual(result, {
+      status: "skipped",
+      recordingId: recording.id,
+      reason: "recording state is Uploaded",
+    });
+    assert.equal(files.length, 0);
+  });
+
+  it("upserts the same recording instead of duplicating files", async () => {
+    const recording = makeRecording();
+    const { claap, drive, files } = createMocks([recording]);
+    const options = { rootFolderId: "root", uploadVideo: false, maxVideoBytes: 1 };
+
+    await archiveRecording({ claap, drive, recordingId: recording.id, options });
+    await archiveRecording({ claap, drive, recordingId: recording.id, options });
+
+    assert.equal(files.length, 2);
+  });
+
+  it("archives a page of recordings during backfill", async () => {
+    const recordings = [
+      makeRecording({ id: "rec_1" }),
+      makeRecording({ id: "rec_2", recorder: { ...makeRecording().recorder, email: "iris@dust.tt" } }),
+    ];
+    const { claap, drive, files, folders } = createMocks(recordings);
+
+    const results = await archiveRecordingsSince({
+      claap,
+      drive,
+      createdAfter: "2026-09-01T00:00:00.000Z",
+      options: { rootFolderId: "root", uploadVideo: false, maxVideoBytes: 1 },
+    });
+
+    assert.equal(results.length, 2);
+    assert.equal(folders.get("root/iris@dust.tt"), "folder_2");
+    assert.equal(files.length, 4);
+  });
+});

--- a/x/claap-drive-archive/tests/document.test.ts
+++ b/x/claap-drive-archive/tests/document.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { buildArchiveMarkdown, formatTranscript } from "../src/document.ts";
+import { makeRecording, makeTranscript } from "./fixtures.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+describe("document", () => {
+  it("puts recorder and participant metadata above the raw transcript", () => {
+    const markdown = buildArchiveMarkdown({
+      recording: makeRecording(),
+      transcript: makeTranscript(),
+    });
+
+    assert.match(markdown, /^---\n/);
+    assert.match(markdown, /claap_id: rec_abc123/);
+    assert.match(markdown, /recorder_name: "Ilias Bettaieb"/);
+    assert.match(markdown, /recorder_email: ilias@dust\.tt/);
+    assert.match(markdown, /meeting_type: external/);
+    assert.match(markdown, /email: jane@acme\.com/);
+    assert.match(markdown, /# Transcript\n\n\[00:02:16\] speaker_1: Hello there!/);
+    assert.match(markdown, /\[00:02:18\] speaker_2: Thanks for joining\./);
+  });
+
+  it("does not copy generated notes into the markdown archive", () => {
+    const markdown = buildArchiveMarkdown({
+      recording: makeRecording(),
+      transcript: makeTranscript(),
+    });
+
+    assert.doesNotMatch(markdown, /MEDICC/);
+    assert.doesNotMatch(markdown, /Generated notes must stay out/);
+    assert.doesNotMatch(markdown, /Do not put this in the markdown/);
+  });
+
+  it("matches the checked-in sample document", () => {
+    const markdown = buildArchiveMarkdown({
+      recording: makeRecording(),
+      transcript: makeTranscript(),
+    });
+    const sample = readFileSync(join(here, "../examples/sample-archive.md"), "utf8");
+    assert.equal(markdown, sample);
+  });
+
+  it("explains when no transcript exists", () => {
+    assert.equal(
+      formatTranscript({ languageCode: "en", segments: [] }),
+      "_No transcript was available for this recording._"
+    );
+  });
+});

--- a/x/claap-drive-archive/tests/filenames.test.ts
+++ b/x/claap-drive-archive/tests/filenames.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { archiveBaseName, recorderFolderName, sanitizeFilenamePart } from "../src/filenames.ts";
+import { makeRecording } from "./fixtures.ts";
+
+describe("filenames", () => {
+  it("sanitizes path characters and whitespace", () => {
+    assert.equal(sanitizeFilenamePart("Discovery call with Acme / Q3"), "Discovery-call-with-Acme-Q3");
+    assert.equal(sanitizeFilenamePart(""), "untitled");
+  });
+
+  it("groups archives by recorder email", () => {
+    assert.equal(recorderFolderName(makeRecording()), "ilias@dust.tt");
+    assert.equal(
+      recorderFolderName(makeRecording({ recorder: { ...makeRecording().recorder, email: "" } })),
+      "_unknown"
+    );
+  });
+
+  it("keeps the recording id in the file stem", () => {
+    assert.equal(
+      archiveBaseName(makeRecording()),
+      "2026-09-12_Discovery-call-with-Acme-Q3_rec_abc123"
+    );
+  });
+});

--- a/x/claap-drive-archive/tests/fixtures.ts
+++ b/x/claap-drive-archive/tests/fixtures.ts
@@ -1,0 +1,82 @@
+import type { ClaapRecording, ClaapTranscript } from "../src/types.ts";
+
+export function makeRecording(
+  overrides: Partial<ClaapRecording> = {}
+): ClaapRecording {
+  return {
+    id: "rec_abc123",
+    state: "Ready",
+    title: "Discovery call with Acme / Q3",
+    createdAt: "2026-09-12T15:04:05.000Z",
+    durationSeconds: 1842,
+    source: "GoogleMeet",
+    url: "https://app.claap.io/dust/discovery-call-with-acme-rec_abc123",
+    transcriptOnly: false,
+    labels: ["customer"],
+    recorder: {
+      attended: true,
+      email: "ilias@dust.tt",
+      id: "user_1",
+      name: "Ilias Bettaieb",
+    },
+    channel: { id: "ch_ext", name: "External" },
+    workspace: { id: "ws_dust", name: "Dust" },
+    meeting: {
+      conferenceUrl: "https://meet.google.com/aaa-bbbb-cccc",
+      startingAt: "2026-09-12T14:30:00.000Z",
+      endingAt: "2026-09-12T15:00:00.000Z",
+      type: "external",
+      participants: [
+        {
+          attended: true,
+          email: "jane@acme.com",
+          name: "Jane Doe",
+        },
+        {
+          attended: true,
+          email: "ilias@dust.tt",
+          name: "Ilias Bettaieb",
+        },
+      ],
+    },
+    companies: [{ id: "co_1", name: "Acme" }],
+    deal: { id: "deal_1", name: "Acme — Enterprise" },
+    crmInfo: { crm: "hubspot", deal: { id: "hs_1" } },
+    video: { url: "https://cdn.claap.io/video/rec_abc123.mp4?token=tmp" },
+    transcripts: [
+      {
+        isActive: true,
+        isTranscript: true,
+        langIso2: "en",
+        textUrl: "https://cdn.claap.io/transcript.txt",
+        url: "https://cdn.claap.io/transcript.json",
+      },
+    ],
+    aiFields: [{ title: "MEDICC", description: "Do not put this in the markdown." }],
+    keyTakeaways: [{ langIso2: "en", text: "Generated notes must stay out." }],
+    outlines: [{ langIso2: "en", text: "Outline" }],
+    ...overrides,
+  };
+}
+
+export function makeTranscript(): ClaapTranscript {
+  return {
+    languageCode: "en",
+    segments: [
+      {
+        startedAt: 136.1,
+        endedAt: 137.5,
+        speaker: "speaker_1",
+        text: "Hello there!",
+        languageCode: "en",
+      },
+      {
+        startedAt: 138.2,
+        endedAt: 141.0,
+        speaker: "speaker_2",
+        text: "Thanks for joining.",
+        languageCode: "en",
+      },
+    ],
+  };
+}

--- a/x/claap-drive-archive/tests/webhook.test.ts
+++ b/x/claap-drive-archive/tests/webhook.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  extractRecordingId,
+  isClaapWebhookEvent,
+  verifyClaapWebhookSecret,
+} from "../src/webhook.ts";
+import { makeRecording } from "./fixtures.ts";
+
+const secret = "claap_webhook_secret";
+
+describe("webhook", () => {
+  it("accepts a matching Claap webhook secret", () => {
+    assert.equal(
+      verifyClaapWebhookSecret({ "x-claap-webhook-secret": secret }, secret),
+      true
+    );
+  });
+
+  it("rejects a missing or mismatched secret", () => {
+    assert.equal(verifyClaapWebhookSecret({}, secret), false);
+    assert.equal(
+      verifyClaapWebhookSecret({ "x-claap-webhook-secret": "nope" }, secret),
+      false
+    );
+    assert.equal(
+      verifyClaapWebhookSecret({ "x-claap-webhook-secret": secret }, ""),
+      false
+    );
+  });
+
+  it("reads the recording id from a recording_added payload", () => {
+    const body = {
+      eventId: "evt_1",
+      event: { type: "recording_added" as const, recording: makeRecording() },
+    };
+    assert.equal(isClaapWebhookEvent(body), true);
+    assert.equal(extractRecordingId(body), "rec_abc123");
+  });
+
+  it("rejects payloads without a recording id", () => {
+    assert.equal(isClaapWebhookEvent({ hello: "world" }), false);
+    assert.equal(extractRecordingId({ hello: "world" }), null);
+  });
+});

--- a/x/claap-drive-archive/tests/yaml.test.ts
+++ b/x/claap-drive-archive/tests/yaml.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { yamlScalar } from "../src/yaml.ts";
+
+describe("yamlScalar", () => {
+  it("leaves simple strings unquoted", () => {
+    assert.equal(yamlScalar("ilias@dust.tt"), "ilias@dust.tt");
+    assert.equal(yamlScalar("GoogleMeet"), "GoogleMeet");
+  });
+
+  it("quotes strings that would break YAML", () => {
+    assert.equal(yamlScalar("Acme — Enterprise"), JSON.stringify("Acme — Enterprise"));
+    assert.equal(yamlScalar("a: b"), JSON.stringify("a: b"));
+    assert.equal(yamlScalar(""), JSON.stringify(""));
+    assert.equal(yamlScalar("true"), JSON.stringify("true"));
+  });
+
+  it("serializes primitives", () => {
+    assert.equal(yamlScalar(true), "true");
+    assert.equal(yamlScalar(12), "12");
+    assert.equal(yamlScalar(null), "null");
+    assert.equal(yamlScalar(undefined), "null");
+  });
+});

--- a/x/claap-drive-archive/tsconfig.json
+++ b/x/claap-drive-archive/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "verbatimModuleSyntax": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "scripts/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Internal ops automation, **not Dust product code**. Parked under `x/claap-drive-archive` so we can version and test it; it can move to a private ops repo later.

Claap webhooks cannot be created via API and must return 200 within 5 seconds, so this should live on **Pipedream** rather than in `front` / Temporal.

On each `recording_added` / `recording_updated` event the workflow:

1. Acks Claap immediately
2. Refetches the recording + raw transcript from the Claap API
3. Writes a markdown file (YAML metadata + word-for-word transcript, no AI notes) and a JSON dump into a Shared Drive folder grouped by recorder email

A scheduled backfill upserts the last 48 hours so a failed run does not lose recordings. Video upload is off by default.

Setup: `x/claap-drive-archive/README.md` and `x/claap-drive-archive/pipedream/README.md`.

## Tests

- `cd x/claap-drive-archive && npm test` — 18 unit tests for document format, webhook secret, filenames, skip/upsert/backfill
- `npx tsc --noEmit` — clean
- No live Claap or Drive credentials in this environment, so the Pipedream workflows were not deployed end-to-end

## Risk

None for the Dust product runtime. Nothing in `front`, `front-api`, or workers imports this package.

## Deploy Plan

1. Create a Shared Drive folder (`Claap Recordings`) and copy its ID
2. Paste `pipedream/webhook-archive.js` into a Pipedream HTTP workflow (custom 200 response)
3. Paste `pipedream/scheduled-backfill.js` into a hourly/daily schedule workflow
4. Point a Claap admin webhook (`recording_added` + `recording_updated`) at the HTTP URL
5. Store the Claap API key and webhook secret only in Pipedream
6. Trigger a test recording (or `POST /v1/webhooks/{id}/trigger`) and confirm files land under `{recorder-email}/`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0787aae-8c90-405a-a2e9-9ee9663e1729?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0787aae-8c90-405a-a2e9-9ee9663e1729&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

